### PR TITLE
Improved Dropdown render performance

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -17,7 +17,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
          <div #container [ngClass]="{'ui-dropdown ui-widget ui-state-default ui-corner-all ui-helper-clearfix':true,
             'ui-state-disabled':disabled,'ui-dropdown-open':panelVisible,'ui-state-focus':focus}" 
             (click)="onMouseclick($event,in)" [ngStyle]="style" [class]="styleClass">
-            <div class="ui-helper-hidden-accessible">
+            <div *ngIf="enableAccessibility" class="ui-helper-hidden-accessible">
                 <select [required]="required" tabindex="-1">
                     <option *ngFor="let option of options" [value]="option.value" [selected]="selectedOption == option">{{option.label}}</option>
                 </select>
@@ -38,7 +38,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
                     <span class="fa fa-search"></span>
                 </div>
                 <div #itemswrapper class="ui-dropdown-items-wrapper" [style.max-height]="scrollHeight||'auto'">
-                    <ul class="ui-dropdown-items ui-dropdown-list ui-widget-content ui-widget ui-corner-all ui-helper-reset">
+                    <ul *ngIf="panelVisible" class="ui-dropdown-items ui-dropdown-list ui-widget-content ui-widget ui-corner-all ui-helper-reset">
                         <li *ngFor="let option of optionsToDisplay;let i=index" 
                             [ngClass]="{'ui-dropdown-item ui-corner-all':true, 'ui-state-highlight':(selectedOption == option), 
                             'ui-dropdown-item-empty':!option.label||option.label.length === 0}"
@@ -74,6 +74,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     @Input() editable: boolean;
     
     @Input() appendTo: any;
+    
+    @Input() enableAccessibility: boolean = true;
     
     @Output() onChange: EventEmitter<any> = new EventEmitter();
     

--- a/showcase/demo/dropdown/dropdown.html
+++ b/showcase/demo/dropdown/dropdown.html
@@ -199,6 +199,12 @@ export class MyModel &#123;
                             <td>null</td>
                             <td>Target element to attach the overlay, valid values are "body" or a local template variable of another element.</td>
                         </tr>
+                        <tr>
+                            <td>enableAccessibility</td>
+                            <td>boolean</td>
+                            <td>true</td>
+                            <td>When present, it renders a hidden select list used for accessibility. Set to false if accessibility is not needed to improve render performance.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Drastically improves initial render times for dropdown component when there are a large number of dropdowns on the page (>100).

In a test rendering 100 dropdowns render speed dropped from >3seconds to render, to less than 300ms.

Fix contains two parts; only rendering the dropdown list panel to the DOM when needed, instead of eagerly  rendering it for every dropdown, and also optionally removing the hidden accessibility select list when it's not needed.

Fixes remaining issues for https://github.com/primefaces/primeng/issues/1749