### PR TITLE
dropdown: Prevent form submission on filter input

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -37,7 +37,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
             <div #panel [ngClass]="'ui-dropdown-panel ui-widget-content ui-corner-all ui-helper-hidden ui-shadow'" [@panelState]="panelVisible ? 'visible' : 'hidden'"
                 [style.display]="panelVisible ? 'block' : 'none'" [ngStyle]="panelStyle" [class]="panelStyleClass">
                 <div *ngIf="filter" class="ui-dropdown-filter-container" (input)="onFilter($event)" (click)="$event.stopPropagation()">
-                    <input #filter type="text" autocomplete="off" class="ui-dropdown-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [attr.placeholder]="filterPlaceholder">
+                    <input #filter type="text" autocomplete="off" class="ui-dropdown-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [attr.placeholder]="filterPlaceholder" (keypress)="preventFormSubmit($event)">
                     <span class="fa fa-search"></span>
                 </div>
                 <div #itemswrapper class="ui-dropdown-items-wrapper" [style.max-height]="scrollHeight||'auto'">
@@ -486,6 +486,15 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             this.optionsChanged = true;
         }
         
+    }
+
+    preventFormSubmit(event): void {
+        if(!event)
+            event = window.event;
+        const keyCode = event.keyCode || event.which;
+        if(keyCode === 13) { // Enter pressed
+            return false;
+        }
     }
     
     applyFocus(): void {


### PR DESCRIPTION
Currently when one presses the "Enter" key on the dropdown filtering input, it submits the form surrounding the dropdown. In the following example, the whole form is submitted (whereas the user just wants to search in the dropdown results):

```html
<form (submit)="goToAnotherPage()">
    <p-dropdown [options]="cities" [(ngModel)]="selectedCity"
                placeholder="Select a City"
                filterPlaceholder="Search in existing cities...">
    <input type="text" [(ngModel)]="firstName" />
    <input type="text" [(ngModel)]="lastName" />
    <button>Submit</button>
</form>
```

This commit prevents the form from being submitted by catching the "Enter" key press.

![screenshot](https://cloud.githubusercontent.com/assets/5244945/26557544/939c1dba-44a2-11e7-9051-dcdbb24b134e.png)
