### PR TITLE
Use chart.js's `update()` method when refreshing

### DIFF
--- a/components/chart/chart.ts
+++ b/components/chart/chart.ts
@@ -68,8 +68,7 @@ export class UIChart implements AfterViewInit, OnDestroy {
     
     refresh() {
         if(this.chart) {
-            this.chart.destroy();
-            this.initChart();
+            this.chart.update();
         }
     }
     


### PR DESCRIPTION
If you destroy and re-init the chart every time it needs to be refreshed, it will not smoothly animate between data sets. Chart.js provides an `update()` method for exactly this purpose.

### Defect Fixes
#2102

### Instead of this:
![licecap](https://cloud.githubusercontent.com/assets/1121544/23047644/696f27ee-f4b1-11e6-99cf-1a18085b027f.gif)

### It should be doing this (I hacked PrimeNG locally to do what I want):
![licecap2](https://cloud.githubusercontent.com/assets/1121544/23047652/7312cb70-f4b1-11e6-8561-d3883bc8d118.gif)
