### PR TITLE
DataTable - fixed multisorting with lazy bug

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -28,13 +28,13 @@ import {BlockableUI} from '../common/api';
     `
 })
 export class DTRadioButton {
-    
+
     @Input() checked: boolean;
 
     @Output() onClick: EventEmitter<any> = new EventEmitter();
-    
+
     public hover: boolean;
-    
+
     handleClick(event) {
         this.onClick.emit(event);
     }
@@ -48,7 +48,7 @@ export class DTRadioButton {
                 <input type="checkbox" [checked]="checked">
             </div>
             <div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default" (click)="handleClick($event)"
-                        (mouseover)="hover=true" (mouseout)="hover=false" 
+                        (mouseover)="hover=true" (mouseout)="hover=false"
                         [ngClass]="{'ui-state-hover':hover&&!disabled,'ui-state-active':checked&&!disabled,'ui-state-disabled':disabled}">
                 <span class="ui-chkbox-icon ui-c" [ngClass]="{'fa fa-check':checked}"></span>
             </div>
@@ -56,15 +56,15 @@ export class DTRadioButton {
     `
 })
 export class DTCheckbox {
-    
+
     @Input() checked: boolean;
-    
+
     @Input() disabled: boolean;
 
     @Output() onChange: EventEmitter<any> = new EventEmitter();
-    
+
     public hover: boolean;
-    
+
     handleClick(event) {
         if(!this.disabled) {
             this.onChange.emit({originalEvent: event, checked: !this.checked});
@@ -77,13 +77,13 @@ export class DTCheckbox {
     template: ``
 })
 export class RowExpansionLoader {
-        
+
     @Input() template: TemplateRef<any>;
-    
+
     @Input() rowData: any;
-    
+
     constructor(public viewContainer: ViewContainerRef) {}
-    
+
     ngOnInit() {
         let view = this.viewContainer.createEmbeddedView(this.template, {
             '\$implicit': this.rowData
@@ -96,7 +96,7 @@ export class RowExpansionLoader {
     template: `
         <template ngFor let-col [ngForOf]="columns" let-lastCol="last">
             <th #headerCell [ngStyle]="col.style" [class]="col.styleClass" [style.display]="col.hidden ? 'none' : 'table-cell'" (click)="dt.sort($event,col)" [attr.colspan]="col.colspan" [attr.rowspan]="col.rowspan"
-                [ngClass]="{'ui-state-default ui-unselectable-text':true, 'ui-sortable-column': col.sortable, 'ui-state-active': dt.isSorted(col), 'ui-resizable-column': dt.resizableColumns, 'ui-selection-column':col.selectionMode}" 
+                [ngClass]="{'ui-state-default ui-unselectable-text':true, 'ui-sortable-column': col.sortable, 'ui-state-active': dt.isSorted(col), 'ui-resizable-column': dt.resizableColumns, 'ui-selection-column':col.selectionMode}"
                 (dragstart)="dt.onColumnDragStart($event)" (dragover)="dt.onColumnDragover($event)" (dragleave)="dt.onColumnDragleave($event)" (drop)="dt.onColumnDrop($event)" (mousedown)="dt.onHeaderMousedown($event,headerCell)"
                 [attr.tabindex]="col.sortable ? tabindex : null" (keydown)="dt.onHeaderKeydown($event,col)">
                 <span class="ui-column-resizer" *ngIf="dt.resizableColumns && ((dt.columnResizeMode == 'fit' && !lastCol) || dt.columnResizeMode == 'expand')" (mousedown)="dt.initColumnResize($event)"></span>
@@ -106,7 +106,7 @@ export class RowExpansionLoader {
                 </span>
                 <span class="ui-sortable-column-icon fa fa-fw fa-sort" *ngIf="col.sortable"
                      [ngClass]="{'fa-sort-desc': (dt.getSortOrder(col) == -1),'fa-sort-asc': (dt.getSortOrder(col) == 1)}"></span>
-                <input type="text" pInputText class="ui-column-filter" [attr.placeholder]="col.filterPlaceholder" *ngIf="col.filter&&!col.filterTemplate" [value]="dt.filters[col.field] ? dt.filters[col.field].value : ''" 
+                <input type="text" pInputText class="ui-column-filter" [attr.placeholder]="col.filterPlaceholder" *ngIf="col.filter&&!col.filterTemplate" [value]="dt.filters[col.field] ? dt.filters[col.field].value : ''"
                     (click)="dt.onFilterInputClick($event)" (keyup)="dt.onFilterKeyup($event.target.value, col.field, col.filterMatchMode)"/>
                 <p-columnFilterTemplateLoader [column]="col" *ngIf="col.filterTemplate"></p-columnFilterTemplateLoader>
                 <p-dtCheckbox *ngIf="col.selectionMode=='multiple'" (onChange)="dt.toggleRowsWithCheckbox($event)" [checked]="dt.allSelected" [disabled]="dt.isEmpty()"></p-dtCheckbox>
@@ -115,9 +115,9 @@ export class RowExpansionLoader {
     `
 })
 export class ColumnHeaders {
-        
+
     constructor(@Inject(forwardRef(() => DataTable)) public dt:DataTable) {}
-    
+
     @Input("pColumnHeaders") columns: Column[];
 }
 
@@ -135,9 +135,9 @@ export class ColumnHeaders {
     `
 })
 export class ColumnFooters {
-        
+
     constructor(@Inject(forwardRef(() => DataTable)) public dt:DataTable) {}
-    
+
     @Input("pColumnFooters") columns: Column[];
 }
 
@@ -145,7 +145,7 @@ export class ColumnFooters {
     selector: '[pTableBody]',
     template: `
         <template ngFor let-rowData [ngForOf]="dt.dataToRender" let-even="even" let-odd="odd" let-rowIndex="index">
-            <tr #rowGroupElement class="ui-widget-header ui-rowgroup-header" 
+            <tr #rowGroupElement class="ui-widget-header ui-rowgroup-header"
                 *ngIf="dt.rowGroupMode=='subheader' && (rowIndex === 0||(dt.resolveFieldData(rowData,dt.groupField) !== dt.resolveFieldData(dt.dataToRender[rowIndex - 1], dt.groupField)))"
                 (click)="dt.onRowGroupClick($event)" [ngStyle]="{'cursor': dt.sortableRowGroup ? 'pointer' : 'auto'}">
                 <td [attr.colspan]="columns.length">
@@ -198,11 +198,11 @@ export class ColumnFooters {
     `
 })
 export class TableBody {
-        
+
     constructor(@Inject(forwardRef(() => DataTable)) public dt:DataTable) {}
-    
+
     @Input("pTableBody") columns: Column[];
-    
+
     visibleColumns() {
         return this.columns ? this.columns.filter(c => !c.hidden): [];
     }
@@ -237,85 +237,85 @@ export class TableBody {
     `
 })
 export class ScrollableView implements AfterViewInit,AfterViewChecked,OnDestroy {
-        
+
     constructor(@Inject(forwardRef(() => DataTable)) public dt:DataTable, public domHandler: DomHandler, public el: ElementRef, public renderer: Renderer) {}
-    
+
     @Input("pScrollableView") columns: Column[];
-    
+
     @ViewChild('scrollHeader') scrollHeaderViewChild: ElementRef;
-    
+
     @ViewChild('scrollHeaderBox') scrollHeaderBoxViewChild: ElementRef;
-    
+
     @ViewChild('scrollBody') scrollBodyViewChild: ElementRef;
-    
+
     @ViewChild('scrollTable') scrollTableViewChild: ElementRef;
-    
+
     @ViewChild('scrollTableWrapper') scrollTableWrapperViewChild: ElementRef;
-        
+
     @Input() frozen: boolean;
-    
+
     @Input() width: string;
-    
+
     @Input() virtualScroll: boolean;
-        
+
     @Output() onVirtualScroll: EventEmitter<any> = new EventEmitter();
-    
+
     @Input() loading: boolean;
-                    
+
     public scrollBody: HTMLDivElement;
-    
+
     public scrollHeader: HTMLDivElement
-    
+
     public scrollHeaderBox: HTMLDivElement;
-    
+
     public scrollTable: HTMLDivElement;
-    
+
     public scrollTableWrapper: HTMLDivElement;
-        
+
     public bodyScrollListener: Function;
-    
+
     public headerScrollListener: Function;
-    
+
     public scrollBodyMouseWheelListener: Function;
-    
+
     public scrollFunction: Function;
-    
+
     public rowHeight: number;
-        
+
     public scrollTimeout: any;
-                            
+
     ngAfterViewInit() {
         this.initScrolling();
     }
-    
+
     ngAfterViewChecked() {
         if(this.virtualScroll && !this.rowHeight) {
              let row = this.domHandler.findSingle(this.scrollTable, 'tr.ui-widget-content');
              if(row) {
                  this.rowHeight = this.domHandler.getOuterHeight(row);
-             }             
+             }
         }
     }
-        
+
     initScrolling() {
         this.scrollHeader = <HTMLDivElement> this.scrollHeaderViewChild.nativeElement;
         this.scrollHeaderBox = <HTMLDivElement> this.scrollHeaderBoxViewChild.nativeElement;
         this.scrollBody = <HTMLDivElement> this.scrollBodyViewChild.nativeElement;
         this.scrollTable = <HTMLDivElement> this.scrollTableViewChild.nativeElement;
         this.scrollTableWrapper = <HTMLDivElement> this.scrollTableWrapperViewChild.nativeElement;
-        
+
         if(!this.frozen) {
             let frozenView = this.el.nativeElement.previousElementSibling;
             if(frozenView) {
                 var frozenScrollBody = this.domHandler.findSingle(frozenView, '.ui-datatable-scrollable-body');
             }
-            
+
             this.bodyScrollListener = this.renderer.listen(this.scrollBody, 'scroll', (event) => {
                 this.scrollHeaderBox.style.marginLeft = -1 * this.scrollBody.scrollLeft + 'px';
                 if(frozenScrollBody) {
                     frozenScrollBody.scrollTop = this.scrollBody.scrollTop;
                 }
-                
+
                 if(this.virtualScroll) {
                     clearTimeout(this.scrollTimeout);
                     this.scrollTimeout = setTimeout(() => {
@@ -331,43 +331,43 @@ export class ScrollableView implements AfterViewInit,AfterViewChecked,OnDestroy 
                                 page: page
                             });
                             this.scrollTable.style.top = ((page - 1) * pageHeight) + 'px';
-                        }  
+                        }
                     }, 200);
                 }
             });
-            
+
             //to trigger change detection
             this.scrollBodyMouseWheelListener = this.renderer.listen(this.scrollBody, 'mousewheel', (event) => {});
-            
+
             this.headerScrollListener = this.renderer.listen(this.scrollHeader, 'scroll', () => {
                 this.scrollHeader.scrollLeft = 0;
             });
         }
-        
+
         let scrollBarWidth = this.domHandler.calculateScrollbarWidth();
         if(!this.frozen)
-            this.scrollHeaderBox.style.marginRight = scrollBarWidth + 'px';            
+            this.scrollHeaderBox.style.marginRight = scrollBarWidth + 'px';
         else
-            this.scrollBody.style.paddingBottom = scrollBarWidth + 'px';        
+            this.scrollBody.style.paddingBottom = scrollBarWidth + 'px';
     }
-    
+
     get virtualTableHeight(): string {
         let totalRecords = this.dt.lazy ? this.dt.totalRecords : (this.dt.value ? this.dt.value.length: 0);
         return (totalRecords * this.rowHeight) + 'px';
     }
-                
+
     ngOnDestroy() {
         if(this.bodyScrollListener) {
             this.bodyScrollListener();
         }
-        
+
         if(this.scrollBodyMouseWheelListener) {
             this.scrollBodyMouseWheelListener();
         }
-        
+
         if(this.headerScrollListener) {
             this.headerScrollListener();
-        }       
+        }
     }
 }
 
@@ -398,23 +398,23 @@ export class ScrollableView implements AfterViewInit,AfterViewChecked,OnDestroy 
                     <tbody [ngClass]="{'ui-datatable-data ui-widget-content': true, 'ui-datatable-hoverable-rows': (rowHover||selectionMode)}" [pTableBody]="columns"></tbody>
                 </table>
             </div>
-            
+
             <template [ngIf]="scrollable">
                 <div class="ui-datatable-scrollable-wrapper ui-helper-clearfix" [ngClass]="{'max-height':scrollHeight}">
-                    <div *ngIf="frozenColumns" [pScrollableView]="frozenColumns" frozen="true" 
+                    <div *ngIf="frozenColumns" [pScrollableView]="frozenColumns" frozen="true"
                         [ngStyle]="{'width':this.frozenWidth}" class="ui-datatable-scrollable-view ui-datatable-frozen-view"></div>
                     <div [pScrollableView]="scrollableColumns" [ngStyle]="{'width':this.unfrozenWidth, 'left': this.frozenWidth}"
                         class="ui-datatable-scrollable-view" [virtualScroll]="virtualScroll" (onVirtualScroll)="onVirtualScroll($event)" [loading]="loading"
                         [ngClass]="{'ui-datatable-unfrozen-view': frozenColumns}"></div>
                 </div>
             </template>
-            
+
             <p-paginator [rows]="rows" [first]="first" [totalRecords]="totalRecords" [pageLinkSize]="pageLinks" styleClass="ui-paginator-bottom"
                 (onPageChange)="paginate($event)" [rowsPerPageOptions]="rowsPerPageOptions" *ngIf="paginator && paginatorPosition!='top' || paginatorPosition =='both'"></p-paginator>
             <div class="ui-datatable-footer ui-widget-header" *ngIf="footer">
                 <ng-content select="p-footer"></ng-content>
             </div>
-            
+
             <div class="ui-column-resizer-helper ui-state-highlight" style="display:none"></div>
             <span class="fa fa-arrow-down ui-datatable-reorder-indicator-up" style="position: absolute; display: none;"></span>
             <span class="fa fa-arrow-up ui-datatable-reorder-indicator-down" style="position: absolute; display: none;"></span>
@@ -437,7 +437,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Input() rowsPerPageOptions: number[];
 
     @Input() responsive: boolean;
-    
+
     @Input() stacked: boolean;
 
     @Input() selectionMode: string;
@@ -447,7 +447,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Output() selectionChange: EventEmitter<any> = new EventEmitter();
 
     @Input() editable: boolean;
-    
+
     @Output() onRowClick: EventEmitter<any> = new EventEmitter();
 
     @Output() onRowSelect: EventEmitter<any> = new EventEmitter();
@@ -455,9 +455,9 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Output() onRowUnselect: EventEmitter<any> = new EventEmitter();
 
     @Output() onRowDblclick: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onHeaderCheckboxToggle: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onContextMenuSelect: EventEmitter<any> = new EventEmitter();
 
     @Input() filterDelay: number = 300;
@@ -477,21 +477,21 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Output() onColReorder: EventEmitter<any> = new EventEmitter();
 
     @Input() scrollable: boolean;
-    
+
     @Input() virtualScroll: boolean;
 
     @Input() scrollHeight: any;
 
     @Input() scrollWidth: any;
-    
+
     @Input() frozenWidth: any;
-    
+
     @Input() unfrozenWidth: any;
 
     @Input() style: any;
 
     @Input() styleClass: string;
-    
+
     @Input() tableStyle: any;
 
     @Input() tableStyleClass: string;
@@ -503,23 +503,23 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Input() sortField: string;
 
     @Input() sortOrder: number = 1;
-    
+
     @Input() groupField: string;
 
     @Input() multiSortMeta: SortMeta[];
-    
+
     @Input() contextMenu: any;
-    
+
     @Input() csvSeparator: string = ',';
-    
+
     @Input() exportFilename: string = 'download';
-    
+
     @Input() emptyMessage: string = 'No records found';
-    
+
     @Input() paginatorPosition: string = 'bottom';
-    
+
     @Input() metaKeySelection: boolean = true;
-            
+
     @Output() onEditInit: EventEmitter<any> = new EventEmitter();
 
     @Output() onEditComplete: EventEmitter<any> = new EventEmitter();
@@ -527,59 +527,59 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Output() onEdit: EventEmitter<any> = new EventEmitter();
 
     @Output() onEditCancel: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onPage: EventEmitter<any> = new EventEmitter();
-        
+
     @Output() onSort: EventEmitter<any> = new EventEmitter();
-            
+
     @Output() onFilter: EventEmitter<any> = new EventEmitter();
 
     @ContentChild(Header) header;
 
     @ContentChild(Footer) footer;
-    
+
     @Input() expandableRows: boolean;
-    
+
     @Input() expandedRows: any[];
-    
+
     @Input() expandableRowGroups: boolean;
-    
+
     @Input() rowExpandMode: string = 'multiple';
-    
+
     @Input() public expandedRowsGroups: any[];
-    
+
     @Input() tabindex: number = 1;
-    
+
     @Input() rowStyleClass: Function;
-    
-    @Input() rowGroupMode: string; 
-    
-    @Input() sortableRowGroup: boolean = true; 
-    
-    @Input() sortFile: string; 
+
+    @Input() rowGroupMode: string;
+
+    @Input() sortableRowGroup: boolean = true;
+
+    @Input() sortFile: string;
 
     @Input() rowHover: boolean;
-    
+
     @Input() first: number = 0;
-    
+
     @Input() public filters: {[s: string]: FilterMetadata;} = {};
-        
+
     @Output() onRowExpand: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onRowCollapse: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onRowGroupExpand: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onRowGroupCollapse: EventEmitter<any> = new EventEmitter();
-        
+
     @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate>;
-    
+
     @ContentChildren(Column) cols: QueryList<Column>;
-    
+
     @ContentChild(HeaderColumnGroup) headerColumnGroup: HeaderColumnGroup;
-    
+
     @ContentChild(FooterColumnGroup) footerColumnGroup: FooterColumnGroup;
-        
+
     public dataToRender: any[];
 
     public page: number = 0;
@@ -589,68 +589,68 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     public filteredValue: any[];
 
     public columns: Column[];
-    
+
     public frozenColumns: Column[];
-    
+
     public scrollableColumns: Column[];
 
     public columnsChanged: boolean = false;
-    
+
     public dataChanged: boolean = false;
-    
+
     public stopSortPropagation: boolean;
-    
+
     public sortColumn: Column;
-    
+
     public columnResizing: boolean;
-    
+
     public lastResizerHelperX: number;
-        
+
     public documentColumnResizeListener: Function;
-    
+
     public documentColumnResizeEndListener: Function;
-    
+
     public resizerHelper: any;
-    
+
     public resizeColumn: any;
-    
+
     public reorderIndicatorUp: any;
-    
+
     public reorderIndicatorDown: any;
-    
+
     public draggedColumn: any;
-    
+
     public dropPosition: number;
-            
+
     public tbody: any;
-    
+
     public rowTouched: boolean;
-    
+
     public rowGroupToggleClick: boolean;
-    
+
     public editingCell: any;
-    
+
     public stopFilterPropagation: boolean;
-    
+
     public rowGroupMetadata: any;
-    
+
     public rowGroupHeaderTemplate: TemplateRef<any>;
-    
+
     public rowGroupFooterTemplate: TemplateRef<any>;
-    
+
     public rowExpansionTemplate: TemplateRef<any>;
-    
+
     public scrollBarWidth: number;
-    
+
     public loading: boolean;
-    
+
     differ: any;
 
     globalFilterFunction: any;
-    
+
     columnsSubscription: Subscription;
-    
-    constructor(public el: ElementRef, public domHandler: DomHandler, differs: IterableDiffers, 
+
+    constructor(public el: ElementRef, public domHandler: DomHandler, differs: IterableDiffers,
             public renderer: Renderer, public changeDetector: ChangeDetectorRef, public objectUtils: ObjectUtils) {
         this.differ = differs.find([]).create(null);
     }
@@ -660,25 +660,25 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             this.onLazyLoad.emit(this.createLazyLoadMetadata());
         }
     }
-    
+
     ngAfterContentInit() {
         this.initColumns();
-        
+
         this.columnsSubscription = this.cols.changes.subscribe(_ => {
             this.initColumns();
             this.changeDetector.markForCheck();
         });
-        
+
         this.templates.forEach((item) => {
             switch(item.getType()) {
                 case 'rowexpansion':
                     this.rowExpansionTemplate = item.template;
                 break;
-                
+
                 case 'rowgroupheader':
                     this.rowGroupHeaderTemplate = item.template;
                 break;
-                
+
                 case 'rowgroupfooter':
                     this.rowGroupFooterTemplate = item.template;
                 break;
@@ -698,8 +698,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
 
             this.columnsChanged = false;
         }
-        
-        if(this.dataChanged) {            
+
+        if(this.dataChanged) {
             this.dataChanged = false;
         }
     }
@@ -735,15 +735,15 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                     this._filter();
                 }
             }
-                        
+
             if(this.stopSortPropagation) {
                 this.stopSortPropagation = false;
             }
-            else if(!this.lazy && (this.sortField||this.multiSortMeta)) {  
+            else if(!this.lazy && (this.sortField||this.multiSortMeta)) {
                 if(!this.sortColumn && this.columns) {
                     this.sortColumn = this.columns.find(col => col.field === this.sortField && col.sortable === 'custom');
-                }              
-                
+                }
+
                 if(this.sortMode == 'single')
                     this.sortSingle();
                 else if(this.sortMode == 'multiple')
@@ -753,23 +753,23 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             this.updateDataToRender(this.filteredValue||this.value);
         }
     }
-    
+
     initColumns(): void {
         this.columns = this.cols.toArray();
-        
+
         if(this.scrollable) {
             this.scrollableColumns = [];
             this.cols.forEach((col) => {
                 if(col.frozen) {
                     this.frozenColumns = this.frozenColumns||[];
                     this.frozenColumns.push(col);
-                } 
+                }
                 else {
                     this.scrollableColumns.push(col);
                 }
             });
         }
-        
+
         this.columnsChanged = true;
     }
 
@@ -794,7 +794,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             return null;
         }
     }
-    
+
     updateRowGroupMetadata() {
         this.rowGroupMetadata = {};
         if(this.dataToRender) {
@@ -803,7 +803,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 let group = this.resolveFieldData(rowData, this.sortField);
                 if(i == 0) {
                     this.rowGroupMetadata[group] = {index:0, size: 1};
-                }  
+                }
                 else {
                     let previousRowData = this.dataToRender[i-1];
                     let previousRowGroup = this.resolveFieldData(previousRowData, this.sortField);
@@ -817,7 +817,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             }
         }
     }
-    
+
     updatePaginator() {
         //total records
         this.totalRecords = this.lazy ? this.totalRecords : (this.value ? this.value.length: 0);
@@ -836,7 +836,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         if(this.lazy) {
             this.stopFilterPropagation = true;
             this.onLazyLoad.emit(this.createLazyLoadMetadata());
-        }            
+        }
         else {
             this.updateDataToRender(this.filteredValue||this.value);
         }
@@ -864,34 +864,34 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         else {
             this.dataToRender = datasource;
         }
-        
+
         if(this.rowGroupMode) {
             this.updateRowGroupMetadata();
         }
-        
+
         this.loading = false;
     }
-        
+
     onVirtualScroll(event) {
         this.loading = true;
         this.first = (event.page - 1) * this.rows;
-        
+
         if(this.lazy) {
             this.stopFilterPropagation = true;
             this.onLazyLoad.emit(this.createLazyLoadMetadata());
-        }            
+        }
         else {
             this.updateDataToRender(this.filteredValue||this.value);
         }
     }
-    
+
     onHeaderKeydown(event, column: Column) {
         if(event.keyCode == 13) {
             this.sort(event, column);
             event.preventDefault();
         }
     }
-    
+
     onHeaderMousedown(event, header: any) {
         if(this.reorderableColumns) {
             if(event.target.nodeName !== 'INPUT') {
@@ -901,12 +901,12 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             }
         }
     }
-    
+
     sort(event, column: Column) {
         if(!column.sortable) {
             return;
         }
-        
+
         let targetNode = event.target.nodeName;
         if(targetNode == 'TH' || (targetNode == 'SPAN' && !this.domHandler.hasClass(event.target, 'ui-c'))) {
             let columnSortField = column.sortField||column.field;
@@ -919,20 +919,19 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 this.stopFilterPropagation = true;
                 this.onLazyLoad.emit(this.createLazyLoadMetadata());
             }
-            else {
-                if(this.sortMode == 'multiple') {
-                    if(!this.multiSortMeta||!metaKey) {
-                        this.multiSortMeta = [];
-                    }
 
-                    this.addSortMeta({field: this.sortField, order: this.sortOrder});
-                    this.sortMultiple();
+            if(this.sortMode == 'multiple') {
+                if(!this.multiSortMeta||!metaKey) {
+                    this.multiSortMeta = [];
                 }
-                else {
-                    this.sortSingle();
-                }
+
+                this.addSortMeta({field: this.sortField, order: this.sortOrder});
+                this.sortMultiple();
             }
-            
+            else {
+                this.sortSingle();
+            }
+
             this.onSort.emit({
                 field: this.sortField,
                 order: this.sortOrder,
@@ -969,14 +968,14 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                     return (this.sortOrder * result);
                 });
             }
-            
+
             this.first = 0;
 
             if(this.hasFilter()) {
                 this._filter();
             }
         }
-        
+
         //prevent resort at ngDoCheck
         this.stopSortPropagation = true;
     }
@@ -991,7 +990,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 this._filter();
             }
         }
-        
+
         //prevent resort at ngDoCheck
         this.stopSortPropagation = true;
     }
@@ -1036,9 +1035,9 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         if(!column.sortable) {
             return false;
         }
-        
+
         let columnSortField = column.sortField||column.field;
-        
+
         if(this.sortMode === 'single') {
             return (this.sortField && columnSortField === this.sortField);
         }
@@ -1059,7 +1058,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     getSortOrder(column: Column) {
         let order = 0;
         let columnSortField = column.sortField||column.field;
-        
+
         if(this.sortMode === 'single') {
             if(this.sortField && columnSortField === this.sortField) {
                 order = this.sortOrder;
@@ -1077,13 +1076,13 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         }
         return order;
     }
-    
+
     onRowGroupClick(event) {
         if(this.rowGroupToggleClick) {
             this.rowGroupToggleClick = false;
             return;
         }
-        
+
         if(this.sortableRowGroup) {
             let targetNode = event.target.nodeName;
             if((targetNode == 'TD' || (targetNode == 'SPAN' && !this.domHandler.hasClass(event.target, 'ui-c')))) {
@@ -1098,22 +1097,22 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             }
         }
     }
-    
-    handleRowClick(event, rowData) {        
+
+    handleRowClick(event, rowData) {
         let targetNode = event.target.nodeName;
         if(targetNode == 'TD' || (targetNode == 'SPAN' && !this.domHandler.hasClass(event.target, 'ui-c'))) {
             this.onRowClick.next({originalEvent: event, data: rowData});
-            
+
             if(!this.selectionMode) {
                 return;
             }
-            
+
             let selected = this.isSelected(rowData);
             let metaSelection = this.rowTouched ? false : this.metaKeySelection;
-            
+
             if(metaSelection) {
                 let metaKey = event.metaKey||event.ctrlKey;
-                
+
                 if(selected && metaKey) {
                     if(this.isSingleSelectionMode()) {
                         this.selection = null;
@@ -1123,7 +1122,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                         this.selection.splice(this.findIndexInSelection(rowData), 1);
                         this.selectionChange.emit(this.selection);
                     }
-                    
+
                     this.onRowUnselect.emit({originalEvent: event, data: rowData, type: 'row'});
                 }
                 else {
@@ -1134,9 +1133,9 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                     else if(this.isMultipleSelectionMode()) {
                         if(metaKey)
                             this.selection = this.selection||[];
-                        else 
+                        else
                             this.selection = [];
-                        
+
                         this.selection.push(rowData);
                         this.selectionChange.emit(this.selection);
                     }
@@ -1166,18 +1165,18 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                         this.onRowSelect.emit({originalEvent: event, data: rowData, type: 'row'});
                     }
                 }
-                
+
                 this.selectionChange.emit(this.selection);
             }
         }
-        
+
         this.rowTouched = false;
     }
 
     handleRowTouchEnd(event) {
         this.rowTouched = true;
     }
-    
+
     selectRowWithRadio(event, rowData:any) {
         if(this.selection != rowData) {
             this.selection = rowData;
@@ -1185,40 +1184,40 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             this.onRowSelect.emit({originalEvent: event, data: rowData, type: 'radiobutton'});
         }
     }
-    
+
     toggleRowWithCheckbox(event,rowData) {
         let selectionIndex = this.findIndexInSelection(rowData);
         this.selection = this.selection||[];
-        
+
         if(selectionIndex != -1) {
             this.selection.splice(selectionIndex, 1);
             this.onRowUnselect.emit({originalEvent: event, data: rowData, type: 'checkbox'});
         }
-            
+
         else {
             this.selection.push(rowData);
             this.onRowSelect.emit({originalEvent: event, data: rowData, type: 'checkbox'});
         }
-                 
+
         this.selectionChange.emit(this.selection);
     }
-    
+
     toggleRowsWithCheckbox(event) {
         if(event.checked)
             this.selection = this.dataToRender.slice(0);
         else
             this.selection = [];
-            
+
         this.selectionChange.emit(this.selection);
-        
+
         this.onHeaderCheckboxToggle.emit({originalEvent: event, checked: event.checked});
     }
-    
+
     onRowRightClick(event, rowData) {
         if(this.contextMenu) {
             let selectionIndex = this.findIndexInSelection(rowData);
             let selected = selectionIndex != -1;
-            
+
             if(!selected) {
                 if(this.isSingleSelectionMode()) {
                     this.selection = rowData;
@@ -1231,7 +1230,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 }
             }
 
-            this.contextMenu.show(event);            
+            this.contextMenu.show(event);
             this.onContextMenuSelect.emit({originalEvent: event, data: rowData});
         }
     }
@@ -1265,7 +1264,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     isSelected(rowData) {
         return ((rowData && this.objectUtils.equals(rowData, this.selection)) || this.findIndexInSelection(rowData) != -1);
     }
-    
+
     get allSelected() {
         let val = true;
         if(this.dataToRender && this.selection && (this.dataToRender.length <= this.selection.length)) {
@@ -1289,32 +1288,32 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
 
         this.filterTimeout = setTimeout(() => {
             this.filter(value, field, matchMode);
-            this.filterTimeout = null;            
+            this.filterTimeout = null;
         }, this.filterDelay);
     }
-    
+
     filter(value, field, matchMode) {
         if(!this.isFilterBlank(value))
             this.filters[field] = {value: value, matchMode: matchMode};
         else if(this.filters[field])
             delete this.filters[field];
-        
-        this._filter(); 
+
+        this._filter();
     }
-    
+
     isFilterBlank(filter: any): boolean {
         if(filter !== null && filter !== undefined) {
             if((typeof filter === 'string' && filter.trim().length == 0) || (filter instanceof Array && filter.length == 0))
                 return true;
             else
                 return false;
-        } 
+        }
         return true;
     }
 
     _filter() {
         this.first = 0;
-        
+
         if(this.lazy) {
             this.stopFilterPropagation = true;
             this.onLazyLoad.emit(this.createLazyLoadMetadata());
@@ -1373,7 +1372,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
 
             this.updateDataToRender(this.filteredValue||this.value);
         }
-        
+
         this.onFilter.emit({
             filters: this.filters
         });
@@ -1418,7 +1417,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             if(value === undefined || value === null) {
                 return false;
             }
-            
+
             return value.toString().toLowerCase().indexOf(filter.toLowerCase()) !== -1;
         },
 
@@ -1434,19 +1433,19 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             let filterValue = filter.toString().toLowerCase();
             return value.toString().toLowerCase().indexOf(filterValue, value.toString().length - filterValue.length) !== -1;
         },
-        
+
         equals(value, filter): boolean {
             if(filter === undefined || filter === null || (typeof filter === 'string' && filter.trim() === '')) {
                 return true;
             }
-            
+
             if(value === undefined || value === null) {
                 return false;
             }
-            
+
             return value.toString().toLowerCase() == filter.toString().toLowerCase();
         },
-        
+
         in(value, filter: any[]): boolean {
             if(filter === undefined || filter === null || filter.length === 0) {
                 return true;
@@ -1455,23 +1454,23 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             if(value === undefined || value === null) {
                 return false;
             }
-            
+
             for(let i = 0; i < filter.length; i++) {
                 if(filter[i] === value)
                     return true;
             }
-            
+
             return false;
         }
     }
 
     switchCellToEditMode(cell: any, column: Column, rowData: any) {
-        if(!this.selectionMode && this.editable && column.editable) {           
+        if(!this.selectionMode && this.editable && column.editable) {
             if(cell != this.editingCell) {
                 if(this.editingCell && this.domHandler.find(this.editingCell, '.ng-invalid.ng-dirty').length == 0) {
                     this.domHandler.removeClass(this.editingCell, 'ui-cell-editing');
                 }
-                
+
                 this.editingCell = cell;
                 this.onEditInit.emit({column: column, data: rowData});
                 this.domHandler.addClass(cell, 'ui-cell-editing');
@@ -1485,14 +1484,14 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
 
     switchCellToViewMode(element: any) {
         this.editingCell = null;
-        let cell = this.findCell(element); 
+        let cell = this.findCell(element);
         this.domHandler.removeClass(cell, 'ui-cell-editing');
     }
 
     onCellEditorKeydown(event, column: Column, rowData: any, colIndex: number) {
         if(this.editable) {
             this.onEdit.emit({originalEvent: event, column: column, data: rowData});
-            
+
             //enter
             if(event.keyCode == 13) {
                 this.onEditComplete.emit({column: column, data: rowData});
@@ -1500,7 +1499,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 this.switchCellToViewMode(event.target);
                 event.preventDefault();
             }
-            
+
             //escape
             else if(event.keyCode == 27) {
                 this.onEditCancel.emit({column: column, data: rowData});
@@ -1508,13 +1507,13 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 this.switchCellToViewMode(event.target);
                 event.preventDefault();
             }
-            
+
             //tab
             else if(event.keyCode == 9) {
                 let currentCell = this.findCell(event.target);
                 let row = currentCell.parentElement;
                 let targetCell;
-                
+
                 if(event.shiftKey) {
                     if(colIndex == 0) {
                         let previousRow = row.previousElementSibling;
@@ -1537,7 +1536,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                         targetCell = row.children[colIndex + 1];
                     }
                 }
-                
+
                 if(targetCell) {
                     this.renderer.invokeElementMethod(targetCell, 'click');
                     event.preventDefault();
@@ -1559,13 +1558,13 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         this.tbody = this.domHandler.findSingle(this.el.nativeElement, 'tbody.ui-datatable-data');
         this.resizerHelper = this.domHandler.findSingle(this.el.nativeElement, 'div.ui-column-resizer-helper');
         this.fixColumnWidths();
-        
+
         this.documentColumnResizeListener = this.renderer.listenGlobal('body', 'mousemove', (event) => {
             if(this.columnResizing) {
                 this.onColumnResize(event);
             }
         });
-        
+
         this.documentColumnResizeEndListener = this.renderer.listenGlobal('body', 'mouseup', (event) => {
             if(this.columnResizing) {
                 this.columnResizing = false;
@@ -1573,7 +1572,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             }
         });
     }
-    
+
     initColumnResize(event) {
         let container = this.el.nativeElement.children[0];
         let containerLeft = this.domHandler.getOffset(container).left;
@@ -1581,7 +1580,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         this.columnResizing = true;
         this.lastResizerHelperX = (event.pageX - containerLeft);
     }
-    
+
     onColumnResize(event) {
         let container = this.el.nativeElement.children[0];
         let containerLeft = this.domHandler.getOffset(container).left;
@@ -1591,32 +1590,32 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         if(event.pageX > containerLeft && event.pageX < (containerLeft + container.offsetWidth)) {
             this.resizerHelper.style.left = (event.pageX - containerLeft) + 'px';
         }
-        
+
         this.resizerHelper.style.display = 'block';
     }
-    
+
     onColumnResizeEnd(event) {
         let delta = this.resizerHelper.offsetLeft - this.lastResizerHelperX;
         let columnWidth = this.resizeColumn.offsetWidth;
         let newColumnWidth = columnWidth + delta;
         let minWidth = this.resizeColumn.style.minWidth||15;
-        
+
         if(columnWidth + delta > parseInt(minWidth)) {
             if(this.columnResizeMode === 'fit') {
                 let nextColumn = this.resizeColumn.nextElementSibling;
                 let nextColumnWidth = nextColumn.offsetWidth - delta;
-                
+
                 if(newColumnWidth > 15 && nextColumnWidth > 15) {
                     this.resizeColumn.style.width = newColumnWidth + 'px';
                     if(nextColumn) {
                         nextColumn.style.width = nextColumnWidth + 'px';
                     }
-                    
+
                     if(this.scrollable) {
                         let colGroup = this.domHandler.findSingle(this.el.nativeElement, 'colgroup.ui-datatable-scrollable-colgroup');
                         let resizeColumnIndex = this.domHandler.index(this.resizeColumn);
                         colGroup.children[resizeColumnIndex].style.width = newColumnWidth + 'px';
-                        
+
                         if(nextColumn) {
                             colGroup.children[resizeColumnIndex + 1].style.width = nextColumnWidth + 'px';
                         }
@@ -1627,7 +1626,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 this.tbody.parentElement.style.width = this.tbody.parentElement.offsetWidth + delta + 'px';
                 this.resizeColumn.style.width = newColumnWidth + 'px';
                 let containerWidth = this.tbody.parentElement.style.width;
-                
+
                 if(this.scrollable) {
                     this.scrollBarWidth = this.scrollBarWidth||this.domHandler.calculateScrollbarWidth();
                     this.el.nativeElement.children[0].style.width = parseFloat(containerWidth) + this.scrollBarWidth + 'px';
@@ -1638,27 +1637,27 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 else {
                     this.el.nativeElement.children[0].style.width = containerWidth;
                 }
-            }    
-            
+            }
+
             this.onColResize.emit({
                 element: this.resizeColumn,
                 delta: delta
             });
         }
-                
+
         this.resizerHelper.style.display = 'none';
         this.resizeColumn = null;
         this.domHandler.removeClass(this.el.nativeElement.children[0], 'ui-unselectable-text');
     }
-    
+
     fixColumnWidths() {
         let columns = this.domHandler.find(this.el.nativeElement, 'th.ui-resizable-column');
-        
+
         for(let col of columns) {
             col.style.width = col.offsetWidth + 'px';
         }
     }
-    
+
     onColumnDragStart(event) {
         if (this.columnResizing) {
             event.preventDefault();
@@ -1668,7 +1667,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         this.draggedColumn = this.findParentHeader(event.target);
         event.dataTransfer.setData('text', 'b'); // Firefox requires this to make dragging possible
     }
-    
+
     onColumnDragover(event) {
         if(this.reorderableColumns && this.draggedColumn) {
             event.preventDefault();
@@ -1678,12 +1677,12 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             let container = this.el.nativeElement.children[0];
             let containerOffset = this.domHandler.getOffset(container);
             let dropHeaderOffset = this.domHandler.getOffset(dropHeader);
-            
+
             if(this.draggedColumn != dropHeader) {
                 let targetLeft =  dropHeaderOffset.left - containerOffset.left;
                 let targetTop =  containerOffset.top - dropHeaderOffset.top;
                 let columnCenter = dropHeaderOffset.left + dropHeader.offsetWidth / 2;
-                
+
                 this.reorderIndicatorUp.style.top = dropHeaderOffset.top - containerOffset.top - (iconHeight - 1) + 'px';
                 this.reorderIndicatorDown.style.top = dropHeaderOffset.top - containerOffset.top + dropHeader.offsetHeight + 'px';
 
@@ -1697,7 +1696,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                     this.reorderIndicatorDown.style.left = (targetLeft - Math.ceil(iconWidth / 2))+ 'px';
                     this.dropPosition = -1;
                 }
-                                
+
                 this.reorderIndicatorUp.style.display = 'block';
                 this.reorderIndicatorDown.style.display = 'block';
             }
@@ -1706,7 +1705,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             }
         }
     }
-    
+
     onColumnDragleave(event) {
         if(this.reorderableColumns && this.draggedColumn) {
             event.preventDefault();
@@ -1714,7 +1713,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             this.reorderIndicatorDown.style.display = 'none';
         }
     }
-    
+
     onColumnDrop(event) {
         event.preventDefault();
         if(this.draggedColumn) {
@@ -1724,7 +1723,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             if(allowDrop && ((dropIndex - dragIndex == 1 && this.dropPosition === -1) || (dragIndex - dropIndex == 1 && this.dropPosition === 1))) {
                 allowDrop = false;
             }
-        
+
             if(allowDrop) {
                 this.columns.splice(dropIndex, 0, this.columns.splice(dragIndex, 1)[0]);
 
@@ -1734,7 +1733,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                     columns: this.columns
                 });
             }
-            
+
             this.reorderIndicatorUp.style.display = 'none';
             this.reorderIndicatorDown.style.display = 'none';
             this.draggedColumn.draggable = false;
@@ -1747,7 +1746,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         this.reorderIndicatorUp = this.domHandler.findSingle(this.el.nativeElement.children[0], 'span.ui-datatable-reorder-indicator-up');
         this.reorderIndicatorDown = this.domHandler.findSingle(this.el.nativeElement.children[0], 'span.ui-datatable-reorder-indicator-down');
     }
-    
+
     findParentHeader(element) {
         if(element.nodeName == 'TH') {
             return element;
@@ -1760,7 +1759,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             return parent;
         }
     }
-            
+
     hasFooter() {
         if(this.footerColumnGroup) {
             return true;
@@ -1792,18 +1791,18 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             multiSortMeta: this.multiSortMeta
         };
     }
-    
+
     toggleRow(row: any, event?: Event) {
         if(!this.expandedRows) {
             this.expandedRows = [];
         }
-        
+
         let expandedRowIndex = this.findExpandedRowIndex(row);
-                
+
         if(expandedRowIndex != -1) {
             this.expandedRows.splice(expandedRowIndex, 1);
             this.onRowCollapse.emit({
-                originalEvent: event, 
+                originalEvent: event,
                 data: row
             });
         }
@@ -1811,19 +1810,19 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             if(this.rowExpandMode === 'single') {
                 this.expandedRows = [];
             }
-            
+
             this.expandedRows.push(row);
             this.onRowExpand.emit({
-                originalEvent: event, 
+                originalEvent: event,
                 data: row
             });
         }
-        
+
         if(event) {
             event.preventDefault();
         }
     }
-    
+
     findExpandedRowIndex(row: any): number {
         let index = -1
         if(this.expandedRows) {
@@ -1836,11 +1835,11 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         }
         return index;
     }
-    
+
     isRowExpanded(row: any): boolean {
         return this.findExpandedRowIndex(row) != -1;
     }
-    
+
     findExpandedRowGroupIndex(row: any): number {
         let index = -1;
         if(this.expandedRowsGroups && this.expandedRowsGroups.length) {
@@ -1855,11 +1854,11 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         }
         return index;
     }
-    
+
     isRowGroupExpanded(row: any): boolean {
         return this.findExpandedRowGroupIndex(row) != -1;
     }
-    
+
     toggleRowGroup(event: Event, row: any): void {
         this.rowGroupToggleClick = true;
         let index = this.findExpandedRowGroupIndex(row);
@@ -1867,7 +1866,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         if(index >= 0) {
             this.expandedRowsGroups.splice(index, 1);
             this.onRowGroupCollapse.emit({
-                originalEvent: event, 
+                originalEvent: event,
                 group: rowGroupField
             });
         }
@@ -1875,17 +1874,17 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             this.expandedRowsGroups = this.expandedRowsGroups||[],
             this.expandedRowsGroups.push(rowGroupField);
             this.onRowGroupExpand.emit({
-                originalEvent: event, 
+                originalEvent: event,
                 group: rowGroupField
             });
         }
         event.preventDefault();
     }
-        
+
     public reset() {
         this.sortField = null;
         this.sortOrder = 1;
-        
+
         this.filteredValue = null;
         this.filters = {};
 
@@ -1899,40 +1898,40 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             this.updateDataToRender(this.value);
         }
     }
-    
+
     public exportCSV() {
         let data = this.value;
         let csv = '';
-        
+
         //headers
         for(let i = 0; i < this.columns.length; i++) {
             if(this.columns[i].field) {
                 csv += this.columns[i].header || this.columns[i].field;
-                
+
                 if(i < (this.columns.length - 1)) {
                     csv += this.csvSeparator;
                 }
             }
         }
-        
-        //body        
+
+        //body
         this.value.forEach((record, i) => {
             csv += '\n';
             for(let i = 0; i < this.columns.length; i++) {
                 if(this.columns[i].field) {
                     csv += this.resolveFieldData(record, this.columns[i].field);
-                    
+
                     if(i < (this.columns.length - 1)) {
                         csv += this.csvSeparator;
                     }
                 }
             }
         });
-        
+
         let blob = new Blob([csv],{
             type: 'text/csv;charset=utf-8;'
         });
-        
+
         if(window.navigator.msSaveOrOpenBlob) {
             navigator.msSaveOrOpenBlob(blob, this.exportFilename + '.csv');
         }
@@ -1953,11 +1952,11 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             document.body.removeChild(link);
         }
     }
-    
+
     getBlockableElement(): HTMLElement {
         return this.el.nativeElement.children[0];
     }
-    
+
     getRowStyleClass(rowData: any, rowIndex: number) {
         let styleClass = 'ui-widget-content';
         if(this.rowStyleClass) {
@@ -1968,11 +1967,11 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         }
         return styleClass;
     }
-    
+
     visibleColumns() {
         return this.columns ? this.columns.filter(c => !c.hidden): [];
     }
-    
+
     get containerWidth() {
         if(this.scrollable) {
             if(this.scrollWidth) {
@@ -1992,12 +1991,12 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         if(this.globalFilterFunction) {
             this.globalFilterFunction();
         }
-                
+
         if(this.resizableColumns && this.documentColumnResizeListener && this.documentColumnResizeEndListener) {
             this.documentColumnResizeListener();
             this.documentColumnResizeEndListener();
         }
-        
+
         if(this.columnsSubscription) {
             this.columnsSubscription.unsubscribe();
         }


### PR DESCRIPTION
When using lazy loading with multiple sorting, multiSortMetadata was not being filled. Because of that multiSort information was not sent to server-side.

Also, the effect adding fa-sort-asc / fa-sort-desc arrows didn't trigger in lazy mode beacuse of this bug.