### PR TITLE
fix(DataTable): Support comma fields in CSV export

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -1992,7 +1992,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         //headers
         for(let i = 0; i < this.columns.length; i++) {
             if(this.columns[i].field) {
-                csv += this.columns[i].header || this.columns[i].field;
+                csv += '"' + (this.columns[i].header || this.columns[i].field) + '"';
                 
                 if(i < (this.columns.length - 1)) {
                     csv += this.csvSeparator;
@@ -2005,7 +2005,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
             csv += '\n';
             for(let i = 0; i < this.columns.length; i++) {
                 if(this.columns[i].field) {
-                    csv += this.resolveFieldData(record, this.columns[i].field);
+                    csv += '"' + this.resolveFieldData(record, this.columns[i].field) + '"';
                     
                     if(i < (this.columns.length - 1)) {
                         csv += this.csvSeparator;


### PR DESCRIPTION
Previously, table fields/cells with commas would throw off the CSV export formatting. This change surrounds fields with double quotes in case they contain commas or other special characters that would throw off the CSV formatting (following RFC 4180 (see https://tools.ietf.org/html/rfc4180#section-2)).

Fixes #2460 