### PR TITLE
fix(calender): make button clickable on  IE9/10

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -714,7 +714,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     onButtonClick(event,inputfield) {
         this.closeOverlay = false;
         
-        if(!this.overlay.offsetParent) {
+        if(!this.overlay.offsetParent || this.overlay.style.display === 'none') {
             inputfield.focus();
             this.showOverlay();
         }


### PR DESCRIPTION
###Defect Fixes
Check style.display of this.overlay in case of IE9/10 ==> because offsetParent will _not_ get null when datepicker (=overlay) gets hidden.