### PR TITLE
#3868 Fix Calendar updateUI bug when selectionMode is not single

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1121,7 +1121,10 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     }
     
     updateUI() {
-        let val = this.value||this.defaultDate||new Date();
+        let val = Array.isArray(this.value) ? this.value[0] : this.value;
+        if (!(val instanceof Date)) {
+          val = (this.defaultDate instanceof Date) ? this.defaultDate : new Date();
+        }
         this.createMonth(val.getMonth(), val.getFullYear());
         
         if(this.showTime||this.timeOnly) {


### PR DESCRIPTION
Fixes the issue where this.value is not a Date object.

The issue is documented in #3868 by @sgodoy and occurs when selectionMode is "multiple"  or "range"