### PR TITLE
Fixed #1107 - Min height when label is null

### DIFF
--- a/components/dropdown/dropdown.css
+++ b/components/dropdown/dropdown.css
@@ -72,6 +72,7 @@
     margin:1px 0;
     padding:3px 5px;
     text-align:left;
+    min-height: 1em;
 }
 
 .ui-dropdown-panel .ui-dropdown-item-group {


### PR DESCRIPTION
Fixed #1107 min-height when the ui-dropdown-item have a null label.

**min-height: 1em** is the best way, because "em" is "Relative to the **font-size of the element** (2em means 2 times the size of the current font)" 

Preview:

![image](https://cloud.githubusercontent.com/assets/106457/20963721/bf74f4dc-bc55-11e6-888a-f6777d957f3a.png)

The same solution has applied on select2 in the past https://github.com/select2/select2/commit/4530e74e9536adda1c5b637c3e43d7bf607bb6ab