### PR TITLE
Add proper character encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
+        <meta charset="utf-8">
         <script>document.write('<base href="' + document.location + '" />');</script>
         
         <link rel="apple-touch-icon" sizes="57x57" href="showcase/resources/favicon/apple-icon-57x57.png">


### PR DESCRIPTION
Noticed that there's an error message in the console in Firefox related to the character encoding of the page. Because it was missing there was a possibility some of the text to be rendered incorrectly. See screenshot for reference.

![skitch](https://cloud.githubusercontent.com/assets/1096332/20248708/dcb3ed10-a9e9-11e6-8af0-1c41de3ab9eb.png)
