### PR TITLE
Ensure no border of .ui-datatable-scrollable-header

### DIFF
--- a/components/datatable/datatable.css
+++ b/components/datatable/datatable.css
@@ -69,11 +69,11 @@
 }
 .ui-datatable-scrollable-header {
     overflow: hidden;
-    border: 0px none;
 }
 
 .ui-datatable-scrollable .ui-datatable-scrollable-header {
     position: relative;
+    border: 0px none;
 }
 
 .ui-datatable-scrollable .ui-datatable-scrollable-header td {


### PR DESCRIPTION
I found that when add a theme.css, the definition of `.ui-widget-header { border: 1px solid #d9d9d9; }` whihin the theme.css will override the definition of
`.ui-datatable-scrollable-header { border: 0px none; }`, so I just move the `border: 0px none;` from **.ui-datatable-scrollable-header** to **.ui-datatable-scrollable .ui-datatable-scrollable-header** to make sure that the .ui-datatable-scrollable-header having no border.
![1pxdiffer](https://cloud.githubusercontent.com/assets/18899610/20916167/4b9b1b08-bbc5-11e6-955a-556573fb1031.png)

