### PR TITLE
MultiSelect as a table filter triggers sort

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -225,6 +225,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     }
     
     onItemClick(event, value) {
+        event.stopPropagation();
         let selectionIndex = this.findSelectionIndex(value);
         if(selectionIndex != -1)
             this.value = this.value.filter((val,i) => i!=selectionIndex);


### PR DESCRIPTION
When multiselect is used as datatable column filter, clicking on multiselect option triggers the column sort.
