### PR TITLE
Update tooltip.ts

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -164,7 +164,7 @@ export class Tooltip implements OnDestroy {
     
     updateText () {
         if(this.escape) {
-            this.tooltipText.innerHTML = null;
+            this.tooltipText.innerHTML = '';
             this.tooltipText.appendChild(document.createTextNode(this._text));
         }
 		else {


### PR DESCRIPTION
Changing updateText() method (line 167).
Changed value of this.tooltipText.innerHTML from null to '' (empty string).
I've performed that change because from some reason, IE renders the innerHtml null to 'null' (as a string), and whatever the updated tooltip text is, it gets 'null' before it. (e.g: 'FieldError' becomes  'nullFieldError').