### PR TITLE
Add new page number to onPageChange $event

### DIFF
--- a/components/paginator/paginator.ts
+++ b/components/paginator/paginator.ts
@@ -104,6 +104,7 @@ export class Paginator {
         if(p >= 0 && p < pc) {
             this.first = this.rows * p;
             var state = {
+                page: p,
                 first: this.first,
                 rows: this.rows,
                 pageCount: pc


### PR DESCRIPTION
The onPageChange $event of Paginator doesn't expose the actual new page number.