### PR TITLE
support `onPush` in parent component with `ngModel` binding.

### DIFF
--- a/src/app/components/listbox/listbox.ts
+++ b/src/app/components/listbox/listbox.ts
@@ -1,4 +1,4 @@
-import {NgModule,Component,ElementRef,Input,Output,EventEmitter,AfterContentInit,ContentChildren,QueryList,TemplateRef,IterableDiffers,forwardRef} from '@angular/core';
+import {NgModule,Component,ElementRef,Input,Output,EventEmitter,AfterContentInit,ContentChildren,QueryList,TemplateRef,IterableDiffers,forwardRef,ChangeDetectorRef} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {SelectItem} from '../common/selectitem';
 import {SharedModule,PrimeTemplate} from '../common/shared';
@@ -65,11 +65,11 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
     @Input() checkbox: boolean = false;
 
     @Input() filter: boolean = false;
-    
+
     @Input() metaKeySelection: boolean = true;
-    
+
     @Input() dataKey: string;
-    
+
     @Input() showToggleAll: boolean = true;
 
     @Output() onChange: EventEmitter<any> = new EventEmitter();
@@ -77,11 +77,11 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
     @Output() onDblClick: EventEmitter<any> = new EventEmitter();
 
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
-    
+
     public itemTemplate: TemplateRef<any>;
 
     public filterValue: string;
-    
+
     public visibleOptions: SelectItem[];
 
     public filtered: boolean;
@@ -93,18 +93,18 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
     public onModelTouched: Function = () => { };
 
     public checkboxClick: boolean;
-    
+
     public optionTouched: boolean;
 
-    constructor(public el: ElementRef, public domHandler: DomHandler, public objectUtils: ObjectUtils) {}
-    
+    constructor(public el: ElementRef, public domHandler: DomHandler, public objectUtils: ObjectUtils, private cd: ChangeDetectorRef) {}
+
     ngAfterContentInit() {
         this.templates.forEach((item) => {
             switch(item.getType()) {
                 case 'item':
                     this.itemTemplate = item.template;
                 break;
-                
+
                 default:
                     this.itemTemplate = item.template;
                 break;
@@ -114,6 +114,7 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
 
     writeValue(value: any): void {
         this.value = value;
+        this.cd.markForCheck();
     }
 
     registerOnChange(fn: Function): void {
@@ -142,26 +143,26 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
         else {
             this.checkboxClick = false;
         }
-        
+
         this.optionTouched = false;
     }
-    
+
     onOptionTouchEnd(event, option) {
         if(this.disabled) {
             return;
         }
-        
+
         this.optionTouched = true;
     }
 
-    onOptionClickSingle(event, option) {        
+    onOptionClickSingle(event, option) {
         let selected = this.isSelected(option);
         let valueChanged = false;
         let metaSelection = this.optionTouched ? false : this.metaKeySelection;
 
         if(metaSelection) {
             let metaKey = (event.metaKey || event.ctrlKey);
-            
+
             if(selected) {
                 if(metaKey) {
                     this.value = null;
@@ -174,7 +175,7 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
             }
         }
         else {
-            this.value = selected ? null : option.value;            
+            this.value = selected ? null : option.value;
             valueChanged = true;
         }
 
@@ -187,14 +188,14 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
         }
     }
 
-    onOptionClickMultiple(event, option) {        
+    onOptionClickMultiple(event, option) {
         let selected = this.isSelected(option);
         let valueChanged = false;
         let metaSelection = this.optionTouched ? false : this.metaKeySelection;
 
         if(metaSelection) {
             let metaKey = (event.metaKey || event.ctrlKey);
-            
+
             if(selected) {
                 if(metaKey) {
                     this.removeOption(option);
@@ -217,7 +218,7 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
             else {
                 this.value = [...this.value||[],option.value];
             }
-            
+
             valueChanged = true;
         }
 
@@ -229,7 +230,7 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
             });
         }
     }
-    
+
     removeOption(option: any): void {
         this.value = this.value.filter(val => !this.objectUtils.equals(val, option.value, this.dataKey));
     }
@@ -260,7 +261,7 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
         else
             return this.value&&this.options&&(this.value.length == this.options.length);
     }
-    
+
     allFilteredSelected(): boolean {
         let allSelected: boolean;
         if(this.value && this.visibleOptions && this.visibleOptions.length) {
@@ -272,14 +273,14 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
                         selected = true;
                     }
                 }
-                
+
                 if(!selected) {
                     allSelected = false;
                     break;
                 }
             }
         }
-                
+
         return allSelected;
     }
 
@@ -299,7 +300,7 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
         if(this.disabled || (this.filterValue && this.filterValue.trim().length && (!this.visibleOptions || this.visibleOptions.length === 0))) {
             return;
         }
-        
+
         if(checkbox.checked) {
             this.value = [];
         }
@@ -309,13 +310,13 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
                 this.value = [];
                 for(let i = 0; i < opts.length; i++) {
                     this.value.push(opts[i].value);
-                } 
+                }
             }
         }
         checkbox.checked = !checkbox.checked;
         this.onModelChange(this.value);
         this.onChange.emit({originalEvent: event, value: this.value});
-    } 
+    }
 
     isItemVisible(option: SelectItem): boolean {
         if(this.filterValue && this.filterValue.trim().length) {
@@ -334,18 +335,18 @@ export class Listbox implements AfterContentInit,ControlValueAccessor {
         if(this.disabled) {
             return;
         }
-        
+
         this.onDblClick.emit({
             originalEvent: event,
             value: this.value
         })
     }
-    
+
     onCheckboxClick(event: Event, option: SelectItem) {
         if(this.disabled) {
             return;
         }
-        
+
         this.checkboxClick = true;
         let selected = this.isSelected(option);
 


### PR DESCRIPTION
According to angular [asynchronous implementation  of template-driven forms ](https://github.com/angular/angular/blob/c65f18a2fa4e605a0900a6ca18caece5e2bd27fc/aio/content/guide/reactive-forms.md#async-vs-sync) `onPush` strategy can't be used. Change detection should be manually activated. 

[Issue discussed here](https://github.com/angular/angular/issues/10816)

[problem example](http://plnkr.co/edit/gJva0X?p=preview)