### PR TITLE
Color picker pickHue resets saturation and brightness

### DIFF
--- a/src/app/components/colorpicker/colorpicker.ts
+++ b/src/app/components/colorpicker/colorpicker.ts
@@ -51,108 +51,108 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
     @Input() style: any;
 
     @Input() styleClass: string;
-    
+
     @Input() inline: boolean;
-    
+
     @Input() format: string = 'hex';
-    
+
     @Input() appendTo: string;
-    
+
     @Input() disabled: boolean;
-    
+
     @Input() tabindex: string;
-    
+
     @Input() inputId: string;
-    
+
     @Output() onChange: EventEmitter<any> = new EventEmitter();
-    
+
     @ViewChild('panel') panelViewChild: ElementRef;
-    
+
     @ViewChild('colorSelector') colorSelectorViewChild: ElementRef;
-    
+
     @ViewChild('colorHandle') colorHandleViewChild: ElementRef;
-    
+
     @ViewChild('hue') hueViewChild: ElementRef;
-    
+
     @ViewChild('hueHandle') hueHandleViewChild: ElementRef;
-    
+
     @ViewChild('input') inputViewChild: ElementRef;
-    
+
     value: any;
-    
+
     inputBgColor: string;
-    
+
     shown: boolean;
-    
+
     panelVisible: boolean;
-    
+
     defaultColor: string = 'ff0000';
-    
+
     onModelChange: Function = () => {};
-    
+
     onModelTouched: Function = () => {};
-    
+
     documentClickListener: Function;
-    
+
     documentMousemoveListener: Function;
-    
+
     documentMouseupListener: Function;
-    
+
     documentHueMoveListener: Function;
-                
+
     selfClick: boolean;
-    
+
     colorDragging: boolean;
-    
+
     hueDragging: boolean;
-                
+
     constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public cd: ChangeDetectorRef) {}
-    
+
     ngAfterViewChecked() {
         if(this.shown) {
             this.onShow();
             this.shown = false;
         }
     }
-    
+
     onHueMousedown(event: MouseEvent) {
         if(this.disabled) {
             return;
         }
-        
+
         this.bindDocumentMousemoveListener();
         this.bindDocumentMouseupListener();
-        
+
         this.hueDragging = true;
         this.pickHue(event);
     }
-    
+
     pickHue(event: MouseEvent) {
         let top: number = this.hueViewChild.nativeElement.getBoundingClientRect().top + document.body.scrollTop;
         this.value = this.validateHSB({
             h: Math.floor(360 * (150 - Math.max(0, Math.min(150, (event.pageY - top)))) / 150),
-            s: 100,
-            b: 100
+            s: this.value.s,
+            b: this.value.b
         });
-        
+
         this.updateColorSelector();
         this.updateUI();
         this.updateModel();
-        this.onChange.emit({originalEvent: event, value: this.value});
+        this.onChange.emit({originalEvent: event, value: this.getValueToUpdate()});
     }
-    
+
     onColorMousedown(event: MouseEvent) {
         if(this.disabled) {
             return;
         }
-        
+
         this.bindDocumentMousemoveListener();
         this.bindDocumentMouseupListener();
-        
+
         this.colorDragging = true;
         this.pickColor(event);
     }
-    
+
     pickColor(event: MouseEvent) {
         let rect = this.colorSelectorViewChild.nativeElement.getBoundingClientRect();
         let top = rect.top + document.body.scrollTop;
@@ -164,31 +164,31 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
             s: saturation,
             b: brightness
         });
-        
+
         this.updateUI();
         this.updateModel();
         this.onChange.emit({originalEvent: event, value: this.getValueToUpdate()});
     }
-    
+
     getValueToUpdate() {
         let val: any;
         switch(this.format) {
             case 'hex':
                 val = '#' + this.HSBtoHEX(this.value);
             break;
-            
+
             case 'rgb':
                 val = this.HSBtoRGB(this.value);
             break;
-            
+
             case 'hsb':
                 val = this.value;
             break;
         }
-        
+
         return val;
     }
-    
+
     updateModel(): void {
         this.onModelChange(this.getValueToUpdate());
     }
@@ -199,11 +199,11 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
                 case 'hex':
                     this.value = this.HEXtoHSB(value);
                 break;
-                
+
                 case 'rgb':
                     this.value = this.RGBtoHSB(value);
                 break;
-                
+
                 case 'hsb':
                     this.value = value;
                 break;
@@ -212,61 +212,61 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
         else {
             this.value = this.HEXtoHSB(this.defaultColor);
         }
-        
+
         this.updateColorSelector();
         this.updateUI();
     }
-    
+
     updateColorSelector() {
         this.colorSelectorViewChild.nativeElement.style.backgroundColor = '#' + this.HSBtoHEX(this.value);
     }
-        
+
     updateUI() {
         this.colorHandleViewChild.nativeElement.style.left =  Math.floor(150 * this.value.s / 100) + 'px';
         this.colorHandleViewChild.nativeElement.style.top =  Math.floor(150 * (100 - this.value.b) / 100) + 'px';
         this.hueHandleViewChild.nativeElement.style.top = Math.floor(150 - (150 * this.value.h / 360)) + 'px';
         this.inputBgColor = '#' + this.HSBtoHEX(this.value);
     }
-    
+
     onInputFocus() {
         this.onModelTouched();
     }
-    
+
     show() {
         this.panelViewChild.nativeElement.style.zIndex = String(++DomHandler.zindex);
         this.panelVisible = true;
         this.shown = true;
     }
-    
+
     hide() {
         this.panelVisible = false;
         this.unbindDocumentClickListener();
     }
-    
+
     onShow() {
         this.alignPanel();
         this.bindDocumentClickListener();
     }
-     
+
     alignPanel() {
         if(this.appendTo)
             this.domHandler.absolutePosition(this.panelViewChild.nativeElement, this.inputViewChild.nativeElement);
         else
             this.domHandler.relativePosition(this.panelViewChild.nativeElement, this.inputViewChild.nativeElement);
     }
-    
+
     onInputClick() {
         this.selfClick = true;
         this.togglePanel();
     }
-    
+
     togglePanel() {
         if(!this.panelVisible)
             this.show();
         else
             this.hide();
     }
-    
+
     onInputKeydown(event: KeyboardEvent) {
         switch(event.which) {
             //space
@@ -274,7 +274,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
                 this.togglePanel();
                 event.preventDefault();
             break;
-                        
+
             //escape and tab
             case 27:
             case 9:
@@ -282,11 +282,11 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
             break;
         }
     }
-        
+
     onPanelClick() {
         this.selfClick = true;
     }
-    
+
     registerOnChange(fn: Function): void {
         this.onModelChange = fn;
     }
@@ -294,11 +294,11 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
     registerOnTouched(fn: Function): void {
         this.onModelTouched = fn;
     }
-    
+
     setDisabledState(val: boolean): void {
         this.disabled = val;
     }
-    
+
     bindDocumentClickListener() {
         if(!this.documentClickListener) {
             this.documentClickListener = this.renderer.listen('document', 'click', () => {
@@ -306,41 +306,41 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
                     this.panelVisible = false;
                     this.unbindDocumentClickListener();
                 }
-                
+
                 this.selfClick = false;
                 this.cd.markForCheck();
             });
-        }    
+        }
     }
-    
+
     unbindDocumentClickListener() {
         if(this.documentClickListener) {
             this.documentClickListener();
             this.documentClickListener = null;
         }
     }
-    
+
     bindDocumentMousemoveListener() {
         if(!this.documentMousemoveListener) {
             this.documentMousemoveListener = this.renderer.listen('document', 'mousemove', (event: MouseEvent) => {
                 if(this.colorDragging) {
                     this.pickColor(event);
                 }
-                
+
                 if(this.hueDragging) {
                     this.pickHue(event);
                 }
             });
         }
     }
-    
+
     unbindDocumentMousemoveListener() {
         if(this.documentMousemoveListener) {
             this.documentMousemoveListener();
             this.documentMousemoveListener = null;
         }
     }
-    
+
     bindDocumentMouseupListener() {
         if(!this.documentMouseupListener) {
             this.documentMouseupListener = this.renderer.listen('document', 'mouseup', () => {
@@ -351,7 +351,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
             });
         }
     }
-    
+
     unbindDocumentMouseupListener() {
         if(this.documentMouseupListener) {
             this.documentMouseupListener();
@@ -366,7 +366,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
             b: Math.min(100, Math.max(0, hsb.b))
         };
     }
-    
+
     validateRGB(rgb) {
         return {
             r: Math.min(255, Math.max(0, rgb.r)),
@@ -374,7 +374,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
             b: Math.min(255, Math.max(0, rgb.b))
         };
     }
-    
+
     validateHEX(hex) {
         var len = 6 - hex.length;
         if (len > 0) {
@@ -387,16 +387,16 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
         }
         return hex;
     }
-    
+
     HEXtoRGB(hex) {
         let hexValue = parseInt(((hex.indexOf('#') > -1) ? hex.substring(1) : hex), 16);
         return {r: hexValue >> 16, g: (hexValue & 0x00FF00) >> 8, b: (hexValue & 0x0000FF)};
     }
-    
+
     HEXtoHSB(hex) {
         return this.RGBtoHSB(this.HEXtoRGB(hex));
     }
-    
+
     RGBtoHSB(rgb) {
         var hsb = {
             h: 0,
@@ -408,7 +408,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
         var delta = max - min;
         hsb.b = max;
         if (max != 0) {
-            
+
         }
         hsb.s = max != 0 ? 255 * delta / max : 0;
         if (hsb.s != 0) {
@@ -430,7 +430,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
         hsb.b *= 100/255;
         return hsb;
     }
-    
+
     HSBtoRGB(hsb) {
         var rgb = {
             r: null, g: null, b: null
@@ -444,7 +444,7 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
                 g: v,
                 b: v
             }
-        } 
+        }
         else {
             var t1 = v;
             var t2 = (255-s)*v/255;
@@ -460,27 +460,27 @@ export class ColorPicker implements ControlValueAccessor, AfterViewChecked, OnDe
         }
         return {r:Math.round(rgb.r), g:Math.round(rgb.g), b:Math.round(rgb.b)};
     }
-    
+
     RGBtoHEX(rgb) {
         var hex = [
             rgb.r.toString(16),
             rgb.g.toString(16),
             rgb.b.toString(16)
         ];
-        
+
         for(var key in hex) {
             if(hex[key].length == 1) {
                 hex[key] = '0' + hex[key];
             }
-        }        
+        }
 
         return hex.join('');
     }
-    
+
     HSBtoHEX(hsb) {
         return this.RGBtoHEX(this.HSBtoRGB(hsb));
     }
-    
+
     ngOnDestroy() {
         this.unbindDocumentClickListener();
     }


### PR DESCRIPTION
Keep the same saturation and brightness when changing hue in colorpicker.
Use getValueToUpdate() when emitting onChange in pickHue.

###Defect Fixes
When the user changes the hue, the value passed to onChange has not the format specified by the "format" attribute. Also, changing the hue resets the current saturation (s) and brightness (b) values.