### PR TITLE
OverlayPanel : add refreshPosition

### DIFF
--- a/components/overlaypanel/overlaypanel.ts
+++ b/components/overlaypanel/overlaypanel.ts
@@ -108,6 +108,14 @@ export class OverlayPanel implements OnInit, OnDestroy {
         }
     }
     
+    refreshPosition(event, target?) {
+        if(this.visible) {
+            let elementTarget = target||event.currentTarget||event.target;
+            let container = this.el.nativeElement.children[0];
+            this.domHandler.absolutePosition(container, elementTarget);
+        }
+    }
+    
     onPanelClick() {
         if(this.dismissable) {
             this.selfClick = true;


### PR DESCRIPTION
Hi !

Just a little method in OverlayPanel class for explicitly recalculate the panel position.
In my head, this is in the same philosophy that Dialog's center method.

For example (in my case), this can be use to refresh the OverlayPanel position when its content changes.

Actually in my case, without this PR, the "most beautiful" walkthrough that I found was to bypass the private TypeScript policy of _this.el_ to get the ElementRef of 
```javascript
(<any> this._overlayPanel).domHandler.absolutePosition (
    (<any> this._overlayPanel).el.nativeElement.children[0], 
    this._saveEvent.currentTarget || this._saveEvent.target
);
```
That's a bit disgusting...

I'm open to all your suggestions :)
