### PR TITLE
Real readonly attribute to p-calendar

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -25,7 +25,7 @@ export interface LocaleSettings {
     template:  `
         <span [ngClass]="{'ui-calendar':true,'ui-calendar-w-btn':showIcon}" [ngStyle]="style" [class]="styleClass">
             <input type="text" pInputText *ngIf="!inline" (focus)="onInputFocus($event)" (keydown)="onInputKeydown($event)" (click)="closeOverlay=false" (blur)="onInputBlur($event)"
-                    [readonly]="readonlyInput" (input)="onInput($event)" [ngStyle]="inputStyle" [class]="inputStyleClass" [placeholder]="placeholder||''" [disabled]="disabled"
+                    [readonly]="noTypeful || readonly" (input)="onInput($event)" [ngStyle]="inputStyle" [class]="inputStyleClass" [placeholder]="placeholder||''" [disabled]="disabled"
                     ><button type="button" [icon]="icon" pButton *ngIf="showIcon" (click)="onButtonClick($event)"
                     [ngClass]="{'ui-datepicker-trigger':true,'ui-state-disabled':disabled}" [disabled]="disabled"></button>
             <div class="ui-datepicker ui-widget ui-widget-content ui-helper-clearfix ui-corner-all" [ngClass]="{'ui-datepicker-inline':inline,'ui-shadow':!inline,'ui-state-disabled':disabled}" 
@@ -159,7 +159,9 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     
     @Input() appendTo: any;
     
-    @Input() readonlyInput: boolean;
+    @Input() noTypeful: boolean;
+
+    @Input() readonly: boolean;
     
     @Input() shortYearCutoff: any = '+10';
     
@@ -545,7 +547,10 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     
     onInputFocus(event) {
         this.focus = true;
-        this.showOverlay(event);
+
+        if(!this.readonly) {
+            this.showOverlay(event);
+        }
     }
     
     onInputBlur(event) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,23 @@
     "url": "https://github.com/primefaces/primeng.git"
   },
   "license": "Apache-2.0",
+  "dependencies": {
+    "@angular/common": "~2.1.1",
+    "@angular/compiler": "~2.1.1",
+    "@angular/core": "~2.1.1",
+    "@angular/forms": "~2.1.1",
+    "@angular/http": "~2.1.1",
+    "@angular/platform-browser": "~2.1.1",
+    "@angular/platform-browser-dynamic": "~2.1.1",
+    "@angular/router": "~3.1.1",
+    "@angular/upgrade": "~2.1.1",
+    "angular-in-memory-web-api": "~0.1.13",
+    "core-js": "^2.4.1",
+    "reflect-metadata": "^0.1.8",
+    "rxjs": "5.0.0-beta.12",
+    "systemjs": "0.19.39",
+    "zone.js": "^0.6.25"
+  },
   "devDependencies": {
     "@types/node": "^6.0.45",
     "del": "^2.2.0",

--- a/showcase/demo/calendar/calendardemo.html
+++ b/showcase/demo/calendar/calendardemo.html
@@ -24,9 +24,9 @@
         
         <div class="ui-g-12 ui-md-4">
             <h3>Restrict</h3>
-            <p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true"></p-calendar> {{date4|date}}
+            <p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" [noTypeful]="true"></p-calendar> {{date4|date}}
         </div>
-        
+
         <div class="ui-g-12 ui-md-4">
             <h3>Navigators</h3>
             <p-calendar [(ngModel)]="date5" [monthNavigator]="true" [yearNavigator]="true" yearRange="2000:2030"></p-calendar> {{date5|date}}
@@ -44,7 +44,13 @@
     </div>
     
     <h3>Inline {{date8|date}}</h3>
-    <p-calendar [(ngModel)]="date8" [inline]="true"></p-calendar> 
+    <p-calendar [(ngModel)]="date8" [inline]="true"></p-calendar>
+
+    <div class="ui-g-12 ui-md-4">
+        <h3>Readonly</h3>
+        <p-calendar [(ngModel)]="date9" [minDate]="minDate" [maxDate]="maxDate" [readonly]="true"></p-calendar> {{date9|date}}
+    </div> 
+    
 </div>
 
 <div class="ContentSideSections Source">
@@ -131,11 +137,11 @@ export class MyModel &#123;
 </pre>
 
             <h3>Date Restriction</h3>
-            <p>To disable entering dates manually, set readonlyInput to true and to restrict selectable dates use minDate
+            <p>To disable entering dates manually, set noTypeful to true and to restrict selectable dates use minDate
                 and maxDate options..</p>
 <pre>
 <code class="language-markup" pCode>
-&lt;p-calendar [(ngModel)]="dateValue" [minDate]="minDateValue" [maxDate]="+maxDateValue" readonlyInput="readonlyInput">&gt;&lt;/p-calendar&gt;
+&lt;p-calendar [(ngModel)]="dateValue" [minDate]="minDateValue" [maxDate]="+maxDateValue" noTypeful="noTypeful">&gt;&lt;/p-calendar&gt;
 </code>
 </pre>
 
@@ -265,10 +271,16 @@ export class MyModel &#123;
                             <td>Target element to attach the overlay, valid values are "body" or a local template variable of another element.</td>
                         </tr>
                         <tr>
-                            <td>readonlyInput</td>
+                            <td>noTypeful</td>
                             <td>string</td>
                             <td>null</td>
                             <td>When specified, prevents entering the date manually with keyboard.</td>
+                        </tr>
+                        <tr>
+                            <td>readonly</td>
+                            <td>boolean</td>
+                            <td>null</td>
+                            <td>When specified, prevents user to change the value of the field.</td>
                         </tr>
                         <tr>
                             <td>shortYearCuto</td>
@@ -409,7 +421,7 @@ export class MyModel &#123;
     
     &lt;div class="ui-g-12 ui-md-4"&gt;
         &lt;h3&gt;Restrict&lt;/h3&gt;
-        &lt;p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true"&gt;&lt;/p-calendar&gt; &#123;&#123;date4|date&#125;&#125;
+        &lt;p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" [noTypeful]="true"&gt;&lt;/p-calendar&gt; &#123;&#123;date4|date&#125;&#125;
     &lt;/div&gt;
     
     &lt;div class="ui-g-12 ui-md-4"&gt;

--- a/showcase/demo/calendar/calendardemo.ts
+++ b/showcase/demo/calendar/calendardemo.ts
@@ -20,6 +20,8 @@ export class CalendarDemo {
     date7: Date;
     
     date8: Date;
+
+    date9: Date;
     
     minDate: Date;
     
@@ -45,5 +47,6 @@ export class CalendarDemo {
         this.minDate.setMonth(prevMonth);
         this.maxDate = new Date();
         this.maxDate.setMonth(nextMonth);
+        this.date9 = new Date();
     }
 }


### PR DESCRIPTION
I was using the p-calendar, but in a new work, i needed to not allow changes in p-calendar value. But the 'readonlyInput' is just to not allow keyboard digits, but we can select in calendar. I think 'readonlyInput' is not the best name for this behavior, 'readonly' is just to read, not to change.

So i changed the attribute 'readonlyInput' to 'noTypeful', and i created an attribute 'readonly' to not allow changes, the real behavior.

I updated the code, and the docs.
It needs review.
Thanks.

Ps.: package.json changes is not part of the commit