### PR TITLE
Fix several bugs in fileupload component.

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -1,4 +1,4 @@
-import {NgModule,Component,OnInit,Input,Output,EventEmitter,TemplateRef,AfterContentInit,ContentChildren,QueryList} from '@angular/core';
+import {NgModule,Component,OnInit,Input,Output,EventEmitter,TemplateRef,AfterContentInit,ContentChildren,QueryList,ViewChild,ElementRef} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {DomSanitizer} from '@angular/platform-browser';
 import {ButtonModule} from '../button/button';
@@ -12,7 +12,7 @@ import {PrimeTemplate,SharedModule} from '../common/shared';
     template: `
         <div [ngClass]="'ui-fileupload ui-widget'" [ngStyle]="style" [class]="styleClass" *ngIf="mode === 'advanced'">
             <div class="ui-fileupload-buttonbar ui-widget-header ui-corner-top">
-                <span class="ui-fileupload-choose" [label]="chooseLabel" icon="fa-plus" pButton  [ngClass]="{'ui-fileupload-choose-selected': hasFiles(),'ui-state-focus': focus}" [attr.disabled]="disabled" > 
+                <span class="ui-fileupload-choose" [label]="chooseLabel" icon="fa-plus" pButton  [ngClass]="{'ui-fileupload-choose-selected': hasFiles() && !multiple,'ui-state-focus': focus}" [attr.disabled]="disabled" > 
                     <input #fileinput type="file" (change)="onFileSelect($event)" [multiple]="multiple" [accept]="accept" [disabled]="disabled" (focus)="onFocus()" (blur)="onBlur()">
                 </span>
 
@@ -120,6 +120,8 @@ export class FileUpload implements OnInit,AfterContentInit {
     @Output() uploadHandler: EventEmitter<any> = new EventEmitter();
     
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
+
+    @ViewChild('fileinput') fileinput: ElementRef;
      
     public files: File[];
     
@@ -188,6 +190,7 @@ export class FileUpload implements OnInit,AfterContentInit {
         if(this.hasFiles() && this.auto) {
             this.upload();
         }
+        this.fileinput.nativeElement.value = '';
     }
         
     validate(file: File): boolean {
@@ -302,10 +305,12 @@ export class FileUpload implements OnInit,AfterContentInit {
 
     clear() {
         this.files = [];
+        this.fileinput.nativeElement.value = '';
         this.onClear.emit();
     }
     
     remove(event: Event, index: number) {
+        this.fileinput.nativeElement.value = '';
         this.onRemove.emit({originalEvent: event, file: this.files[index]});
         this.files.splice(index, 1);
     }


### PR DESCRIPTION
###Defect Fixes

Fix not to be able to select twice the same file even if you have press clean or remove item (clear fileinput value)
Fix to open twice the file selector dialog in multiple mode (not apply ui-fileupload-choose-selected class style in multiple mode)

Probably fix [#3491](https://github.com/primefaces/primeng/issues/3491) and [#3385](https://github.com/primefaces/primeng/issues/3385)
