### PR TITLE
Added a new event to file upload

### DIFF
--- a/components/fileupload/fileupload.ts
+++ b/components/fileupload/fileupload.ts
@@ -77,6 +77,8 @@ export class FileUpload implements OnInit,AfterContentInit {
     @Input() cancelLabel: string = 'Cancel';
         
     @Output() onBeforeUpload: EventEmitter<any> = new EventEmitter();
+	
+	@Output() onBeforeSend: EventEmitter<any> = new EventEmitter();
         
     @Output() onUpload: EventEmitter<any> = new EventEmitter();
     
@@ -205,6 +207,11 @@ export class FileUpload implements OnInit,AfterContentInit {
         };
         
         xhr.open('POST', this.url, true);
+		
+		this.onBeforeSend.emit({
+			'xhr': xhr,
+            'formData': formData 
+		});
         
         xhr.send(formData);
     }

--- a/showcase/demo/fileupload/fileuploaddemo.html
+++ b/showcase/demo/fileupload/fileuploaddemo.html
@@ -221,7 +221,14 @@ import &#123;FileUploadModule&#125; from 'primeng/primeng';
                             <td>event.xhr: XmlHttpRequest instance. <br/>
                                 event.formData: FormData object.</td>
                             <td>Callback to invoke before file upload begins to customize the request
-                                such as adding header and post parameters.</td>
+                                such as post parameters.</td>
+                        </tr>
+						<tr>
+                            <td>onBeforeSend</td>
+                            <td>event.xhr: XmlHttpRequest instance. <br/>
+                                event.formData: FormData object.</td>
+                            <td>Callback to invoke before file send begins to customize the request
+                                such as adding headers.</td>
                         </tr>
                         <tr>
                             <td>onUpload</td>


### PR DESCRIPTION
Fileupload component didn't allow it's users to set headers anymore after 1.1.0. because of the moved onBeforeUpload event.
Added onBeforeSend event after the open method for the XMLHttpRequest to allow setting of headers once again.