### PR TITLE
Wrongful import in gmapdemo documentation

### DIFF
--- a/src/app/showcase/components/gmap/gmapdemo.html
+++ b/src/app/showcase/components/gmap/gmapdemo.html
@@ -43,7 +43,7 @@
             <h3>Import</h3>
 <pre>
 <code class="language-typescript" pCode ngNonBindable>
-import &#123;GMapModule&#125; from 'primeng/primeng';
+import &#123;GMapModule&#125; from 'primeng/components/gmap/gmap';
 </code>
 </pre>
 


### PR DESCRIPTION
The Gmaps documentation shows an incorrect import statement. The example code uses the correct import.