### PR TITLE
Schedule component: Fix uninitialized object

### DIFF
--- a/components/schedule/schedule.ts
+++ b/components/schedule/schedule.ts
@@ -236,7 +236,7 @@ export class Schedule {
     ngDoCheck() {
         let changes = this.differ.diff(this.events);
         
-        if(changes) {
+        if(this.schedule && changes) {
             this.schedule.fullCalendar('refetchEvents');
         }
     }


### PR DESCRIPTION
It seems that in some cases, `ngDoCheck()` is called before `this.schedule` is initialized with `ngAfterViewInit()`.

This commit adds a check to prevent such failures.

Fixes: #226