### PR TITLE
Use contains for dropdown filter

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -395,7 +395,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
             this.optionsToDisplay = [];
             for(let i = 0; i < this.options.length; i++) {
                 let option = this.options[i];
-                if(option.label.toLowerCase().startsWith(val)) {
+                if(option.label.toLowerCase().search(val) > -1) {
                     this.optionsToDisplay.push(option);
                 }
             }

--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -395,7 +395,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterViewChecked,DoCheck,O
             this.optionsToDisplay = [];
             for(let i = 0; i < this.options.length; i++) {
                 let option = this.options[i];
-                if(option.label.toLowerCase().search(val) > -1) {
+                if(option.label.toLowerCase().indexOf(val) > -1) {
                     this.optionsToDisplay.push(option);
                 }
             }


### PR DESCRIPTION
Changed to search instead of startsWith.
It's easier to find the available options in the dropdown.