### PR TITLE
Center dialog horizontally if only positionTop is used

### DIFF
--- a/components/dialog/dialog.ts
+++ b/components/dialog/dialog.ts
@@ -156,6 +156,9 @@ export class Dialog implements AfterViewInit,OnDestroy {
         if(this.positionLeft >= 0 && this.positionTop >= 0) {
             this.container.style.left = this.positionLeft + 'px';
             this.container.style.top = this.positionTop + 'px';
+        } else if (this.positionTop >= 0) {
+          this.center();
+          this.container.style.top = this.positionTop + 'px';
         }
         else{
             this.center();


### PR DESCRIPTION
###Feature Requests
Added the ability to simply center and position the dialog just based on the screen top position. Helps with dialogs with dynamically generated content that don't center in the screen well since their height is not known at the time the dialog is initially rendered.