### PR TITLE
IE11 rendering bug with <p-calendar></p-calendar> CalendarModule --- Update calendar.ts

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -15,7 +15,7 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
         <span [ngStyle]="style" [class]="styleClass" [ngClass]="'ui-calendar'" *ngIf="!inline">
         <input #in type="text" [attr.placeholder]="placeholder" [ngStyle]="inputStyle" [class]="inputStyleClass"
                 [value]="value||''" (input)="onInput($event)" [readonly]="readonlyInput"
-                [disabled]="disabled" (mouseenter)="hovered=true" (mouseleave)="hovered=false" (focus)="focused=true" (blur)="handleBlur($event)"
+                [disabled]="disabled" (focus)="focused=true" (blur)="handleBlur($event)"
                 [ngClass]="{'ui-inputtext ui-widget ui-state-default': true, 'ui-corner-all': !showIcon, 'ui-corner-left': showIcon,
                     'ui-state-hover':hovered,'ui-state-focus':focused,'ui-state-disabled':disabled}"
         ><button type="button" [icon]="icon" pButton *ngIf="showIcon" (click)="onButtonClick($event,in)" 


### PR DESCRIPTION
Two days ago I downloaed "primeng" with this cmd comand:	npm install primeng
and I imported correctly the "CalendarModule".

There is a problem with <p-calendar></p-calendar> on IE 11  (Version 11.187.14393.0)

The problem is related to the (mouseenter) and (mouseleave) events.

Once the Calendar popup is shown, on mouseOver the input field changes abnormally his size and color.

You can check this issiue on your web site (using IE 11): http://www.primefaces.org/primeng/#/calendar
If you change the used "themes" using the drop-down menu it works correctly.


I solved the issiue removing the following code inside the template (line 18 of calendar.ts file) :
(mouseenter)="hovered=true" (mouseleave)="hovered=false"

Maybe it's not the best solution but just a simple workaround.
Thank for your attention :)



