### PR TITLE
Fix #3664 Added the missing template reference

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -48,7 +48,7 @@ import {PrimeTemplate,SharedModule} from '../common/shared';
         [ngClass]="{'ui-fileupload-choose-selected': hasFiles(),'ui-state-focus': focus}">
             <span class="ui-button-icon-left fa" [ngClass]="{'fa-plus': !hasFiles()||auto, 'fa-upload': hasFiles()&&!auto}"></span>
             <span class="ui-button-text ui-clickable">{{auto ? chooseLabel : hasFiles() ? files[0].name : chooseLabel}}</span>
-            <input type="file" [accept]="accept" [multiple]="multiple" [disabled]="disabled"
+            <input #fileinput type="file" [accept]="accept" [multiple]="multiple" [disabled]="disabled"
                 (change)="onFileSelect($event)" *ngIf="!hasFiles()" (focus)="onFocus()" (blur)="onBlur()">
         </span>
     `


### PR DESCRIPTION
Fix for #3664 

The issue was a missing ***#fileinput*** template reference variable when mode is *'basic'*.
```html
<span class="ui-button ui-fileupload-choose ui-widget ui-state-default ui-corner-all ui-button-text-icon-left" *ngIf="mode === 'basic'" . . .
. . .
<input #fileinput type="file" . . . 
```
