### PR TITLE
Spelling fixes on chart documentation

### DIFF
--- a/showcase/demo/chart/chartdemo.html
+++ b/showcase/demo/chart/chartdemo.html
@@ -131,7 +131,7 @@ update(event: Event) &#123;
 
 <pre>
 <code class="language-markup" pCode>
-&lt;p-chart type="line" [data]="data"&gt;&lt;/p-chart&gt;t
+&lt;p-chart type="line" [data]="data"&gt;&lt;/p-chart&gt;
 </code>
 </pre>
 
@@ -222,7 +222,7 @@ selectData(event) &#123;
     //event.dataset = Selected dataset
     //event.element = Selected element
     //event.element._datasetIndex = Index of the dataset in data
-    //event.element_index = Index of the data in dataset
+    //event.element._index = Index of the data in dataset
 &#125;
 </code>
 </pre>  


### PR DESCRIPTION
The missing "dot" for element._index added time to debugging events. Removed extraneous 't' from sample code

###Defect Fixes
#2371