### PR TITLE
#3349  autoResize bug fixed

### DIFF
--- a/src/app/components/inputtextarea/inputtextarea.ts
+++ b/src/app/components/inputtextarea/inputtextarea.ts
@@ -32,8 +32,12 @@ export class InputTextarea implements OnInit,DoCheck {
     constructor(public el: ElementRef) {}
     
     ngOnInit() {
-        this.rowsDefault = this.rows;
-        this.colsDefault = this.cols;
+      if(this.rows === undefined)
+        this.rows = 5;
+      if(this.cols === undefined)
+        this.cols = 30;
+      this.rowsDefault = this.rows;
+      this.colsDefault = this.cols;
     }
     
     ngDoCheck() {


### PR DESCRIPTION
If  the user would like to use autoResize property, the row and column number had to be  declared otherwise they return as undefined and autoResize had not worked.
After the fix, if the user does not declare row or column number and would like to use autoResize, there happens a text area with default row = 5 and default column = 30 with autorResize property.

###Defect Fixes
#3349 
###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.