### PR TITLE
Support angular 2 universal

### DIFF
--- a/components/button/button.ts
+++ b/components/button/button.ts
@@ -2,6 +2,8 @@ import {NgModule,Directive,ElementRef,AfterViewInit,OnDestroy,HostBinding,HostLi
 import {DomHandler} from '../dom/domhandler';
 import {CommonModule} from '@angular/common';
 
+const Event = (global as any).Event as Event;
+
 @Directive({
     selector: '[pButton]',
     host: {


### PR DESCRIPTION
The error when using latest [universal-starter](https://github.com/angular/universal-starter) and primeng.

`/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:103208
        __metadata('design:paramtypes', [Event]), `
                                         ^

`ReferenceError: Event is not defined
    at /Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:103208:42
    at Object.module.exports.c (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:103259:2)
    at __webpack_require__ (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:21:30)
    at Object.module.exports.c (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:73386:16)
    at __webpack_require__ (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:21:30)
    at Object.<anonymous> (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:60796:25)
    at __webpack_require__ (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:21:30)
    at Object.<anonymous> (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:108594:18)
    at __webpack_require__ (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:21:30)
    at /Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:65:18
    at Object.<anonymous> (/Users/dmitrij/projects/smsbox/modules/client/dist/server/index.js:68:10)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.runMain (module.js:604:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
    at bootstrap_node.js:509:3`