### PR TITLE
Show active state on menuBar items that use routerLinks

### DIFF
--- a/components/menubar/menubar.ts
+++ b/components/menubar/menubar.ts
@@ -13,7 +13,7 @@ import {Router, RouterModule} from '@angular/router';
             <template ngFor let-child [ngForOf]="(root ? item : item.items)">
                 <li #item [ngClass]="{'ui-menuitem ui-widget ui-corner-all':true,'ui-menu-parent':child.items,'ui-menuitem-active':item==activeItem}"
                     (mouseenter)="onItemMouseEnter($event,item,child)" (mouseleave)="onItemMouseLeave($event,item)">
-                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" [routerLink]="child.routerLink" routerLinkActive="ui-state-active"
+                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" [routerLink]="child.routerLink || []" [routerLinkActive]="child.routerLink ? ['ui-state-active'] : ''"
                         [ngClass]="{'ui-state-hover':link==activeLink&&!child.disabled,'ui-state-disabled':child.disabled}" (click)="itemClick($event, child)">
                         <span class="ui-submenu-icon fa fa-fw" *ngIf="child.items" [ngClass]="{'fa-caret-down':root,'fa-caret-right':!root}"></span>
                         <span class="ui-menuitem-icon fa fa-fw" *ngIf="child.icon" [ngClass]="child.icon"></span>

--- a/components/menubar/menubar.ts
+++ b/components/menubar/menubar.ts
@@ -3,7 +3,7 @@ import {CommonModule} from '@angular/common';
 import {DomHandler} from '../dom/domhandler';
 import {MenuItem} from '../common/api';
 import {Location} from '@angular/common';
-import {Router} from '@angular/router';
+import {Router, RouterModule} from '@angular/router';
 
 @Component({
     selector: 'p-menubarSub',
@@ -13,7 +13,7 @@ import {Router} from '@angular/router';
             <template ngFor let-child [ngForOf]="(root ? item : item.items)">
                 <li #item [ngClass]="{'ui-menuitem ui-widget ui-corner-all':true,'ui-menu-parent':child.items,'ui-menuitem-active':item==activeItem}"
                     (mouseenter)="onItemMouseEnter($event,item,child)" (mouseleave)="onItemMouseLeave($event,item)">
-                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" 
+                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" [routerLink]="child.routerLink" routerLinkActive="ui-state-active"
                         [ngClass]="{'ui-state-hover':link==activeLink&&!child.disabled,'ui-state-disabled':child.disabled}" (click)="itemClick($event, child)">
                         <span class="ui-submenu-icon fa fa-fw" *ngIf="child.items" [ngClass]="{'fa-caret-down':root,'fa-caret-right':!root}"></span>
                         <span class="ui-menuitem-icon fa fa-fw" *ngIf="child.icon" [ngClass]="child.icon"></span>
@@ -88,10 +88,6 @@ export class MenubarSub {
             });
         }
 
-        if(item.routerLink) {
-            this.router.navigate(item.routerLink);
-        }
-        
         this.activeItem = null;
         this.activeLink = null;
     }
@@ -146,7 +142,7 @@ export class Menubar implements OnDestroy {
 }
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [CommonModule, RouterModule],
     exports: [Menubar],
     declarations: [Menubar,MenubarSub]
 })

--- a/components/menubar/menubar.ts
+++ b/components/menubar/menubar.ts
@@ -1,9 +1,8 @@
-import {NgModule,Component,ElementRef,AfterViewInit,OnDestroy,Input,Output,Renderer,EventEmitter} from '@angular/core';
+import {NgModule,Component,ElementRef,OnDestroy,Input,EventEmitter} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {DomHandler} from '../dom/domhandler';
 import {MenuItem} from '../common/api';
-import {Location} from '@angular/common';
-import {Router} from '@angular/router';
+import {Router, RouterModule} from '@angular/router';
 
 @Component({
     selector: 'p-menubarSub',
@@ -13,7 +12,7 @@ import {Router} from '@angular/router';
             <template ngFor let-child [ngForOf]="(root ? item : item.items)">
                 <li #item [ngClass]="{'ui-menuitem ui-widget ui-corner-all':true,'ui-menu-parent':child.items,'ui-menuitem-active':item==activeItem}"
                     (mouseenter)="onItemMouseEnter($event,item,child)" (mouseleave)="onItemMouseLeave($event,item)">
-                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" 
+                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" [routerLink]="child.routerLink" routerLinkActive="ui-state-active"
                         [ngClass]="{'ui-state-hover':link==activeLink&&!child.disabled,'ui-state-disabled':child.disabled}" (click)="itemClick($event, child)">
                         <span class="ui-submenu-icon fa fa-fw" *ngIf="child.items" [ngClass]="{'fa-caret-down':root,'fa-caret-right':!root}"></span>
                         <span class="ui-menuitem-icon fa fa-fw" *ngIf="child.icon" [ngClass]="child.icon"></span>
@@ -29,27 +28,27 @@ import {Router} from '@angular/router';
 export class MenubarSub {
 
     @Input() item: MenuItem;
-    
+
     @Input() root: boolean;
-    
+
     constructor(public domHandler: DomHandler, public router: Router) {}
-    
+
     activeItem: any;
-    
+
     activeLink: any;
-            
+
     onItemMouseEnter(event, item, menuitem: MenuItem) {
         if(menuitem.disabled) {
             return;
         }
-        
+
         this.activeItem = item;
         this.activeLink = item.children[0];
         let nextElement =  item.children[0].nextElementSibling;
         if(nextElement) {
             let sublist = nextElement.children[0];
             sublist.style.zIndex = ++DomHandler.zindex;
-            
+
             if(this.root) {
                 sublist.style.top = this.domHandler.getOuterHeight(item.children[0]) + 'px';
                 sublist.style.left = '0px'
@@ -60,42 +59,38 @@ export class MenubarSub {
             }
         }
     }
-    
+
     onItemMouseLeave(event, link) {
         this.activeItem = null;
         this.activeLink = null;
     }
-    
+
     itemClick(event, item: MenuItem) {
         if(item.disabled) {
             event.preventDefault();
             return;
         }
-        
+
         if(!item.url||item.routerLink) {
             event.preventDefault();
         }
-        
+
         if(item.command) {
             if(!item.eventEmitter) {
                 item.eventEmitter = new EventEmitter();
                 item.eventEmitter.subscribe(item.command);
             }
-            
+
             item.eventEmitter.emit({
                 originalEvent: event,
                 item: item
             });
         }
 
-        if(item.routerLink) {
-            this.router.navigate(item.routerLink);
-        }
-        
         this.activeItem = null;
         this.activeLink = null;
     }
-        
+
     listClick(event) {
         this.activeItem = null;
         this.activeLink = null;
@@ -120,22 +115,22 @@ export class Menubar implements OnDestroy {
     @Input() style: any;
 
     @Input() styleClass: string;
-            
-    constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer) {}
-    
+
+    constructor(public el: ElementRef, public domHandler: DomHandler) {}
+
     unsubscribe(item: any) {
         if(item.eventEmitter) {
             item.eventEmitter.unsubscribe();
         }
-        
+
         if(item.items) {
             for(let childItem of item.items) {
                 this.unsubscribe(childItem);
             }
         }
     }
-        
-    ngOnDestroy() {        
+
+    ngOnDestroy() {
         if(this.model) {
             for(let item of this.model) {
                 this.unsubscribe(item);
@@ -146,7 +141,7 @@ export class Menubar implements OnDestroy {
 }
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [CommonModule, RouterModule],
     exports: [Menubar],
     declarations: [Menubar,MenubarSub]
 })

--- a/components/menubar/menubar.ts
+++ b/components/menubar/menubar.ts
@@ -1,8 +1,9 @@
-import {NgModule,Component,ElementRef,OnDestroy,Input,EventEmitter} from '@angular/core';
+import {NgModule,Component,ElementRef,AfterViewInit,OnDestroy,Input,Output,Renderer,EventEmitter} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {DomHandler} from '../dom/domhandler';
 import {MenuItem} from '../common/api';
-import {Router, RouterModule} from '@angular/router';
+import {Location} from '@angular/common';
+import {Router} from '@angular/router';
 
 @Component({
     selector: 'p-menubarSub',
@@ -12,7 +13,7 @@ import {Router, RouterModule} from '@angular/router';
             <template ngFor let-child [ngForOf]="(root ? item : item.items)">
                 <li #item [ngClass]="{'ui-menuitem ui-widget ui-corner-all':true,'ui-menu-parent':child.items,'ui-menuitem-active':item==activeItem}"
                     (mouseenter)="onItemMouseEnter($event,item,child)" (mouseleave)="onItemMouseLeave($event,item)">
-                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" [routerLink]="child.routerLink" routerLinkActive="ui-state-active"
+                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" 
                         [ngClass]="{'ui-state-hover':link==activeLink&&!child.disabled,'ui-state-disabled':child.disabled}" (click)="itemClick($event, child)">
                         <span class="ui-submenu-icon fa fa-fw" *ngIf="child.items" [ngClass]="{'fa-caret-down':root,'fa-caret-right':!root}"></span>
                         <span class="ui-menuitem-icon fa fa-fw" *ngIf="child.icon" [ngClass]="child.icon"></span>
@@ -28,27 +29,27 @@ import {Router, RouterModule} from '@angular/router';
 export class MenubarSub {
 
     @Input() item: MenuItem;
-
+    
     @Input() root: boolean;
-
+    
     constructor(public domHandler: DomHandler, public router: Router) {}
-
+    
     activeItem: any;
-
+    
     activeLink: any;
-
+            
     onItemMouseEnter(event, item, menuitem: MenuItem) {
         if(menuitem.disabled) {
             return;
         }
-
+        
         this.activeItem = item;
         this.activeLink = item.children[0];
         let nextElement =  item.children[0].nextElementSibling;
         if(nextElement) {
             let sublist = nextElement.children[0];
             sublist.style.zIndex = ++DomHandler.zindex;
-
+            
             if(this.root) {
                 sublist.style.top = this.domHandler.getOuterHeight(item.children[0]) + 'px';
                 sublist.style.left = '0px'
@@ -59,38 +60,42 @@ export class MenubarSub {
             }
         }
     }
-
+    
     onItemMouseLeave(event, link) {
         this.activeItem = null;
         this.activeLink = null;
     }
-
+    
     itemClick(event, item: MenuItem) {
         if(item.disabled) {
             event.preventDefault();
             return;
         }
-
+        
         if(!item.url||item.routerLink) {
             event.preventDefault();
         }
-
+        
         if(item.command) {
             if(!item.eventEmitter) {
                 item.eventEmitter = new EventEmitter();
                 item.eventEmitter.subscribe(item.command);
             }
-
+            
             item.eventEmitter.emit({
                 originalEvent: event,
                 item: item
             });
         }
 
+        if(item.routerLink) {
+            this.router.navigate(item.routerLink);
+        }
+        
         this.activeItem = null;
         this.activeLink = null;
     }
-
+        
     listClick(event) {
         this.activeItem = null;
         this.activeLink = null;
@@ -115,22 +120,22 @@ export class Menubar implements OnDestroy {
     @Input() style: any;
 
     @Input() styleClass: string;
-
-    constructor(public el: ElementRef, public domHandler: DomHandler) {}
-
+            
+    constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer) {}
+    
     unsubscribe(item: any) {
         if(item.eventEmitter) {
             item.eventEmitter.unsubscribe();
         }
-
+        
         if(item.items) {
             for(let childItem of item.items) {
                 this.unsubscribe(childItem);
             }
         }
     }
-
-    ngOnDestroy() {
+        
+    ngOnDestroy() {        
         if(this.model) {
             for(let item of this.model) {
                 this.unsubscribe(item);
@@ -141,7 +146,7 @@ export class Menubar implements OnDestroy {
 }
 
 @NgModule({
-    imports: [CommonModule, RouterModule],
+    imports: [CommonModule],
     exports: [Menubar],
     declarations: [Menubar,MenubarSub]
 })

--- a/components/menubar/menubar.ts
+++ b/components/menubar/menubar.ts
@@ -13,7 +13,7 @@ import {Router, RouterModule} from '@angular/router';
             <template ngFor let-child [ngForOf]="(root ? item : item.items)">
                 <li #item [ngClass]="{'ui-menuitem ui-widget ui-corner-all':true,'ui-menu-parent':child.items,'ui-menuitem-active':item==activeItem}"
                     (mouseenter)="onItemMouseEnter($event,item,child)" (mouseleave)="onItemMouseLeave($event,item)">
-                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" [routerLink]="child.routerLink || []" [routerLinkActive]="child.routerLink ? ['ui-state-active'] : ''"
+                    <a #link [href]="child.url||'#'" class="ui-menuitem-link ui-corner-all" [routerLink]="child.routerLink || []" [routerLinkActive]="child.routerLink ? 'ui-state-active' : ''"
                         [ngClass]="{'ui-state-hover':link==activeLink&&!child.disabled,'ui-state-disabled':child.disabled}" (click)="itemClick($event, child)">
                         <span class="ui-submenu-icon fa fa-fw" *ngIf="child.items" [ngClass]="{'fa-caret-down':root,'fa-caret-right':!root}"></span>
                         <span class="ui-menuitem-icon fa fa-fw" *ngIf="child.icon" [ngClass]="child.icon"></span>


### PR DESCRIPTION
Simple change to Menubar to make items that use routerLinks show the active state (the "ui-state-active" class is added) whenever their routes are activated.