### PR TITLE
Calendar always populates AM

### DIFF
--- a/components/calendar/calendar.ts
+++ b/components/calendar/calendar.ts
@@ -1035,7 +1035,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         }
         
         if(this.hourFormat == '12') {
-            output += hours > 11 ? ' PM' : ' AM';
+            output += date.getHours() > 11 ? ' PM' : ' AM';
         }
         
         return output;


### PR DESCRIPTION
We need to remember two points to know the reason for this change
   1. this.pm code snippet always give time zone based on default date or current time zone.
   2. this.hours is always less than 11 due to previous code lines