### PR TITLE
cache calculateScrollbarWidth for improve performace

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -5,6 +5,8 @@ export class DomHandler {
 
     public static zindex: number = 1000;
 
+    private calculatedScrollbarWidth: number = null;
+
     public addClass(element: any, className: string): void {
         if (element.classList)
             element.classList.add(className);
@@ -384,12 +386,17 @@ export class DomHandler {
     }
     
     calculateScrollbarWidth(): number {
+        if(this.calculatedScrollbarWidth !== null)
+            return this.calculatedScrollbarWidth;
+        
         let scrollDiv = document.createElement("div");
         scrollDiv.className = "ui-scrollbar-measure";
         document.body.appendChild(scrollDiv);
 
         let scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
         document.body.removeChild(scrollDiv);
+
+        this.calculatedScrollbarWidth = scrollbarWidth;
         
         return scrollbarWidth;
     }


### PR DESCRIPTION
### Defect Fixes
fix #3195 

### Cause: 
- When use `resizableColumns` it register mousemove event so every mouse move it `ngAfterViewChecked`. 
- And in `ScrollableView` if it not frozen, it call `alignScrollBar` and it use `calculateScrollbarWidth`. 
- `calculateScrollbarWidth` create a element for calculate scrollbar width (it touch a dom)
- So every mouse move. it create and remove element every time.

### How i fix
- cache `calculateScrollbarWidth` result. so it calculate only once