### PR TITLE
Avoid negative offset when positioning

### DIFF
--- a/components/dom/domhandler.ts
+++ b/components/dom/domhandler.ts
@@ -100,7 +100,8 @@ export class DomHandler {
         let viewport = this.getViewport();
         let top, left;
 
-        if (targetOffset.top + targetOuterHeight + elementOuterHeight > viewport.height)
+        if ((targetOffset.top + targetOuterHeight + elementOuterHeight > viewport.height) &&
+          (targetOffset.top + windowScrollTop > elementOuterHeight))
             top = targetOffset.top + windowScrollTop - elementOuterHeight;
         else
             top = targetOuterHeight + targetOffset.top + windowScrollTop;


### PR DESCRIPTION
This fixes issue #1904.

I have a large-ish OverlayPanel that constantly gets negative values for top but would be usable with this patch (and the user would have to scroll a little bit the page).

Of course, with the negative value the panel is entirely unusable as the close button is not accessible.