### PR TITLE
#3376 bug fixed

### DIFF
--- a/src/app/components/colorpicker/colorpicker.ts
+++ b/src/app/components/colorpicker/colorpicker.ts
@@ -174,7 +174,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
         let val: any;
         switch(this.format) {
             case 'hex':
-                val = this.HSBtoHEX(this.value);
+                val = "#" + this.HSBtoHEX(this.value);
             break;
             
             case 'rgb':

--- a/src/app/showcase/components/colorpicker/colorpickerdemo.html
+++ b/src/app/showcase/components/colorpicker/colorpickerdemo.html
@@ -9,7 +9,7 @@
     <h3 class="first">Inline</h3>
     <p-colorPicker [(ngModel)]="color1" inline="true"></p-colorPicker>
     
-    <p style="margin-top:.5em">Selected Color: <span style="display:inline-block;width:32px;height:32px;vertical-align:middle" [style.backgroundColor]="'#' + color1"></span> {{color1}} </p>    
+    <p style="margin-top:.5em">Selected Color: <span style="display:inline-block;width:32px;height:32px;vertical-align:middle" [style.backgroundColor]="color1"></span> {{color1}} </p>    
     
     <h3>Overlay</h3>
     <p-colorPicker [(ngModel)]="color2"></p-colorPicker>


### PR DESCRIPTION
The '#' character added to colorpicker.ts when the format is default (hex). Then, in HTML, we do not need to add '#' for providing style.backgroundColor, because it already includes '#'

###Defect Fixes
#3376 

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.