### PR TITLE
Tieredmenu performance fix

### DIFF
--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -125,13 +125,6 @@ export class TieredMenu implements AfterViewInit,OnDestroy {
                 else
                     this.domHandler.appendChild(this.container, this.appendTo);
             }
-            
-            this.documentClickListener = this.renderer.listen('document', 'click', () => {
-                if(!this.preventDocumentDefault) {
-                    this.hide();
-                }
-                this.preventDocumentDefault = false;
-            });
         }
     }
     
@@ -147,9 +140,22 @@ export class TieredMenu implements AfterViewInit,OnDestroy {
         this.container.style.display = 'block';
         this.domHandler.absolutePosition(this.container, event.target);
         this.domHandler.fadeIn(this.container, 250);
+
+        if (this.popup && !this.documentClickListener) {
+            this.documentClickListener = this.renderer.listen('document', 'click', () => {
+                if (!this.preventDocumentDefault) {
+                    this.hide();
+                }
+                this.preventDocumentDefault = false;
+            });
+        }
     }
     
     hide() {
+        if(this.popup && this.documentClickListener) {
+            this.documentClickListener();
+            this.documentClickListener = null;
+        }
         this.container.style.display = 'none';
     }
 


### PR DESCRIPTION
Fixes performance issues described in https://github.com/primefaces/primeng/issues/3476

Fix shifts listener binding to show method and ensures that listener is discarded on hide method - Component listens to document click event only when its required.

For ~70 popup tiered menus on page it reduces click execution time from circa 3 seconds to almost instantaneous.
