### PR TITLE
fix(Editor): rename next() to emit()

### DIFF
--- a/components/editor/editor.ts
+++ b/components/editor/editor.ts
@@ -169,14 +169,14 @@ export class Editor implements AfterViewInit,OnDestroy {
                 htmlValue = null;
             }
             
-            this.onTextChange.next({
+            this.onTextChange.emit({
                 htmlValue: htmlValue,
                 textValue: this.quill.getText(),
                 delta: delta,
                 source: source
             });
             
-            this.valueChange.next(htmlValue);
+            this.valueChange.emit(htmlValue);
         });
         
         if(this.value) {


### PR DESCRIPTION
This is a small change, but it's a fix since `next()` was deprecated long ago for EventEmitter, instead we should be using `emit()`. See https://github.com/angular/angular/pull/5302.



PS : I found out about this component through twitter and by digging in the code I saw this. I hope this it's not a problem.

PS2 : Sorry if I missed some guidelines, but I didn't see any contribution guide in your repo, I hope also not being doing anything wrong.

Cheers!