### PR TITLE
Add timezone property to Schedule

### DIFF
--- a/components/schedule/schedule.ts
+++ b/components/schedule/schedule.ts
@@ -80,6 +80,8 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,AfterViewChecked {
     @Input() eventConstraint: any;
     
     @Input() locale: any;
+    
+    @Input() timezone: boolean | string = false;
 
     @Input() eventRender: Function;
     
@@ -139,6 +141,7 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,AfterViewChecked {
             aspectRatio: this.aspectRatio,
             eventLimit: this.eventLimit,
             defaultDate: this.defaultDate,
+            timezone: this.timezone,
             editable: this.editable,
             droppable: this.droppable,
             eventStartEditable: this.eventStartEditable,


### PR DESCRIPTION
Not sure if this counts as a defect fix or a minor feature. I believe issue #1942 is caused by the missing attribute that this PR adds.

At the moment it is not possible to pass the timezone attribute to Fullcalendar through the Schedule component. Please consider including this feature in 2.0 final.