### PR TITLE
Fixed 2-way binding ngModel

### DIFF
--- a/components/editor/editor.ts
+++ b/components/editor/editor.ts
@@ -86,8 +86,6 @@ export class Editor implements AfterViewInit,ControlValueAccessor {
     
     onModelTouched: Function = () => {};
     
-    selfChange: boolean;
-
     quill: any;
     
     constructor(protected el: ElementRef, protected domHandler: DomHandler) {}
@@ -110,7 +108,6 @@ export class Editor implements AfterViewInit,ControlValueAccessor {
         }
         
         this.quill.on('text-change', (delta, source) => {
-            this.selfChange = true;
             let html = editorElement.children[0].innerHTML;
             let text = this.quill.getText();
             if(html == '<p><br></p>') {
@@ -140,15 +137,10 @@ export class Editor implements AfterViewInit,ControlValueAccessor {
         this.value = value;
         
         if(this.quill) {
-            if(this.selfChange) {
-                this.selfChange = false;
-            }
-            else {
-                if(value)
-                    this.quill.pasteHTML(value);
-                else
-                    this.quill.setText('');
-            }
+            if(value)
+                this.quill.pasteHTML(value);
+            else
+                this.quill.setText('');
         }
     }
     


### PR DESCRIPTION
Editor Content is not being updated right after ngModel changed.
So removed selfChange variable

Explanation (Hope I explain it well enough):

First time
-------------------
ngModel is updated -> writeValue -> Editor pick up on-text change and set selfChange

2nd time
------------------------
ngModel is updated 
-> Because self change = true -> set self change = false and STOP update editor content.

3rd will be same as first as selfChange is now false unless type in anything then it' same as 2nd time.

Cheers,
