### PR TITLE
Fix issue #654: using a global filter prohibits sorting

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -1014,7 +1014,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             }
         }
 
-        return !empty;
+        return !empty || (this.globalFilter && this.globalFilter.value!=='');
     }
 
     onFilterInputClick(event) {


### PR DESCRIPTION
This fixes issue #654. Sorting now works in a data table with an enabled global filter. I fixed this by making hasFilter() aware of the global filter.