### PR TITLE
MultiSelect preselection may not work correctly 

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -339,7 +339,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
         let label = null;
         for(let i = 0; i < this.options.length; i++) {
             let option = this.options[i];
-            if(option.value == val || this.objectUtils.equals(option.value, val, this.dataKey)) {
+            if(this.objectUtils.equals(option.value, val, this.dataKey)) {
                 label = option.label;
                 break; 
             }

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -339,7 +339,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
         let label = null;
         for(let i = 0; i < this.options.length; i++) {
             let option = this.options[i];
-            if(option.value == val || (this.objectUtils.equals(option.value, val, this.dataKey)) {
+            if(option.value == val || this.objectUtils.equals(option.value, val, this.dataKey)) {
                 label = option.label;
                 break; 
             }

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -339,7 +339,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
         let label = null;
         for(let i = 0; i < this.options.length; i++) {
             let option = this.options[i];
-            if(option.value == val) {
+            if(option.value == val || (this.dataKey && val && option.value[this.dataKey]==val[this.dataKey])) {
                 label = option.label;
                 break; 
             }

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -339,7 +339,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
         let label = null;
         for(let i = 0; i < this.options.length; i++) {
             let option = this.options[i];
-            if(option.value == val || (this.dataKey && val && option.value[this.dataKey]==val[this.dataKey])) {
+            if(option.value == val || (this.objectUtils.equals(option.value, val, this.dataKey)) {
                 label = option.label;
                 break; 
             }


### PR DESCRIPTION
###Defect Fixes
When trying to initialize the MultiSelect Component, if it's no the same instance of the object(options vs formControlName), fails to locate it on the options of the MultiSelect Component, and show null as label in the input.
