### PR TITLE
Fixed #2814 - rowgroupheader colspan not tracking visible columns

### DIFF
--- a/components/datatable/datatable.ts
+++ b/components/datatable/datatable.ts
@@ -147,7 +147,7 @@ export class ColumnFooters {
             <tr #rowGroupElement class="ui-widget-header ui-rowgroup-header" 
                 *ngIf="dt.rowGroupMode=='subheader' && (rowIndex === 0||(dt.resolveFieldData(rowData,dt.groupField) !== dt.resolveFieldData(dt.dataToRender[rowIndex - 1], dt.groupField)))"
                 (click)="dt.onRowGroupClick($event)" [ngStyle]="{'cursor': dt.sortableRowGroup ? 'pointer' : 'auto'}">
-                <td [attr.colspan]="columns.length">
+                <td [attr.colspan]="dt.visibleColumns().length">
                     <a href="#" *ngIf="dt.expandableRowGroups" (click)="dt.toggleRowGroup($event,rowData)">
                         <span class="fa fa-fw" [ngClass]="{'fa-chevron-circle-down':dt.isRowGroupExpanded(rowData), 'fa-chevron-circle-right': !dt.isRowGroupExpanded(rowData)}"></span>
                     </a>


### PR DESCRIPTION
Use dt.visibleColumns().length rather than columns.length for colspan
on subheader mode row grouping.

###Defect Fixes
#2814 
