### PR TITLE
Added a "Limited Range" option for p-slider

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -107,8 +107,6 @@ export class Calendar implements AfterViewInit,OnChanges,OnDestroy,ControlValueA
     @Input() locale: any;
     
     @Input() icon: string = 'fa-calendar';
-	
-	@Input() hideOnSelect: boolean = true;
     
     @Output() onBlur: EventEmitter<any> = new EventEmitter();
     
@@ -152,11 +150,7 @@ export class Calendar implements AfterViewInit,OnChanges,OnDestroy,ControlValueA
                     this.value = dateText;
                     this.onModelChange(this.value);
                     this.onSelect.emit(this.value);
-					if(this.hideOnSelect){
-						this.calendarElement.datepicker("hide");
-					}
                 });
-				
             }
         };
         

--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -107,6 +107,8 @@ export class Calendar implements AfterViewInit,OnChanges,OnDestroy,ControlValueA
     @Input() locale: any;
     
     @Input() icon: string = 'fa-calendar';
+	
+	@Input() hideOnSelect: boolean = true;
     
     @Output() onBlur: EventEmitter<any> = new EventEmitter();
     
@@ -150,7 +152,11 @@ export class Calendar implements AfterViewInit,OnChanges,OnDestroy,ControlValueA
                     this.value = dateText;
                     this.onModelChange(this.value);
                     this.onSelect.emit(this.value);
+					if(this.hideOnSelect){
+						this.calendarElement.datepicker("hide");
+					}
                 });
+				
             }
         };
         

--- a/components/slider/slider.ts
+++ b/components/slider/slider.ts
@@ -22,6 +22,10 @@ export class Slider implements AfterViewInit,OnDestroy,OnChanges,ControlValueAcc
     @Input() min: number;
 
     @Input() max: number;
+	
+	@Input() limitedMin: number;
+	
+	@Input() limitedMax: number;
 
     @Input() orientation: string;
 
@@ -66,6 +70,15 @@ export class Slider implements AfterViewInit,OnDestroy,OnChanges,ControlValueAcc
                     this.onChange.emit({originalEvent: event, values: ui.values});
                 }
                 else {
+					if(ui.value > this.limitedMax){
+						ui.value = this.limitedMax;
+						jQuery(this.el.nativeElement.children[0]).slider("value", this.limitedMax);
+						event.preventDefault();
+					} else if (ui.value < this.limitedMin) {
+						ui.value = this.limitedMin;
+						jQuery(this.el.nativeElement.children[0]).slider("value", this.limitedMin);
+						event.preventDefault();
+					}
                     this.onModelChange(ui.value);
                     this.onChange.emit({originalEvent: event, value: ui.value});
                 }

--- a/showcase/demo/slider/sliderdemo.html
+++ b/showcase/demo/slider/sliderdemo.html
@@ -11,7 +11,7 @@
 
     <h3>Input: {{val2}}</h3>
     <input type="text" pInputText [(ngModel)]="val2" style="width:190px" readonly/>
-    <p-slider [(ngModel)]="val2" [style]="{'width':'200px'}"></p-slider>
+	<p-slider [(ngModel)]="val2" [style]="{'width':'200px'}"></p-slider>
 
     <h3>Animate: {{val3}}</h3>
     <p-slider [(ngModel)]="val3" [style]="{'width':'200px'}" [animate]="true"></p-slider>
@@ -24,6 +24,17 @@
 
     <h3>Vertical: {{val5}}</h3>
     <p-slider [(ngModel)]="val5" [style]="{'height':'200px'}" orientation="vertical"></p-slider>
+	
+	<h3>Limited Range: {{val6}}</h3>
+    <p-slider [limitedMax]="limitedMax" [limitedMin]="limitedMin" [(ngModel)]="val6" [style]="{'width':'200px'}"></p-slider>
+	<div>
+		<strong>Lower limit: </strong>
+		<input type="number" [(ngModel)]="limitedMin" style="width: 40px; margin-top: 10px;}"/>
+	</div>
+	<div>
+		<strong>Upper limit: </strong>
+		<input type="number" [(ngModel)]="limitedMax" style="width: 40px;"/>
+	</div>
 </div>
 
 <div class="ContentSideSections Source">

--- a/showcase/demo/slider/sliderdemo.ts
+++ b/showcase/demo/slider/sliderdemo.ts
@@ -22,6 +22,11 @@ export class SliderDemo {
     val4: number;
 
     val5: number;
+	
+	val6: number = 50;
+	
+	limitedMin: number = 20;
+	limitedMax: number = 80;
 
     rangeValues: number[] = [20,80];
 }


### PR DESCRIPTION
An application I've been working on uses a group of related sliders to assign a fixed quantity of something among a number of sliders. In this scenario, the maximum value for each slider should be the total quantity, since any slider could have the entire quantity assigned to it, but the range of each slider should be capped dynamically such that it cannot be increased past the point where the sum of all slider values is equal to the total quantity. (The payment slider at https://www.humblebundle.com is similar to what I'm trying to develop, though theirs readjusts the other sliders automatically).

To allow for this, I added "limitedMin" and "limitedMax" attributes as inputs to p-slider and changed the logic in the slide function to prevent the value of the slider from exceeding these values in either direction. The effective range of the slider can be adjusted dynamically simply by changing these inputs. I added an example with this functionality to the demo page (link to a screen recording below), but did not go so far as to change any of the documentation.

http://screencast.com/t/BinHh0lavO1

EDIT: Sorry about the additional add/revert. First time making a pull request, so I didn't realize additional changes would get added to this automatically. Made a new branch/pull request for the second issue.