### PR TITLE
Captcha component can now be triggered through onload parameter of reCAPTCHA

### DIFF
--- a/components/captcha/captcha.ts
+++ b/components/captcha/captcha.ts
@@ -18,6 +18,8 @@ export class Captcha implements AfterViewInit {
     @Input() tabindex = 0;
     
     @Input() language: string = null;
+     
+    @Input() callback = "recaptchaLoaded";
     
     @Output() onResponse: EventEmitter<any> = new EventEmitter();
     
@@ -33,8 +35,9 @@ export class Captcha implements AfterViewInit {
         if ((<any>window).grecaptcha)
             this.init();
         else {
-            console.warn("Recaptcha is not loaded");
-            return;
+            (<any>window)[this.callback] = () => {
+              this.init();
+            }
         } 
     }
     


### PR DESCRIPTION
captcha component now registers a callback that can be triggered through onload parameter of reCAPTCHA

###Defect Fixes
This fixes https://github.com/primefaces/primeng/issues/2584

now you can add reCAPTCHA script as follows:


`<script src="https://www.google.com/recaptcha/api.js?render=explicit&onload=recaptchaLoaded" async defer></script>`


once its loaded, it will call recaptchaLoaded which will be registered globally by captcha component and it will render the captcha.

Also, the callback name is configured through the "callback" attribute