### PR TITLE
Row should call getRowStyleClass even if table is scrollable

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -254,7 +254,7 @@ export class RowExpansionLoader {
                                 (click)="onRowGroupClick($event)" [ngStyle]="{'cursor': sortableRowGroup ? 'pointer' : 'auto'}">
                                 <td [attr.colspan]="columns.length"><p-templateLoader [template]="rowGroupHeaderTemplate" [data]="rowData"></p-templateLoader></td>
                             </tr>
-                            <tr #rowElement class="ui-widget-content" (mouseenter)="hoveredRow = $event.target" (mouseleave)="hoveredRow = null"
+                            <tr #rowElement class="ui-widget-content" [class]="getRowStyleClass(rowData,rowIndex)" (mouseenter)="hoveredRow = $event.target" (mouseleave)="hoveredRow = null"
                                     (click)="handleRowClick($event, rowData)" (dblclick)="rowDblclick($event,rowData)" (contextmenu)="onRowRightClick($event,rowData)"
                                     [ngClass]="{'ui-datatable-even':even,'ui-datatable-odd':odd,'ui-state-hover': ( (rowHover || selectionMode) && rowElement == hoveredRow), 'ui-state-highlight': isSelected(rowData)}">
                                 <template ngFor let-col [ngForOf]="columns" let-colIndex="index">


### PR DESCRIPTION
This fixes https://github.com/primefaces/primeng/issues/1613

---

## Bug:

Plunkr demo: http://plnkr.co/edit/25NZ7M?p=preview

**Current behavior**

If the table has `[scrollable]` set to `true`, the method passed to `[rowStyleClass]` is never called. If the table is _not_ scrollable, the method is called as expected.

**Expected behavior**

The method passed to `[rowStyleClass]` should be called for every row; even if the table is scrollable.

**Minimal reproduction of the problem with instructions**

Plunkr demo: http://plnkr.co/edit/25NZ7M?p=preview

1. Define a table with `scrollable` set to `true`:
1. Pass a method to `rowStyleClass` that should be called with row data:

```html
<p-dataTable [value]="items" [scrollable]="false" [rowStyleClass]="tableOneHighlight">
    <p-column field="id" header="ID"></p-column>
    <p-column field="name" header="Name"></p-column>
</p-dataTable>
```

**What is the motivation / use case for changing the behavior?**
I need to add a custom class to rows even when inside a scrollable table


* **Angular version:** 

2.3.0

* **PrimeNG version:** 

1.1.1
