### PR TITLE
AutoComplete - added ability to optionally auto select first suggestion

### DIFF
--- a/components/autocomplete/autocomplete.ts
+++ b/components/autocomplete/autocomplete.ts
@@ -95,6 +95,8 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
     @Input() multiple: boolean;
 
     @Input() tabindex: number;
+
+    @Input() autoSelectSuggestion: boolean;
     
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     
@@ -146,6 +148,9 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
             if(this.suggestions && this.suggestions.length) {
                 this.show();
                 this.suggestionsUpdated = true;
+                if (this.autoSelectSuggestion) {
+                    this.calculateOptionToHighlight();
+                }
             }
             else {
                 this.hide();
@@ -316,37 +321,20 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
     }
         
     onKeydown(event) {
-        if(this.panelVisible) {
-            let highlightItemIndex = this.findOptionIndex(this.highlightOption);
-            
+        if(this.panelVisible) {             
             switch(event.which) {
                 //down
                 case 40:
-                    if(highlightItemIndex != -1) {
-                        var nextItemIndex = highlightItemIndex + 1;
-                        if(nextItemIndex != (this.suggestions.length)) {
-                            this.highlightOption = this.suggestions[nextItemIndex];
-                            this.highlightOptionChanged = true;
-                        }
-                    }
-                    else {
-                        this.highlightOption = this.suggestions[0];
-                    }
-                    
+                    this.calculateOptionToHighlight(true);
                     event.preventDefault();
                 break;
-                
+
                 //up
                 case 38:
-                    if(highlightItemIndex > 0) {
-                        let prevItemIndex = highlightItemIndex - 1;
-                        this.highlightOption = this.suggestions[prevItemIndex];
-                        this.highlightOptionChanged = true;
-                    }
-                    
+                    this.calculateOptionToHighlight(false);
                     event.preventDefault();
                 break;
-                
+
                 //enter
                 case 13:
                     if(this.highlightOption) {
@@ -361,7 +349,6 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
                     this.hide();
                     event.preventDefault();
                 break;
-
                 
                 //tab
                 case 9:
@@ -434,6 +421,36 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
         }
                 
         return index;
+    }
+
+    calculateOptionToHighlight(selectNextOption?: boolean) {
+        let highlightItemIndex = this.findOptionIndex(this.highlightOption);
+
+        // Nothing is currently highlighted so highlight the first suggestion
+        if (highlightItemIndex === -1 && selectNextOption === null) {
+            let nextItemIndex = 0;
+            if (nextItemIndex != (this.suggestions.length)) {
+                this.highlightOption = this.suggestions[nextItemIndex];
+                this.highlightOptionChanged = true;
+            }
+        }
+        // Something is highlighted and we want to highlight the next option
+        else if (highlightItemIndex != -1 && selectNextOption) {
+            let nextItemIndex = highlightItemIndex + 1;
+            if (nextItemIndex != (this.suggestions.length)) {
+                this.highlightOption = this.suggestions[nextItemIndex];
+                this.highlightOptionChanged = true;
+            }
+        }
+        // Something is highlighted and we want to highlight the previous option
+        else if (highlightItemIndex > 0 && selectNextOption === false) {
+            let prevItemIndex = highlightItemIndex - 1;
+            this.highlightOption = this.suggestions[prevItemIndex];
+            this.highlightOptionChanged = true;
+        }
+        else {
+            this.highlightOption = this.suggestions[0];
+        }
     }
     
     updateFilledState() {

--- a/showcase/demo/autocomplete/autocompletedemo.html
+++ b/showcase/demo/autocomplete/autocompletedemo.html
@@ -308,6 +308,12 @@ export class AutoCompleteDemo &#123;
                             <td>null</td>
                             <td>Index of the element in tabbing order.</td>
                         </tr>
+                        <tr>
+                            <td>autoSelectSuggestion</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>Auto selects the first suggestion after every search.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Currently after every search, no suggestions are highlighted in the suggestion list, even if there is only one suggestion remaining. This means that after every search, an extra step is forced on the user as they have to either click the suggestion using the mouse or by using the down arrow key. 

I've added an extra `@Input()` to the autocomplete component called `autoSelectSuggestion` which defaults to `false`. Passing `true` results in the first result of every search being auto selected in the suggestion list. This is especially useful for multi select fields when choosing many options, or as mentioned above, when there is only one suggestion remaining. This results in less keyboard/mouse interaction overall.

As part of this PR I also tidied up the logic for figuring out which option to highlight by moving it into its own function, which also tidies up the `onKeydown` function. Calling the logic to trigger the auto select happens inside the `ngDoCheck` using a simple `if` statement check on the `autoSelectSuggestion` property.

Addresses issue discussed in #2040 