### PR TITLE
spinner crashes angular in dev mode

### DIFF
--- a/components/spinner/spinner.ts
+++ b/components/spinner/spinner.ts
@@ -90,7 +90,7 @@ export class Spinner implements AfterViewInit,ControlValueAccessor {
         
         this.inputtext = this.domHandler.findSingle(this.el.nativeElement, 'input');
         if((this.value !== null && this.value !== undefined)) {
-            this.inputtext.value = this.value;
+            setTimeout(() => this.inputtext.value = this.value);
         }
     }
     


### PR DESCRIPTION
This solves a problem when angular is run in dev mode under the following conditions:
- spinner is in a reactive form;
- spinner's initial value is not null or empty string (some numeric value)
- spinner control's inclusion in template is conditional (within element with *ngIf attribute)
Problem: angular crashes whenever the control is hidden, then displayed. 
Reason: angular reports that a value was changed after it was checked. 

The timeout proposed eliminates the error with no side effect that I could detect.