### PR TITLE
Input parameter 'unit' added to ProgressBar component

### DIFF
--- a/components/progressbar/progressbar.ts
+++ b/components/progressbar/progressbar.ts
@@ -25,5 +25,4 @@ export class ProgressBar {
     exports: [ProgressBar],
     declarations: [ProgressBar]
 })
-
 export class ProgressBarModule { }

--- a/components/progressbar/progressbar.ts
+++ b/components/progressbar/progressbar.ts
@@ -14,10 +14,10 @@ export class ProgressBar {
 
     @Input() value: any;
     
-    @Input() unit: string = '%';
-    
     @Input() showValue: boolean = true;
 
+    @Input() unit: string = '%';
+    
 }
 
 @NgModule({

--- a/components/progressbar/progressbar.ts
+++ b/components/progressbar/progressbar.ts
@@ -26,3 +26,4 @@ export class ProgressBar {
     declarations: [ProgressBar]
 })
 export class ProgressBarModule { }
+

--- a/components/progressbar/progressbar.ts
+++ b/components/progressbar/progressbar.ts
@@ -14,7 +14,7 @@ export class ProgressBar {
 
     @Input() value: any;
     
-    @Input() unit: String = "%";
+    @Input() unit: string = '%';
     
     @Input() showValue: boolean = true;
 
@@ -25,5 +25,5 @@ export class ProgressBar {
     exports: [ProgressBar],
     declarations: [ProgressBar]
 })
-export class ProgressBarModule { }
 
+export class ProgressBarModule { }

--- a/components/progressbar/progressbar.ts
+++ b/components/progressbar/progressbar.ts
@@ -6,13 +6,15 @@ import {CommonModule} from '@angular/common';
     template: `
         <div class="ui-progressbar ui-widget ui-widget-content ui-corner-all" role="progressbar" aria-valuemin="0" [attr.aria-valuenow]="value" aria-valuemax="100">
             <div class="ui-progressbar-value ui-progressbar-value-animate ui-widget-header ui-corner-all" [style.width]="value + '%'" style="display:block"></div>
-            <div class="ui-progressbar-label" [style.display]="value ? 'block' : 'none'" *ngIf="showValue">{{value}}%</div>
+            <div class="ui-progressbar-label" [style.display]="value ? 'block' : 'none'" *ngIf="showValue">{{value}}{{unit}}</div>
         </div>
     `
 })
 export class ProgressBar {
 
     @Input() value: any;
+    
+    @Input() unit: String = "%";
     
     @Input() showValue: boolean = true;
 

--- a/showcase/demo/progressbar/progressbardemo.html
+++ b/showcase/demo/progressbar/progressbardemo.html
@@ -61,6 +61,18 @@ export class ModelComponent &#123;
                             <td>null</td>
                             <td>Current value of the progress.</td>
                         </tr>
+                        <tr>
+                            <td>showValue</td>
+                            <td>boolean</td>
+                            <td>true</td>
+                            <td>Show or hide progress bar value.</td>
+                        </tr>
+                        <tr>
+                            <td>unit</td>
+                            <td>string</td>
+                            <td>%</td>
+                            <td>Unit sign appended to the value.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
It would be nice to let user to define '%' as input parameter. It allows user to hide '%' or change it to some other unit e.g. 'MB' . With default '%' the backward compatibility should be preserved.