### PR TITLE
Implement styleClass for ui-treenode element on Tree

### DIFF
--- a/components/common/api.ts
+++ b/components/common/api.ts
@@ -60,6 +60,7 @@ export interface TreeNode {
     type?: string;
     parent?: TreeNode;
     partialSelected?: boolean;
+    styleClass?: string;
 }
 
 export interface Confirmation {

--- a/components/tree/tree.ts
+++ b/components/tree/tree.ts
@@ -27,7 +27,7 @@ export class TreeNodeTemplateLoader implements OnInit {
     selector: 'p-treeNode',
     template: `
         <template [ngIf]="node">
-            <li class="ui-treenode" *ngIf="!tree.horizontal" [ngClass]="{'ui-treenode-leaf': isLeaf()}">
+            <li class="ui-treenode {{node.styleClass}}" *ngIf="!tree.horizontal" [ngClass]="{'ui-treenode-leaf': isLeaf()}">
                 <div class="ui-treenode-content" (click)="onNodeClick($event)" (contextmenu)="onNodeRightClick($event)"
                     [ngClass]="{'ui-treenode-selectable':tree.selectionMode}">
                     <span class="ui-tree-toggler  fa fa-fw" [ngClass]="{'fa-caret-right':!node.expanded,'fa-caret-down':node.expanded}"


### PR DESCRIPTION
This adds the styleClass property for ui-treenode elements. The documentation shows 'styleClass' as a property of the TreeNode API, however the current codebase does not include this.  Issue #1963 describes this further.