### PR TITLE
Improve Calendar initial render performance

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -32,7 +32,7 @@ export interface LocaleSettings {
             </template>
             <div #datepicker class="ui-datepicker ui-widget ui-widget-content ui-helper-clearfix ui-corner-all" [ngClass]="{'ui-datepicker-inline':inline,'ui-shadow':!inline,'ui-state-disabled':disabled,'ui-datepicker-timeonly':timeOnly}" 
                 [ngStyle]="{'display': inline ? 'inline-block' : (overlayVisible ? 'block' : 'none')}" (click)="onDatePickerClick($event)" [@overlayState]="inline ? 'visible' : (overlayVisible ? 'visible' : 'hidden')">
-                <div class="ui-datepicker-header ui-widget-header ui-helper-clearfix ui-corner-all" *ngIf="!timeOnly">
+                <div class="ui-datepicker-header ui-widget-header ui-helper-clearfix ui-corner-all" *ngIf="!timeOnly && (overlayVisible || inline)">
                     <a class="ui-datepicker-prev ui-corner-all" href="#" (click)="prevMonth($event)">
                         <span class="fa fa-angle-left"></span>
                     </a>
@@ -50,7 +50,7 @@ export interface LocaleSettings {
                         <span class="ui-datepicker-year" *ngIf="!yearNavigator">{{currentYear}}</span>
                     </div>
                 </div>
-                <table class="ui-datepicker-calendar" *ngIf="!timeOnly">
+                <table class="ui-datepicker-calendar" *ngIf="!timeOnly && (overlayVisible || inline)">
                     <thead>
                         <tr>
                             <th scope="col" *ngFor="let weekDay of weekDays;let begin = first; let end = last">


### PR DESCRIPTION
Drastically improves initial render times for Calendar component when there are a large number of calendars on the page (>100).

In a test rendering 100 calendars render speed dropped from >4seconds to render, to less than 400ms.

Fix involves only rendering the calendar component when the overlay is display (either when the input field has focus, or is set to inline mode).

Fixes remaining issues for #1785 