### PR TITLE
Fixes #3855 Move all should only move visible items

### DIFF
--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -396,6 +396,7 @@ export class PickList implements AfterViewChecked,AfterContentInit {
           
             for(let i = 0; i < this.source.length; i++) {
                 if (this.isItemVisible(this.source[i], -1)) {
+                  this.source.splice(i, 1);            
                   this.target.push(this.source[i]);
                   sourceItems.push(this.source[i]);
                 }           
@@ -435,6 +436,7 @@ export class PickList implements AfterViewChecked,AfterContentInit {
           
             for(let i = 0; i < this.target.length; i++) {
               if(this.isItemVisible(this.target[i], 1)) {
+                this.target.splice(i, 1);
                 this.source.push(this.target[i]);
                 targetItems.push(this.source[i]);
               }            

--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -392,11 +392,14 @@ export class PickList implements AfterViewChecked,AfterContentInit {
 
     moveAllRight() {
         if(this.source) {
+            const sourceItems: any[] = [];
+          
             for(let i = 0; i < this.source.length; i++) {
-                this.target.push(this.source[i]);
+                if (this.isItemVisible(this.source[i], -1)) {
+                  this.target.push(this.source[i]);
+                  sourceItems.push(this.source[i]);
+                }           
             }
-            
-            const sourceItems = this.source.splice(0, this.source.length);
     
             this.onMoveToTarget.emit({
                 items: sourceItems
@@ -428,11 +431,14 @@ export class PickList implements AfterViewChecked,AfterContentInit {
 
     moveAllLeft() {
         if(this.target) {
+            const targetItems: any[] = []; 
+          
             for(let i = 0; i < this.target.length; i++) {
+              if(this.isItemVisible(this.target[i], 1)) {
                 this.source.push(this.target[i]);
+                targetItems.push(this.source[i]);
+              }            
             }
-            
-            const targetItems = this.target.splice(0, this.target.length);
     
             this.onMoveToSource.emit({
                 items: targetItems


### PR DESCRIPTION
Fixes the moveAllRight() and moveAllLeft() methods to only push the items that are visible.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.