### PR TITLE
Added the support for seconds in calender-time-picker

### DIFF
--- a/components/calendar/calendar.css
+++ b/components/calendar/calendar.css
@@ -226,6 +226,10 @@
     margin-left: 0px;
 }
 
+.ui-timepicker > .ui-second-picker {
+    margin-left: 0px;
+}
+
 .ui-timepicker > .ui-separator {
     margin-left: 0px;
     min-width: 12px;

--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -100,6 +100,24 @@ export interface LocaleSettings {
                             <span class="fa fa-angle-down"></span>
                         </a>
                     </div>
+                    <div class="ui-separator">
+                        <a href="#">
+                            <span class="fa fa-angle-up"></span>
+                        </a>
+                        <span>:</span>
+                        <a href="#">
+                            <span class="fa fa-angle-down"></span>
+                        </a>
+                    </div>
+                    <div class="ui-second-picker">
+                        <a href="#" (click)="incrementSecond($event)">
+                            <span class="fa fa-angle-up"></span>
+                        </a>
+                        <span [ngStyle]="{'display': currentSecond < 10 ? 'inline': 'none'}">0</span><span>{{currentSecond}}</span>
+                        <a href="#" (click)="decrementSecond($event)">
+                            <span class="fa fa-angle-down"></span>
+                        </a>
+                    </div>
                     <div class="ui-ampm-picker" *ngIf="hourFormat=='12'">
                         <a href="#" (click)="toggleAMPM($event)">
                             <span class="fa fa-angle-up"></span>
@@ -209,6 +227,8 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     currentHour: number;
     
     currentMinute: number;
+
+    currentSecond: number;
     
     pm: boolean;
     
@@ -275,6 +295,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         this.currentYear = date.getFullYear();
         if(this.showTime) {
             this.currentMinute = date.getMinutes();
+            this.currentSecond = date.getSeconds();
             this.pm = date.getHours() > 11;
             
             if(this.hourFormat == '12')
@@ -285,6 +306,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         else if(this.timeOnly) {
             this.currentMinute = 0;
             this.currentHour = 0;
+            this.currentSecond = 0;
         }
 
         this.createMonth(this.currentMonth, this.currentYear);
@@ -456,6 +478,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
                 this.value.setHours(this.currentHour);
 
             this.value.setMinutes(this.currentMinute);
+            this.value.setSeconds(this.currentSecond);
         }
         this.updateModel();
         this.onSelect.emit(this.value);
@@ -668,6 +691,27 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         event.preventDefault();
     }
     
+    incrementSecond(event) {
+        if(this.currentSecond === 59)
+            this.currentSecond = 0;
+        else
+            this.currentSecond++;
+            
+        this.updateTime();
+                
+        event.preventDefault();
+    }
+    
+    decrementSecond(event) {
+        if(this.currentSecond === 0)
+            this.currentSecond = 59;
+        else
+            this.currentSecond--;
+        
+        this.updateTime();
+        
+        event.preventDefault();
+    }
     updateTime() {
         this.value = this.value||new Date();
         if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
@@ -676,6 +720,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
             this.value.setHours(this.currentHour);
         
         this.value.setMinutes(this.currentMinute);
+        this.value.setSeconds(this.currentSecond);
         this.updateModel();
         this.onSelect.emit(this.value);
         this.updateInputfield();
@@ -736,6 +781,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         }
 
         value.setMinutes(time.minute);
+        value.setSeconds(time.second);
     }
     
     updateUI() {
@@ -760,6 +806,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
             }
             
             this.currentMinute = val.getMinutes();
+            this.currentSecond = val.getSeconds();
         }
     }
     
@@ -888,6 +935,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         let output = '';
         let hours = date.getHours();
         let minutes = date.getMinutes();
+        let seconds = date.getSeconds();
         
         if(this.hourFormat == '12' && this.pm && hours != 12) {
             hours-=12;
@@ -896,6 +944,8 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         output += (hours < 10) ? '0' + hours : hours;
         output += ':';
         output += (minutes < 10) ? '0' + minutes : minutes;
+        output += ':';
+        output += (seconds < 10) ? '0' + seconds : seconds;
         
         if(this.hourFormat == '12') {
             output += this.pm ? ' PM' : ' AM';
@@ -906,13 +956,14 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     
     parseTime(value) {
         let tokens: string[] = value.split(':');
-        if(tokens.length !== 2) {
+        if(tokens.length !== 3) {
             throw "Invalid time";
         }
         
         let h = parseInt(tokens[0]);
         let m = parseInt(tokens[1]);
-        if(isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12)) {
+        let s = parseInt(tokens[2]);
+        if(isNaN(h) || isNaN(m) || isNaN(s) || h > 23 || m > 59 || s > 59 || (this.hourFormat == '12' && h > 12)) {
             throw "Invalid time";
         }
         else {
@@ -920,7 +971,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
                 h+= 12;
             }
 
-            return {hour: parseInt(tokens[0]), minute: parseInt(tokens[1])};
+            return {hour: parseInt(tokens[0]), minute: parseInt(tokens[1]), second: parseInt(tokens[2])};
         }
     }
     


### PR DESCRIPTION
Hi,
This is in response to : https://github.com/primefaces/primeng/issues/1454

As mentioned now we can set seconds in the calender.
Have tested for the following cases =>

1. Wether the input text is changing when we click on increment/decrement buttons
2. When input text is being changed wether the change is being reflected in the seconds area near increment/decrement buttons

3. Correct time is being emmited for onSelect output.

time format for days months and years is same as it was before. However for hours and minutes it will be => hours : minutes : seconds. If not in this format existing exception ("Invalid time") is thrown

Please suggest changes and improvements if any :)

Thanks