### PR TITLE
Fixes #2846 - Growl's onClose event references wrong message when mes…

### DIFF
--- a/components/growl/growl.ts
+++ b/components/growl/growl.ts
@@ -87,9 +87,9 @@ export class Growl implements AfterViewInit,OnDestroy {
         this.domHandler.fadeOut(msgel, 250);
         
         setTimeout(() => {
-            this.value = this.value.filter((val,i) => i!=index);
-            this.valueChange.emit(this.value);
             this.onClose.emit({message:this.value[index]});
+            this.value = this.value.filter((val,i) => i!=index);
+            this.valueChange.emit(this.value);           
         }, 250);        
     }
     


### PR DESCRIPTION
Fixes an issue where the removal of a growl message was returning the incorrect message from the onClose event.