### PR TITLE
Fix #2846 (event onClose receiving wrong element)

### DIFF
--- a/components/growl/growl.ts
+++ b/components/growl/growl.ts
@@ -87,9 +87,9 @@ export class Growl implements AfterViewInit,OnDestroy {
         this.domHandler.fadeOut(msgel, 250);
         
         setTimeout(() => {
+            this.onClose.emit({message:this.value[index]});
             this.value = this.value.filter((val,i) => i!=index);
             this.valueChange.emit(this.value);
-            this.onClose.emit({message:this.value[index]});
         }, 250);        
     }
     


### PR DESCRIPTION
###Defect Fixes
Fix #2846

The item was removed from values before emit onClose with the value, so in this case index of value is the next (if is the last, return undefined). 