### PR TITLE
Header checkbox may not always get checked

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -999,7 +999,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     
     get allSelected() {
         let val = true;
-        if(this.dataToRender && this.selection && (this.dataToRender.length == this.selection.length)) {
+        if(this.dataToRender && this.selection && (this.dataToRender.length <= this.selection.length)) {
             for(let data of this.dataToRender) {
                 if(!this.isSelected(data)) {
                     val = false;


### PR DESCRIPTION
Fixes #1206
Allows paged datatable header checkbox to behave correctly when programmatically selecting entire dataset