### PR TITLE
Dialog positioning fix

### DIFF
--- a/components/dialog/dialog.ts
+++ b/components/dialog/dialog.ts
@@ -224,8 +224,8 @@ export class Dialog implements AfterViewInit,AfterViewChecked,OnDestroy {
             this.container.style.visibility = 'visible';
         }
         let viewport = this.domHandler.getViewport();
-        let x = (viewport.width - elementWidth) / 2;
-        let y = (viewport.height - elementHeight) / 2;
+        let x = Math.max((viewport.width - elementWidth) / 2, 0);
+        let y = Math.max((viewport.height - elementHeight) / 2, 0);
 
         this.container.style.left = x + 'px';
         this.container.style.top = y + 'px';


### PR DESCRIPTION
Fixing bug where large dialog content or small screens would cause the dialog to be positioned outside the viewport. See issue #1925 