### PR TITLE
fixing typo at doughnutchartdemo.html

### DIFF
--- a/src/app/showcase/components/chart/doughnutchart/doughnutchartdemo.html
+++ b/src/app/showcase/components/chart/doughnutchart/doughnutchartdemo.html
@@ -16,7 +16,7 @@
     </a>
     
     <p-tabView effect="fade">
-        <p-tabPanel header="doughnutchartdmeo.ts">
+        <p-tabPanel header="doughnutchartdemo.ts">
 <pre>
 <code class="language-typescript" pCode ngNonBindable>
 export class DoughnutChartDemo &#123;
@@ -47,7 +47,7 @@ export class DoughnutChartDemo &#123;
 </pre>            
         </p-tabPanel>
 
-        <p-tabPanel header="doughnutchartdmeo.html">
+        <p-tabPanel header="doughnutchartdemo.html">
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-chart type="doughnut" [data]="data"&gt;&lt;/p-chart&gt;


### PR DESCRIPTION
Simple typo fix for tab headers

I am not changing anything about the code, but a simple typo at documentation :)