### PR TITLE
Chips margin bottom for multiline

### DIFF
--- a/components/chips/chips.css
+++ b/components/chips/chips.css
@@ -16,6 +16,7 @@
     white-space: nowrap;
     position: relative;
     margin-right: .125em;
+    margin-bottom: .125em;
     border: 0 none;
     font-size: .9em;
 }


### PR DESCRIPTION
Adds the same margin to the bottom of a chip as is on its right, for same spacing if chips reach a second line.