### PR TITLE
Next month grey date was throwing Nan/Nan/Nan

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -582,6 +582,7 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         }
         else {
             m = month + 1;
+            y = year;
         }
         
         return {'month':m,'year':y};


### PR DESCRIPTION
I have added this fix so that when you are opening the calendar and you have set the attribute [selectOtherMonths]="true", you will be able to select the next month grayed out dates. Without this fix you will get NaN/NaN/NaN.
