### PR TITLE
fix for: github.com/primefaces/primeng/issues/582

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -839,8 +839,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,OnInit,DoCheck 
                 return false;
             }
 
-            let filterValue = filter.toLowerCase();
-            return value.toString().toLowerCase().indexOf(filterValue, value.length - filterValue.length) !== -1;
+            let filterValue = filter.toString().toLowerCase();
+            return value.toString().toLowerCase().indexOf(filterValue, value.toString().length - filterValue.length) !== -1;
         }
     }
 

--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -840,7 +840,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,OnInit,DoCheck 
             }
 
             let filterValue = filter.toLowerCase();
-            return value.indexOf(filterValue, value.length - filterValue.length) !== -1;
+            return value.toString().toLowerCase().indexOf(filterValue, value.length - filterValue.length) !== -1;
         }
     }
 


### PR DESCRIPTION
When you enter a whole number in the filter if installed 'endsWith' mode
there is an exception:
EXCEPTION: TypeError: value.indexOf is not a function vendor.bundle.js:46281

[filter]="true" filterMatchMode="endsWith">

https://github.com/primefaces/primeng/issues/582