### PR TITLE
DataTable: Fix rows not updated by model since v1.1

### DIFF
--- a/components/common/shared.ts
+++ b/components/common/shared.ts
@@ -1,4 +1,4 @@
-import {NgModule,EventEmitter,Directive,ViewContainerRef,Input,Output,ContentChildren,ContentChild,TemplateRef,OnInit,AfterContentInit,QueryList} from '@angular/core';
+import {NgModule,EventEmitter,Directive,ViewContainerRef,Input,Output,ContentChildren,ContentChild,TemplateRef,OnInit,OnChanges,AfterContentInit,QueryList} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {Component} from '@angular/core';
 
@@ -147,22 +147,32 @@ export class FooterColumnGroup {
     selector: 'p-columnBodyTemplateLoader',
     template: ``
 })
-export class ColumnBodyTemplateLoader {
+export class ColumnBodyTemplateLoader implements OnInit, OnChanges {
         
     @Input() column: any;
         
     @Input() rowData: any;
     
     @Input() rowIndex: number;
+
+    private context: {'\$implicit': any, 'rowData': any, 'rowIndex': number};
     
     constructor(public viewContainer: ViewContainerRef) {}
     
     ngOnInit() {
-        let view = this.viewContainer.createEmbeddedView(this.column.bodyTemplate, {
+        this.context = {
             '\$implicit': this.column,
             'rowData': this.rowData,
             'rowIndex': this.rowIndex
-        });
+        };
+        let view = this.viewContainer.createEmbeddedView(this.column.bodyTemplate, this.context);
+    }
+
+    ngOnChanges() {
+        if (this.context) {
+            this.context.rowData = this.rowData;
+            this.context.rowIndex = this.rowIndex;
+        }
     }
 }
 


### PR DESCRIPTION
Since PrimeNG 1.1.2 (and with Angular 2.4), updating the data model of a DataTable doesn't update the table rows that are already present. For instance, if the data model is:

```ts
this.cars = [
    {"brand":"Brand 1","year":2001},
    {"brand":"Brand 2","year":2002},
];
```

and an event changes this data to:

```ts
this.cars = [
    {"brand":"Brand 3","year":2003},
    {"brand":"Brand 4","year":2004},
    {"brand":"Brand 5","year":2005},
];
```

the table will still display `2001` and `2002` rows, and append `2005` at the end.

Demonstration of the bug in a Plunker: http://plnkr.co/edit/6BvfsmCkIvXfvKYBc0hT?p=preview

Credits to Victor Ponce (@wujitouch) for the fix.

Closes #1645