### PR TITLE
Feature to Calendar : class marking as daily td

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -69,8 +69,9 @@ export interface LocaleSettings {
                     </thead>
                     <tbody>
                         <tr *ngFor="let week of dates">
-                            <td *ngFor="let date of week" [ngClass]="{'ui-datepicker-other-month ui-state-disabled':date.otherMonth,
-                                'ui-datepicker-current-day':isSelected(date),'ui-datepicker-today':date.today}">
+                            <td *ngFor="let date of week; let i = index" [ngClass]="{'ui-datepicker-other-month ui-state-disabled':date.otherMonth,
+                                'ui-datepicker-current-day':isSelected(date),'ui-datepicker-today':date.today, 
+                                'ui-datepicker-saturday': i === 6, 'ui-datepicker-sunday': i === 0}">
                                 <a class="ui-state-default" href="#" *ngIf="date.otherMonth ? showOtherMonths : true" 
                                     [ngClass]="{'ui-state-active':isSelected(date), 'ui-state-highlight':date.today, 'ui-state-disabled':!date.selectable}"
                                     (click)="onDateSelect($event,date)">{{date.day}}</a>


### PR DESCRIPTION
Hello, Team.

This feature add classes on daily `td` . 
Its purpose is marking only, not css decoration. So this pr isnot contains .scss file.

I added following marks.
1. saturday (dayOfWeek == 6)
2. sunday (dayOfWeek == 0)
3. custom classname and specified day (configuration via @Input specialDay)
usage:
- template
```
<p-calendar [(ngModel)]="date9" [inline]="true" [specialDay]="specialDay"></p-calendar> 
```
- component
```
this.specialDay = [
            { year: 2017, month: 4, day: 30, classname: "special_day"},
            { year: 2018, month: 1, day: 1, classname: "special_newyear_2018"},
            { year: 2018, month: 2, day: 3, classname: "special_day_one_2018"},
            { year: 2018, month: 2, day: 3, classname: "special_day_two_2018"},
            { year: 2019, month: 1, day: 1, classname: "special_newyear_2019"}
        ];
```

Please scrutiny it.