### PR TITLE
Add inputId property where it makes sense.

### DIFF
--- a/components/autocomplete/autocomplete.ts
+++ b/components/autocomplete/autocomplete.ts
@@ -17,7 +17,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
     selector: 'p-autoComplete',
     template: `
         <span [ngClass]="{'ui-autocomplete ui-widget':true,'ui-autocomplete-dd':dropdown,'ui-autocomplete-multiple':multiple}" [ngStyle]="style" [class]="styleClass">
-            <input *ngIf="!multiple" #in type="text" [ngStyle]="inputStyle" [class]="inputStyleClass" autocomplete="off" [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all'"
+            <input *ngIf="!multiple" #in type="text" [attr.id]="inputId" [ngStyle]="inputStyle" [class]="inputStyleClass" autocomplete="off" [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all'"
             [value]="value ? (field ? objectUtils.resolveFieldData(value,field)||value : value) : null" (input)="onInput($event)" (keydown)="onKeydown($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)"
             [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled"
             [ngClass]="{'ui-autocomplete-input':true,'ui-autocomplete-dd-input':dropdown}"
@@ -28,7 +28,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                     <ng-template *ngIf="selectedItemTemplate" [pTemplateWrapper]="selectedItemTemplate" [item]="val"></ng-template>
                 </li>
                 <li class="ui-autocomplete-input-token">
-                    <input #multiIn type="text" [disabled]="disabled" [attr.placeholder]="placeholder" [attr.tabindex]="tabindex" (input)="onInput($event)" (keydown)="onKeydown($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" autocomplete="off">
+                    <input #multiIn type="text" [attr.id]="inputId" [disabled]="disabled" [attr.placeholder]="placeholder" [attr.tabindex]="tabindex" (input)="onInput($event)" (keydown)="onKeydown($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" autocomplete="off">
                 </li>
             </ul
             ><button type="button" pButton icon="fa-fw fa-caret-down" class="ui-autocomplete-dropdown" [disabled]="disabled"
@@ -61,6 +61,8 @@ export class AutoComplete implements AfterViewInit,DoCheck,AfterViewChecked,Cont
     @Input() styleClass: string;
     
     @Input() inputStyle: any;
+
+    @Input() inputId: string;
     
     @Input() inputStyleClass: string;
     

--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -31,7 +31,7 @@ export interface LocaleSettings {
     template:  `
         <span [ngClass]="{'ui-calendar':true,'ui-calendar-w-btn':showIcon}" [ngStyle]="style" [class]="styleClass">
             <ng-template [ngIf]="!inline">
-                <input #inputfield type="text" [attr.required]="required" [value]="inputFieldValue" (focus)="onInputFocus(inputfield, $event)" (keydown)="onInputKeydown($event)" (click)="closeOverlay=false" (blur)="onInputBlur($event)"
+                <input #inputfield type="text" [attr.id]="inputId" [attr.required]="required" [value]="inputFieldValue" (focus)="onInputFocus(inputfield, $event)" (keydown)="onInputKeydown($event)" (click)="closeOverlay=false" (blur)="onInputBlur($event)"
                     [readonly]="readonlyInput" (input)="onInput($event)" [ngStyle]="inputStyle" [class]="inputStyleClass" [placeholder]="placeholder||''" [disabled]="disabled" [attr.tabindex]="tabindex"
                     [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all'"
                     ><button type="button" [icon]="icon" pButton *ngIf="showIcon" (click)="onButtonClick($event,inputfield)"
@@ -165,6 +165,8 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     @Input() styleClass: string;
     
     @Input() inputStyle: string;
+
+    @Input() inputId: string;
     
     @Input() inputStyleClass: string;
     

--- a/components/checkbox/checkbox.ts
+++ b/components/checkbox/checkbox.ts
@@ -13,7 +13,7 @@ export const CHECKBOX_VALUE_ACCESSOR: any = {
     template: `
         <div class="ui-chkbox ui-widget">
             <div class="ui-helper-hidden-accessible">
-                <input #cb type="checkbox" [name]="name" [value]="value" [checked]="checked" (focus)="onFocus($event)" (blur)="onBlur($event)"
+                <input #cb type="checkbox" [attr.id]="inputId" [name]="name" [value]="value" [checked]="checked" (focus)="onFocus($event)" (blur)="onBlur($event)"
                 [ngClass]="{'ui-state-focus':focused}" (change)="handleChange($event)" [disabled]="disabled" [attr.tabindex]="tabindex">
             </div>
             <div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default" (click)="onClick($event,cb,true)"
@@ -38,6 +38,8 @@ export class Checkbox implements ControlValueAccessor {
     @Input() label: string;
 
     @Input() tabindex: number;
+
+    @Input() inputId: string;
     
     @Output() onChange: EventEmitter<any> = new EventEmitter();
     

--- a/components/chips/chips.ts
+++ b/components/chips/chips.ts
@@ -22,7 +22,7 @@ export const CHIPS_VALUE_ACCESSOR: any = {
                     <ng-template *ngIf="itemTemplate" [pTemplateWrapper]="itemTemplate" [item]="item"></ng-template>
                 </li>
                 <li class="ui-chips-input-token">
-                    <input #inputtext type="text" [attr.placeholder]="placeholder" [attr.tabindex]="tabindex" (keydown)="onKeydown($event,inputtext)" 
+                    <input #inputtext type="text" [attr.id]="inputId" [attr.placeholder]="placeholder" [attr.tabindex]="tabindex" (keydown)="onKeydown($event,inputtext)" 
                         (focus)="onFocus()" (blur)="onBlur()" [disabled]="maxedOut||disabled" [disabled]="disabled">
                 </li>
             </ul>
@@ -49,6 +49,8 @@ export class Chips implements AfterContentInit,ControlValueAccessor {
     @Input() max: number;
 
     @Input() tabindex: number;
+
+    @Input() inputId: string;
     
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     

--- a/components/inputmask/inputmask.ts
+++ b/components/inputmask/inputmask.ts
@@ -39,7 +39,7 @@ export const INPUTMASK_VALUE_ACCESSOR: any = {
 
 @Component({
     selector: 'p-inputMask',
-    template: `<input #input pInputText [attr.type]="type" [attr.name]="name" [ngStyle]="style" [ngClass]="styleClass" [attr.placeholder]="placeholder"
+    template: `<input #input pInputText [attr.id]="inputId" [attr.type]="type" [attr.name]="name" [ngStyle]="style" [ngClass]="styleClass" [attr.placeholder]="placeholder"
         [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [disabled]="disabled" [readonly]="readonly"
         (focus)="onFocus($event)" (blur)="onInputBlur($event)" (keydown)="onKeyDown($event)" (keypress)="onKeyPress($event)"
         (input)="onInput($event)" (paste)="handleInputChange($event)">`,
@@ -60,6 +60,8 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
     @Input() autoClear: boolean = true;
         
     @Input() style: string;
+
+    @Input() inputId: string;
     
     @Input() styleClass: string;
     

--- a/components/inputswitch/inputswitch.ts
+++ b/components/inputswitch/inputswitch.ts
@@ -23,7 +23,7 @@ export const INPUTSWITCH_VALUE_ACCESSOR: any = {
             </div>
             <div [ngClass]="{'ui-inputswitch-handle ui-state-default':true, 'ui-state-focus':focused}"></div>
             <div class="ui-helper-hidden-accessible">
-                <input #in type="checkbox" (focus)="onFocus($event)" (blur)="onBlur($event)" readonly="readonly" [attr.tabindex]="tabindex"/>
+                <input #in type="checkbox" [attr.id]="inputId" (focus)="onFocus($event)" (blur)="onBlur($event)" readonly="readonly" [attr.tabindex]="tabindex"/>
             </div>
         </div>
     `,
@@ -42,6 +42,8 @@ export class InputSwitch implements ControlValueAccessor,AfterViewInit,AfterView
     @Input() styleClass: string;
 
     @Input() tabindex: number;
+
+    @Input() inputId: string;
 
     @Output() onChange: EventEmitter<any> = new EventEmitter();
 

--- a/components/multiselect/multiselect.ts
+++ b/components/multiselect/multiselect.ts
@@ -17,7 +17,7 @@ export const MULTISELECT_VALUE_ACCESSOR: any = {
         <div #container [ngClass]="{'ui-multiselect ui-widget ui-state-default ui-corner-all':true,'ui-state-focus':focus,'ui-state-disabled': disabled}" [ngStyle]="style" [class]="styleClass"
             (click)="onMouseclick($event,in)">
             <div class="ui-helper-hidden-accessible">
-                <input #in type="text" readonly="readonly" (focus)="onFocus($event)" (blur)="onBlur($event)" [disabled]="disabled" [attr.tabindex]="tabindex">
+                <input #in type="text" readonly="readonly" [attr.id]="inputId" (focus)="onFocus($event)" (blur)="onBlur($event)" [disabled]="disabled" [attr.tabindex]="tabindex">
             </div>
             <div class="ui-multiselect-label-container" [title]="valuesAsString">
                 <label class="ui-multiselect-label ui-corner-all">{{valuesAsString}}</label>
@@ -78,6 +78,8 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
     @Input() style: any;
 
     @Input() styleClass: string;
+
+    @Input() inputId: string;
 
     @Input() disabled: boolean;
     

--- a/components/radiobutton/radiobutton.ts
+++ b/components/radiobutton/radiobutton.ts
@@ -13,7 +13,7 @@ export const RADIO_VALUE_ACCESSOR: any = {
     template: `
         <div class="ui-radiobutton ui-widget">
             <div class="ui-helper-hidden-accessible">
-                <input #rb type="radio" [attr.name]="name" [attr.value]="value" [attr.tabindex]="tabindex" 
+                <input #rb type="radio" [attr.id]="inputId" [attr.name]="name" [attr.value]="value" [attr.tabindex]="tabindex" 
                     [checked]="checked" (change)="onChange($event)" (focus)="onFocus($event)" (blur)="onBlur($event)">
             </div>
             <div (click)="handleClick()"
@@ -37,6 +37,8 @@ export class RadioButton implements ControlValueAccessor,AfterViewInit {
     @Input() label: string;
 
     @Input() tabindex: number;
+
+    @Input() inputId: string;
 
     @Output() onClick: EventEmitter<any> = new EventEmitter();
     

--- a/components/spinner/spinner.ts
+++ b/components/spinner/spinner.ts
@@ -14,7 +14,7 @@ export const SPINNER_VALUE_ACCESSOR: any = {
     selector: 'p-spinner',
     template: `
         <span class="ui-spinner ui-widget ui-corner-all">
-            <input #in type="text" class="ui-spinner-input" [value]="valueAsString" class="ui-inputtext ui-widget ui-state-default ui-corner-all"
+            <input #in type="text" [attr.id]="inputId" class="ui-spinner-input" [value]="valueAsString" class="ui-inputtext ui-widget ui-state-default ui-corner-all"
             [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [attr.placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly"
             (keydown)="onInputKeydown($event)" (keyup)="onInput($event,in.value)" (keypress)="onInputKeyPress($event)" (blur)="onBlur()" (change)="handleChange($event)" (focus)="onFocus()">
             <button type="button" [ngClass]="{'ui-spinner-button ui-spinner-up ui-corner-tr ui-button ui-widget ui-state-default':true,'ui-state-disabled':disabled}" [disabled]="disabled"
@@ -48,6 +48,8 @@ export class Spinner implements OnInit,ControlValueAccessor {
     @Input() size: number;
 
     @Input() placeholder: string;
+
+    @Input() inputId: string;
 
     @Input() disabled: boolean;
     

--- a/components/togglebutton/togglebutton.ts
+++ b/components/togglebutton/togglebutton.ts
@@ -15,7 +15,7 @@ export const TOGGLEBUTTON_VALUE_ACCESSOR: any = {
                 'ui-state-active': checked,'ui-state-focus':focus,'ui-state-disabled':disabled}" [ngStyle]="style" [class]="styleClass" 
                 (click)="toggle($event)">
             <div class="ui-helper-hidden-accessible">
-                <input #checkbox type="checkbox" [checked]="checked" (focus)="onFocus()" (blur)="onBlur()" [attr.tabindex]="tabindex">
+                <input #checkbox type="checkbox" [attr.id]="inputId" [checked]="checked" (focus)="onFocus()" (blur)="onBlur()" [attr.tabindex]="tabindex">
             </div>
             <span *ngIf="onIcon||offIcon" [class]="getIconClass()"></span>
             <span class="ui-button-text ui-unselectable-text">{{checked ? onLabel : offLabel}}</span>
@@ -38,6 +38,8 @@ export class ToggleButton implements ControlValueAccessor,AfterViewInit {
     @Input() style: any;
 
     @Input() styleClass: string;
+
+    @Input() inputId: string;
 
     @Input() tabindex: number;
 

--- a/components/tristatecheckbox/tristatecheckbox.ts
+++ b/components/tristatecheckbox/tristatecheckbox.ts
@@ -13,7 +13,7 @@ export const TRISTATECHECKBOX_VALUE_ACCESSOR: any = {
     template: `
         <div class="ui-chkbox ui-tristatechkbox ui-widget">
             <div class="ui-helper-hidden-accessible">
-                <input #input type="text" [name]="name" [attr.tabindex]="tabindex" readonly [disabled]="disabled" (keyup)="onKeyup($event)" (keydown)="onKeydown($event)" (focus)="onFocus()" (blur)="onBlur()">
+                <input #input type="text" [attr.id]="inputId" [name]="name" [attr.tabindex]="tabindex" readonly [disabled]="disabled" (keyup)="onKeyup($event)" (keydown)="onKeydown($event)" (focus)="onFocus()" (blur)="onBlur()">
             </div>
             <div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default" (click)="onClick($event,input)"
                 [ngClass]="{'ui-state-active':value!=null,'ui-state-disabled':disabled,'ui-state-focus':focus}">
@@ -32,6 +32,8 @@ export class TriStateCheckbox implements ControlValueAccessor  {
     @Input() name: string;
 
     @Input() tabindex: number;
+
+    @Input() inputId: string;
     
     @Output() onChange: EventEmitter<any> = new EventEmitter();
         

--- a/showcase/demo/autocomplete/autocompletedemo.html
+++ b/showcase/demo/autocomplete/autocompletedemo.html
@@ -267,6 +267,12 @@ export class AutoCompleteDemo &#123;
                             <td>Inline style of the input field.</td>
                         </tr>
                         <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
+                        <tr>
                             <td>placeholder</td>
                             <td>string</td>
                             <td>null</td>

--- a/showcase/demo/calendar/calendardemo.html
+++ b/showcase/demo/calendar/calendardemo.html
@@ -235,6 +235,12 @@ export class MyModel &#123;
                             <td>Style class of the input field.</td>
                         </tr>
                         <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
+                        <tr>
                             <td>placeholder</td>
                             <td>string</td>
                             <td>null</td>

--- a/showcase/demo/checkbox/checkboxdemo.html
+++ b/showcase/demo/checkbox/checkboxdemo.html
@@ -156,6 +156,12 @@ export class ModelComponent &#123;
                             <td>null</td>
                             <td>Index of the element in tabbing order.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/chips/chipsdemo.html
+++ b/showcase/demo/chips/chipsdemo.html
@@ -117,6 +117,12 @@ export class MyModel &#123;
                             <td>null</td>
                             <td>Index of the element in tabbing order.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/inputmask/inputmaskdemo.html
+++ b/showcase/demo/inputmask/inputmaskdemo.html
@@ -188,6 +188,12 @@ import &#123;InputMaskModule&#125; from 'primeng/primeng';
                             <td>null</td>
                             <td>Name of the input field.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/inputswitch/inputswitch.html
+++ b/showcase/demo/inputswitch/inputswitch.html
@@ -111,6 +111,12 @@ export class ModelComponent &#123;
                           <td>null</td>
                           <td>Index of the element in tabbing order.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/multiselect/multiselectdemo.html
+++ b/showcase/demo/multiselect/multiselectdemo.html
@@ -132,6 +132,12 @@ export class MyModel &#123;
                             <td>null</td>
                             <td>A property to uniquely identify a value in options.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/radiobutton/radiobuttondemo.html
+++ b/showcase/demo/radiobutton/radiobuttondemo.html
@@ -122,6 +122,12 @@ export class ModelComponent &#123;
                             <td>null</td>
                             <td>Index of the element in tabbing order.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/spinner/spinnerdemo.html
+++ b/showcase/demo/spinner/spinnerdemo.html
@@ -145,6 +145,12 @@ import &#123;SpinnerModule&#125; from 'primeng/primeng';
                             <td>true</td>
                             <td>When present, formats the user input.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/togglebutton/togglebuttondemo.html
+++ b/showcase/demo/togglebutton/togglebuttondemo.html
@@ -124,12 +124,18 @@ export class ModelComponent &#123;
                             <td>false</td>
                             <td>When present, it specifies that the element should be disabled.</td>
                         </tr>
-                         <tr>
-                           <td>tabindex</td>
-                           <td>number</td>
-                           <td>null</td>
-                           <td>Index of the element in tabbing order.</td>
-                         </tr>
+                        <tr>
+                          <td>tabindex</td>
+                          <td>number</td>
+                          <td>null</td>
+                          <td>Index of the element in tabbing order.</td>
+                        </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>

--- a/showcase/demo/tristatecheckbox/tristatecheckboxdemo.html
+++ b/showcase/demo/tristatecheckbox/tristatecheckboxdemo.html
@@ -76,6 +76,12 @@ export class ModelComponent &#123;
                             <td>null</td>
                             <td>Index of the element in tabbing order.</td>
                         </tr>
+                        <tr>
+                            <td>inputId</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Identifier of the focus input to match a label defined for the component.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
This PR adds `inputId` property in most input components. This allows the developer to use them with a label:

```
<label for="checkbox">Checkbox</label>
<p-checkbox inputId="checkbox"></p-checkbox>
```