### PR TITLE
Added panelStyle and panelStyleClass attributes to dropdown component

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -31,8 +31,8 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
             <div class="ui-dropdown-trigger ui-state-default ui-corner-right">
                 <span class="fa fa-fw fa-caret-down ui-c"></span>
             </div>
-            <div #panel class="ui-dropdown-panel ui-widget-content ui-corner-all ui-helper-hidden ui-shadow" 
-                [style.display]="panelVisible ? 'block' : 'none'">
+            <div #panel [ngClass]="{'ui-dropdown-panel ui-widget-content ui-corner-all ui-helper-hidden ui-shadow': true}" 
+                [style.display]="panelVisible ? 'block' : 'none'" [ngStyle]="panelStyle" [class]="panelStyleClass">
                 <div *ngIf="filter" class="ui-dropdown-filter-container" (input)="onFilter($event)" (click)="$event.stopPropagation()">
                     <input type="text" autocomplete="off" class="ui-dropdown-filter ui-inputtext ui-widget ui-state-default ui-corner-all">
                     <span class="fa fa-search"></span>
@@ -62,8 +62,12 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     @Input() filter: boolean;
 
     @Input() style: any;
+    
+    @Input() panelStyle: any;
 
     @Input() styleClass: string;
+    
+    @Input() panelStyleClass: string;
     
     @Input() disabled: boolean;
     

--- a/showcase/demo/dropdown/dropdown.html
+++ b/showcase/demo/dropdown/dropdown.html
@@ -158,10 +158,22 @@ export class MyModel &#123;
                             <td>Inline style of the element.</td>
                         </tr>
                         <tr>
+                            <td>panelStyle</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Inline style of the opening panel element.</td>
+                        </tr>
+                        <tr>
                             <td>styleClass</td>
                             <td>string</td>
                             <td>null</td>
                             <td>Style class of the element.</td>
+                        </tr>
+                        <tr>
+                            <td>panelStyleClass</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Style class of the opening panel element.</td>
                         </tr>
                         <tr>
                             <td>filter</td>


### PR DESCRIPTION
**panelStyleClass**

Applying attribute `appendTo` to the dropdown element does not have any connection to the `original ui-dropdown` container element.
This means when we want to style a different look to a dropdown, we cannot apply the same style to its `ui-dropdown-panel` element since it is attached for instance to the body and they have no custom class on them.
This is why, we have to introduce `panelStyleClass` to make sure we can collaborate with the original `ui-dropdown` element.

**panelStyle**

Attribute `panelStyle` is very useful when we want to apply a custom width or any other style to `ui-dropdown-panel` element when `appendTo` is also applied.