### PR TITLE
Add between (range) to filter constraints (datatable.ts)

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -1520,9 +1520,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         },
         
         between(value: any, filter: any): boolean {
-            if (filter === undefined || filter === null ||
-                filter.start === undefined || filter.start === null ||
-                filter.end === undefined || filter.end === null) {
+            if (filter === undefined || filter === null) {
                 return true;
             }
 
@@ -1530,7 +1528,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 return false;
             }
 
-            if (filter.start <= value && filter.end >= value) {
+            if ((filter.start <= value || filter.start === undefined || filter.start === null) && 
+            	(filter.end >= value || filter.end === undefined || filter.end === null)) {
                 return true;
             }
             

--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -1517,6 +1517,24 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             }
             
             return false;
+        },
+        
+        between(value: any, filter: any): boolean {
+            if (filter === undefined || filter === null ||
+                filter.start === undefined || filter.start === null ||
+                filter.end === undefined || filter.end === null) {
+                return true;
+            }
+
+            if (value === undefined || value === null) {
+                return false;
+            }
+
+            if (filter.start <= value && filter.end >= value) {
+                return true;
+            }
+            
+            return false;
         }
     }
 


### PR DESCRIPTION
Feature Request
Add 'between' filter to the filterConstraints property of the DataTable.
this feature enables to filter according to a specific range. I chose this name because of the same operator in SQL that named 'between' (But it also make sense to call it 'range').

This filter pass values within a given range. The values can be numbers, text, or dates.
it gets also only a one range limit.

I created a new property for this so as to not alter the previous behavior of the filterConstraints or any another behavior of the DataTable.

I saw some requests for a feature like this for example:
https://forum.primefaces.org/viewtopic.php?f=35&t=50389