### PR TITLE
Fixed bug that closes multiselect overlay when appendTo=body is used …

### DIFF
--- a/components/multiselect/multiselect.ts
+++ b/components/multiselect/multiselect.ts
@@ -133,7 +133,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
         this.updateLabel();
         
         this.documentClickListener = this.renderer.listenGlobal('body', 'click', () => {
-            if(!this.selfClick && this.overlayVisible) {
+            if(!this.selfClick && !this.panelClick && this.overlayVisible) {
                 this.hide();
             }
             


### PR DESCRIPTION
…after every click

###Defect Fixes
https://github.com/primefaces/primeng/issues/2345

###Feature Requests
I created a post in the forum https://forum.primefaces.org/viewtopic.php?f=35&t=50568 that documents the issue. This is a fix for the first issue. Once this is merged, the second issue mentioned will appear, but I don't know if my workaround that is proper solution, so I let that to you.