### PR TITLE
Fix for growl messages with long detail bug #1646

### DIFF
--- a/components/growl/growl.css
+++ b/components/growl/growl.css
@@ -31,8 +31,8 @@
 
 .ui-growl-title {
 	font-weight: bold;
-	padding: 0 0 .5em 0;
-	display: block;
+	padding: 0.2em 0 .5em 0;
+	display: inline-block;
 }
 
 .ui-growl-image {

--- a/components/growl/growl.ts
+++ b/components/growl/growl.ts
@@ -15,8 +15,8 @@ import {DomHandler} from '../dom/domhandler';
                      <span class="ui-growl-image fa fa-2x"
                         [ngClass]="{'fa-info-circle':msg.severity == 'info','fa-warning':msg.severity == 'warn',
                                 'fa-close':msg.severity == 'error','fa-check':msg.severity == 'success'}"></span>
+                     <span class="ui-growl-title">{{msg.summary}}</span>
                      <div class="ui-growl-message">
-                        <span class="ui-growl-title">{{msg.summary}}</span>
                         <p [innerHTML]="msg.detail"></p>
                      </div>
                      <div style="clear: both;"></div>


### PR DESCRIPTION
Fixes growl component. Messages with longer content will not push the
title down with it