### PR TITLE
#3820 on drop in orderlist call the onReorder.emit method

### DIFF
--- a/src/app/components/orderlist/orderlist.ts
+++ b/src/app/components/orderlist/orderlist.ts
@@ -333,6 +333,7 @@ export class OrderList implements AfterViewChecked,AfterContentInit {
         let dropIndex = (this.draggedItemIndex > index) ? index : (index === 0) ? 0 : index - 1;
         this.objectUtils.reorderArray(this.value, this.draggedItemIndex, dropIndex);
         this.dragOverItemIndex = null;
+        this.onReorder.emit(event);
     }
     
     onDragEnd(event: DragEvent) {


### PR DESCRIPTION
…re-order has occurred consistent with the current move functionality.

Currently the callback only occurs when clicking the move buttons. On drop, the list is re-ordered but the callback is not called.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
https://github.com/primefaces/primeng/issues/3820

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.