### PR TITLE
Enable dropdown to use OnPush change detection strategy

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -136,7 +136,6 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     
     public panelVisible$ = this.panelVisibleSubject.asObservable();
 
-    // getter property to maintain backwards compatability
     public get panelVisible() {
         return this.panelVisibleSubject.value;
     } 
@@ -292,7 +291,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         if(!this.itemClick) {
             input.focus();
             
-            if(this.panelVisibleSubject.value)
+            if(this.panelVisible)
                 this.hide();
             else {
                 this.show(this.panel,this.container);
@@ -365,7 +364,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         switch(event.which) {
             //down
             case 40:
-                if(!this.panelVisibleSubject.value && event.altKey) {
+                if(!this.panelVisible && event.altKey) {
                     this.show(this.panel, this.container);
                 }
                 else {
@@ -400,7 +399,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
 
             //space
             case 32:
-                this.panelVisibleSubject.next(!this.panelVisibleSubject.value);
+                this.panelVisibleSubject.next(!this.panelVisible);
                 
                 event.preventDefault();
             break;


### PR DESCRIPTION
Fixes #1754 

When the dropdown is used in a large nested component tree performance noticeable degrades when opening/closing the dropdown as this triggers all components in the component tree to run through change detection.

The change in this PR allows components that use this component to use the OnPush change detection strategy to prevent the entire component tree from running change detection and therefore reducing the amount of time between the user clicking the dropdown and the panel opening. Tests in my environment show a reduction from 400ms from click to panel opening to <100ms.

