### PR TITLE
Add Base64 Encoded Image Support

### DIFF
--- a/components/lightbox/lightbox.ts
+++ b/components/lightbox/lightbox.ts
@@ -9,6 +9,11 @@ import {DomHandler} from '../dom/domhandler';
                 <img [src]="image.thumbnail" [title]="image.title" [alt]="image.alt">
             </a>
         </div>
+        <div [ngStyle]="style" [class]="styleClass" *ngIf="(type == 'encoded')">
+            <a *ngFor="let image of images; let i = index;" [src]="'data:image/(format);base64,' +image.source" (click)="onImageClick($event,image,i,content)">
+                <img [src]="'data:image/(format);base64,' +image.thumbnail" [title]="image.title" [alt]="image.alt">
+            </a>
+        </div>
         <span [ngStyle]="style" [class]="styleClass" *ngIf="(type == 'content')" (click)="onLinkClick($event,content)">
             <ng-content select="a"></ng-content>
         </span>
@@ -46,7 +51,9 @@ export class Lightbox implements AfterViewInit,OnDestroy{
     @Input() easing: 'ease-out';
     
     @Input() effectDuration: any = '500ms';
-                
+
+    @Input() format: string = 'png';
+
     protected visible: boolean;
     
     protected loading: boolean;

--- a/components/lightbox/lightbox.ts
+++ b/components/lightbox/lightbox.ts
@@ -10,8 +10,8 @@ import {DomHandler} from '../dom/domhandler';
             </a>
         </div>
         <div [ngStyle]="style" [class]="styleClass" *ngIf="(type == 'encoded')">
-            <a *ngFor="let image of images; let i = index;" [src]="'data:image/(format);base64,' +image.source" (click)="onImageClick($event,image,i,content)">
-                <img [src]="'data:image/(format);base64,' +image.thumbnail" [title]="image.title" [alt]="image.alt">
+            <a *ngFor="let image of images; let i = index;" (click)="onImageClick($event,image,i,content)">
+                <img [src]="'data:image/'+(format)+';base64,' +image.thumbnail" [title]="image.title" [alt]="image.alt">
             </a>
         </div>
         <span [ngStyle]="style" [class]="styleClass" *ngIf="(type == 'content')" (click)="onLinkClick($event,content)">
@@ -22,9 +22,14 @@ import {DomHandler} from '../dom/domhandler';
            <div class="ui-lightbox-content-wrapper">
               <a class="ui-state-default ui-lightbox-nav-left ui-corner-right" [style.zIndex]="zindex + 1" (click)="prev(img)"
                 [ngClass]="{'ui-helper-hidden':!leftVisible}"><span class="fa fa-fw fa-caret-left"></span></a>
-              <div #content class="ui-lightbox-content ui-corner-all" #content [ngClass]="{'ui-lightbox-loading': loading}" 
+              <div *ngIf="(type == 'image')" #content class="ui-lightbox-content ui-corner-all" #content [ngClass]="{'ui-lightbox-loading': loading}" 
                 [style.transitionProperty]="'width,height'" [style.transitionDuration]="effectDuration" [style.transitionTimingFunction]="easing">
                 <img #img [src]="currentImage ? currentImage.source||'' : ''" (load)="onImageLoad($event,content)" style="display:none">
+                <ng-content></ng-content>
+              </div>
+              <div *ngIf="(type == 'encoded')" #content class="ui-lightbox-content ui-corner-all" #content [ngClass]="{'ui-lightbox-loading': loading}"
+              [style.transitionProperty]="'width,height'" [style.transitionDuration]="effectDuration" [style.transitionTimingFunction]="easing">
+                <img #img [src]="'data:image/'+(format)+';base64,' +currentImage?.source" (load)="onImageLoad($event,content)" style="display:none">
                 <ng-content></ng-content>
               </div>
               <a class="ui-state-default ui-lightbox-nav-right ui-corner-left ui-helper-hidden" [style.zIndex]="zindex + 1" (click)="next(img)"

--- a/showcase/demo/lightbox/lightboxdemo.html
+++ b/showcase/demo/lightbox/lightboxdemo.html
@@ -29,8 +29,9 @@ import {Lightbox} from 'primeng/primeng';
 </pre>
 
             <h3>Getting Started</h3>
-            <p>Lightbox has two modes; <i>image</i> and <i>custom content</i> defined using type property. In image mode a collection of
-            images are required to display where an image object in the collection defines the source of the original image, thumbnail image and the title.</p>
+            <p>Lightbox has three modes; <i>image</i> <i>encoded</i> and <i>custom content</i> defined using type property. In image mode a collection of
+            images are required to display where an image object in the collection defines the source of the original image, thumbnail image and the title.
+            In encoded mode a collection of images are required just like image mode the only additional requirement is the format property, which is the decoded image type.</p>
 <pre>
 <code class="language-markup" pCode>
 &lt;p-lightbox [images]="images"&gt;&lt;/p-lightbox&gt;
@@ -62,6 +63,14 @@ export class LightboxDemo {
     &lt;/a&gt;
     &lt;iframe width="560" height="315" src="https://www.youtube.com/embed/9bZkp7q19f0" frameborder="0" allowfullscreen&gt;&lt;/iframe&gt;
 &lt;/p-lightbox&gt;
+</code>
+</pre>
+
+</pre>
+            <p>Encoded mode is enabled by setting type property to "encoded", and setting the format property to the decoded image type, "png" is default</p>
+<pre>
+<code class="language-markup" pCode>
+&lt;p-lightbox [images]="images" type="encoded" format="png"&gt;&lt;/p-lightbox&gt;
 </code>
 </pre>
 
@@ -97,7 +106,13 @@ export class LightboxDemo {
                             <td>type</td>
                             <td>string</td>
                             <td>image</td>
-                            <td>Type of the lightbox, valid values are "image" and "content".</td>
+                            <td>Type of the lightbox, valid values are "image", "content", "encoded".</td>
+                        </tr>
+                        <tr>
+                            <td>format</td>
+                            <td>string</td>
+                            <td>png</td>
+                            <td>Encoded image format.</td>
                         </tr>
                         <tr>
                             <td>style</td>


### PR DESCRIPTION
Setting of type property of "encoded" allows for showing of base64 encoded images using the same object properties as type "image" adding the requirement of setting the format property to the image type for decoding target ie. format = "png"