### PR TITLE
Calendar fix #1036 - handle min/max date change

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -293,6 +293,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     set minDate(date: Date) {
         this._minDate = date;
         this.createMonth(this.currentMonth, this.currentYear);
+        if (this.value < date) this.updateDate(date);
     }
     
     @Input() get maxDate(): Date {
@@ -302,6 +303,13 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     set maxDate(date: Date) {
         this._maxDate = date;
         this.createMonth(this.currentMonth, this.currentYear);
+        if (this.value > date) this.updateDate(date);
+    }
+    
+    updateDate(date: Date) {
+        let dateMeta = {day: date.getDate(), month: date.getMonth(), year: date.getFullYear()};
+        this.selectDate(dateMeta);
+        this.updateInputfield();
     }
 
     constructor(public el: ElementRef, public domHandler: DomHandler,public renderer: Renderer) {}

--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -293,7 +293,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     set minDate(date: Date) {
         this._minDate = date;
         this.createMonth(this.currentMonth, this.currentYear);
-        if (this.value < date) this.updateDate(date);
+        if (this.value && this.value < date) this.updateDate(date);
     }
     
     @Input() get maxDate(): Date {
@@ -303,7 +303,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     set maxDate(date: Date) {
         this._maxDate = date;
         this.createMonth(this.currentMonth, this.currentYear);
-        if (this.value > date) this.updateDate(date);
+        if (this.value && this.value > date) this.updateDate(date);
     }
     
     updateDate(date: Date) {


### PR DESCRIPTION
Make sure that date value is updated correctly and onSelect event is sent out with the new date whenever minDate or maxDate is updated and currently selected date falls outside the new range.