### PR TITLE
fixed xhr request not sending credentials onupload

### DIFF
--- a/components/fileupload/fileupload.ts
+++ b/components/fileupload/fileupload.ts
@@ -59,6 +59,8 @@ export class FileUpload implements OnInit,AfterContentInit {
     @Input() disabled: boolean;
     
     @Input() auto: boolean;
+
+    @Input() withCredentials: boolean;
         
     @Input() maxFileSize: number;
     
@@ -81,10 +83,10 @@ export class FileUpload implements OnInit,AfterContentInit {
     @Input() uploadLabel: string = 'Upload';
     
     @Input() cancelLabel: string = 'Cancel';
-        
+
     @Output() onBeforeUpload: EventEmitter<any> = new EventEmitter();
 	
-	  @Output() onBeforeSend: EventEmitter<any> = new EventEmitter();
+	@Output() onBeforeSend: EventEmitter<any> = new EventEmitter();
         
     @Output() onUpload: EventEmitter<any> = new EventEmitter();
     
@@ -263,6 +265,8 @@ export class FileUpload implements OnInit,AfterContentInit {
 			'xhr': xhr,
             'formData': formData 
 		});
+
+        xhr.withCredentials = this.withCredentials;
         
         xhr.send(formData);
     }

--- a/showcase/demo/fileupload/fileuploaddemo.html
+++ b/showcase/demo/fileupload/fileuploaddemo.html
@@ -222,6 +222,12 @@ import &#123;FileUploadModule&#125; from 'primeng/primeng';
                             <td>Cancel</td>
                             <td>Label of the cancel button.</td>
                         </tr>
+                        <tr>
+                            <td>withCredentials</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>Cross-site Access-Control requests should be made using credentials such as cookies, authorization headers or TLS client certificates.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Defect Number
#2745

Fileupload class calls the url without sending auth cookie or Kerberos token, I have created a boolean variable which will fix this issue. its a minor change and is working as expectedly.

`withCredentials: boolean;`

if set to true on the component it will add Authentication cookie/Kerberos token.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials

I have also created the issue on stackoverflow which i will close

http://stackoverflow.com/questions/43866580/angular-4-primeng-upload-url-windows-authentication-cookie