### PR TITLE
doc(messages): add missing function in demo

### DIFF
--- a/src/app/showcase/components/messages/messagesdemo.html
+++ b/src/app/showcase/components/messages/messagesdemo.html
@@ -193,6 +193,11 @@ hide() &#123;
 export class MessagesDemo &#123;
 
     msgs: Message[] = [];
+    
+    showSuccess() &#123;
+        this.msgs = [];
+        this.msgs.push(&#123;severity:'success', summary:'Success Message', detail:'Order submitted'&#125;);
+    &#125;
 
     showInfo() &#123;
         this.msgs = [];


### PR DESCRIPTION
The `showSuccess()` function called by `Success` button was missing from demo code