### PR TITLE
Field undefined extended sub-property protection

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -559,6 +559,9 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 let fields: string[] = field.split('.');
                 let value = data;
                 for(var i = 0, len = fields.length; i < len; ++i) {
+                    if (value === undefined){
+                        return null;
+                    }
                     value = value[fields[i]];
                 }
                 return value;


### PR DESCRIPTION
Use ng2 elvis-operator style protection for data field sub-properties that could be undefined to help prevent `Cannot read property 'X' of undefined` exceptions.

**For example:**
In the following datatable column declaration, primeng datatables would throw a `Cannot read property 'c' of undefined` exception if `b` was `undefined`. It is often the case that extended field sub-properties are present for some collections/rows, and not present for others. This PR solves this problem, while still allowing primeng datatables' built-in features that rely on the fully-qualified `field` property (such as sorting and filtering) to work correctly:

`<p-column field="a.b.c" header="C"></p-column>`