### PR TITLE
Correct error in height measurement

### DIFF
--- a/components/dom/domhandler.ts
+++ b/components/dom/domhandler.ts
@@ -268,7 +268,7 @@ export class DomHandler {
         let height = el.offsetHeight;
         let style = getComputedStyle(el);
 
-        height -= parseInt(style.paddingTop) + parseInt(style.paddingBottom) + parseInt(style.borderTopWidth) + parseInt(style.borderBottomWidth);
+        height -= parseFloat(style.paddingTop) + parseFloat(style.paddingBottom) + parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
 
         return height;
     }


### PR DESCRIPTION
It is assumed that padding and border widths can only be integral values in px units. But if CSS sets padding and border width in ems, this is likely to result in a floating value when converted to px.

Using parseInt can result in the height being overestimated by 0 to 4 px.