### PR TITLE
Dropdown: Add `filterPlaceholder` attribute

### DIFF
--- a/components/dropdown/dropdown.ts
+++ b/components/dropdown/dropdown.ts
@@ -37,7 +37,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
             <div #panel [ngClass]="'ui-dropdown-panel ui-widget-content ui-corner-all ui-helper-hidden ui-shadow'" [@panelState]="panelVisible ? 'visible' : 'hidden'"
                 [style.display]="panelVisible ? 'block' : 'none'" [style.width.px]="container.clientWidth" [ngStyle]="panelStyle" [class]="panelStyleClass">
                 <div *ngIf="filter" class="ui-dropdown-filter-container" (input)="onFilter($event)" (click)="$event.stopPropagation()">
-                    <input #filter type="text" autocomplete="off" class="ui-dropdown-filter ui-inputtext ui-widget ui-state-default ui-corner-all">
+                    <input #filter type="text" autocomplete="off" class="ui-dropdown-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [placeholder]=\"filterPlaceholder || ''\">
                     <span class="fa fa-search"></span>
                 </div>
                 <div #itemswrapper class="ui-dropdown-items-wrapper" [style.max-height]="scrollHeight||'auto'">
@@ -100,6 +100,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     
     @Input() placeholder: string;
     
+    @Input() filterPlaceholder: string;
+
     @Input() inputId: string;
     
     @Input() dataKey: string;

--- a/showcase/demo/dropdown/dropdown.html
+++ b/showcase/demo/dropdown/dropdown.html
@@ -182,6 +182,12 @@ export class MyModel &#123;
                             <td>When specified, displays an input field to filter the items on keyup.</td>
                         </tr>
                         <tr>
+                            <td>filterPlaceholder</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Placeholder text to show when filter input is empty.</td>
+                        </tr>
+                        <tr>
                             <td>autoWidth</td>
                             <td>boolean</td>
                             <td>true</td>


### PR DESCRIPTION
Add the ability to set a placeholder to the `<input>` used to filter entries in the list.

Example for `<p-dropdown filterPlaceholder="type here...">`:

![filterplaceholder](https://cloud.githubusercontent.com/assets/5244945/25391278/316b79e2-29d6-11e7-99b8-d9598d48916e.png)
