### PR TITLE
#3358 Added separator definition for excel

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -2368,6 +2368,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     public exportCSV() {
         let data = this.filteredValue||this.value;
         let csv = '\ufeff';
+        csv += 'sep=' + this.csvSeparator + '\r\n';
         
         //headers
         for(let i = 0; i < this.columns.length; i++) {


### PR DESCRIPTION
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

#3358 True parsing of separator field for excel.

Very minor change.  I was able to test the changes in my local which worked.  

Should instead of using hard '\r\n' find a platform independent way in the browser to insert line endings.

@cagataycivici 