### PR TITLE
Tooltips - fix for hideTimeout bug due to rapid mouseenter/mouseleave events

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -47,6 +47,11 @@ export class Tooltip implements OnDestroy {
     @HostListener('mouseenter', ['$event']) 
     onMouseEnter(e: Event) {
         if(this.tooltipEvent === 'hover') {
+            if(this.hideTimeout) {
+                clearTimeout(this.hideTimeout);
+                this.destroy();
+            }
+
             this.activate();
         }
     }

--- a/src/app/showcase/components/tooltip/tooltipdemo.html
+++ b/src/app/showcase/components/tooltip/tooltipdemo.html
@@ -24,6 +24,8 @@
     
     <h3>Focus and Blur</h3>
     <input type="text" pInputText pTooltip="Enter your username" placeholder="Right" tooltipEvent="focus" style="margin-left:.5em">
+
+    <button pTooltip="Tooltip Text!" showDelay="200" hideDelay="500">HELLO MOM</button>
 </div>
 
 <div class="content-section documentation">

--- a/src/app/showcase/components/tooltip/tooltipdemo.html
+++ b/src/app/showcase/components/tooltip/tooltipdemo.html
@@ -24,8 +24,6 @@
     
     <h3>Focus and Blur</h3>
     <input type="text" pInputText pTooltip="Enter your username" placeholder="Right" tooltipEvent="focus" style="margin-left:.5em">
-
-    <button pTooltip="Tooltip Text!" showDelay="200" hideDelay="500">HELLO MOM</button>
 </div>
 
 <div class="content-section documentation">


### PR DESCRIPTION
Essentially, if tooltip has hideDelay, mouseenter handler will manually clear the hideTimeout and destroy() tooltip before activating. Fix for [issue #3462](https://github.com/primefaces/primeng/issues/3462).