### PR TITLE
Feature to allow html in confirmdialog message

### DIFF
--- a/components/confirmdialog/confirmdialog.ts
+++ b/components/confirmdialog/confirmdialog.ts
@@ -19,7 +19,7 @@ import {Subscription}   from 'rxjs/Subscription';
             </div>
             <div class="ui-dialog-content ui-widget-content">
                 <i [class]="icon"></i>
-                <span class="ui-confirmdialog-message">{{message}}</span>
+                <span class="ui-confirmdialog-message" [innerHTML]="message"></span>
             </div>
             <div class="ui-dialog-buttonpane ui-widget-content ui-helper-clearfix" *ngIf="footer">
                 <ng-content select="p-footer"></ng-content>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,21 @@
     "url": "https://github.com/primefaces/primeng.git"
   },
   "license": "MIT",
+  "dependencies": {
+    "@angular/common": "^2.4.0",
+    "@angular/compiler": "^2.4.0",
+    "@angular/compiler-cli": "^2.4.0",
+    "@angular/core": "^2.4.0",
+    "@angular/forms": "^2.4.0",
+    "@angular/http": "^2.4.0",
+    "@angular/platform-browser": "^2.4.0",
+    "@angular/platform-browser-dynamic": "^2.4.0",
+    "@angular/platform-server": "^2.4.0",
+    "@angular/router": "^3.4.0",
+    "core-js": "^2.4.1",
+    "rxjs": "^5.0.1",
+    "zone.js": "^0.7.0"
+  },
   "devDependencies": {
     "@types/node": "^6.0.45",
     "del": "^2.2.0",


### PR DESCRIPTION
Changed p-confirmDialog component template to allow HTML in the message property.

Basically changed this:

`<span class="ui-confirmdialog-message">{{message}}</span`

to this:

`<span class="ui-confirmdialog-message" [innerHTML]="message"></span`

