### PR TITLE
Patch 2

### DIFF
--- a/components/dom/domhandler.ts
+++ b/components/dom/domhandler.ts
@@ -265,10 +265,8 @@ export class DomHandler {
     }
 
     public getHeight(el): number {
-        let height = el.offsetHeight;
         let style = getComputedStyle(el);
-        height -= parseFloat(style.paddingTop) + parseFloat(style.paddingBottom) + parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
-        return height;
+        return parseFloat(style.height);
     }
 
     public getWidth(el): number {

--- a/components/dom/domhandler.ts
+++ b/components/dom/domhandler.ts
@@ -221,7 +221,7 @@ export class DomHandler {
 
         if (margin) {
             let style = getComputedStyle(el);
-            width += parseInt(style.marginLeft) + parseInt(style.marginRight);
+            width += parseFloat(style.marginLeft) + parseFloat(style.marginRight);
         }
 
         return width;
@@ -229,19 +229,19 @@ export class DomHandler {
 
     public getHorizontalPadding(el) {
         let style = getComputedStyle(el);
-        return parseInt(style.paddingLeft) + parseInt(style.paddingRight);
+        return parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
     }
 
     public getHorizontalMargin(el) {
         let style = getComputedStyle(el);
-        return parseInt(style.marginLeft) + parseInt(style.marginRight);
+        return parseFloat(style.marginLeft) + parseFloat(style.marginRight);
     }
 
     public innerWidth(el) {
         let width = el.offsetWidth;
         let style = getComputedStyle(el);
 
-        width += parseInt(style.paddingLeft) + parseInt(style.paddingRight);
+        width += parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
         return width;
     }
 
@@ -249,7 +249,7 @@ export class DomHandler {
         let width = el.offsetWidth;
         let style = getComputedStyle(el);
 
-        width -= parseInt(style.paddingLeft) + parseInt(style.paddingRight);
+        width -= parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
         return width;
     }
 
@@ -258,7 +258,7 @@ export class DomHandler {
 
         if (margin) {
             let style = getComputedStyle(el);
-            height += parseInt(style.marginTop) + parseInt(style.marginBottom);
+            height += parseFloat(style.marginTop) + parseFloat(style.marginBottom);
         }
 
         return height;
@@ -267,9 +267,7 @@ export class DomHandler {
     public getHeight(el): number {
         let height = el.offsetHeight;
         let style = getComputedStyle(el);
-
-        height -= parseInt(style.paddingTop) + parseInt(style.paddingBottom) + parseInt(style.borderTopWidth) + parseInt(style.borderBottomWidth);
-
+        height -= parseFloat(style.paddingTop) + parseFloat(style.paddingBottom) + parseFloat(style.borderTopWidth) + parseFloat(style.borderBottomWidth);
         return height;
     }
 
@@ -277,7 +275,7 @@ export class DomHandler {
         let width = el.offsetWidth;
         let style = getComputedStyle(el);
 
-        width -= parseInt(style.paddingLeft) + parseInt(style.paddingRight) + parseInt(style.borderLeftWidth) + parseInt(style.borderRightWidth);
+        width -= parseFloat(style.paddingLeft) + parseFloat(style.paddingRight) + parseFloat(style.borderLeftWidth) + parseFloat(style.borderRightWidth);
 
         return width;
     }


### PR DESCRIPTION
regarding getHeight function, used in dialog resizing, there's no point in getting offsetHeight, then subtract padding and border to obtain the original height.

If we're going to write the corrected height to style.height in the end, we should get style.height as original height value.

Why is this important? Because style.height is the inner or outer height depending on what box-sizing is set to.

If box-sizing is set to 'box-content', style.height is outer height. And if we adjust the inner height and then write the result to style.height, we get a dialog that shrinks uncontrollably when resized.
