### PR TITLE
Fix for #1269

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -1067,7 +1067,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     hasFilter() {
         let empty = true;
         for(let prop in this.filters) {
-            if(this.filters.hasOwnProperty(prop) && this.filters[prop].value.length) {
+            if(this.filters.hasOwnProperty(prop) && this.filters[prop].value && this.filters[prop].value.length) {
                 empty = false;
                 break;
             }

--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -545,6 +545,10 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                     this.sortMultiple();
             }
 
+            if (!this.lazy && this.hasFilter()) {
+                this.filter();
+            }
+
             this.updateDataToRender(this.filteredValue||this.value);
         }
     }
@@ -1063,7 +1067,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     hasFilter() {
         let empty = true;
         for(let prop in this.filters) {
-            if(this.filters.hasOwnProperty(prop)) {
+            if(this.filters.hasOwnProperty(prop) && this.filters[prop].value.length) {
                 empty = false;
                 break;
             }


### PR DESCRIPTION
Avoids infinite loop with lazy loading by not filtering when lazy, since the data source is responsible for lazy filtering anyway.
Tightens hasFilter() to only be true if filter text exists. This avoids unnecessary runs through the filter.