### PR TITLE
Add official editEvent method in Schedule component

### DIFF
--- a/src/app/components/schedule/schedule.ts
+++ b/src/app/components/schedule/schedule.ts
@@ -221,7 +221,7 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
                 });
             },
             eventDrop: (event, delta, revertFunc, jsEvent, ui, view) => {
-                this.updateEvent(event);
+                this._updateEvent(event);
                 
                 this.onEventDrop.emit({
                     'event': event,
@@ -246,7 +246,7 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
                 });
             },
             eventResize: (event, delta, revertFunc, jsEvent, ui, view) => {
-                this.updateEvent(event);
+                this._updateEvent(event);
                 
                 this.onEventResize.emit({
                     'event': event,
@@ -349,8 +349,12 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
     getDate() {
         return this.schedule.fullCalendar('getDate');
     }
-    
-    findEvent(id: string) {
+   
+    updateEvent(event: any) {
+        this.schedule.fullCalendar('updateEvent', event);
+    }
+ 
+    _findEvent(id: string) {
         let event;
         if(this.events) {
             for(let e of this.events) {
@@ -363,8 +367,8 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
         return event;
     }
     
-    updateEvent(event: any) {
-        let sourceEvent = this.findEvent(event.id);
+    _updateEvent(event: any) {
+        let sourceEvent = this._findEvent(event.id);
         if(sourceEvent) {
             sourceEvent.start = event.start.format();
             if(event.end) {

--- a/src/app/showcase/components/schedule/scheduledemo.html
+++ b/src/app/showcase/components/schedule/scheduledemo.html
@@ -545,6 +545,11 @@ export class MyModel &#123;
                             <td>viewName: A valid view string to change to</td>
                             <td><a href="https://fullcalendar.io/docs/views/changeView/">Read more</a></td>
                         </tr>
+                        <tr>
+                          <td>updateEvent(event)</td>
+                          <td>event: Original Event Object for an event (not merely a reconstructed object)</td>
+                          <td><a href="https://fullcalendar.io/docs/event_data/updateEvent/">Read more</a></td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
This PR adds the official `editEvent(event)` method of FullCalendar to the Schedule component. It renames the internally used `editEvent` method to `_editEvent()` and also renames the internal `findEvent()` method as well. Updates to showcase documentation are included.

Please let me know if there is anything I can do to help get this change merged. Thanks so much for all your hard work!