### PR TITLE
Feature Request: Add DataTable Checkbox Header Toggle All Pages Option

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -487,6 +487,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     
     @Output() onHeaderCheckboxToggle: EventEmitter<any> = new EventEmitter();
     
+    @Input() headerCheckboxToggleAllPages: boolean;
+    
     @Output() onContextMenuSelect: EventEmitter<any> = new EventEmitter();
 
     @Input() filterDelay: number = 300;
@@ -1259,8 +1261,9 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     }
     
     toggleRowsWithCheckbox(event) {
-        if(event.checked)
-            this.selection = this.dataToRender.slice(0);
+        if(event.checked){
+            this.selection = this.headerCheckboxToggleAllPages ? this.value.slice() : this.dataToRender.slice();
+        }
         else
             this.selection = [];
             
@@ -1322,7 +1325,10 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     
     get allSelected() {
         let val = true;
-        if(this.dataToRender && this.selection && (this.dataToRender.length <= this.selection.length)) {
+        if(this.headerCheckboxToggleAllPages && this.selection && this.selection.length === this.totalRecords){
+            return val;
+        }
+        if(!this.headerCheckboxToggleAllPages && this.dataToRender && this.selection && (this.dataToRender.length <= this.selection.length)) {
             for(let data of this.dataToRender) {
                 if(!this.isSelected(data)) {
                     val = false;

--- a/showcase/demo/datatable/datatabledemo.html
+++ b/showcase/demo/datatable/datatabledemo.html
@@ -1011,6 +1011,16 @@ loadData(event: LazyLoadEvent) &#123;
                             <td>string</td>
                             <td>null</td>
                             <td>Specifies the selection mode, valid values are "single" and "multiple".</td>
+                        </tr>                        
+                        <tr>
+                            <td>headerCheckboxToggleAllPages</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>
+                                When set to true, the header checkbox on paged DataTables with checkbox multiple 
+                                selection enabled will toggle the selection of items across all pages. See the
+                                <a [routerLink]="['/datatable/selection']">live example.</a>
+                            </td>
                         </tr>
                         <tr>
                             <td>selection</td>

--- a/showcase/demo/datatable/datatableselectiondemo.html
+++ b/showcase/demo/datatable/datatableselectiondemo.html
@@ -76,6 +76,28 @@
             </ul>
         </p-footer>
     </p-dataTable>
+
+    <h3>Checkbox with Paging</h3>
+    <p>
+        When using checkboxes for multiple selection with paging and clicking the header checkbox, by default, items on 
+        all other pages will be deselected and only the current page's items will be toggled. Often, the more desired 
+        approach is to toggle all items across all pages. This can be accomplished by setting the 
+        "headerCheckboxToggleAllPages" property to "true" on your paged DataTable. Notice how the header checkbox only 
+        stays checked when all items across all pages are selected. 
+    </p>
+    <p-dataTable [value]="cars" [(selection)]="selectedCars3" dataKey="vin" [paginator]="true" [rows]="5" [headerCheckboxToggleAllPages]="true">
+        <p-header>Checkbox Multiple Selection with Paging</p-header>
+        <p-column [style]="&#123;'width':'38px'&#125;" selectionMode="multiple"></p-column>
+        <p-column field="vin" header="Vin"></p-column>
+        <p-column field="year" header="Year"></p-column>
+        <p-column field="brand" header="Brand"></p-column>
+        <p-column field="color" header="Color"></p-column>
+        <p-footer>
+            <ul>
+                <li *ngFor="let car of selectedCars3" style="text-align: left">{{car.vin + ' - ' + car.brand + ' - ' + car.year + ' - ' + car.color}}</li>
+            </ul>
+        </p-footer>
+    </p-dataTable>
 </div>
 
 <div class="content-section source">
@@ -92,8 +114,14 @@ export class DataTableSelectionDemo implements OnInit &#123;
     selectedCar1: Car;
 
     selectedCar2: Car;
+    
+    selectedCar3: Car;
 
-    selectedCars: Car[];
+    selectedCars1: Car[];
+    
+    selectedCars2: Car[];
+    
+    selectedCars3: Car[];
 
     constructor(private carService: CarService) &#123; &#125;
 
@@ -180,6 +208,28 @@ export class DataTableSelectionDemo implements OnInit &#123;
     &lt;p-footer&gt;
         &lt;ul&gt;
             &lt;li *ngFor="let car of selectedCars2" style="text-align: left"&gt;{{car.vin + ' - ' + car.brand + ' - ' + car.year + ' - ' + car.color}}&lt;/li&gt;
+        &lt;/ul&gt;
+    &lt;/p-footer&gt;
+&lt;/p-dataTable&gt;
+    
+&lt;h3&gt;Checkbox with Paging&lt;/h3&gt;
+&lt;p&gt; 
+    When using checkboxes for multiple selection with paging and clicking the header checkbox, by default, items on all 
+    other pages will be deselected and only the current page's items will be toggled. Often, the more desired approach
+    is to toggle all items across all pages. This can be accomplished by setting the 
+    "headerCheckboxToggleAllPages" property to "true" on your paged DataTable. Notice how the header
+    checkbox only stays checked when all items across all pages are selected. 
+&lt;/p&gt;
+&lt;p-dataTable [value]="cars" [(selection)]="selectedCars3" dataKey="vin" [paginator]="true" [rows]="5" [headerCheckboxToggleAllPages]="true"&gt;
+    &lt;p-header&gt;Checkbox Multiple Selection with Paging&lt;/p-header&gt;
+    &lt;p-column [style]="&#123;'width':'38px'&#125;" selectionMode="multiple"&gt;&lt;/p-column&gt;
+    &lt;p-column field="vin" header="Vin"&gt;&lt;/p-column&gt;
+    &lt;p-column field="year" header="Year"&gt;&lt;/p-column&gt;
+    &lt;p-column field="brand" header="Brand"&gt;&lt;/p-column&gt;
+    &lt;p-column field="color" header="Color"&gt;&lt;/p-column&gt;
+    &lt;p-footer&gt;
+        &lt;ul&gt;
+            &lt;li *ngFor="let car of selectedCars3" style="text-align: left"&gt;{{car.vin + ' - ' + car.brand + ' - ' + car.year + ' - ' + car.color}}&lt;/li&gt;
         &lt;/ul&gt;
     &lt;/p-footer&gt;
 &lt;/p-dataTable&gt;

--- a/showcase/demo/datatable/datatableselectiondemo.ts
+++ b/showcase/demo/datatable/datatableselectiondemo.ts
@@ -21,6 +21,8 @@ export class DataTableSelectionDemo implements OnInit {
     selectedCars1: Car[];
     
     selectedCars2: Car[];
+    
+    selectedCars3: Car[];
 
     constructor(private carService: CarService) { }
 


### PR DESCRIPTION
Add `headerCheckboxToggleAllPages` DataTable property to allow the header checkbox on paged DataTables with checkbox multiple selection enabled to toggle the selection of items across all pages. Previously this was only possible via the `onHeaderCheckboxToggle` event--however, doing so produced strange results where the header checkbox would remain checked even if only the current page's items were selected. This change provides the expected results. This is an improvement over the original fix provided in #1412.
Update demo/documentation to reflect new property.

I created a new property for this so as to not alter the previous behavior of the header checkbox on paged DataTables--however, if that isn't a concern we could simplify this and remove the new property by just having the header checkbox toggle the selection of all items across all pages as its default behavior (for paged checkbox DataTables).