### PR TITLE
Add input property 'cellIsEditiable' in DataTable, which verifies editability of a cell

### DIFF
--- a/components/common/shared.ts
+++ b/components/common/shared.ts
@@ -79,6 +79,11 @@ export class Column implements AfterContentInit{
     @Input() expander: boolean;
     @Input() selectionMode: string;
     @Input() filterPlaceholder: string;
+	@Input() editType: string = "text";
+	@Input() editMin: string;
+	@Input() editMax: string;
+	@Input() editStep: string;
+	@Input() editPattern: string;
     @Output() sortFunction: EventEmitter<any> = new EventEmitter();
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     @ContentChild(TemplateRef) template: TemplateRef<any>;

--- a/components/common/shared.ts
+++ b/components/common/shared.ts
@@ -80,10 +80,10 @@ export class Column implements AfterContentInit{
     @Input() selectionMode: string;
     @Input() filterPlaceholder: string;
 	@Input() editType: string = "text";
-	@Input() editMin: string;
-	@Input() editMax: string;
-	@Input() editStep: string;
-	@Input() editPattern: string;
+	@Input() editMin: string = "";
+	@Input() editMax: string = "";
+	@Input() editStep: string = "any";
+	@Input() editPattern: string = "";
     @Output() sortFunction: EventEmitter<any> = new EventEmitter();
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     @ContentChild(TemplateRef) template: TemplateRef<any>;

--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -434,6 +434,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Output() onRowGroupExpand: EventEmitter<any> = new EventEmitter();
     
     @Output() onRowGroupCollapse: EventEmitter<any> = new EventEmitter();
+	
+	@Input() cellIsEditable: Function;
         
     @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate>;
     
@@ -1333,6 +1335,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
 
     switchCellToEditMode(element: any, column: Column, rowData: any) {
         if(!this.selectionMode && this.editable && column.editable) {
+			if(this.cellIsEditable && !this.cellIsEditable(column, rowData))
+				return;
             let cell = this.findCell(element);
             if(cell != this.editingCell) {
                 this.editingCell = cell;

--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -191,7 +191,7 @@ export class RowExpansionLoader {
                                         <span class="ui-cell-data" *ngIf="col.bodyTemplate">
                                             <p-columnBodyTemplateLoader [column]="col" [rowData]="rowData" [rowIndex]="rowIndex + first"></p-columnBodyTemplateLoader>
                                         </span>
-                                        <input type="text" class="ui-cell-editor ui-state-highlight" *ngIf="col.editable" [(ngModel)]="rowData[col.field]"
+                                        <input [type]="col.editType" class="ui-cell-editor ui-state-highlight" *ngIf="col.editable" [(ngModel)]="rowData[col.field]" [min]="col.editMin" [max]="col.editMax" [step]="col.editStep" [pattern]="col.editPattern"
                                                 (blur)="switchCellToViewMode($event.target,col,rowData,true)" (keydown)="onCellEditorKeydown($event, col, rowData, colIndex)"/>
                                         <div class="ui-row-toggler fa fa-fw ui-c" [ngClass]="{'fa-chevron-circle-down':isRowExpanded(rowData), 'fa-chevron-circle-right': !isRowExpanded(rowData)}"
                                             *ngIf="col.expander" (click)="toggleRow($event,rowData)"></div>
@@ -268,7 +268,7 @@ export class RowExpansionLoader {
                                     <span class="ui-cell-data" *ngIf="col.bodyTemplate">
                                         <p-columnBodyTemplateLoader [column]="col" [rowData]="rowData" [rowIndex]="rowIndex + first"></p-columnBodyTemplateLoader>
                                     </span>
-                                    <input type="text" class="ui-cell-editor ui-state-highlight" *ngIf="col.editable" [(ngModel)]="rowData[col.field]"
+                                    <input [type]="col.editType" class="ui-cell-editor ui-state-highlight" *ngIf="col.editable" [(ngModel)]="rowData[col.field]" [min]="col.editMin" [max]="col.editMax" [step]="col.editStep" [pattern]="col.editPattern"
                                             (blur)="switchCellToViewMode($event.target,col,rowData,true)" (keydown)="onCellEditorKeydown($event, col, rowData, colIndex)"/>
                                     <div class="ui-row-toggler fa fa-fw ui-c" [ngClass]="{'fa-chevron-circle-down':isRowExpanded(rowData), 'fa-chevron-circle-right': !isRowExpanded(rowData)}"
                                         *ngIf="col.expander" (click)="toggleRow(rowData)"></div>

--- a/showcase/demo/datatable/datatabledemo.html
+++ b/showcase/demo/datatable/datatabledemo.html
@@ -219,6 +219,36 @@ export class DataTableDemo implements OnInit &#123;
                             <td>null</td>
                             <td>Defines column based selection mode, options are "single" and "multiple".</td>
                         </tr>
+                        <tr>
+                            <td>editType</td>
+                            <td>string</td>
+                            <td>text</td>
+                            <td>When column is editable, then defines input type.</td>
+                        </tr>
+                        <tr>
+                            <td>editMin</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>When column is editable, then defines input minimum value.</td>
+                        </tr>
+                        <tr>
+                            <td>editMax</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>When column is editable, then defines input maximum value.</td>
+                        </tr>
+                        <tr>
+                            <td>editStep</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>When column is editable, then defines input step value.</td>
+                        </tr>
+                        <tr>
+                            <td>editPattern</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>When column is editable, then defines input pattern.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/datatable/datatabledemo.html
+++ b/showcase/demo/datatable/datatabledemo.html
@@ -1084,6 +1084,12 @@ loadData(event: LazyLoadEvent) &#123;
                             <td>null</td>
                             <td>Function that gets the row data and row index as parameters and returns a style class for the row.</td>
                         </tr>
+                        <tr>
+                            <td>cellIsEditable</td>
+                            <td>function</td>
+                            <td>null</td>
+                            <td>Check whether editing is permitted in the column and row.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/datatable/datatabledemo.html
+++ b/showcase/demo/datatable/datatabledemo.html
@@ -240,7 +240,7 @@ export class DataTableDemo implements OnInit &#123;
                         <tr>
                             <td>editStep</td>
                             <td>string</td>
-                            <td>null</td>
+                            <td>any</td>
                             <td>When column is editable, then defines input step value.</td>
                         </tr>
                         <tr>

--- a/showcase/demo/datatable/datatableeditabledemo.html
+++ b/showcase/demo/datatable/datatableeditabledemo.html
@@ -9,7 +9,7 @@
 </div>
 
 <div class="ContentSideSections Implementation">
-    <p-dataTable [value]="cars" [editable]="true">
+    <p-dataTable [value]="cars" [editable]="true" [cellIsEditable]="cellIsEditable">
         <p-column field="vin" header="Vin" [editable]="true"></p-column>
         <p-column field="year" header="Year" [editable]="true"></p-column>
         <p-column field="brand" header="Brand" [editable]="true"></p-column>
@@ -31,15 +31,20 @@ export class DataTableEditableDemo implements OnInit &#123;
     ngOnInit() &#123;
         this.carService.getCarsSmall().then(cars => this.cars = cars);
     &#125;
+	
+    cellIsEditable(column: Column, rowData: any) &#123;
+        return rowData.color != 'Black' || column.field == 'color';
+    &#125;
 &#125;
 </code>
-</pre>            
+</pre>           
+<p>With function cellIsEditable, all lines with color 'Black' can't be edited, except column Color.</p> 
         </p-tabPanel>
 
         <p-tabPanel header="datatableeditabledemo.html">
 <pre>
 <code class="language-markup" pCode>
-&lt;p-dataTable [value]="cars" [editable]="true"&gt;
+&lt;p-dataTable [value]="cars" [editable]="true" [cellIsEditable]="cellIsEditable"&gt;
     &lt;p-column field="vin" header="Vin" [editable]="true"&gt;&lt;/p-column&gt;
     &lt;p-column field="year" header="Year" [editable]="true"&gt;&lt;/p-column&gt;
     &lt;p-column field="brand" header="Brand" [editable]="true"&gt;&lt;/p-column&gt;

--- a/showcase/demo/datatable/datatableeditabledemo.html
+++ b/showcase/demo/datatable/datatableeditabledemo.html
@@ -11,7 +11,7 @@
 <div class="ContentSideSections Implementation">
     <p-dataTable [value]="cars" [editable]="true" [cellIsEditable]="cellIsEditable">
         <p-column field="vin" header="Vin" [editable]="true"></p-column>
-        <p-column field="year" header="Year" [editable]="true"></p-column>
+        <p-column field="year" header="Year" [editable]="true" editType="number" editMin="1900" editStep="1"></p-column>
         <p-column field="brand" header="Brand" [editable]="true"></p-column>
         <p-column field="color" header="Color" [editable]="true"></p-column>
     </p-dataTable>
@@ -46,7 +46,7 @@ export class DataTableEditableDemo implements OnInit &#123;
 <code class="language-markup" pCode>
 &lt;p-dataTable [value]="cars" [editable]="true" [cellIsEditable]="cellIsEditable"&gt;
     &lt;p-column field="vin" header="Vin" [editable]="true"&gt;&lt;/p-column&gt;
-    &lt;p-column field="year" header="Year" [editable]="true"&gt;&lt;/p-column&gt;
+    &lt;p-column field="year" header="Year" [editable]="true" editType="number" editMin="1900" editStep="1"&gt;&lt;/p-column&gt;
     &lt;p-column field="brand" header="Brand" [editable]="true"&gt;&lt;/p-column&gt;
     &lt;p-column field="color" header="Color" [editable]="true"&gt;&lt;/p-column&gt;
 &lt;/p-dataTable&gt;

--- a/showcase/demo/datatable/datatableeditabledemo.ts
+++ b/showcase/demo/datatable/datatableeditabledemo.ts
@@ -1,6 +1,7 @@
 import {Component,OnInit} from '@angular/core';
 import {Car} from '../domain/car';
 import {CarService} from '../service/carservice';
+import {Column} from "../../../components/common/shared";
 
 @Component({
     templateUrl: 'showcase/demo/datatable/datatableeditabledemo.html'
@@ -14,4 +15,8 @@ export class DataTableEditableDemo implements OnInit {
     ngOnInit() {
         this.carService.getCarsSmall().then(cars => this.cars = cars);
     }
+	
+	cellIsEditable(column: Column, rowData: any) {		
+		return rowData.color != 'Black' || column.field == 'color';
+	}
 }


### PR DESCRIPTION
With the specified function of the "cellIsEditable" property, cells can
be locked for editing.
Thus, depending on the row data, it is possible to lock individual cells
for editing.