### PR TITLE
#1880

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -1814,7 +1814,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         //headers
         for(let i = 0; i < this.columns.length; i++) {
             if(this.columns[i].field) {
-                csv += this.columns[i].field;
+                csv += this.columns[i].header || this.columns[i].field;
                 
                 if(i < (this.columns.length - 1)) {
                     csv += this.csvSeparator;


### PR DESCRIPTION
Export CSV should use headers value as column name if provided

###Defect Fixes
The column header names in the excel file are the same as the field names, not the p-column headers, can it be changed? It makes more sense for the user to see the display headers.

###Feature Requests
As mention in #1880