### PR TITLE
Fixe typo in documentation of panel menubar

### DIFF
--- a/showcase/demo/panelmenu/panelmenudemo.html
+++ b/showcase/demo/panelmenu/panelmenudemo.html
@@ -103,7 +103,7 @@ import {PanelMenu} from 'primeng/primeng';
             &lt;/ul&gt;
         &lt;/div&gt;
     &lt;/div&gt;
-&lt;p-panelMenu&gt;
+&lt;/p-panelMenu&gt;
 </code>
 </pre>
             


### PR DESCRIPTION
Hello primefaces team,
this pull request is a fixe in documentation of panel menubar. the p-panelMenu element is not closed properly.