### PR TITLE
fix(dropdown): ngModel set before options

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -109,6 +109,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
     private hoveredItem: any;
     
     private selectedOptionUpdated: boolean;
+    
+    private ngModelValue: any;
             
     ngOnInit() {
         this.optionsToDisplay = this.options;
@@ -128,6 +130,9 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
         
         if(changes && this.initialized) {
             this.optionsToDisplay = this.options;
+            if(!this.selectedOption){
+                this.updateSelectedOption(this.ngModelValue);
+            }
             this.updateSelectedOption(this.selectedOption ? this.selectedOption.value: null);
             this.optionsChanged = true;
         }
@@ -175,6 +180,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
     }
     
     writeValue(value: any): void {
+        this.ngModelValue = value;
         this.updateSelectedOption(value);
     }
     


### PR DESCRIPTION
When the ngModel is set before the [options] binding is populated then
when the options do arrive (possibly from an Observable) then the
selectedValue is not highlighted in the ui.