### PR TITLE
Tree - child nodes may not accessible #1733

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -43,7 +43,7 @@ export class TreeNodeTemplateLoader implements OnInit, OnDestroy {
                 <div class="ui-treenode-content" (click)="onNodeClick($event)" (contextmenu)="onNodeRightClick($event)" (touchend)="onNodeTouchEnd()"
                     (drop)="onDropNode($event)" (dragover)="onDropNodeDragOver($event)" (dragenter)="onDropNodeDragEnter($event)" (dragleave)="onDropNodeDragLeave($event)"
                     [ngClass]="{'ui-treenode-selectable':tree.selectionMode && node.selectable !== false,'ui-treenode-dragover':draghoverNode}" [draggable]="tree.draggableNodes" (dragstart)="onDragStart($event)" (dragend)="onDragStop($event)">
-                    <span class="ui-tree-toggler  fa fa-fw" [ngClass]="{'fa-caret-right':!node.expanded,'fa-caret-down':node.expanded}"
+                    <span class="ui-tree-toggler  fa fa-fw" [ngClass]="{'fa-caret-right':(node.children || node.leaf) && !node.expanded,'fa-caret-down': (node.children || node.leaf) && node.expanded}"
                             (click)="toggle($event)"></span
                     ><div class="ui-chkbox" *ngIf="tree.selectionMode == 'checkbox'"><div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default">
                         <span class="ui-chkbox-icon ui-clickable fa" 


### PR DESCRIPTION
Fix to a bug that made every tree node with a caret/arrow for children even when there was no children or the parameter leaf was disable if you did not import a theme. Also fix the issue: Tree - child nodes may not accessible #1733 when you have a theme imported if you remove the following lines in primeng.css (wich i can't find on github) :
.ui-tree .ui-treenode.ui-treenode-leaf > .ui-treenode-content > .ui-tree-toggler {
visibility: hidden;
}

Sorry the fix is ugly but i did not have enough time to make it better.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.