### PR TITLE
Steps dead code with disabled menu item

### DIFF
--- a/components/steps/steps.ts
+++ b/components/steps/steps.ts
@@ -43,11 +43,6 @@ export class Steps {
         
         this.activeIndexChange.emit(i);
         
-        if(item.disabled) {
-            event.preventDefault();
-            return;
-        }
-        
         if(!item.url||item.routerLink) {
             event.preventDefault();
         }


### PR DESCRIPTION
The disabled condition is already defined at the beginning of the method. So the specific code block is not reachable. 