### PR TITLE
Fixes #3871 DataTable paginator causes route reset

### DIFF
--- a/src/app/components/paginator/paginator.ts
+++ b/src/app/components/paginator/paginator.ts
@@ -147,6 +147,10 @@ export class Paginator {
     changePageToFirst(event) {
       if (!this.isFirstPage()){
         this.changePage(0, event);
+      } else {
+          if(event) {
+            event.preventDefault();
+          } 
       }
     }
 
@@ -161,6 +165,10 @@ export class Paginator {
     changePageToLast(event) {
       if (!this.isLastPage()){
         this.changePage(this.getPageCount() - 1, event);
+      } else {
+          if(event) {
+            event.preventDefault();
+          } 
       }
     }
     


### PR DESCRIPTION
Fixes when on the first or last page and clicking on the go to first / go to last paginator buttons routes to the default route.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.