### PR TITLE
Revert #1182 patch 1

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -585,9 +585,6 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 let fields: string[] = field.split('.');
                 let value = data;
                 for(var i = 0, len = fields.length; i < len; ++i) {
-                    if (value === undefined){
-                        return null;
-                    }
                     value = value[fields[i]];
                 }
                 return value;

--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -585,6 +585,9 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 let fields: string[] = field.split('.');
                 let value = data;
                 for(var i = 0, len = fields.length; i < len; ++i) {
+                    if (value == undefined){
+                        return null;
+                    }
                     value = value[fields[i]];
                 }
                 return value;


### PR DESCRIPTION
Have one problem in fix #1182
```
   null === undefined // false
   null == undefined // true
   null === null // true
```

We need use just "==" to check if have value in the field, it's wrong use "===".

If we try check a JSON with null values, the exception keep occurring.