### PR TITLE
Support HTML in growl message

### DIFF
--- a/components/growl/growl.ts
+++ b/components/growl/growl.ts
@@ -17,7 +17,7 @@ import {DomHandler} from '../dom/domhandler';
                                 'fa-close':msg.severity == 'error','fa-check':msg.severity == 'success'}"></span>
                      <div class="ui-growl-message">
                         <span class="ui-growl-title">{{msg.summary}}</span>
-                        <p>{{msg.detail}}</p>
+                        <p [innerHTML]="msg.detail"></p>
                      </div>
                      <div style="clear: both;"></div>
                 </div>


### PR DESCRIPTION
Before change, some string like "first line. <br> and  here goes the second line." do not work as expected.
This revision brings the flexibility without security risks. (eg. 'first line <br> second line.<script>alert("lalala")</script>' comes with no alert dialogue.)