### PR TITLE
Dialog fires unwanted onHide event

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -131,7 +131,7 @@ export class Dialog implements AfterViewInit,OnDestroy {
     
     preWidth: number;
     
-    preventVisibleChangePropagation: boolean;
+    preventVisibleChangePropagation: boolean = true;
                 
     constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2) {}
     
@@ -208,6 +208,7 @@ export class Dialog implements AfterViewInit,OnDestroy {
         if(this.visible) {
             this.show();
         }
+        this.preventVisibleChangePropagation = false;
     }
         
     center() {


### PR DESCRIPTION
When the dialog is created with property visible set to false, the setter for this property calls dialog#hide, which fires the event. The onHide event should only fire when a visible dialog is closed, not when it hasn't yet been visible.

The proposed change sets the property preventVisibleChangePropagation to true initially, preventing the call to dialog#hide (which fires the event) when creating the dialog. It is set back to false in dialog#AfterViewInit, which could also be done in dialog#ngOnInit if this method was added.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.