### PR TITLE
add state css classes on checkbox and radio labels

### DIFF
--- a/src/app/components/checkbox/checkbox.ts
+++ b/src/app/components/checkbox/checkbox.ts
@@ -21,7 +21,9 @@ export const CHECKBOX_VALUE_ACCESSOR: any = {
                 <span class="ui-chkbox-icon ui-clickable" [ngClass]="{'fa fa-check':checked}"></span>
             </div>
         </div>
-        <label class="ui-chkbox-label" (click)="onClick($event,cb,true)" *ngIf="label" [attr.for]="inputId">{{label}}</label>
+        <label class="ui-chkbox-label" (click)="onClick($event,cb,true)" 
+            [ngClass]="{'ui-label-state-active':checked,'ui-label-state-disabled':disabled,'ui-label-state-focus':focused}"
+            *ngIf="label" [attr.for]="inputId">{{label}}</label>
     `,
     providers: [CHECKBOX_VALUE_ACCESSOR]
 })

--- a/src/app/components/radiobutton/radiobutton.ts
+++ b/src/app/components/radiobutton/radiobutton.ts
@@ -22,7 +22,9 @@ export const RADIO_VALUE_ACCESSOR: any = {
                 <span class="ui-radiobutton-icon ui-clickable" [ngClass]="{'fa fa-circle':rb.checked}"></span>
             </div>
         </div>
-        <label class="ui-radiobutton-label" (click)="select()" *ngIf="label" [attr.for]="inputId">{{label}}</label>
+        <label class="ui-radiobutton-label" (click)="select()" 
+            [ngClass]="{'ui-label-state-active':checked,'ui-label-state-disabled':disabled,'ui-label-state-focus':focused}"
+            *ngIf="label" [attr.for]="inputId">{{label}}</label>
     `,
     providers: [RADIO_VALUE_ACCESSOR]
 })

--- a/src/app/components/radiobutton/radiobutton.ts
+++ b/src/app/components/radiobutton/radiobutton.ts
@@ -23,7 +23,7 @@ export const RADIO_VALUE_ACCESSOR: any = {
             </div>
         </div>
         <label class="ui-radiobutton-label" (click)="select()" 
-            [ngClass]="{'ui-label-state-active':checked,'ui-label-state-disabled':disabled,'ui-label-state-focus':focused}"
+            [ngClass]="{'ui-label-state-active':rb.checked,'ui-label-state-disabled':disabled,'ui-label-state-focus':focused}"
             *ngIf="label" [attr.for]="inputId">{{label}}</label>
     `,
     providers: [RADIO_VALUE_ACCESSOR]


### PR DESCRIPTION
https://github.com/primefaces/primeng/issues/3578: I've added unique dynamic classes to the checkbox and radio button features, so that the labels for these components can be styled based on checked, focused, and inactive states. I've searched through all of the components and have only found these two to be using ```<label>``` tags.

###Defect Fixes When submitting a PR, please also create an issue documenting the error.

###Feature Requests Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes. Smaller scaled feature implementations such as adding a property to a component will be considered for merging.