### PR TITLE
AutoComplete should clear highlight option on suggestions change

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -189,6 +189,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
     
     handleSuggestionsChange() {
         if(this.panelEL && this.panelEL.nativeElement) {
+            this.highlightOption = null;
             if(this._suggestions && this._suggestions.length) {
                 this.noResults = false;
                 this.show();


### PR DESCRIPTION
current input when tabbing out of the control without highlighting a new value
