### PR TITLE
Fix #2143 - Slider highlights surrounding text

### DIFF
--- a/components/slider/slider.ts
+++ b/components/slider/slider.ts
@@ -98,6 +98,8 @@ export class Slider implements AfterViewInit,OnDestroy,ControlValueAccessor {
         this.updateDomData();
         this.sliderHandleClick = true;
         this.handleIndex = index;
+        
+        event.preventDefault();
     }
 
     onTouchStart(event, index?:number) {


### PR DESCRIPTION
When dragged with a mouse, the slider highlights surrounding text. This commit prevents slider input from inadvertently selecting text elsewhere in the app.