### PR TITLE
Fix bug: PanelMenu not opening external links

### DIFF
--- a/components/panelmenu/panelmenu.ts
+++ b/components/panelmenu/panelmenu.ts
@@ -15,7 +15,6 @@ export class BasePanelMenuItem {
         }
         
         item.expanded = !item.expanded;
-        event.preventDefault();
         
         if(!item.url||item.routerLink) {
             event.preventDefault();


### PR DESCRIPTION
PanelMenu allways fire event.preventDefault(), so anchor tag can't href to external tag