### PR TITLE
Disables click on disabled accordion tab

### DIFF
--- a/components/accordion/accordion.ts
+++ b/components/accordion/accordion.ts
@@ -90,7 +90,7 @@ export class AccordionTab {
 
     toggle(event) {
         if(this.disabled) {
-            return;
+            return false;
         }
         
         this.animating = true;


### PR DESCRIPTION
Clicking on a disabled accordion tab was following the anchor tag hash.
Not sure that was the desired behaviour. Just in case it helps, a small fix to return false when toggled & disabled.