### PR TITLE
Open fileupload request before onBeforeUpload for header modification

### DIFF
--- a/components/fileupload/fileupload.ts
+++ b/components/fileupload/fileupload.ts
@@ -193,12 +193,13 @@ export class FileUpload implements OnInit,AfterContentInit {
             }
         };
         
+        xhr.open('POST', this.url, true);
+
         this.onBeforeUpload.emit({
             'xhr': xhr,
             'formData': formData 
         });
         
-        xhr.open('POST', this.url, true);
         xhr.send(formData);
     }
 


### PR DESCRIPTION
Hello,

I try your fileupload component with the beta14 and I can not add a header (authentication token) to the upload command.

After this modification, the upload works.

Could you include this proposition in your next release ?

Thanks,
Frederic.