### PR TITLE
Fixed #1845

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -173,9 +173,11 @@ export class ColumnFooters {
             </tr>
             <tr #rowElement *ngIf="!dt.expandableRowGroups||dt.isRowGroupExpanded(rowData)"
                     (click)="dt.handleRowClick($event, rowData, rowIndex)" (dblclick)="dt.rowDblclick($event,rowData)" (contextmenu)="dt.onRowRightClick($event,rowData)" (touchend)="dt.handleRowTouchEnd($event)"
+                    (mouseenter)="dt.setHoveredRow(rowData)" (mouseleave)="dt.clearHoveredRow(rowData)"
                     [ngClass]="[even&&dt.rowGroupMode!='rowspan'? 'ui-datatable-even':'',
                                 odd&&dt.rowGroupMode!='rowspan'?'ui-datatable-odd':'',
                                 dt.isSelected(rowData)? 'ui-state-highlight': '',
+                                dt.isHoveredRow(rowData)? 'ui-state-hover' : '',
                                 dt.expandableRows && dt.isRowExpanded(rowData)? 'ui-expanded-row': '',
                                 dt.getRowStyleClass(rowData,rowIndex)]">
                 <ng-template ngFor let-col [ngForOf]="columns" let-colIndex="index">
@@ -208,9 +210,11 @@ export class ColumnFooters {
                 <p-templateLoader class="ui-helper-hidden" [data]="rowData" [template]="dt.rowGroupFooterTemplate"></p-templateLoader>
             </tr>
             <tr *ngIf="dt.expandableRows && dt.isRowExpanded(rowData)"
+                    (mouseenter)="dt.setHoveredRow(rowData)" (mouseleave)="dt.clearHoveredRow(rowData)"
                     [ngClass]="[even&&dt.rowGroupMode!='rowspan'? 'ui-datatable-even':'',
                                 odd&&dt.rowGroupMode!='rowspan'?'ui-datatable-odd':'',
                                 dt.isSelected(rowData)? 'ui-state-highlight': '',
+                                dt.isHoveredRow(rowData)? 'ui-state-hover' : '',
                                 dt.expandableRows && dt.isRowExpanded(rowData)? 'ui-expanded-row-content': '',
                                 dt.getRowStyleClass(rowData,rowIndex)]">
                 <td [attr.colspan]="dt.visibleColumns().length">
@@ -740,6 +744,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     _selection: any;
     
     _totalRecords: number;
+
+    _hoveredRow: any;
         
     globalFilterFunction: any;
     
@@ -1580,6 +1586,10 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         }
         
         return false;
+    }
+
+    isHoveredRow(rowData) {
+        return rowData && this._hoveredRow && this.equals(rowData, this._hoveredRow);
     }
     
     equals(data1, data2) {
@@ -2465,6 +2475,16 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         
         if(this.columnsSubscription) {
             this.columnsSubscription.unsubscribe();
+        }
+    }
+
+    private setHoveredRow(rowData) {
+        this._hoveredRow = rowData;
+    }
+
+    private clearHoveredRow(rowData) {
+        if (this.isHoveredRow(rowData)) {
+            this._hoveredRow = undefined;
         }
     }
 }

--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -175,7 +175,8 @@ export class ColumnFooters {
                     (click)="dt.handleRowClick($event, rowData, rowIndex)" (dblclick)="dt.rowDblclick($event,rowData)" (contextmenu)="dt.onRowRightClick($event,rowData)" (touchend)="dt.handleRowTouchEnd($event)"
                     [ngClass]="[even&&dt.rowGroupMode!='rowspan'? 'ui-datatable-even':'',
                                 odd&&dt.rowGroupMode!='rowspan'?'ui-datatable-odd':'',
-                                dt.isSelected(rowData)? 'ui-state-highlight': '', 
+                                dt.isSelected(rowData)? 'ui-state-highlight': '',
+                                dt.expandableRows && dt.isRowExpanded(rowData)? 'ui-expanded-row': '',
                                 dt.getRowStyleClass(rowData,rowIndex)]">
                 <ng-template ngFor let-col [ngForOf]="columns" let-colIndex="index">
                     <td #cell *ngIf="!dt.rowGroupMode || (dt.rowGroupMode == 'subheader') ||
@@ -206,7 +207,12 @@ export class ColumnFooters {
             <tr class="ui-widget-header" *ngIf="dt.rowGroupFooterTemplate && dt.rowGroupMode=='subheader' && ((rowIndex === dt.dataToRender.length - 1)||(dt.resolveFieldData(rowData,dt.groupField) !== dt.resolveFieldData(dt.dataToRender[rowIndex + 1],dt.groupField))) && (!dt.expandableRowGroups || dt.isRowGroupExpanded(rowData))">
                 <p-templateLoader class="ui-helper-hidden" [data]="rowData" [template]="dt.rowGroupFooterTemplate"></p-templateLoader>
             </tr>
-            <tr *ngIf="dt.expandableRows && dt.isRowExpanded(rowData)">
+            <tr *ngIf="dt.expandableRows && dt.isRowExpanded(rowData)"
+                    [ngClass]="[even&&dt.rowGroupMode!='rowspan'? 'ui-datatable-even':'',
+                                odd&&dt.rowGroupMode!='rowspan'?'ui-datatable-odd':'',
+                                dt.isSelected(rowData)? 'ui-state-highlight': '',
+                                dt.expandableRows && dt.isRowExpanded(rowData)? 'ui-expanded-row-content': '',
+                                dt.getRowStyleClass(rowData,rowIndex)]">
                 <td [attr.colspan]="dt.visibleColumns().length">
                     <p-rowExpansionLoader [rowData]="rowData" [rowIndex]="rowIndex" [template]="dt.rowExpansionTemplate"></p-rowExpansionLoader>
                 </td>

--- a/src/app/showcase/components/datatable/datatabledemo.html
+++ b/src/app/showcase/components/datatable/datatabledemo.html
@@ -1675,6 +1675,13 @@ update(dt: DataTable) &#123;
                             <td>ui-datatable-emptymessage</td>
                             <td>Cell containing the empty message.</td>
                         </tr>
+                        <tr>
+                            <td>ui-expanded-row</td>
+                            <td>Expanded row element.</td>
+                        </tr>
+                        <tr>
+                            <td>ui-expanded-row-content</td>
+                            <td>The row element that appears below <code>ui-expanded-row</code>.</td>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
This PR adds two new style classes to be able to change styles of `DataTable` rows that are expanded:
* `ui-expanded-row` is added to the `<tr>` the user can click in order to show or hide relevant information.
* `ui-expanded-row-content` is added to the `<tr>` below.

The other classes (such as `.ui-datatable-even`) are now shared between both rows because it's impossible to reach previous sibling element via CSS (imagine you might want the odd and even expanded rows colored differently). Unfortunately, this will break the workaround stated in #1845.