### PR TITLE
Update tree.ts to allow bypass propagation

### DIFF
--- a/components/tree/tree.ts
+++ b/components/tree/tree.ts
@@ -189,6 +189,8 @@ export class Tree implements AfterContentInit {
     @Input() contextMenu: any;
     
     @Input() layout: string = 'vertical';
+     
+    @Input() propagateSelection: string;
     
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     
@@ -310,6 +312,7 @@ export class Tree implements AfterContentInit {
     }
     
     propagateSelectionUp(node: TreeNode, select: boolean) {
+         if (this.isPropagateSelection() == 'true') {
         if(node.children && node.children.length) {
             let selectedCount: number = 0;
             let childPartialSelected: boolean = false;
@@ -346,6 +349,7 @@ export class Tree implements AfterContentInit {
         if(parent) {
             this.propagateSelectionUp(parent, select);
         }
+      }
     }
     
     propagateSelectionDown(node: TreeNode, select: boolean) {
@@ -360,10 +364,11 @@ export class Tree implements AfterContentInit {
         }
         
         node.partialSelected = false;
-        
-        if(node.children && node.children.length) {
-            for(let child of node.children) {
-                this.propagateSelectionDown(child, select);
+        if (this.isPropagateSelection() == 'true') {
+            if(node.children && node.children.length) {
+                for(let child of node.children) {
+                    this.propagateSelectionDown(child, select);
+                }
             }
         }
     }

--- a/components/tree/tree.ts
+++ b/components/tree/tree.ts
@@ -389,6 +389,10 @@ export class Tree implements AfterContentInit {
         return this.selectionMode && this.selectionMode == 'checkbox';
     }
 
+    isPropagateSelection(): string {       
+        return ((this.propagateSelection !== undefined) ? this.propagateSelection : 'true');   
+    }
+     
     getTemplateForNode(node: TreeNode): TemplateRef<any> {
         if(this.templateMap)
             return node.type ? this.templateMap[node.type] : this.templateMap['default'];


### PR DESCRIPTION
Allows bypass propagation by using propagateSelection="false" in the p-tree tag. If property is not supplied it will default to normal propagation. This was discussed in the forums at: http://forum.primefaces.org/viewtopic.php?f=35&t=48730&p=150623