### PR TITLE
Only upload when files array is non-empty in 'auto' mode

### DIFF
--- a/components/fileupload/fileupload.ts
+++ b/components/fileupload/fileupload.ts
@@ -145,7 +145,7 @@ export class FileUpload implements OnInit,AfterContentInit {
         
         this.onSelect.emit({originalEvent: event, files: files});
         
-        if(this.files && this.auto) {
+        if(this.hasFiles() && this.auto) {
             this.upload();
         }
     }


### PR DESCRIPTION
In auto mode, if a file doesn't pass validation, a POST is still being done with an empty files list. The test does a boolean check on the files array instead of checking the length. This change calls the hasFiles() function which performs the proper check.