### PR TITLE
Autocomplete improvements

### DIFF
--- a/components/autocomplete/autocomplete.ts
+++ b/components/autocomplete/autocomplete.ts
@@ -232,24 +232,37 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
     }
     
     selectItem(item: any) {
-        let itemIndex = this.domHandler.index(item);
-        let selectedValue = this.suggestions[itemIndex];
-        
-        if(this.multiple) {
-            this.input.value = '';
-            this.value = this.value||[];
-            this.value.push(selectedValue);
-            this.onModelChange(this.value);
-        }
-        else {
-            this.input.value = this.field ? this.resolveFieldData(selectedValue): selectedValue;
-            this.value = selectedValue;
-            this.onModelChange(this.value);
-        }
-        
-        this.onSelect.emit(selectedValue);
-        
-        this.input.focus();
+		var selectedValue;
+
+		if (item == null) {
+			if (this.suggestions && this.field) {
+				let lcValue = this.input.value.toLowerCase();				
+				let matches = this.suggestions.filter(x => x[this.field].toLowerCase() === lcValue);
+				if (matches.length > 0)
+					selectedValue = matches[0];
+			}
+		} else {
+			let itemIndex = this.domHandler.index(item);
+			selectedValue = this.suggestions[itemIndex];
+		}
+
+		if (selectedValue) {
+			if (this.multiple) {
+				this.input.value = '';
+				this.value = this.value || [];
+				if (this.value.indexOf(selectedValue) === -1) {
+					this.value.push(selectedValue);
+					this.onModelChange(this.value);
+				}
+			} else {
+				this.input.value = this.field ? this.resolveFieldData(selectedValue) : selectedValue;
+				this.value = selectedValue;
+				this.onModelChange(this.value);
+			}
+
+			this.onSelect.emit(selectedValue);
+		}
+		this.hide();	    
     }
     
     findListItem(element) {
@@ -356,10 +369,8 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
                 
                 //enter
                 case 13:
-                    if(highlightedItem) {
-                        this.selectItem(highlightedItem);
-                        this.hide();
-                    }
+                    this.selectItem(highlightedItem);
+                    this.hide();                    
                     event.preventDefault();
                 break;
                 

--- a/components/autocomplete/autocomplete.ts
+++ b/components/autocomplete/autocomplete.ts
@@ -17,7 +17,7 @@ const AUTOCOMPLETE_VALUE_ACCESSOR: Provider = CONST_EXPR(
     template: `
         <span [ngClass]="{'ui-autocomplete ui-widget':true,'ui-autocomplete-dd':dropdown}" [attr.style]="style" [class]="styleClass">
             <input *ngIf="!multiple" #in pInputText type="text" [attr.style]="inputStyle" [class]="inputStyleClass" 
-            [value]="value ? (field ? resolveFieldData(value)||value : value) : null" (input)="onInput($event)" (keydown)="onKeydown($event)" (blur)="onBlur()"
+            [value]="value ? (field ? resolveFieldData(value)||value : value) : null" (input)="onInput($event)" (keydown)="onKeydown($event)" (blur)="onBlur()" (focus)="showSuggestionsIfAny()"
             [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.readonly]="readonly" [disabled]="disabled" 
             ><ul *ngIf="multiple" class="ui-autocomplete-multiple ui-widget ui-inputtext ui-state-default ui-corner-all" (click)="multiIn.focus()">
                 <li #token *ngFor="#val of value" class="ui-autocomplete-token ui-state-highlight ui-corner-all">
@@ -25,7 +25,7 @@ const AUTOCOMPLETE_VALUE_ACCESSOR: Provider = CONST_EXPR(
                     <span class="ui-autocomplete-token-label">{{field ? val[field] : val}}</span>
                 </li>
                 <li class="ui-autocomplete-input-token">
-                    <input #multiIn type="text" pInputText (input)="onInput($event)" (keydown)="onKeydown($event)" (blur)="onBlur()">
+                    <input #multiIn type="text" pInputText (input)="onInput($event)" (keydown)="onKeydown($event)" (blur)="onBlur()" (focus)="showSuggestionsIfAny()">
                 </li>
             </ul
             ><button type="button" pButton icon="fa-fw fa-caret-down" class="ui-autocomplete-dropdown" [disabled]="disabled"
@@ -117,17 +117,21 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
     
     ngDoCheck() {
         let changes = this.differ.diff(this.suggestions);
+	    if (changes)
+			this.showSuggestionsIfAny();
+    }
 
-        if(changes && this.panel) {
-            if(this.suggestions && this.suggestions.length) {
+	showSuggestionsIfAny() {
+		if (this.panel) {
+            if (this.suggestions && this.suggestions.length) {
                 this.show();
                 this.suggestionsUpdated = true;
             }
             else {
                 this.hide();
             }
-        }
-    }
+        }		
+	}
     
     ngAfterViewInit() {
         this.input = this.domHandler.findSingle(this.el.nativeElement, 'input');


### PR DESCRIPTION
* If the user enters a value that corresponds with an object found in the suggestion list, and then hit TAB or Enter, that object should be selected.

* Prevent multiple identical selections to be made when autocomplete is in multiple-mode

* Closing the autocomplete suggestion on the blur event in stead of using a global event listener attached to the body. This makes the suggestions go away when tabbing to the next field

* When revisiting an autocomplete field that already has suggestions, those should be shown when field receives focus again
