### PR TITLE
Allow resetting of the DataScroller

### DIFF
--- a/components/datascroller/datascroller.ts
+++ b/components/datascroller/datascroller.ts
@@ -116,6 +116,7 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
     reset() {
         this.first = 0;
         this.dataToRender = [];
+        this.load();
     }
 
     isEmpty() {

--- a/components/datascroller/datascroller.ts
+++ b/components/datascroller/datascroller.ts
@@ -112,6 +112,11 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
         }
         this.first = this.first + this.rows;
     }
+     
+    reset() {
+        this.first = 0;
+        this.dataToRender = [];
+    }
 
     isEmpty() {
         return !this.dataToRender||(this.dataToRender.length == 0);


### PR DESCRIPTION
It'd be nice to be able to use the DataScroller in such a way that it can reused for different data sets. For example, an infinite scrolling list that's searchable by the user.

When the user first arrives on the page, a set of search results appear. The user can then change the search criteria to provider better results for their specific need. The onLazyLoad handler is aware of the search criteria and returns the data accordingly. In order for this to work though, the scroller needs to be reset, so the loaded data starts again at the beginning.