### PR TITLE
Bug fix for #3657 -

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -468,9 +468,11 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
 
             //space
             case 32:
-                this.show();
-                
-                event.preventDefault();
+            case 32:
+                if(!this.panelVisible){
+                    this.show();
+                    event.preventDefault();
+                }
             break;
             
             //enter


### PR DESCRIPTION
Spaces are no longer blocked when the dropdown is open. If the dropdown is closed, space will still open it, preserving the intended functionality.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.