### PR TITLE
Add a "Message closed" event to the growl (primefaces/primeng#2703)

### DIFF
--- a/components/common/api.ts
+++ b/components/common/api.ts
@@ -42,6 +42,7 @@ export interface Message {
     severity?: string;
     summary?: string;
     detail?: string;
+    id?: any;
 }
 
 export interface SelectItem {

--- a/components/growl/growl.ts
+++ b/components/growl/growl.ts
@@ -1,4 +1,4 @@
-import {NgModule,Component,ElementRef,AfterViewInit,OnDestroy,Input,Output,ViewChild} from '@angular/core';
+import { NgModule, Component, ElementRef, AfterViewInit, OnDestroy, Input, Output, ViewChild, EventEmitter } from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {Message} from '../common/api';
 import {DomHandler} from '../dom/domhandler';
@@ -35,6 +35,8 @@ export class Growl implements AfterViewInit,OnDestroy {
     @Input() style: any;
         
     @Input() styleClass: string;
+
+    @Output() onClosedMessage: EventEmitter<Message> = new EventEmitter<Message>();
     
     @ViewChild('container') containerViewChild: ElementRef;
     
@@ -83,9 +85,9 @@ export class Growl implements AfterViewInit,OnDestroy {
         this.domHandler.fadeOut(msgel, 250);
         
         setTimeout(() => {
+            this.onClosedMessage.emit(this._value[index]);
             this.value = this.value.filter((val,i) => i!=index);
         }, 250);
-        
     }
     
     removeAll() {
@@ -93,6 +95,7 @@ export class Growl implements AfterViewInit,OnDestroy {
             this.domHandler.fadeOut(this.container, 250);
             
             setTimeout(() => {
+                this.value.forEach((msg, index) => this.onClosedMessage.emit(this._value[index]));
                 this.value = [];
             }, 250);
         }

--- a/showcase/demo/growl/growldemo.html
+++ b/showcase/demo/growl/growldemo.html
@@ -6,7 +6,7 @@
 </div>
 
 <div class="content-section implementation">
-    <p-growl [value]="msgs" sticky="sticky"></p-growl>
+    <p-growl [value]="msgs" sticky="sticky" (onClosedMessage)="log($event)"></p-growl>
 
     <div>
         <button type="button" pButton (click)="showSuccess()" label="Success" class="ui-button-success"></button>
@@ -128,6 +128,28 @@ hide() &#123;
                 </table>
             </div>
 
+            <h4>Events</h4>
+            <div class="doc-tablewrapper">
+                <table class="doc-table">
+                    <thead>
+                    <tr>
+                        <th>Name</th>
+                        <th>Parameters</th>
+                        <th>Description</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr>
+                        <td>onMessageClosed</td>
+                        <td>
+                            event: The closed message
+                        </td>
+                        <td>Callback to invoke when a message is closed by the user.</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+
             <h3>Styling</h3>
             <p>Following is the list of structural style classes, for theming classes visit <a href="#" [routerLink]="['/theming']">theming page</a>.</p>
             <div class="doc-tablewrapper">
@@ -178,7 +200,7 @@ hide() &#123;
         <p-tabPanel header="Source">
 <pre>
 <code class="language-markup" pCode>
-&lt;p-growl [value]="msgs" sticky="sticky"&gt;&lt;/p-growl&gt;
+&lt;p-growl [value]="msgs" sticky="sticky" (onMessageClosed)="log($event)"&gt;&lt;/p-growl&gt;
 
 &lt;div&gt;
     &lt;button type="button" pButton (click)="showSuccess()" label="Success" class="ui-button-success"&gt;&lt;/button&gt;
@@ -223,6 +245,10 @@ export class GrowlDemo &#123;
 
     clear() &#123;
         this.msgs = [];
+    &#125;
+
+    log(m) &#123;
+        console.log(m);
     &#125;
 &#125;
 </code>

--- a/showcase/demo/growl/growldemo.ts
+++ b/showcase/demo/growl/growldemo.ts
@@ -31,12 +31,16 @@ export class GrowlDemo {
 
     showMultiple() {
         this.msgs = [];
-        this.msgs.push({severity:'info', summary:'Message 1', detail:'PrimeNG rocks'});
-        this.msgs.push({severity:'info', summary:'Message 2', detail:'PrimeUI rocks'});
+        this.msgs.push({severity:'info', summary:'Message 1', detail:'PrimeNG rocks', id: 1});
+        this.msgs.push({severity:'info', summary:'Message 2', detail:'PrimeUI rocks', id: 2});
         this.msgs.push({severity:'info', summary:'Message 3', detail:'PrimeFaces rocks'});
     }
 
     clear() {
         this.msgs = [];
+    }
+
+    log(m) {
+        console.log(m);
     }
 }


### PR DESCRIPTION
- Adds the `onMessageClosed` event to the growl component which fires,
if a message is removed from the view
- Add an optional `id` field to the `Message` interface, to enable growl
users to identify closed messaged
- Adapt the showcase

###Feature Requests
This is an implementation of primefaces/primeng#2703.
It is a very small feature without any braking API changes involved and it is tested on the showcase page.