### PR TITLE
Update confirmdialogdemo.html

### DIFF
--- a/showcase/demo/confirmdialog/confirmdialogdemo.html
+++ b/showcase/demo/confirmdialog/confirmdialogdemo.html
@@ -277,7 +277,7 @@ export class ConfirmDialogDemo &#123;
             </div>
 
             <h3>Dependencies</h3>
-            <p>None.</p>
+            <p>ConfirmationService</p>
         </p-tabPanel>
 
         <p-tabPanel header="Source">


### PR DESCRIPTION
The doc reads that ConfirmDialog has no dependencies:
http://www.primefaces.org/primeng/#/confirmdialog

Added a dependency ConfirmationService. From the Angular perspective. if a component may need injection - it's a dependency. #If you consider only third-party libraries as dependencies, please ignore this PR.