### PR TITLE
Label click should trigger Radio onClick event

### DIFF
--- a/src/app/components/radiobutton/radiobutton.ts
+++ b/src/app/components/radiobutton/radiobutton.ts
@@ -62,13 +62,13 @@ export class RadioButton implements ControlValueAccessor {
     
     handleClick() {
         if(!this.disabled) {
-            this.onClick.emit(null);
             this.select();
         }
     }
     
     select() {
         if(!this.disabled) {
+            this.onClick.emit(null);
             this.inputViewChild.nativeElement.checked = true;
             this.checked = true;
             this.onModelChange(this.value);


### PR DESCRIPTION
Currently the onClick event only gets fired only when the user clicks on the radio-button.
When toggling the button using the label, the event does not get fired.
Here's the fix.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.