### PR TITLE
add tableStyleClass and tableStyle to TreeTable

### DIFF
--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -25,7 +25,7 @@ import {DomHandler} from '../dom/domhandler';
         </div>
         <div *ngIf="node.children && node.expanded" class="ui-treetable-row" style="display:table-row">
             <td [attr.colspan]="treeTable.columns.length" class="ui-treetable-child-table-container">
-                <table>
+                <table [class]="treeTable.tableStyleClass" [ngStyle]="treeTable.tableStyle">
                     <tbody pTreeRow *ngFor="let childNode of node.children" [node]="childNode" [level]="level+1" [labelExpand]="labelExpand" [labelCollapse]="labelCollapse" [parentNode]="node"></tbody>
                 </table>
             </td>
@@ -113,7 +113,7 @@ export class UITreeRow implements OnInit {
                 <ng-content select="p-header"></ng-content>
             </div>
             <div class="ui-treetable-tablewrapper">
-                <table #tbl class="ui-widget-content">
+                <table #tbl class="ui-widget-content" [class]="tableStyleClass" [ngStyle]="tableStyle">
                     <thead>
                         <tr class="ui-state-default">
                             <th #headerCell *ngFor="let col of columns; let lastCol=last "  [ngStyle]="col.style" [class]="col.styleClass" 
@@ -167,6 +167,10 @@ export class TreeTable implements AfterContentInit {
     @Input() contextMenu: any;
 
     @Input() toggleColumnIndex: number = 0;
+
+    @Input() tableStyle: any;
+
+    @Input() tableStyleClass: string;
         
     @Output() onRowDblclick: EventEmitter<any> = new EventEmitter();    
     


### PR DESCRIPTION
DataTable has these `tableStyleClass` and `tableStyle` input so users can customize the class and styles of the table, the TreeTable also use table but don't have these inputs, this makes it hard to make the treetable match the style of our own design.

So this PR add these two input to TreeTable.