### PR TITLE
Safer MultiSelect label display with null check

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -315,10 +315,13 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
         if(this.value && this.options && this.value.length && this.displaySelectedLabel) {
             let label = '';
             for(let i = 0; i < this.value.length; i++) {
-                if(i != 0) {
-                    label = label + ', ';
+                let itemLabel = this.findLabelByValue(this.value[i]);
+                if (itemLabel) {
+                    if(label.length > 0) {
+                        label = label + ',';
+                    }
+                    label = label + itemLabel;
                 }
-                label = label + this.findLabelByValue(this.value[i]);
             }
             
             if(this.value.length <= this.maxSelectedLabels) {


### PR DESCRIPTION
Change to the way the label is built to handle cases where the label is null
