### PR TITLE
Updated documentation to match change from #284.

### DIFF
--- a/showcase/demo/datatable/datatableselectiondemo.html
+++ b/showcase/demo/datatable/datatableselectiondemo.html
@@ -12,7 +12,7 @@
     <p-growl [value]="msgs"></p-growl>
 
     <h3 class="first">Single</h3>
-    <p>In single mode, a row is selected on click event of a row, if the metaKey is on and row is already selected then the row gets unselected.</p>
+    <p>In single mode, a row is selected on click event of a row. If the row is already selected then the row gets unselected.</p>
     <p-dataTable [value]="cars" selectionMode="single" [(selection)]="selectedCar1">
         <header>Single Selection</header>
         <footer><div style="text-align: left">Selected Car: {{selectedCar1 ? selectedCar1.vin + ' - ' + selectedCar1.brand + ' - ' + selectedCar1.year + ' - ' + selectedCar1.color: 'none'}}</div></footer>
@@ -91,7 +91,7 @@ export class DataTableSelectionDemo implements OnInit {
 &lt;p-growl [value]="msgs"&gt;&lt;/p-growl&gt;
 
 &lt;h3 class="first"&gt;Single&lt;/h3&gt;
-&lt;p&gt;In single mode, a row is selected on click event of a row, if the metaKey is on and row is already selected then the row gets unselected.&lt;/p&gt;
+&lt;p&gt;In single mode, a row is selected on click event of a row. If the row is already selected then the row gets unselected.&lt;/p&gt;
 &lt;p-dataTable [value]="cars" selectionMode="single" [(selection)]="selectedCar1"&gt;
     &lt;header&gt;Single Selection&lt;/header&gt;
     &lt;footer&gt;&lt;div style="text-align: left"&gt;Selected Car: {{selectedCar1 ? selectedCar1.vin + ' - ' + selectedCar1.brand + ' - ' + selectedCar1.year + ' - ' + selectedCar1.color: 'none'}}&lt;/div&gt;&lt;/footer&gt;


### PR DESCRIPTION
The commit for #284 changed the functionality of unselecting a row in single mode and dropped the requirement for having the metakey selected during the click. The documentation still referenced needing the meta key pressed. This PR updates the documentation.

If the intention was to still have the metakey selected to unselect a row in single selection mode (The original issue only made reference to multi selection mode) let me know and I can create a ticket and PR with the fix. Otherwise, this update to the docs should be good.

Thanks!