### PR TITLE
Listbox's events should pass the current value

### DIFF
--- a/components/listbox/listbox.ts
+++ b/components/listbox/listbox.ts
@@ -101,7 +101,10 @@ export class Listbox implements ControlValueAccessor {
         
         if(valueChanged) {
             this.onModelChange(this.value);
-            this.onChange.emit(event);
+            this.onChange.emit({
+            originalEvent: event,
+            value: this.value
+        });
         }
     }
     
@@ -128,7 +131,10 @@ export class Listbox implements ControlValueAccessor {
         
         if(valueChanged) {
             this.onModelChange(this.value);
-            this.onChange.emit(event);
+            this.onChange.emit({
+            originalEvent: event,
+            value: this.value
+        });
         }
     }
     
@@ -169,7 +175,7 @@ export class Listbox implements ControlValueAccessor {
     onDoubleClick(event: Event, option: SelectItem): any {
         this.onDblClick.emit({
             originalEvent: event,
-            value: option
+            value: this.value
         })
     }
 }


### PR DESCRIPTION
Currently listbox's events don't behave according to their documentation: they just pass the original event instead of also passing the currently selected value.