### PR TITLE
Bug with filtertimeout cancellation on DataTable and Bug with footer column template now showing

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -2223,7 +2223,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         else {
             if(this.columns) {
                 for(let i = 0; i  < this.columns.length; i++) {
-                    if(this.columns[i].footer) {
+                    if(this.columns[i].footer || this.columns[i].footerTemplate) {
                         return true;
                     }
                 }

--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -814,6 +814,9 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     ngAfterViewInit() {
         if(this.globalFilter) {
             this.globalFilterFunction = this.renderer.listen(this.globalFilter, 'keyup', () => {
+                if (this.filterTimeout) {
+					clearTimeout(this.filterTimeout);
+				}
                 this.filterTimeout = setTimeout(() => {
                     this._filter();
                     this.filterTimeout = null;

--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -815,8 +815,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         if(this.globalFilter) {
             this.globalFilterFunction = this.renderer.listen(this.globalFilter, 'keyup', () => {
                 if (this.filterTimeout) {
-					clearTimeout(this.filterTimeout);
-				}
+                    clearTimeout(this.filterTimeout);
+                }
                 this.filterTimeout = setTimeout(() => {
                     this._filter();
                     this.filterTimeout = null;


### PR DESCRIPTION
###Defect Fixes
While using filter with datatable the setTimeout is not cancelled before a new one is created. As a result if you type n characters fast enough (faster than filterDelay property value) the this._filter() method is called n times instead of one.

