### PR TITLE
Improve selectOtherMonths to switch current month displayed

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -476,8 +476,12 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
         }
         
         if(dateMeta.otherMonth) {
-            if(this.selectOtherMonths)
+			if(this.selectOtherMonths) {
+                this.currentMonth = dateMeta.month;
+                this.currentYear = dateMeta.year;
+                this.createMonth(this.currentMonth, this.currentYear);
                 this.selectDate(dateMeta);
+            }
         }
         else {
              this.selectDate(dateMeta);


### PR DESCRIPTION
When selectOtherMonths is enabled on the calendar, and a date on a different month is selected, it will now switch to that month