### PR TITLE
Single FileUpload still behaves as multiple

### DIFF
--- a/components/fileupload/fileupload.ts
+++ b/components/fileupload/fileupload.ts
@@ -140,7 +140,10 @@ export class FileUpload implements OnInit,AfterContentInit {
                 if(this.isImage(file)) {
                     file.objectURL = this.sanitizer.bypassSecurityTrustUrl((window.URL.createObjectURL(files[i])));
                 }
-                
+                if (!this.multiple) {
+                    this.files = [ files[i] ];
+                    continue;
+                }
                 this.files.push(files[i]);
             }
         }


### PR DESCRIPTION
In single selection mode the image should be set inside a single-item array instead of adding it to the existing images.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.