### PR TITLE
Revise License

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "git",
     "url": "https://github.com/primefaces/primeng.git"
   },
-  "license": "Apache-2.0",
+  "license": "MIT",
   "devDependencies": {
     "@types/node": "^6.0.45",
     "del": "^2.2.0",


### PR DESCRIPTION
PrimeNG is Published by MIT License, but "Apache 2.0" is written in package.json. so I revise this signage.