### PR TITLE
Added for-Attribute to inner Label of radiobutton- and checkbox...

### DIFF
--- a/src/app/components/checkbox/checkbox.ts
+++ b/src/app/components/checkbox/checkbox.ts
@@ -21,7 +21,7 @@ export const CHECKBOX_VALUE_ACCESSOR: any = {
                 <span class="ui-chkbox-icon ui-clickable" [ngClass]="{'fa fa-check':checked}"></span>
             </div>
         </div>
-        <label class="ui-chkbox-label" (click)="onClicck($event,cb,true)" *ngIf="label" [attr.for]="inputId">{{label}}</label>
+        <label class="ui-chkbox-label" (click)="onClick($event,cb,true)" *ngIf="label" [attr.for]="inputId">{{label}}</label>
     `,
     providers: [CHECKBOX_VALUE_ACCESSOR]
 })

--- a/src/app/components/checkbox/checkbox.ts
+++ b/src/app/components/checkbox/checkbox.ts
@@ -21,7 +21,7 @@ export const CHECKBOX_VALUE_ACCESSOR: any = {
                 <span class="ui-chkbox-icon ui-clickable" [ngClass]="{'fa fa-check':checked}"></span>
             </div>
         </div>
-        <label class="ui-chkbox-label" (click)="onClick($event,cb,true)" *ngIf="label">{{label}}</label>
+        <label class="ui-chkbox-label" (click)="onClicck($event,cb,true)" *ngIf="label" [attr.for]="inputId">{{label}}</label>
     `,
     providers: [CHECKBOX_VALUE_ACCESSOR]
 })

--- a/src/app/components/radiobutton/radiobutton.ts
+++ b/src/app/components/radiobutton/radiobutton.ts
@@ -22,7 +22,7 @@ export const RADIO_VALUE_ACCESSOR: any = {
                 <span class="ui-radiobutton-icon ui-clickable" [ngClass]="{'fa fa-circle':rb.checked}"></span>
             </div>
         </div>
-        <label class="ui-radiobutton-label" (click)="select()" *ngIf="label">{{label}}</label>
+        <label class="ui-radiobutton-label" (click)="select()" *ngIf="label" [attr.for]="inputId">{{label}}</label>
     `,
     providers: [RADIO_VALUE_ACCESSOR]
 })

--- a/src/app/showcase/components/checkbox/checkboxdemo.html
+++ b/src/app/showcase/components/checkbox/checkboxdemo.html
@@ -8,9 +8,9 @@
 <div class="content-section implementation">
     <h3 class="first">Basic</h3>
     <div class="ui-g" style="width:250px;margin-bottom:10px">
-        <div class="ui-g-12"><p-checkbox name="group1" value="New York" label="New York" [(ngModel)]="selectedCities"></p-checkbox></div>
-        <div class="ui-g-12"><p-checkbox name="group1" value="San Francisco" label="San Francisco" [(ngModel)]="selectedCities"></p-checkbox></div>
-        <div class="ui-g-12"><p-checkbox name="group1" value="Los Angeles" label="Los Angeles" [(ngModel)]="selectedCities"></p-checkbox></div>
+        <div class="ui-g-12"><p-checkbox name="group1" value="New York" label="New York" [(ngModel)]="selectedCities" inputId="ny"></p-checkbox></div>
+        <div class="ui-g-12"><p-checkbox name="group1" value="San Francisco" label="San Francisco" [(ngModel)]="selectedCities" inputId="sf"></p-checkbox></div>
+        <div class="ui-g-12"><p-checkbox name="group1" value="Los Angeles" label="Los Angeles" [(ngModel)]="selectedCities" inputId="la"></p-checkbox></div>
     </div>
 
     Selected Cities: <span *ngFor="let city of selectedCities" style="margin-right:10px">{{city}}</span>

--- a/src/app/showcase/components/radiobutton/radiobuttondemo.html
+++ b/src/app/showcase/components/radiobutton/radiobuttondemo.html
@@ -8,9 +8,9 @@
 <div class="content-section implementation">
     <h3 class="first">Basic</h3>
     <div class="ui-g" style="width:250px;margin-bottom:10px">
-        <div class="ui-g-12"><p-radioButton name="group1" value="Option 1" label="Option 1" [(ngModel)]="val1"></p-radioButton></div>
-        <div class="ui-g-12"><p-radioButton name="group1" value="Option 2" label="Option 2" [(ngModel)]="val1"></p-radioButton></div>
-        <div class="ui-g-12"><p-radioButton name="group1" value="Option 3" label="Option 3" [(ngModel)]="val1"></p-radioButton></div>
+        <div class="ui-g-12"><p-radioButton name="group1" value="Option 1" label="Option 1" [(ngModel)]="val1" inputId="opt1"></p-radioButton></div>
+        <div class="ui-g-12"><p-radioButton name="group1" value="Option 2" label="Option 2" [(ngModel)]="val1" inputId="opt2"></p-radioButton></div>
+        <div class="ui-g-12"><p-radioButton name="group1" value="Option 3" label="Option 3" [(ngModel)]="val1" inputId="opt3"></p-radioButton></div>
     </div>
     Selected Value = {{val1||'none'}}
 


### PR DESCRIPTION
...-component pointing to inputId-Property of the Component. Additionally added inputId-Attribute to showcase.
This implements the feature requested in #3617 by addings the for-Attribute to inner Labels respectively.
This would also solve screenreader problems finding the label auf the input-component.

I additionally added an inputId-Attribute to the first group of both checkboxes and raidobuttons in the showcase.