### PR TITLE
Fix img urls for ContextMenu showcase, add missing code for messages showcase

### DIFF
--- a/src/app/showcase/components/contextmenu/contextmenudemo.html
+++ b/src/app/showcase/components/contextmenu/contextmenudemo.html
@@ -11,7 +11,7 @@
     
     <p-contextMenu [target]="img" [model]="items2" ></p-contextMenu>
     
-    <img #img src="/assets/showcase/images/primeng.svg" alt="Logo">
+    <img #img src="assets/showcase/images/primeng.svg" alt="Logo">
 </div>
 
 <div class="content-section documentation">
@@ -41,7 +41,7 @@ import &#123;ContextMenuModule,MenuItem&#125; from 'primeng/primeng';
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-contextMenu [target]="img" [model]="items2" &gt;&lt;/p-contextMenu&gt;
 
-&lt;img #img src="/assets/showcase/images/primeng.svg" alt="Logo"&gt;
+&lt;img #img src="assets/showcase/images/primeng.svg" alt="Logo"&gt;
 </code>
 </pre>
 
@@ -221,7 +221,7 @@ export class ContextMenuDemo &#123;
 
 &lt;p-contextMenu [target]="img" [model]="items2" &gt;&lt;/p-contextMenu&gt;
 
-&lt;img #img src="/assets/showcase/images/primeng.svg" alt="Logo"&gt;
+&lt;img #img src="assets/showcase/images/primeng.svg" alt="Logo"&gt;
 </code>
 </pre>
 

--- a/src/app/showcase/components/messages/messagesdemo.html
+++ b/src/app/showcase/components/messages/messagesdemo.html
@@ -194,6 +194,11 @@ export class MessagesDemo &#123;
 
     msgs: Message[] = [];
 
+    showSuccess() &#123;
+        this.msgs = [];
+        this.msgs.push(&#123;severity:'success', summary:'Success Message', detail:'Order submitted'&#125;);
+    &#125;
+
     showInfo() &#123;
         this.msgs = [];
         this.msgs.push(&#123;severity:'info', summary:'Info Message', detail:'PrimeNG rocks'&#125;);


### PR DESCRIPTION
ConextMenu showcase has broken img url:
https://www.primefaces.org/primeng/#/contextmenu
It was broken by copy&paste fail in 5818101eb21535aad5eb93225620cc857667a4b5

Apply #3057 for messages showcase