### PR TITLE
Dropdown panel misaligned on filtering with appendTo

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -225,7 +225,12 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     
     ngAfterViewChecked() {
         if(this.optionsChanged) {
-            this.domHandler.relativePosition(this.panel, this.container);
+            if (this.appendTo) {
+                this.domHandler.absolutePosition(this.panel, this.container);
+            } else {
+                this.domHandler.relativePosition(this.panel, this.container);
+            }        
+        
             this.optionsChanged = false;
         }
         


### PR DESCRIPTION
In case of appendTo property is used on p-dropdown when typing into the filter the container of the options goes to the upper left corner. This is because appendTo property is not checked and position is always calculated as a relative position. In the proposed fix i check if this.appendTo property is used and if so, absolutePosition function is called instead of the relativePosition.