### PR TITLE
Bug fix: Radio button label not disabling

### DIFF
--- a/components/radiobutton/radiobutton.ts
+++ b/components/radiobutton/radiobutton.ts
@@ -22,7 +22,7 @@ export const RADIO_VALUE_ACCESSOR: any = {
                 <span class="ui-radiobutton-icon" [ngClass]="{'fa fa-fw fa-circle':checked}"></span>
             </div>
         </div>
-        <label class="ui-radiobutton-label" (click)="select()" *ngIf="label">{{label}}</label>
+        <label class="ui-radiobutton-label" (click)="handleClick()" *ngIf="label">{{label}}</label>
     `,
     providers: [RADIO_VALUE_ACCESSOR]
 })


### PR DESCRIPTION
This merge addresses an issue with the radio button component, allowing a user to select a radio value through the label although the input was disabled. 

Signed-off-by: Derek Barrera <derekbarrera@gmail.com>