### PR TITLE
Fix issue #849: Added dropdownOpen property and refactored show() to be called with no parameters

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -97,8 +97,12 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
     focus: boolean;
     
     differ: any;
+	
+	get dropdownOpen(): boolean {
+		return this.panelVisible;
+	}
     
-    panelVisible: boolean = false;
+    protected panelVisible: boolean = false;
     
     protected documentClickListener: any;
     

--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -98,7 +98,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
     
     differ: any;
     
-    protected panelVisible: boolean = false;
+    panelVisible: boolean = false;
     
     protected documentClickListener: any;
     
@@ -251,7 +251,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
             if(this.panelVisible)
                 this.hide();
             else {
-                this.show(this.panel,this.container);
+                this.show();
             }
         }
     }
@@ -270,12 +270,12 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
         });
     }
     
-    show(panel,container) {
+    show() {
         if(this.options && this.options.length) {
             this.panelVisible = true;
-            panel.style.zIndex = ++DomHandler.zindex;
-            this.domHandler.relativePosition(panel, container);
-            this.domHandler.fadeIn(panel,250);
+            this.panel.style.zIndex = ++DomHandler.zindex;
+            this.domHandler.relativePosition(this.panel, this.container);
+            this.domHandler.fadeIn(this.panel,250);
         }
     }
     
@@ -299,7 +299,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
             //down
             case 40:
                 if(!this.panelVisible && event.altKey) {
-                    this.show(this.panel, this.container);
+                    this.show();
                 }
                 else {
                     if(selectedItemIndex != -1) {


### PR DESCRIPTION
As described in issue #849, it would be nice to be able to determine whether the dropdown panel is open or not and to be able to hide/show it from a component implementing p-dropdown. Among other things, this would make it much easier for users to customize hotkeys for showing the dropdown panel.

I added a public property called dropdownOpen that returns the value of panelVisible, since, ideally, a user should be able to read this field but should only be setting it by means of the hide/show functions. 

The show function was already public, but was invoked with two private fields, essentially rendering it private. I refactored the method to be called with no parameters, since the parameters being passed in are just fields on the dropdown component that can be referenced from within show without being explicitly passed in.
