### PR TITLE
Make it possible to make the date selection at UTC midnight. eg: If y…

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -214,6 +214,8 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
 
     @Input() required: boolean;
 
+    @Input() basedOnUTC: boolean; 
+
     @Input() showOnFocus: boolean = true;
     
     @Input() dataType: string = 'date';
@@ -512,7 +514,11 @@ export class Calendar implements AfterViewInit,OnInit,OnDestroy,ControlValueAcce
     }
     
     selectDate(dateMeta) {
-        this.value = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
+        if(this.basedOnUTC){
+            this.value = new Date(Date.UTC(dateMeta.year, dateMeta.month, dateMeta.day));
+        } else {
+            this.value = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
+        }
         if(this.showTime) {
             if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
                 this.value.setHours(this.currentHour + 12);


### PR DESCRIPTION
Make it possible to make the date selection at UTC midnight. eg: If you would choose 2017-01-01T00:00:00 while in a +02:00 timezone, the UTC timestamp sent to backend would be 2016-12-31T22:00:00, which is the day before.

###Defect Fixes
Problems with timezones