### PR TITLE
Inputmask autoclear bug fix

### DIFF
--- a/components/inputmask/inputmask.ts
+++ b/components/inputmask/inputmask.ts
@@ -493,7 +493,7 @@ export class InputMask implements AfterViewInit,OnDestroy,ControlValueAccessor {
         if (allow) {
             this.writeBuffer();
         } else if (lastMatch + 1 < this.partialPosition) {
-            if (!this.autoClear || this.buffer.join('') === this.defaultBuffer) {
+            if (this.autoClear && this.buffer.join('') === this.defaultBuffer) {
                 // Invalid value. Remove it and replace it with the
                 // mask, which is the default behavior.
                 if(this.input.value) this.input.value = '';

--- a/components/inputmask/inputmask.ts
+++ b/components/inputmask/inputmask.ts
@@ -493,7 +493,7 @@ export class InputMask implements AfterViewInit,OnDestroy,ControlValueAccessor {
         if (allow) {
             this.writeBuffer();
         } else if (lastMatch + 1 < this.partialPosition) {
-            if (this.autoClear || this.buffer.join('') === this.defaultBuffer) {
+            if (!this.autoClear || this.buffer.join('') === this.defaultBuffer) {
                 // Invalid value. Remove it and replace it with the
                 // mask, which is the default behavior.
                 if(this.input.value) this.input.value = '';


### PR DESCRIPTION
When setting the autoClear value to "false" we want to preserve the value entered by the user.