### PR TITLE
docs(dialogdemo): add Event API of visibleChange

### DIFF
--- a/showcase/demo/dialog/dialogdemo.html
+++ b/showcase/demo/dialog/dialogdemo.html
@@ -240,6 +240,11 @@ export class ModelComponent &#123;
                             <td>event: Event object</td>
                             <td>Callback to invoke when dialog is hidden.</td>
                         </tr>
+                        <tr>
+                            <td>visibleChange</td>
+                            <td>event: Event object</td>
+                            <td>Callback to invoke when dialog is closed.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
The docs of dialog lack the event api of visibleChange.