### PR TITLE
Implement Calendar accessibility fully support readers and all keyboard interactions

### DIFF
--- a/src/app/components/calendar/calendar.css
+++ b/src/app/components/calendar/calendar.css
@@ -15,7 +15,7 @@
 .ui-calendar .ui-calendar-button:enabled:hover,
 .ui-calendar .ui-calendar-button:focus {
     border-left: 0 none;
-} 
+}
 
 /* Fluid */
 .ui-fluid .ui-calendar {
@@ -188,13 +188,13 @@
 }
 
 .ui-calendar.ui-calendar-w-btn input {
-    -moz-border-radius-topright: 0px; 
-    -webkit-border-top-right-radius: 0px; 
-    -khtml-border-top-right-radius: 0px; 
+    -moz-border-radius-topright: 0px;
+    -webkit-border-top-right-radius: 0px;
+    -khtml-border-top-right-radius: 0px;
     border-top-right-radius: 0px;
-    -moz-border-radius-bottomright: 0px; 
-    -webkit-border-bottom-right-radius: 0px; 
-    -khtml-border-bottom-right-radius: 0px; 
+    -moz-border-radius-bottomright: 0px;
+    -webkit-border-bottom-right-radius: 0px;
+    -khtml-border-bottom-right-radius: 0px;
     border-bottom-right-radius: 0px;
 }
 
@@ -233,4 +233,25 @@
     display: block;
     opacity: 1;
     filter:Alpha(Opacity=100);
+}
+
+.ui-calendar .ui-calendar-button:focus {
+  -moz-box-shadow: 0px 0px 5px #1f89ce;
+  -webkit-box-shadow: 0px 0px 5px #1f89ce;
+  box-shadow: 0px 0px 5px #1f89ce;
+  background: #2399e5;
+  color: #fff;
+}
+
+.ui-calendar .ui-calendar-button{
+  color: #4B4B4B;
+  background: #ffffff;
+  border: 1px solid #d6d6d6;
+}
+
+
+.ui-datepicker .ui-datepicker-calendar td:not(.ui-state-disabled) a:focus {
+  /* border-color: #c0c0c0; */
+  background-color: rgba(255, 218, 86, 0.38);
+  color: #212121;
 }

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -14,62 +14,78 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
 };
 
 export interface LocaleSettings {
-    firstDayOfWeek?: number;
-    dayNames: string[];
-	dayNamesShort: string[];
-	dayNamesMin: string[];
-    monthNames: string[];
-    monthNamesShort: string[];
-    today: string,
-    clear: string
+  firstDayOfWeek?: number;
+  dayNames: string[];
+  dayNamesShort: string[];
+  dayNamesMin: string[];
+  monthNames: string[];
+  monthNamesShort: string[];
+  today: string;
+  clear: string;
+  close: string;
+  showDatePicker: string;
+  nextMonth: string;
+  prevMonth: string;
+  directionality: string;
 }
 
 @Component({
-    selector: 'p-calendar',
-    template:  `
+  selector: 'p-calendar',
+  template: `
         <span [ngClass]="{'ui-calendar':true,'ui-calendar-w-btn':showIcon}" [ngStyle]="style" [class]="styleClass">
             <ng-template [ngIf]="!inline">
                 <input #inputfield type="text" [attr.id]="inputId" [attr.name]="name" [attr.required]="required" [value]="inputFieldValue" (focus)="onInputFocus($event)" (keydown)="onInputKeydown($event)" (click)="datepickerClick=true" (blur)="onInputBlur($event)"
                     [readonly]="readonlyInput" (input)="onUserInput($event)" [ngStyle]="inputStyle" [class]="inputStyleClass" [placeholder]="placeholder||''" [disabled]="disabled" [attr.tabindex]="tabindex"
                     [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all'"
-                    ><button type="button" [icon]="icon" pButton *ngIf="showIcon" (click)="onButtonClick($event,inputfield)" class="ui-datepicker-trigger ui-calendar-button"
-                    [ngClass]="{'ui-state-disabled':disabled}" [disabled]="disabled" tabindex="-1"></button>
+                    ><button  [attr.aria-label]="_locale.showDatePicker" [title]="_locale.showDatePicker" type="button" [icon]="icon" pButton *ngIf="showIcon" (click)="onButtonClick($event,inputfield)" class="ui-datepicker-trigger ui-calendar-button"
+                    [ngClass]="{'ui-state-disabled':disabled}" [disabled]="disabled" [attr.tabindex]="!tabFocusIcon ? '-1' : null"></button>
             </ng-template>
-            <div #datepicker class="ui-datepicker ui-widget ui-widget-content ui-helper-clearfix ui-corner-all" [ngClass]="{'ui-datepicker-inline':inline,'ui-shadow':!inline,'ui-state-disabled':disabled,'ui-datepicker-timeonly':timeOnly}" 
+            <div #datepicker (keydown)="handleKeyDown($event)" (keypress)="handleKeyPress($event)" class="ui-datepicker ui-widget ui-widget-content ui-helper-clearfix ui-corner-all" [ngClass]="{'ui-datepicker-inline':inline,'ui-shadow':!inline,'ui-state-disabled':disabled,'ui-datepicker-timeonly':timeOnly}"
                 [ngStyle]="{'display': inline ? 'inline-block' : (overlayVisible ? 'block' : 'none')}" (click)="onDatePickerClick($event)" [@overlayState]="inline ? 'visible' : (overlayVisible ? 'visible' : 'hidden')">
 
                 <div class="ui-datepicker-header ui-widget-header ui-helper-clearfix ui-corner-all" *ngIf="!timeOnly && (overlayVisible || inline)">
                     <ng-content select="p-header"></ng-content>
-                    <a class="ui-datepicker-prev ui-corner-all" href="#" (click)="prevMonth($event)">
+                    <a tabindex="-1" #fastPrevMonthBtn class="ui-datepicker-prev ui-corner-all" href="#" (click)="prevMonth($event)" [title]="locale.nextMonth">
                         <span class="fa fa-angle-left"></span>
                     </a>
-                    <a class="ui-datepicker-next ui-corner-all" href="#" (click)="nextMonth($event)">
+                    <a tabindex="-1" #fastNextMonthBtn class="ui-datepicker-next ui-corner-all" href="#" (click)="nextMonth($event)"  [title]="locale.prevMonth">
                         <span class="fa fa-angle-right"></span>
                     </a>
                     <div class="ui-datepicker-title">
-                        <span class="ui-datepicker-month" *ngIf="!monthNavigator">{{locale.monthNames[currentMonth]}}</span>
+                        <span class="ui-datepicker-month"
+                        [title]="locale.monthNames[currentMonth]" *ngIf="!monthNavigator">{{locale.monthNames[currentMonth]}}</span>
                         <select class="ui-datepicker-month" *ngIf="monthNavigator" (change)="onMonthDropdownChange($event.target.value)">
-                            <option [value]="i" *ngFor="let month of locale.monthNames;let i = index" [selected]="i == currentMonth">{{month}}</option>
+                            <option [title]="month" [value]="i" *ngFor="let month of locale.monthNames;let i = index"
+                            [selected]="i == currentMonth">{{month}}</option>
                         </select>
                         <select class="ui-datepicker-year" *ngIf="yearNavigator" (change)="onYearDropdownChange($event.target.value)">
-                            <option [value]="year" *ngFor="let year of yearOptions" [selected]="year == currentYear">{{year}}</option>
+                            <option [title]="year"
+                            [value]="year" *ngFor="let year of yearOptions" [selected]="year == currentYear">{{year}}</option>
                         </select>
-                        <span class="ui-datepicker-year" *ngIf="!yearNavigator">{{currentYear}}</span>
+                        <span class="ui-datepicker-year" [title]="currentYear" *ngIf="!yearNavigator">{{currentYear}}</span>
                     </div>
                 </div>
-                <table class="ui-datepicker-calendar" *ngIf="!timeOnly && (overlayVisible || inline)">
+                <table #overlayTable class="ui-datepicker-calendar" *ngIf="!timeOnly && (overlayVisible || inline)" role="grid" aria-readonly="true"
+                aria-labelledby="datepicker-month-date" tabindex="0" (focus)="onOverlayTableFocus($event)">
                     <thead>
                         <tr>
-                            <th scope="col" *ngFor="let weekDay of weekDays;let begin = first; let end = last">
-                                <span>{{weekDay}}</span>
+                            <th scope="col" *ngFor="let weekDay of weekDays;let i = index; let begin = first; let end = last" [attr.aria-label]="weekFullDays[i]">
+                            <abbr [title]="weekFullDays[i]">{{weekDay}}</abbr>
                             </th>
                         </tr>
                     </thead>
                     <tbody>
                         <tr *ngFor="let week of dates">
-                            <td *ngFor="let date of week" [ngClass]="{'ui-datepicker-other-month ui-state-disabled':date.otherMonth,
+                            <td *ngFor="let date of week" [id]="'cell'+date.day+'-date'" class="selectable"
+                            [attr.data-value]="date.day"
+                                role="gridcell"
+                                aria-selected="false"
+                                [attr.aria-label]="formatDate(''+date.year+','+date.month+','+date.day+'','DD, MM dd, yy')"
+                                [title]="formatDate(''+date.year+','+(date.month+1)+','+date.day+'','DD, MM dd, yy')"
+                                [ngClass]="{'ui-datepicker-other-month ui-state-disabled':date.otherMonth,
                                 'ui-datepicker-current-day':isSelected(date),'ui-datepicker-today':date.today}">
-                                <a class="ui-state-default" href="#" *ngIf="date.otherMonth ? showOtherMonths : true" 
+                                <a class="ui-state-default" href="#" *ngIf="date.otherMonth ? showOtherMonths : true"
+                                    [attr.aria-disabled]="!date.selectable"
                                     [ngClass]="{'ui-state-active':isSelected(date), 'ui-state-highlight':date.today, 'ui-state-disabled':!date.selectable}"
                                     (click)="onDateSelect($event,date)">
                                     <span *ngIf="!dateTemplate">{{date.day}}</span>
@@ -138,10 +154,17 @@ export interface LocaleSettings {
                 <div class="ui-datepicker-buttonbar ui-widget-header" *ngIf="showButtonBar">
                     <div class="ui-g">
                         <div class="ui-g-6">
-                            <button type="button" [label]="_locale.today" (click)="onTodayButtonClick($event)" pButton [ngClass]="[todayButtonStyleClass]"></button>
+                            <button [attr.aria-label]="_locale.today" [title]="_locale.today" #todayBtn type="button" [label]="_locale.today" (click)="onTodayButtonClick($event)" pButton [ngClass]="[todayButtonStyleClass]"></button>
                         </div>
                         <div class="ui-g-6">
-                            <button type="button" [label]="_locale.clear" (click)="onClearButtonClick($event)" pButton [ngClass]="[clearButtonStyleClass]"></button>
+                            <button  [attr.aria-label]="_locale.clear" [title]="_locale.clear" #clearBtn type="button" [label]="_locale.clear" (click)="onClearButtonClick($event)" pButton [ngClass]="[clearButtonStyleClass]"></button>
+                        </div>
+                    </div>
+                </div>
+                <div class="ui-datepicker-buttonbar ui-widget-header" *ngIf="showCloseButton">
+                    <div class="ui-g">
+                        <div class="ui-g-12">
+                            <button [attr.aria-label]="_locale.close || 'Close'" [title]="_locale.close || 'Close'" #closeBtn type="button" [label]="_locale.close || 'Close'" style="width:100%" (click)="onCloseButtonClick($event)" pButton ></button>
                         </div>
                     </div>
                 </div>
@@ -149,1397 +172,2102 @@ export interface LocaleSettings {
             </div>
         </span>
     `,
-    animations: [
-        trigger('overlayState', [
-            state('hidden', style({
-                opacity: 0
-            })),
-            state('visible', style({
-                opacity: 1
-            })),
-            transition('visible => hidden', animate('400ms ease-in')),
-            transition('hidden => visible', animate('400ms ease-out'))
-        ])
-    ],
-    host: {
-        '[class.ui-inputwrapper-filled]': 'filled',
-        '[class.ui-inputwrapper-focus]': 'focus'
-    },
-    providers: [DomHandler,CALENDAR_VALUE_ACCESSOR]
+  animations: [
+    trigger('overlayState', [
+      state('hidden', style({
+        opacity: 0
+      })),
+      state('visible', style({
+        opacity: 1
+      })),
+      transition('visible => hidden', animate('400ms ease-in')),
+      transition('hidden => visible', animate('400ms ease-out'))
+    ])
+  ],
+  host: {
+    '[class.ui-inputwrapper-filled]': 'filled',
+    '[class.ui-inputwrapper-focus]': 'focus'
+  },
+  providers: [DomHandler, CALENDAR_VALUE_ACCESSOR]
 })
-export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy,ControlValueAccessor {
-    
-    @Input() defaultDate: Date;
-    
-    @Input() style: string;
-    
-    @Input() styleClass: string;
-    
-    @Input() inputStyle: string;
+export class Calendar implements AfterViewInit, AfterViewChecked, OnInit, OnDestroy, ControlValueAccessor {
 
-    @Input() inputId: string;
-    
-    @Input() name: string;
-    
-    @Input() inputStyleClass: string;
-    
-    @Input() placeholder: string;
-    
-    @Input() disabled: any;
-    
-    @Input() dateFormat: string = 'mm/dd/yy';
-        
-    @Input() inline: boolean = false;
-    
-    @Input() showOtherMonths: boolean = true;
+  @Input() defaultDate: Date;
 
-    @Input() selectOtherMonths: boolean;
-    
-    @Input() showIcon: boolean;
-    
-    @Input() icon: string = 'fa-calendar';
-    
-    @Input() appendTo: any;
-    
-    @Input() readonlyInput: boolean;
-    
-    @Input() shortYearCutoff: any = '+10';
-    
-    @Input() monthNavigator: boolean;
+  @Input() style: string;
 
-    @Input() yearNavigator: boolean;
+  @Input() styleClass: string;
 
-    @Input() yearRange: string;
-    
-    @Input() hourFormat: string = '24';
-    
-    @Input() timeOnly: boolean;
-    
-    @Input() stepHour: number = 1;
-    
-    @Input() stepMinute: number = 1;
-    
-    @Input() stepSecond: number = 1;
-    
-    @Input() showSeconds: boolean = false;
+  @Input() inputStyle: string;
 
-    @Input() required: boolean;
+  @Input() inputId: string;
 
-    @Input() showOnFocus: boolean = true;
-    
-    @Input() dataType: string = 'date';
-        
-    @Input() utc: boolean;
-    
-    @Input() selectionMode: string = 'single';
-    
-    @Input() maxDateCount: number;
-    
-    @Input() showButtonBar: boolean;
-    
-    @Input() todayButtonStyleClass: string = 'ui-button-secondary';
-    
-    @Input() clearButtonStyleClass: string = 'ui-button-secondary';
-        
-    @Output() onFocus: EventEmitter<any> = new EventEmitter();
-    
-    @Output() onBlur: EventEmitter<any> = new EventEmitter();
-    
-    @Output() onClose: EventEmitter<any> = new EventEmitter();
-    
-    @Output() onSelect: EventEmitter<any> = new EventEmitter();
-    
-    @Output() onInput: EventEmitter<any> = new EventEmitter();
-    
-    @Output() onTodayClick: EventEmitter<any> = new EventEmitter();
-    
-    @Output() onClearClick: EventEmitter<any> = new EventEmitter();
-    
-    @ContentChildren(PrimeTemplate) templates: QueryList<any>;
-    
-    _locale: LocaleSettings = {
-        firstDayOfWeek: 0,
-        dayNames: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
-        dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-        dayNamesMin: ["Su","Mo","Tu","We","Th","Fr","Sa"],
-        monthNames: [ "January","February","March","April","May","June","July","August","September","October","November","December" ],
-        monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun","Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
-        today: 'Today',
-        clear: 'Clear'
+  @Input() name: string;
+
+  @Input() inputStyleClass: string;
+
+  @Input() placeholder: string;
+
+  @Input() disabled: any;
+
+  @Input() dateFormat: string = 'mm/dd/yy';
+
+  @Input() inline: boolean = false;
+
+  @Input() showOtherMonths: boolean = true;
+
+  @Input() selectOtherMonths: boolean;
+
+  @Input() showIcon: boolean;
+
+  @Input() tabFocusIcon: boolean = true;
+
+  @Input() icon: string = 'fa-calendar';
+
+  @Input() appendTo: any;
+
+  @Input() readonlyInput: boolean;
+
+  @Input() shortYearCutoff: any = '+10';
+
+  @Input() monthNavigator: boolean;
+
+  @Input() yearNavigator: boolean;
+
+  @Input() yearRange: string;
+
+  @Input() hourFormat: string = '24';
+
+  @Input() timeOnly: boolean;
+
+  @Input() stepHour: number = 1;
+
+  @Input() stepMinute: number = 1;
+
+  @Input() stepSecond: number = 1;
+
+  @Input() showSeconds: boolean = false;
+
+  @Input() required: boolean;
+
+  @Input() showOnFocus: boolean = true;
+
+  @Input() dataType: string = 'date';
+
+  @Input() utc: boolean;
+
+  @Input() selectionMode: string = 'single';
+
+  @Input() maxDateCount: number;
+
+  @Input() showButtonBar: boolean;
+
+  @Input() showCloseButton: boolean;
+
+  @Input() todayButtonStyleClass: string = 'ui-button-secondary';
+
+  @Input() clearButtonStyleClass: string = 'ui-button-secondary';
+
+  @Output() onFocus: EventEmitter<any> = new EventEmitter();
+
+  @Output() onBlur: EventEmitter<any> = new EventEmitter();
+
+  @Output() onClose: EventEmitter<any> = new EventEmitter();
+
+  @Output() onSelect: EventEmitter<any> = new EventEmitter();
+
+  @Output() onInput: EventEmitter<any> = new EventEmitter();
+
+  @Output() onTodayClick: EventEmitter<any> = new EventEmitter();
+
+  @Output() onClearClick: EventEmitter<any> = new EventEmitter();
+
+  @Output() onCloseClick: EventEmitter<any> = new EventEmitter();
+
+  @ContentChildren(PrimeTemplate) templates: QueryList<any>;
+
+  _locale: LocaleSettings = {
+    firstDayOfWeek: 0,
+    dayNames: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
+    dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+    dayNamesMin: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+    monthNames: ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"],
+    monthNamesShort: ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    today: 'Today',
+    clear: 'Clear',
+    close: 'Close',
+    showDatePicker: 'Show datepicker',
+    prevMonth: 'Go to next month',
+    nextMonth: 'Go to previous month',
+    directionality: 'LTR'
+  };
+
+  @Input() tabindex: number;
+
+  @ViewChild('datepicker') overlayViewChild: ElementRef;
+
+  @ViewChild('inputfield') inputfieldViewChild: ElementRef;
+
+  @ViewChild('overlayTable') overlayTable: ElementRef;
+
+  @ViewChild('fastPrevMonthBtn') fastPrevMonthBtn: ElementRef;
+
+  @ViewChild('fastNextMonthBtn') fastNextMonthBtn: ElementRef;
+
+  @ViewChild('todayBtn') todayBtn: ElementRef;
+
+  @ViewChild('clearBtn') clearBtn: ElementRef;
+
+  @ViewChild('closeBtn') closeBtn: ElementRef;
+
+  value: any;
+
+  dates: any[];
+
+  weekDays: string[];
+
+  weekFullDays: string[];
+
+  currentMonthText: string;
+
+  currentMonth: number;
+
+  currentYear: number;
+
+  currentHour: number;
+
+  currentMinute: number;
+
+  currentSecond: number;
+
+  pm: boolean;
+
+  overlay: HTMLDivElement;
+
+  overlayVisible: boolean;
+
+  overlayShown: boolean;
+
+  datepickerClick: boolean;
+
+  onModelChange: Function = () => { };
+
+  onModelTouched: Function = () => { };
+
+  calendarElement: any;
+
+  documentClickListener: any;
+
+  ticksTo1970: number;
+
+  yearOptions: number[];
+
+  focus: boolean;
+
+  isKeydown: boolean;
+
+  filled: boolean;
+
+  inputFieldValue: string = null;
+
+  _minDate: Date;
+
+  _maxDate: Date;
+
+  _showTime: boolean;
+
+  preventDocumentListener: boolean;
+
+  dateTemplate: TemplateRef<any>;
+
+  _disabledDates: Array<Date>;
+
+  _disabledDays: Array<number>;
+
+  keydownListener: Function;
+
+  keypressListener: Function;
+
+  styleObserver: MutationObserver;
+
+  keys: any;
+
+  escShowOnFocus: boolean = false;
+
+  @Input() get minDate(): Date {
+    return this._minDate;
+  }
+
+  set minDate(date: Date) {
+    this._minDate = date;
+    if (this.currentMonth && this.currentYear) {
+      this.createMonth(this.currentMonth, this.currentYear);
+    }
+  }
+
+  @Input() get maxDate(): Date {
+    return this._maxDate;
+  }
+
+  set maxDate(date: Date) {
+    this._maxDate = date;
+    if (this.currentMonth && this.currentYear) {
+      this.createMonth(this.currentMonth, this.currentYear);
+    }
+  }
+
+  @Input() get disabledDates(): Date[] {
+    return this._disabledDates;
+  }
+
+  set disabledDates(disabledDates: Date[]) {
+    this._disabledDates = disabledDates;
+    if (this.currentMonth && this.currentYear) {
+      this.createMonth(this.currentMonth, this.currentYear);
+    }
+  }
+
+  @Input() get disabledDays(): number[] {
+    return this._disabledDays;
+  }
+
+  set disabledDays(disabledDays: number[]) {
+    this._disabledDays = disabledDays;
+    if (this.currentMonth && this.currentYear) {
+      this.createMonth(this.currentMonth, this.currentYear);
+    }
+  }
+
+  @Input() get showTime(): boolean {
+    return this._showTime;
+  }
+
+  set showTime(showTime: boolean) {
+    this._showTime = showTime;
+
+    if (this.currentHour === undefined) {
+      this.initTime(this.value || new Date());
+    }
+  }
+
+  get locale() {
+    return this._locale;
+  }
+
+  @Input()
+  set locale(newLocale: LocaleSettings) {
+    this._locale = newLocale;
+    this.createWeekDays();
+    this.createMonth(this.currentMonth, this.currentYear);
+  }
+
+  constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public cd: ChangeDetectorRef) { }
+
+  ngOnInit() {
+    this.keys = {
+      tab: 9,
+      enter: 13,
+      esc: 27,
+      space: 32,
+      pageup: 33,
+      pagedown: 34,
+      end: 35,
+      home: 36,
+      left: 37,
+      up: 38,
+      right: 39,
+      down: 40
     };
-    
-    @Input() tabindex: number;
-    
-    @ViewChild('datepicker') overlayViewChild: ElementRef;
-    
-    @ViewChild('inputfield') inputfieldViewChild: ElementRef;
-    
-    value: any;
-    
-    dates: any[];
-    
-    weekDays: string[];
-    
-    currentMonthText: string;
-    
-    currentMonth: number;
-    
-    currentYear: number;
-    
-    currentHour: number;
-    
-    currentMinute: number;
-    
-    currentSecond: number;
-    
-    pm: boolean;
-    
-    overlay: HTMLDivElement;
-    
-    overlayVisible: boolean;
-    
-    overlayShown: boolean;
-        
-    datepickerClick: boolean;
-        
-    onModelChange: Function = () => {};
-    
-    onModelTouched: Function = () => {};
-    
-    calendarElement: any;
-    
-    documentClickListener: any;
-    
-    ticksTo1970: number;
-    
-    yearOptions: number[];
-    
-    focus: boolean;
-    
-    isKeydown: boolean;
-    
-    filled: boolean;
 
-    inputFieldValue: string = null;
-    
-    _minDate: Date;
-    
-    _maxDate: Date;
-    
-    _showTime: boolean;
-    
-    preventDocumentListener: boolean;
-    
-    dateTemplate: TemplateRef<any>;
-    
-    _disabledDates: Array<Date>;
-    
-    _disabledDays: Array<number>;
+    let date = this.defaultDate || new Date();
+    this.createWeekDays();
 
-    @Input() get minDate(): Date {
-        return this._minDate;
-    }
-    
-    set minDate(date: Date) {
-        this._minDate = date;
-        if(this.currentMonth && this.currentYear) {
-            this.createMonth(this.currentMonth, this.currentYear);
-        }
-    }
-    
-    @Input() get maxDate(): Date {
-        return this._maxDate;
-    }
-    
-    set maxDate(date: Date) {
-        this._maxDate = date;
-        if(this.currentMonth && this.currentYear) {
-            this.createMonth(this.currentMonth, this.currentYear);
-        }
-    }
-    
-    @Input() get disabledDates(): Date[] {
-        return this._disabledDates;
-    }
-    
-    set disabledDates(disabledDates: Date[]) {
-        this._disabledDates = disabledDates;
-        if(this.currentMonth && this.currentYear) {
-            this.createMonth(this.currentMonth, this.currentYear);
-        }
-    }
-    
-    @Input() get disabledDays(): number[] {
-        return this._disabledDays;
-    }
-    
-    set disabledDays(disabledDays: number[]) {
-        this._disabledDays = disabledDays;
-        if(this.currentMonth && this.currentYear) {
-            this.createMonth(this.currentMonth, this.currentYear);
-        }
-    }
-    
-    @Input() get showTime(): boolean {
-        return this._showTime;
-    }
-    
-    set showTime(showTime: boolean) {
-        this._showTime = showTime;
-        
-        if(this.currentHour === undefined) {
-            this.initTime(this.value||new Date());
-        }
-    }
-        
-    get locale() {
-       return this._locale;
-    }
+    this.currentMonth = date.getMonth();
+    this.currentYear = date.getFullYear();
+    this.initTime(date);
 
-    @Input()
-    set locale(newLocale: LocaleSettings) {
-       this._locale = newLocale;
-       this.createWeekDays();
-       this.createMonth(this.currentMonth, this.currentYear);
-    }
+    this.createMonth(this.currentMonth, this.currentYear);
 
-    constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public cd: ChangeDetectorRef) {}
+    this.ticksTo1970 = (((1970 - 1) * 365 + Math.floor(1970 / 4) - Math.floor(1970 / 100) +
+      Math.floor(1970 / 400)) * 24 * 60 * 60 * 10000000);
 
-    ngOnInit() {
-        let date = this.defaultDate||new Date();        
-        this.createWeekDays();
-                
-        this.currentMonth = date.getMonth();
-        this.currentYear = date.getFullYear();
-        this.initTime(date);
+    if (this.yearNavigator && this.yearRange) {
+      this.yearOptions = [];
+      let years = this.yearRange.split(':'),
+        yearStart = parseInt(years[0]),
+        yearEnd = parseInt(years[1]);
 
-        this.createMonth(this.currentMonth, this.currentYear);
-        
-        this.ticksTo1970 = (((1970 - 1) * 365 + Math.floor(1970 / 4) - Math.floor(1970 / 100) +
-    		Math.floor(1970 / 400)) * 24 * 60 * 60 * 10000000);
-            
-        if(this.yearNavigator && this.yearRange) {
-            this.yearOptions = [];
-            let years = this.yearRange.split(':'),
-            yearStart = parseInt(years[0]),
-            yearEnd = parseInt(years[1]);
-            
-            for(let i = yearStart; i <= yearEnd; i++) {
-                this.yearOptions.push(i);
-            }
-        }
+      for (let i = yearStart; i <= yearEnd; i++) {
+        this.yearOptions.push(i);
+      }
     }
-    
-    ngAfterViewInit() {
-        if(!this.inline && this.appendTo) {
-            if(this.appendTo === 'body')
-                document.body.appendChild(this.overlayViewChild.nativeElement);
-            else
-                this.domHandler.appendChild(this.overlayViewChild.nativeElement, this.appendTo);
-        }
+  }
+
+  ngAfterViewInit() {
+    if (!this.inline && this.appendTo) {
+      if (this.appendTo === 'body')
+        document.body.appendChild(this.overlayViewChild.nativeElement);
+      else
+        this.domHandler.appendChild(this.overlayViewChild.nativeElement, this.appendTo);
     }
-    
-    ngAfterViewChecked() {
-        if(this.overlayShown) {
-            this.alignOverlay();
-            this.overlayShown = false;
-        }
+  }
+
+  ngAfterViewChecked() {
+    if (this.overlayShown) {
+      this.alignOverlay();
+      if(this.readonlyInput){
+       this.focusOnDays();
+          }
+      this.overlayShown = false;
     }
-    
-    ngAfterContentInit() {
-        this.templates.forEach((item) => {
-            switch(item.getType()) {
-                case 'date':
-                    this.dateTemplate = item.template;
-                break;
-                
-                default:
-                    this.dateTemplate = item.template;
-                break;
-            }
-        });
+  }
+
+  onOverlayTableFocus(event) {
+    if (!this.timeOnly) {
+      // select the target node
+      const target = this.overlayViewChild.nativeElement;
+      const todayTD: HTMLElement = <HTMLElement>(<HTMLElement>target).querySelector('.ui-datepicker-today');
+      // setTimeout(() => {
+      if (!todayTD) {
+        this.selectGridCell('cell1-date');
+      } else {
+        (<HTMLElement>todayTD).querySelector('a').focus();
+        (<HTMLElement>todayTD).setAttribute('aria-selected', 'true');
+        (<HTMLTableElement>this.overlayTable.nativeElement).setAttribute('aria-activedescendant', todayTD.id);
+      }
+      // }, 100);
     }
-    
-    createWeekDays() {
-        this.weekDays = [];
-        let dayIndex = this.locale.firstDayOfWeek;
-        for(let i = 0; i < 7; i++) {
-            this.weekDays.push(this.locale.dayNamesMin[dayIndex]);
-            dayIndex = (dayIndex == 6) ? 0 : ++dayIndex;
-        }
+  }
+
+  ngAfterContentInit() {
+    this.templates.forEach((item) => {
+      switch (item.getType()) {
+        case 'date':
+          this.dateTemplate = item.template;
+          break;
+
+        default:
+          this.dateTemplate = item.template;
+          break;
+      }
+    });
+  }
+
+  createWeekDays() {
+    this.weekDays = [];
+    this.weekFullDays = [];
+    let dayIndex = this.locale.firstDayOfWeek;
+    for (let i = 0; i < 7; i++) {
+      this.weekDays.push(this.locale.dayNamesMin[dayIndex]);
+      this.weekFullDays.push(this.locale.dayNames[dayIndex]);
+      dayIndex = (dayIndex == 6) ? 0 : ++dayIndex;
     }
-    
-    createMonth(month: number, year: number) {
-        this.dates = [];
-        this.currentMonth = month;
-        this.currentYear = year;
-        this.currentMonthText = this.locale.monthNames[month];
-        let firstDay = this.getFirstDayOfMonthIndex(month, year);
-        let daysLength = this.getDaysCountInMonth(month, year);
-        let prevMonthDaysLength = this.getDaysCountInPrevMonth(month, year);
-        let sundayIndex = this.getSundayIndex();
-        let dayNo = 1;
-        let today = new Date();
-                
-        for(let i = 0; i < 6; i++) {
-            let week = [];
-            
-            if(i == 0) {
-                for(let j = (prevMonthDaysLength - firstDay + 1); j <= prevMonthDaysLength; j++) {
-                    let prev = this.getPreviousMonthAndYear(month, year);
-                    week.push({day: j, month: prev.month, year: prev.year, otherMonth: true, 
-                            today: this.isToday(today, j, prev.month, prev.year), selectable: this.isSelectable(j, prev.month, prev.year)});
-                }
-                
-                let remainingDaysLength = 7 - week.length;
-                for(let j = 0; j < remainingDaysLength; j++) {
-                    week.push({day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year), 
-                            selectable: this.isSelectable(dayNo, month, year)});
-                    dayNo++;
-                }
-            }
-            else {
-                for (let j = 0; j < 7; j++) {
-                    if(dayNo > daysLength) {
-                        let next = this.getNextMonthAndYear(month, year);
-                        week.push({day: dayNo - daysLength, month: next.month, year: next.year, otherMonth:true,
-                                    today: this.isToday(today, dayNo - daysLength, next.month, next.year),
-                                    selectable: this.isSelectable((dayNo - daysLength), next.month, next.year)});
-                    }
-                    else {
-                        week.push({day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year),
-                            selectable: this.isSelectable(dayNo, month, year)});
-                    }
-                    
-                    dayNo++;
-                }
-            }
-            
-            this.dates.push(week);
-        }
-    }
-    
-    initTime(date: Date) {
-        this.pm = date.getHours() > 11;
-        if(this.showTime) {
-            this.currentMinute = date.getMinutes();
-            this.currentSecond = date.getSeconds();
-            
-            if(this.hourFormat == '12')
-                this.currentHour = date.getHours() == 0 ? 12 : date.getHours() % 12;
-            else
-                this.currentHour = date.getHours();
-        }
-        else if(this.timeOnly) {
-            this.currentMinute = 0;
-            this.currentHour = 0;
-            this.currentSecond = 0;
-        }
-    }
-    
-    prevMonth(event) {
-        if(this.disabled) {
-            event.preventDefault();
-            return;
-        }
-        
-        if(this.currentMonth === 0) {
-            this.currentMonth = 11;
-            this.currentYear--;
-            
-            if(this.yearNavigator && this.currentYear < this.yearOptions[0]) {
-                this.currentYear = this.yearOptions[this.yearOptions.length - 1];
-            }
-        }
-        else {
-            this.currentMonth--;
-        }
-        
-        this.createMonth(this.currentMonth, this.currentYear);
-        event.preventDefault();
-    }
-    
-    nextMonth(event) {
-        if(this.disabled) {
-            event.preventDefault();
-            return;
+  }
+
+  createMonth(month: number, year: number) {
+    this.dates = [];
+    this.currentMonth = month;
+    this.currentYear = year;
+    this.currentMonthText = this.locale.monthNames[month];
+    let firstDay = this.getFirstDayOfMonthIndex(month, year);
+    let daysLength = this.getDaysCountInMonth(month, year);
+    let prevMonthDaysLength = this.getDaysCountInPrevMonth(month, year);
+    let sundayIndex = this.getSundayIndex();
+    let dayNo = 1;
+    let today = new Date();
+
+    for (let i = 0; i < 6; i++) {
+      let week = [];
+
+      if (i == 0) {
+        for (let j = (prevMonthDaysLength - firstDay + 1); j <= prevMonthDaysLength; j++) {
+          let prev = this.getPreviousMonthAndYear(month, year);
+          week.push({
+            day: j, month: prev.month, year: prev.year, otherMonth: true,
+            today: this.isToday(today, j, prev.month, prev.year), selectable: this.isSelectable(j, prev.month, prev.year)
+          });
         }
 
-        if(this.currentMonth === 11) {
-            this.currentMonth = 0;
-            this.currentYear++;
-            
-            if(this.yearNavigator && this.currentYear > this.yearOptions[this.yearOptions.length - 1]) {
-                this.currentYear = this.yearOptions[0];
-            }
+        let remainingDaysLength = 7 - week.length;
+        for (let j = 0; j < remainingDaysLength; j++) {
+          week.push({
+            day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year),
+            selectable: this.isSelectable(dayNo, month, year)
+          });
+          dayNo++;
         }
-        else {
-            this.currentMonth++;
-        }
-        
-        this.createMonth(this.currentMonth, this.currentYear);
-        event.preventDefault();
-    }
-    
-    onDateSelect(event, dateMeta) {
-        if(this.disabled || !dateMeta.selectable) {
-            event.preventDefault();
-            return;
-        }
-                
-        if(this.isMultipleSelection() && this.isSelected(dateMeta)) {
-            this.value = this.value.filter((date, i) => {
-                return !this.isDateEquals(date, dateMeta);
+      }
+      else {
+        for (let j = 0; j < 7; j++) {
+          if (dayNo > daysLength) {
+            let next = this.getNextMonthAndYear(month, year);
+            week.push({
+              day: dayNo - daysLength, month: next.month, year: next.year, otherMonth: true,
+              today: this.isToday(today, dayNo - daysLength, next.month, next.year),
+              selectable: this.isSelectable((dayNo - daysLength), next.month, next.year)
             });
-        }
-        else {
-            if(this.shouldSelectDate(dateMeta)) {
-                if(dateMeta.otherMonth) {
-                    if(this.selectOtherMonths) {
-                        this.currentMonth = dateMeta.month;
-                        this.currentYear = dateMeta.year;
-                        this.createMonth(this.currentMonth, this.currentYear);
-                        this.selectDate(dateMeta);
-                    }
-                }
-                else {
-                     this.selectDate(dateMeta);
-                }
-            }
-        }
-        
-        if(this.isSingleSelection()) {
-            this.overlayVisible = false;
-        }
-
-        this.updateInputfield();
-        event.preventDefault();
-    }
-    
-    shouldSelectDate(dateMeta) {
-        if(this.isMultipleSelection())
-            return !this.maxDateCount || !this.value || this.maxDateCount > this.value.length;
-        else
-            return true;
-    }
-    
-    updateInputfield() {
-        let formattedValue = '';
-
-        if(this.value) {
-            if(this.isSingleSelection()) {
-                formattedValue = this.formatDateTime(this.value);
-            }
-            else if(this.isMultipleSelection()) {
-                for(let i = 0; i < this.value.length; i++) {
-                    let dateAsString = this.formatDateTime(this.value[i]);
-                    formattedValue += dateAsString;
-                    if(i !== (this.value.length - 1)) {
-                        formattedValue += ', ';
-                    }
-                }
-            }
-            else if(this.isRangeSelection()) {
-                if(this.value && this.value.length) {
-                    let startDate = this.value[0];
-                    let endDate = this.value[1];
-                    
-                    formattedValue = this.formatDateTime(startDate);
-                    if(endDate) {
-                        formattedValue += ' - ' + this.formatDateTime(endDate);
-                    }
-                }
-            }
-        }
-
-        this.inputFieldValue = formattedValue;
-        this.updateFilledState();
-        if(this.inputfieldViewChild && this.inputfieldViewChild.nativeElement) {
-            this.inputfieldViewChild.nativeElement.value = this.inputFieldValue;
-        }
-    }
-    
-    formatDateTime(date) {
-        let formattedValue = null;
-        if(date) {
-            if(this.timeOnly) {
-                formattedValue = this.formatTime(date);
-            }
-            else {
-                formattedValue = this.formatDate(date, this.dateFormat);
-                if(this.showTime) {
-                    formattedValue += ' ' + this.formatTime(date);
-                }
-            }
-        }
-        
-        return formattedValue;
-    }
-    
-    selectDate(dateMeta) {
-        let date;
-        if(this.utc)
-            date = new Date(Date.UTC(dateMeta.year, dateMeta.month, dateMeta.day));
-        else
-            date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
-        
-        if(this.showTime) {
-            if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
-                date.setHours(this.currentHour + 12);
-            else
-                date.setHours(this.currentHour);
-
-            date.setMinutes(this.currentMinute);
-            date.setSeconds(this.currentSecond);
-        }
-                
-        if(this.isSingleSelection()) {
-            this.updateModel(date);
-        }
-        else if(this.isMultipleSelection()) {
-            this.updateModel(this.value ? [...this.value, date] : [date]);
-        }
-        else if(this.isRangeSelection()) {
-            if(this.value && this.value.length) {
-                let startDate = this.value[0];
-                let endDate = this.value[1];
-                
-                if(!endDate && date.getTime() > startDate.getTime()) {
-                    endDate = date;
-                }
-                else {
-                    startDate = date;
-                    endDate = null;
-                }
-                
-                this.updateModel([startDate, endDate]); 
-            }
-            else {
-                this.updateModel([date, null]); 
-            }
-        }
-            
-        this.onSelect.emit(date);
-    }
-    
-    updateModel(value) {
-        this.value = value;
-        
-        if(this.dataType == 'date')
-            this.onModelChange(this.value);
-        else if(this.dataType == 'string')
-            this.onModelChange(this.formatDateTime(this.value));
-    }
-    
-    getFirstDayOfMonthIndex(month: number, year: number) {
-        let day = new Date();
-        day.setDate(1);
-        day.setMonth(month);
-        day.setFullYear(year);
-        
-        let dayIndex = day.getDay() + this.getSundayIndex();
-        return dayIndex >= 7 ? dayIndex - 7 : dayIndex;
-    }
-    
-    getDaysCountInMonth(month: number, year: number) {
-        return 32 - this.daylightSavingAdjust(new Date(year, month, 32)).getDate();
-    }
-    
-    getDaysCountInPrevMonth(month: number, year: number) {
-        let prev = this.getPreviousMonthAndYear(month, year);
-        return this.getDaysCountInMonth(prev.month, prev.year);
-    }
-    
-    getPreviousMonthAndYear(month: number, year: number) {
-        let m, y;
-        
-        if(month === 0) {
-            m = 11;
-            y = year - 1;
-        }
-        else {
-            m = month - 1;
-            y = year;
-        }
-        
-        return {'month':m,'year':y};
-    }
-    
-    getNextMonthAndYear(month: number, year: number) {
-        let m, y;
-        
-        if(month === 11) {
-            m = 0;
-            y = year + 1;
-        }
-        else {
-            m = month + 1;
-            y = year;
-        }
-        
-        return {'month':m,'year':y};
-    }
-    
-    getSundayIndex() {
-        return this.locale.firstDayOfWeek > 0 ? 7 - this.locale.firstDayOfWeek : 0;
-    }
-    
-    isSelected(dateMeta): boolean {     
-        if(this.value) {
-            if(this.isSingleSelection()) {
-                return this.isDateEquals(this.value, dateMeta);
-            }
-            else if(this.isMultipleSelection()) {
-                let selected = false;
-                for(let date of this.value) {
-                    selected = this.isDateEquals(date, dateMeta);
-                    if(selected) {
-                        break;
-                    }
-                }
-                
-                return selected;
-            }
-            else if(this.isRangeSelection()) {
-                if(this.value[1])
-                    return this.isDateEquals(this.value[0], dateMeta) || this.isDateEquals(this.value[1], dateMeta) || this.isDateBetween(this.value[0], this.value[1], dateMeta);
-                else
-                    return this.isDateEquals(this.value[0], dateMeta)
-            }
-        }
-        else
-            return false;
-    }
-    
-    isDateEquals(value, dateMeta) {
-        if(value)
-            return value.getDate() === dateMeta.day && value.getMonth() === dateMeta.month && value.getFullYear() === dateMeta.year;
-        else
-            return false;
-    }
-    
-    isDateBetween(start, end, dateMeta) {
-        if(start && end) {
-            return start.getDate() < dateMeta.day && start.getMonth() <= dateMeta.month && start.getFullYear() <= dateMeta.year &&
-            end.getDate() > dateMeta.day && end.getMonth() >= dateMeta.month && end.getFullYear() >= dateMeta.year;
-        }
-        else {
-            return false; 
-        }
-    }
-    
-    isSingleSelection(): boolean {
-        return this.selectionMode === 'single';
-    }
-    
-    isRangeSelection(): boolean {
-        return this.selectionMode === 'range';
-    }
-    
-    isMultipleSelection(): boolean {
-        return this.selectionMode === 'multiple';
-    }
-    
-    isToday(today, day, month, year): boolean {     
-        return today.getDate() === day && today.getMonth() === month && today.getFullYear() === year;
-    }
-    
-    isSelectable(day, month, year): boolean {
-        let validMin = true;
-        let validMax = true;
-        let validDate = true;
-        let validDay = true;
-        
-        if(this.minDate) {
-             if(this.minDate.getFullYear() > year) {
-                 validMin = false;
-             }
-             else if(this.minDate.getFullYear() === year) {
-                 if(this.minDate.getMonth() > month) {
-                     validMin = false;
-                 }
-                 else if(this.minDate.getMonth() === month) {
-                     if(this.minDate.getDate() > day) {
-                         validMin = false;
-                     }
-                 }
-             }  
-        }
-        
-        if(this.maxDate) {
-             if(this.maxDate.getFullYear() < year) {
-                 validMax = false;
-             }
-             else if(this.maxDate.getFullYear() === year) {
-                 if(this.maxDate.getMonth() < month) {
-                     validMax = false;
-                 }
-                 else if(this.maxDate.getMonth() === month) {
-                     if(this.maxDate.getDate() < day) {
-                         validMax = false;
-                     }
-                 }
-             }  
-        }
-        
-        if(this.disabledDates) {
-           validDate = !this.isDateDisabled(day,month,year);
-        }
-       
-        if(this.disabledDays) {
-           validDay = !this.isDayDisabled(day,month,year)
-        }
-        
-        return validMin && validMax && validDate && validDay;
-    }
-    
-    isDateDisabled(day:number, month:number, year:number):boolean {
-        if(this.disabledDates) {
-            for(let disabledDate of this.disabledDates) {
-                if(disabledDate.getFullYear() === year && disabledDate.getMonth() === month && disabledDate.getDate() === day) {
-                    return true;
-                }
-            }
-        }
-        
-        return false;
-    }
-    
-    isDayDisabled(day:number, month:number, year:number):boolean {
-        if(this.disabledDays) {
-            let weekday = new Date(year, month, day);
-            let weekdayNumber = weekday.getDay();
-            return this.disabledDays.indexOf(weekdayNumber) !== -1;
-        }
-        return false;
-    }
-    
-    onInputFocus(event: Event) {
-        this.focus = true;
-        if(this.showOnFocus) {
-            this.showOverlay();
-        }
-        this.onFocus.emit(event);
-    }
-    
-    onInputBlur(event: Event) {
-        this.focus = false;
-        this.onBlur.emit(event);
-        this.updateInputfield();
-        this.onModelTouched();
-    }
-    
-    onButtonClick(event,inputfield) {        
-        if(!this.overlayViewChild.nativeElement.offsetParent || this.overlayViewChild.nativeElement.style.display === 'none') {
-            inputfield.focus();
-            this.showOverlay();
-        }
-        else
-            this.overlayVisible = false;
-            
-        this.datepickerClick = true;
-    }
-    
-    onInputKeydown(event) {
-        this.isKeydown = true;
-        if(event.keyCode === 9) {
-            this.overlayVisible = false;
-        }
-    }
-    
-    onMonthDropdownChange(m: string) {
-        this.currentMonth = parseInt(m);
-        this.createMonth(this.currentMonth, this.currentYear);
-    }
-    
-    onYearDropdownChange(y: string) {
-        this.currentYear = parseInt(y);
-        this.createMonth(this.currentMonth, this.currentYear);
-    }
-    
-    incrementHour(event) {
-        let newHour = this.currentHour + this.stepHour;
-        if(this.hourFormat == '24')
-            this.currentHour = (newHour >= 24) ? (newHour - 24) : newHour;        
-        else if(this.hourFormat == '12')
-            this.currentHour = (newHour >= 13) ? (newHour - 12) : newHour;
-        
-        this.updateTime();
-                
-        event.preventDefault();
-    }
-    
-    decrementHour(event) {
-        let newHour = this.currentHour - this.stepHour;
-        if(this.hourFormat == '24')
-            this.currentHour = (newHour < 0) ? (24 + newHour) : newHour;        
-        else if(this.hourFormat == '12')
-            this.currentHour = (newHour <= 0) ? (12 + newHour) : newHour;
-            
-        this.updateTime();
-
-        event.preventDefault();
-    }
-    
-    incrementMinute(event) {
-        let newMinute = this.currentMinute + this.stepMinute;
-        this.currentMinute = (newMinute > 59) ? newMinute - 60 : newMinute;
-            
-        this.updateTime();
-                
-        event.preventDefault();
-    }
-    
-    decrementMinute(event) {
-        let newMinute = this.currentMinute - this.stepMinute;
-        this.currentMinute = (newMinute < 0) ? 60 + newMinute : newMinute;
-            
-        this.updateTime();
-            
-        event.preventDefault();
-    }
-    
-    incrementSecond(event) {
-        let newSecond = this.currentSecond + this.stepSecond;
-        this.currentSecond = (newSecond > 59) ? newSecond - 60 : newSecond;
-            
-        this.updateTime();
-                
-        event.preventDefault();
-    }
-    
-    decrementSecond(event) {
-        let newSecond = this.currentSecond - this.stepSecond;
-        this.currentSecond = (newSecond < 0) ? 60 + newSecond : newSecond;
-            
-        this.updateTime();
-            
-        event.preventDefault();
-    }
-    
-    updateTime() {
-        let value = this.value||new Date();
-        if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
-            value.setHours(this.currentHour + 12);
-        else
-            value.setHours(this.currentHour);
-        
-        value.setMinutes(this.currentMinute);
-        value.setSeconds(this.currentSecond);
-        this.updateModel(value);
-        this.onSelect.emit(value);
-        this.updateInputfield();
-    }
-    
-    toggleAMPM(event) {
-        this.pm = !this.pm;
-        this.updateTime();
-        event.preventDefault();
-    }
-    
-    onUserInput(event) {
-        // IE 11 Workaround for input placeholder : https://github.com/primefaces/primeng/issues/2026
-        if(!this.isKeydown) {
-            return;
-        }
-        this.isKeydown = false;
-        
-        let val = event.target.value;   
-        try {
-            let value = this.parseValueFromString(val);
-            this.updateModel(value);
-            this.updateUI();
-        } 
-        catch(err) {
-            //invalid date
-            this.updateModel(null);
-        }
-        
-        this.filled = val != null && val.length;
-        this.onInput.emit(event);
-    }
-    
-    parseValueFromString(text: string): Date {
-        if(!text || text.trim().length === 0) {
-            return null;
-        }
-        
-        let value: any;
-        
-        if(this.isSingleSelection()) {
-            value = this.parseDateTime(text);
-        }
-        else if(this.isMultipleSelection()) {
-            let tokens = text.split(',');
-            value = [];
-            for(let token of tokens) {
-                value.push(this.parseDateTime(token.trim()));
-            }
-        }
-        else if(this.isRangeSelection()) {
-            let tokens = text.split(' - ');
-            value = [];
-            for(let i = 0; i < tokens.length; i++) {
-                value[i] = this.parseDateTime(tokens[i].trim());
-            }
-        }
-        
-        return value;
-    }
-    
-    parseDateTime(text): Date {
-        let date: Date;
-        let parts: string[] = text.split(' ');
-        
-        if(this.timeOnly) {
-            date = new Date();
-            this.populateTime(date, parts[0], parts[1]);
-        }
-        else {
-            if(this.showTime) {
-                date = this.parseDate(parts[0], this.dateFormat);
-                this.populateTime(date, parts[1], parts[2]);
-            }
-            else {
-                 date = this.parseDate(text, this.dateFormat);
-            }
-        }
-        
-        return date;
-    }
-    
-    populateTime(value, timeString, ampm) {
-        if(this.hourFormat == '12' && !ampm) {
-            throw 'Invalid Time';
-        }
-        
-        this.pm = (ampm === 'PM' || ampm === 'pm');
-        let time = this.parseTime(timeString);
-        value.setHours(time.hour);
-        value.setMinutes(time.minute);
-        value.setSeconds(time.second);
-    }
-    
-    updateUI() {
-        let val = this.value||this.defaultDate||new Date();
-        this.createMonth(val.getMonth(), val.getFullYear());
-        
-        if(this.showTime||this.timeOnly) {
-            let hours = val.getHours();
-            
-            if(this.hourFormat == '12') {
-                if(hours >= 12) {
-                    this.currentHour = (hours == 12) ? 12 : hours - 12;
-                }
-                else {
-                    this.currentHour = (hours == 0) ? 12 : hours;
-                }
-            }
-            else {
-                this.currentHour = val.getHours();
-            }
-            
-            this.currentMinute = val.getMinutes();
-            this.currentSecond = val.getSeconds();
-        }
-    }
-    
-    onDatePickerClick(event) {
-        this.datepickerClick = true;
-    }
-    
-    showOverlay() {
-        this.overlayVisible = true;
-        this.overlayShown = true;
-        this.overlayViewChild.nativeElement.style.zIndex = String(++DomHandler.zindex);
-        
-        this.bindDocumentClickListener();
-    }
-    
-    alignOverlay() {
-        if(this.appendTo)
-            this.domHandler.absolutePosition(this.overlayViewChild.nativeElement, this.inputfieldViewChild.nativeElement);
-        else
-            this.domHandler.relativePosition(this.overlayViewChild.nativeElement, this.inputfieldViewChild.nativeElement);
-    }
-
-    writeValue(value: any) : void {
-        this.value = value;
-        if(this.value && typeof this.value === 'string') {
-            this.value = this.parseValueFromString(this.value);
-        }
-
-        this.updateInputfield();
-        this.updateUI();
-    }
-    
-    registerOnChange(fn: Function): void {
-        this.onModelChange = fn;
-    }
-
-    registerOnTouched(fn: Function): void {
-        this.onModelTouched = fn;
-    }
-    
-    setDisabledState(val: boolean): void {
-        this.disabled = val;
-    }
-    
-    // Ported from jquery-ui datepicker formatDate    
-    formatDate(date, format) {
-        if(!date) {
-            return "";
-        }
-
-        let iFormat,
-        lookAhead = (match) => {
-            let matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
-            if(matches) {
-                iFormat++;
-            }
-            return matches;
-        },
-        formatNumber = (match, value, len) => {
-            let num = "" + value;
-            if(lookAhead(match)) {
-                while (num.length < len) {
-                    num = "0" + num;
-                }
-            }
-            return num;
-        },
-        formatName = (match, value, shortNames, longNames) => {
-            return (lookAhead(match) ? longNames[ value ] : shortNames[ value ]);
-        },
-        output = "",
-        literal = false;
-
-        if(date) {
-            for(iFormat = 0; iFormat < format.length; iFormat++) {
-                if(literal) {
-                    if(format.charAt(iFormat) === "'" && !lookAhead("'"))
-                        literal = false;
-                    else
-                        output += format.charAt(iFormat);
-                }
-                else {
-                    switch (format.charAt(iFormat)) {
-                        case "d":
-                            output += formatNumber("d", date.getDate(), 2);
-                            break;
-                        case "D":
-                            output += formatName("D", date.getDay(), this.locale.dayNamesShort, this.locale.dayNames);
-                            break;
-                        case "o":
-                            output += formatNumber("o",
-                                Math.round((new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / 86400000), 3);
-                            break;
-                        case "m":
-                            output += formatNumber("m", date.getMonth() + 1, 2);
-                            break;
-                        case "M":
-                            output += formatName("M", date.getMonth(), this.locale.monthNamesShort, this.locale.monthNames);
-                            break;
-                        case "y":
-                            output += (lookAhead("y") ? date.getFullYear() :
-                                (date.getFullYear() % 100 < 10 ? "0" : "") + date.getFullYear() % 100);
-                            break;
-                        case "@":
-                            output += date.getTime();
-                            break;
-                        case "!":
-                            output += date.getTime() * 10000 + this.ticksTo1970;
-                            break;
-                        case "'":
-                            if(lookAhead("'"))
-                                output += "'";
-                            else
-                                literal = true;
-
-                            break;
-                        default:
-                            output += format.charAt(iFormat);
-                    }
-                }
-            }
-        }
-        return output;
-	}
-    
-    formatTime(date) {
-        if(!date) {
-            return '';
-        }
-        
-        let output = '';
-        let hours = date.getHours();
-        let minutes = date.getMinutes();
-        let seconds = date.getSeconds();
-        
-        if(this.hourFormat == '12' && hours > 11 && hours != 12) {
-            hours-=12;
-        }
-        
-        output += (hours < 10) ? '0' + hours : hours;
-        output += ':';
-        output += (minutes < 10) ? '0' + minutes : minutes;
-        
-        if(this.showSeconds) {
-            output += ':';
-            output += (seconds < 10) ? '0' + seconds : seconds;
-        }
-        
-        if(this.hourFormat == '12') {
-            output += date.getHours() > 11 ? ' PM' : ' AM';
-        }
-        
-        return output;
-    }
-    
-    parseTime(value) {
-        let tokens: string[] = value.split(':');
-        let validTokenLength = this.showSeconds ? 3 : 2;
-        
-        if(tokens.length !== validTokenLength) {
-            throw "Invalid time";
-        }
-        
-        let h = parseInt(tokens[0]);
-        let m = parseInt(tokens[1]);
-        let s = this.showSeconds ? parseInt(tokens[2]) : null;
-        
-        if(isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
-            throw "Invalid time";
-        }
-        else {
-            if(this.hourFormat == '12' && h !== 12 && this.pm) {
-                h+= 12;
-            }
-            
-            return {hour: h, minute: m, second: s};
-        }
-    }
-    
-    // Ported from jquery-ui datepicker parseDate 
-    parseDate(value, format) {
-		if(format == null || value == null) {
-			throw "Invalid arguments";
-		}
-
-		value = (typeof value === "object" ? value.toString() : value + "");
-		if(value === "") {
-			return null;
-		}
-
-		let iFormat, dim, extra,
-		iValue = 0,
-		shortYearCutoff = (typeof this.shortYearCutoff !== "string" ? this.shortYearCutoff : new Date().getFullYear() % 100 + parseInt(this.shortYearCutoff, 10)),
-		year = -1,
-		month = -1,
-		day = -1,
-		doy = -1,
-		literal = false,
-		date,
-		lookAhead = (match) => {
-			let matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
-			if(matches) {
-				iFormat++;
-			}
-			return matches;
-		},
-		getNumber = (match) => {
-			let isDoubled = lookAhead(match),
-				size = (match === "@" ? 14 : (match === "!" ? 20 :
-				(match === "y" && isDoubled ? 4 : (match === "o" ? 3 : 2)))),
-				minSize = (match === "y" ? size : 1),
-				digits = new RegExp("^\\d{" + minSize + "," + size + "}"),
-				num = value.substring(iValue).match(digits);
-			if(!num) {
-				throw "Missing number at position " + iValue;
-			}
-			iValue += num[ 0 ].length;
-			return parseInt(num[ 0 ], 10);
-		},
-		getName = (match, shortNames, longNames) => {
-            let index = -1;
-            let arr = lookAhead(match) ? longNames : shortNames;
-            let names = [];
-            
-            for(let i = 0; i < arr.length; i++) {
-                names.push([i,arr[i]]);
-            }
-            names.sort((a,b) => {
-                return -(a[ 1 ].length - b[ 1 ].length);
+          }
+          else {
+            week.push({
+              day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year),
+              selectable: this.isSelectable(dayNo, month, year)
             });
-            
-            for(let i = 0; i < names.length; i++) {
-                let name = names[i][1];
-                if(value.substr(iValue, name.length).toLowerCase() === name.toLowerCase()) {
-    				index = names[i][0];
-    				iValue += name.length;
-    				break;
-    			}
-            }
+          }
 
-			if(index !== -1) {
-				return index + 1;
-			} else {
-				throw "Unknown name at position " + iValue;
-			}
-		},
-		checkLiteral = () => {
-			if(value.charAt(iValue) !== format.charAt(iFormat)) {
-				throw "Unexpected literal at position " + iValue;
-			}
-			iValue++;
-		};
-
-		for (iFormat = 0; iFormat < format.length; iFormat++) {
-			if(literal) {
-				if(format.charAt(iFormat) === "'" && !lookAhead("'")) {
-					literal = false;
-				} else {
-					checkLiteral();
-				}
-			} else {
-				switch (format.charAt(iFormat)) {
-					case "d":
-						day = getNumber("d");
-						break;
-					case "D":
-						getName("D", this.locale.dayNamesShort, this.locale.dayNames);
-						break;
-					case "o":
-						doy = getNumber("o");
-						break;
-					case "m":
-						month = getNumber("m");
-						break;
-					case "M":
-						month = getName("M", this.locale.monthNamesShort, this.locale.monthNames);
-						break;
-					case "y":
-						year = getNumber("y");
-						break;
-					case "@":
-						date = new Date(getNumber("@"));
-						year = date.getFullYear();
-						month = date.getMonth() + 1;
-						day = date.getDate();
-						break;
-					case "!":
-						date = new Date((getNumber("!") - this.ticksTo1970) / 10000);
-						year = date.getFullYear();
-						month = date.getMonth() + 1;
-						day = date.getDate();
-						break;
-					case "'":
-						if(lookAhead("'")) {
-							checkLiteral();
-						} else {
-							literal = true;
-						}
-						break;
-					default:
-						checkLiteral();
-				}
-			}
-		}
-
-		if(iValue < value.length) {
-			extra = value.substr(iValue);
-			if(!/^\s+/.test(extra)) {
-				throw "Extra/unparsed characters found in date: " + extra;
-			}
-		}
-
-		if(year === -1) {
-			year = new Date().getFullYear();
-		} else if(year < 100) {
-			year += new Date().getFullYear() - new Date().getFullYear() % 100 +
-				(year <= shortYearCutoff ? 0 : -100);
-		}
-
-		if(doy > -1) {
-			month = 1;
-			day = doy;
-			do {
-				dim = this.getDaysCountInMonth(year, month - 1);
-				if(day <= dim) {
-					break;
-				}
-				month++;
-				day -= dim;
-			} while (true);
-		}
-
-		date = this.daylightSavingAdjust(new Date(year, month - 1, day));
-		if(date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) {
-			throw "Invalid date"; // E.g. 31/02/00
-		}
-		return date;
-	}
-    
-    daylightSavingAdjust(date) {
-        if(!date) {
-            return null;
+          dayNo++;
         }
-        date.setHours(date.getHours() > 12 ? date.getHours() + 2 : 0);
-        return date;
+      }
+
+      this.dates.push(week);
     }
-    
-    updateFilledState() {
-        this.filled = this.inputFieldValue && this.inputFieldValue != '';
+  }
+
+  initTime(date: Date) {
+    this.pm = date.getHours() > 11;
+    if (this.showTime) {
+      this.currentMinute = date.getMinutes();
+      this.currentSecond = date.getSeconds();
+
+      if (this.hourFormat == '12')
+        this.currentHour = date.getHours() == 0 ? 12 : date.getHours() % 12;
+      else
+        this.currentHour = date.getHours();
     }
-    
-    onTodayButtonClick(event) {
-        let date: Date = new Date();
-        let dateMeta = {day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), today: true, selectable: true};
-        
-        this.onDateSelect(event, dateMeta);
-        this.onTodayClick.emit(event);
+    else if (this.timeOnly) {
+      this.currentMinute = 0;
+      this.currentHour = 0;
+      this.currentSecond = 0;
     }
-    
-    onClearButtonClick(event) {
-        this.updateModel(null);
-        this.updateInputfield();
+  }
+
+  prevMonth(event) {
+    if (this.disabled) {
+      event.preventDefault();
+      return;
+    }
+
+    if (this.currentMonth === 0) {
+      this.currentMonth = 11;
+      this.currentYear--;
+
+      if (this.yearNavigator && this.currentYear < this.yearOptions[0]) {
+        this.currentYear = this.yearOptions[this.yearOptions.length - 1];
+      }
+    }
+    else {
+      this.currentMonth--;
+    }
+
+    this.createMonth(this.currentMonth, this.currentYear);
+    event.preventDefault();
+  }
+
+  nextMonth(event) {
+    if (this.disabled) {
+      event.preventDefault();
+      return;
+    }
+
+    if (this.currentMonth === 11) {
+      this.currentMonth = 0;
+      this.currentYear++;
+
+      if (this.yearNavigator && this.currentYear > this.yearOptions[this.yearOptions.length - 1]) {
+        this.currentYear = this.yearOptions[0];
+      }
+    }
+    else {
+      this.currentMonth++;
+    }
+
+    this.createMonth(this.currentMonth, this.currentYear);
+    event.preventDefault();
+  }
+
+  onDateSelect(event, dateMeta) {
+    if (this.disabled || !dateMeta.selectable) {
+      event.preventDefault();
+      return;
+    }
+
+    if (this.isMultipleSelection() && this.isSelected(dateMeta)) {
+      this.value = this.value.filter((date, i) => {
+        return !this.isDateEquals(date, dateMeta);
+      });
+    }
+    else {
+      if (this.shouldSelectDate(dateMeta)) {
+        if (dateMeta.otherMonth) {
+          if (this.selectOtherMonths) {
+            this.currentMonth = dateMeta.month;
+            this.currentYear = dateMeta.year;
+            this.createMonth(this.currentMonth, this.currentYear);
+            this.selectDate(dateMeta);
+          }
+        }
+        else {
+          this.selectDate(dateMeta);
+        }
+      }
+    }
+
+    if (this.isSingleSelection()) {
+      this.overlayVisible = false;
+    }
+
+    this.updateInputfield();
+    event.preventDefault();
+  }
+
+  shouldSelectDate(dateMeta) {
+    if (this.isMultipleSelection())
+      return !this.maxDateCount || !this.value || this.maxDateCount > this.value.length;
+    else
+      return true;
+  }
+
+  updateInputfield() {
+    let formattedValue = '';
+
+    if (this.value) {
+      if (this.isSingleSelection()) {
+        formattedValue = this.formatDateTime(this.value);
+      }
+      else if (this.isMultipleSelection()) {
+        for (let i = 0; i < this.value.length; i++) {
+          let dateAsString = this.formatDateTime(this.value[i]);
+          formattedValue += dateAsString;
+          if (i !== (this.value.length - 1)) {
+            formattedValue += ', ';
+          }
+        }
+      }
+      else if (this.isRangeSelection()) {
+        if (this.value && this.value.length) {
+          let startDate = this.value[0];
+          let endDate = this.value[1];
+
+          formattedValue = this.formatDateTime(startDate);
+          if (endDate) {
+            formattedValue += ' - ' + this.formatDateTime(endDate);
+          }
+        }
+      }
+    }
+
+    this.inputFieldValue = formattedValue;
+    this.updateFilledState();
+    if (this.inputfieldViewChild && this.inputfieldViewChild.nativeElement) {
+      this.inputfieldViewChild.nativeElement.value = this.inputFieldValue;
+    }
+  }
+
+  formatDateTime(date) {
+    let formattedValue = null;
+    if (date) {
+      if (this.timeOnly) {
+        formattedValue = this.formatTime(date);
+      }
+      else {
+        formattedValue = this.formatDate(date, this.dateFormat);
+        if (this.showTime) {
+          formattedValue += ' ' + this.formatTime(date);
+        }
+      }
+    }
+
+    return formattedValue;
+  }
+
+  selectDate(dateMeta) {
+    let date;
+    if (this.utc)
+      date = new Date(Date.UTC(dateMeta.year, dateMeta.month, dateMeta.day));
+    else
+      date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
+
+    if (this.showTime) {
+      if (this.hourFormat === '12' && this.pm && this.currentHour != 12)
+        date.setHours(this.currentHour + 12);
+      else
+        date.setHours(this.currentHour);
+
+      date.setMinutes(this.currentMinute);
+      date.setSeconds(this.currentSecond);
+    }
+
+    if (this.isSingleSelection()) {
+      this.updateModel(date);
+    }
+    else if (this.isMultipleSelection()) {
+      this.updateModel(this.value ? [...this.value, date] : [date]);
+    }
+    else if (this.isRangeSelection()) {
+      if (this.value && this.value.length) {
+        let startDate = this.value[0];
+        let endDate = this.value[1];
+
+        if (!endDate && date.getTime() > startDate.getTime()) {
+          endDate = date;
+        }
+        else {
+          startDate = date;
+          endDate = null;
+        }
+
+        this.updateModel([startDate, endDate]);
+      }
+      else {
+        this.updateModel([date, null]);
+      }
+    }
+
+    this.onSelect.emit(date);
+  }
+
+  updateModel(value) {
+    this.value = value;
+
+    if (this.dataType == 'date')
+      this.onModelChange(this.value);
+    else if (this.dataType == 'string')
+      this.onModelChange(this.formatDateTime(this.value));
+  }
+
+  getFirstDayOfMonthIndex(month: number, year: number) {
+    let day = new Date();
+    day.setDate(1);
+    day.setMonth(month);
+    day.setFullYear(year);
+
+    let dayIndex = day.getDay() + this.getSundayIndex();
+    return dayIndex >= 7 ? dayIndex - 7 : dayIndex;
+  }
+
+  getDaysCountInMonth(month: number, year: number) {
+    return 32 - this.daylightSavingAdjust(new Date(year, month, 32)).getDate();
+  }
+
+  getDaysCountInPrevMonth(month: number, year: number) {
+    let prev = this.getPreviousMonthAndYear(month, year);
+    return this.getDaysCountInMonth(prev.month, prev.year);
+  }
+
+  getPreviousMonthAndYear(month: number, year: number) {
+    let m, y;
+
+    if (month === 0) {
+      m = 11;
+      y = year - 1;
+    }
+    else {
+      m = month - 1;
+      y = year;
+    }
+
+    return { 'month': m, 'year': y };
+  }
+
+  getNextMonthAndYear(month: number, year: number) {
+    let m, y;
+
+    if (month === 11) {
+      m = 0;
+      y = year + 1;
+    }
+    else {
+      m = month + 1;
+      y = year;
+    }
+
+    return { 'month': m, 'year': y };
+  }
+
+  getSundayIndex() {
+    return this.locale.firstDayOfWeek > 0 ? 7 - this.locale.firstDayOfWeek : 0;
+  }
+
+  isSelected(dateMeta): boolean {
+    if (this.value) {
+      if (this.isSingleSelection()) {
+        return this.isDateEquals(this.value, dateMeta);
+      }
+      else if (this.isMultipleSelection()) {
+        let selected = false;
+        for (let date of this.value) {
+          selected = this.isDateEquals(date, dateMeta);
+          if (selected) {
+            break;
+          }
+        }
+
+        return selected;
+      }
+      else if (this.isRangeSelection()) {
+        if (this.value[1])
+          return this.isDateEquals(this.value[0], dateMeta) || this.isDateEquals(this.value[1], dateMeta) || this.isDateBetween(this.value[0], this.value[1], dateMeta);
+        else
+          return this.isDateEquals(this.value[0], dateMeta)
+      }
+    }
+    else
+      return false;
+  }
+
+  isDateEquals(value, dateMeta) {
+    if (value)
+      return value.getDate() === dateMeta.day && value.getMonth() === dateMeta.month && value.getFullYear() === dateMeta.year;
+    else
+      return false;
+  }
+
+  isDateBetween(start, end, dateMeta) {
+    if (start && end) {
+      return start.getDate() < dateMeta.day && start.getMonth() <= dateMeta.month && start.getFullYear() <= dateMeta.year &&
+        end.getDate() > dateMeta.day && end.getMonth() >= dateMeta.month && end.getFullYear() >= dateMeta.year;
+    }
+    else {
+      return false;
+    }
+  }
+
+  isSingleSelection(): boolean {
+    return this.selectionMode === 'single';
+  }
+
+  isRangeSelection(): boolean {
+    return this.selectionMode === 'range';
+  }
+
+  isMultipleSelection(): boolean {
+    return this.selectionMode === 'multiple';
+  }
+
+  isToday(today, day, month, year): boolean {
+    return today.getDate() === day && today.getMonth() === month && today.getFullYear() === year;
+  }
+
+  isSelectable(day, month, year): boolean {
+    let validMin = true;
+    let validMax = true;
+    let validDate = true;
+    let validDay = true;
+
+    if (this.minDate) {
+      if (this.minDate.getFullYear() > year) {
+        validMin = false;
+      }
+      else if (this.minDate.getFullYear() === year) {
+        if (this.minDate.getMonth() > month) {
+          validMin = false;
+        }
+        else if (this.minDate.getMonth() === month) {
+          if (this.minDate.getDate() > day) {
+            validMin = false;
+          }
+        }
+      }
+    }
+
+    if (this.maxDate) {
+      if (this.maxDate.getFullYear() < year) {
+        validMax = false;
+      }
+      else if (this.maxDate.getFullYear() === year) {
+        if (this.maxDate.getMonth() < month) {
+          validMax = false;
+        }
+        else if (this.maxDate.getMonth() === month) {
+          if (this.maxDate.getDate() < day) {
+            validMax = false;
+          }
+        }
+      }
+    }
+
+    if (this.disabledDates) {
+      validDate = !this.isDateDisabled(day, month, year);
+    }
+
+    if (this.disabledDays) {
+      validDay = !this.isDayDisabled(day, month, year)
+    }
+
+    return validMin && validMax && validDate && validDay;
+  }
+
+  isDateDisabled(day: number, month: number, year: number): boolean {
+    if (this.disabledDates) {
+      for (let disabledDate of this.disabledDates) {
+        if (disabledDate.getFullYear() === year && disabledDate.getMonth() === month && disabledDate.getDate() === day) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  isDayDisabled(day: number, month: number, year: number): boolean {
+    if (this.disabledDays) {
+      let weekday = new Date(year, month, day);
+      let weekdayNumber = weekday.getDay();
+      return this.disabledDays.indexOf(weekdayNumber) !== -1;
+    }
+    return false;
+  }
+
+  onInputFocus(event: Event) {
+    this.focus = true;
+    if (!this.escShowOnFocus) {
+      if (this.showOnFocus) {
+        this.showOverlay();
+      }
+      this.onFocus.emit(event);
+    } else {
+      this.escShowOnFocus = false;
+    }
+  }
+
+  onInputBlur(event: Event) {
+    this.focus = false;
+    this.onBlur.emit(event);
+    this.updateInputfield();
+    this.onModelTouched();
+  }
+
+  onButtonClick(event, inputfield) {
+    if (!this.overlayViewChild.nativeElement.offsetParent || this.overlayViewChild.nativeElement.style.display === 'none') {
+      // inputfield.focus();
+      this.showOverlay();
+      this.focusOnDays();
+    }
+    else
+      this.overlayVisible = false;
+
+    this.datepickerClick = true;
+  }
+
+  focusOnDays(){
+
+    if (!this.timeOnly) {
+      // select the target node
+      setTimeout(() => {
+      const target = this.overlayViewChild.nativeElement;
+      const todayTD: HTMLElement = <HTMLElement>(<HTMLElement>target).querySelector('.ui-datepicker-today');
+        if (!todayTD) {
+          this.selectGridCell('cell1-date');
+        } else {
+          (<HTMLElement>todayTD).querySelector('a').focus();
+          (<HTMLElement>todayTD).setAttribute('aria-selected', 'true');
+          (<HTMLTableElement>this.overlayTable.nativeElement).setAttribute('aria-activedescendant', todayTD.id);
+        }
+      }, 50);
+    }
+
+  }
+
+  onInputKeydown(event) {
+    this.isKeydown = true;
+    switch (event.keyCode) {
+      case this.keys.tab:
         this.overlayVisible = false;
-        this.onClearClick.emit(event);
+        break;
+      case this.keys.down:
+        // this.onInputFocus(event);
+        this.onButtonClick(event,this.inputfieldViewChild);
+        break;
+
+      default:
+        break;
     }
-    
-    bindDocumentClickListener() {
-        if(!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
-                if(!this.datepickerClick&&this.overlayVisible) {
-                    this.overlayVisible = false;
-                    this.onClose.emit(event);
+  }
+
+  onMonthDropdownChange(m: string) {
+    this.currentMonth = parseInt(m);
+    this.createMonth(this.currentMonth, this.currentYear);
+  }
+
+  onYearDropdownChange(y: string) {
+    this.currentYear = parseInt(y);
+    this.createMonth(this.currentMonth, this.currentYear);
+  }
+
+  incrementHour(event) {
+    let newHour = this.currentHour + this.stepHour;
+    if (this.hourFormat == '24')
+      this.currentHour = (newHour >= 24) ? (newHour - 24) : newHour;
+    else if (this.hourFormat == '12')
+      this.currentHour = (newHour >= 13) ? (newHour - 12) : newHour;
+
+    this.updateTime();
+
+    event.preventDefault();
+  }
+
+  decrementHour(event) {
+    let newHour = this.currentHour - this.stepHour;
+    if (this.hourFormat == '24')
+      this.currentHour = (newHour < 0) ? (24 + newHour) : newHour;
+    else if (this.hourFormat == '12')
+      this.currentHour = (newHour <= 0) ? (12 + newHour) : newHour;
+
+    this.updateTime();
+
+    event.preventDefault();
+  }
+
+  incrementMinute(event) {
+    let newMinute = this.currentMinute + this.stepMinute;
+    this.currentMinute = (newMinute > 59) ? newMinute - 60 : newMinute;
+
+    this.updateTime();
+
+    event.preventDefault();
+  }
+
+  decrementMinute(event) {
+    let newMinute = this.currentMinute - this.stepMinute;
+    this.currentMinute = (newMinute < 0) ? 60 + newMinute : newMinute;
+
+    this.updateTime();
+
+    event.preventDefault();
+  }
+
+  incrementSecond(event) {
+    let newSecond = this.currentSecond + this.stepSecond;
+    this.currentSecond = (newSecond > 59) ? newSecond - 60 : newSecond;
+
+    this.updateTime();
+
+    event.preventDefault();
+  }
+
+  decrementSecond(event) {
+    let newSecond = this.currentSecond - this.stepSecond;
+    this.currentSecond = (newSecond < 0) ? 60 + newSecond : newSecond;
+
+    this.updateTime();
+
+    event.preventDefault();
+  }
+
+  updateTime() {
+    let value = this.value || new Date();
+    if (this.hourFormat === '12' && this.pm && this.currentHour != 12)
+      value.setHours(this.currentHour + 12);
+    else
+      value.setHours(this.currentHour);
+
+    value.setMinutes(this.currentMinute);
+    value.setSeconds(this.currentSecond);
+    this.updateModel(value);
+    this.onSelect.emit(value);
+    this.updateInputfield();
+  }
+
+  toggleAMPM(event) {
+    this.pm = !this.pm;
+    this.updateTime();
+    event.preventDefault();
+  }
+
+  onUserInput(event) {
+    // IE 11 Workaround for input placeholder : https://github.com/primefaces/primeng/issues/2026
+    if (!this.isKeydown) {
+      return;
+    }
+    this.isKeydown = false;
+
+    let val = event.target.value;
+    try {
+      let value = this.parseValueFromString(val);
+      this.updateModel(value);
+      this.updateUI();
+    }
+    catch (err) {
+      //invalid date
+      this.updateModel(null);
+    }
+
+    this.filled = val != null && val.length;
+    this.onInput.emit(event);
+  }
+
+  parseValueFromString(text: string): Date {
+    if (!text || text.trim().length === 0) {
+      return null;
+    }
+
+    let value: any;
+
+    if (this.isSingleSelection()) {
+      value = this.parseDateTime(text);
+    }
+    else if (this.isMultipleSelection()) {
+      let tokens = text.split(',');
+      value = [];
+      for (let token of tokens) {
+        value.push(this.parseDateTime(token.trim()));
+      }
+    }
+    else if (this.isRangeSelection()) {
+      let tokens = text.split(' - ');
+      value = [];
+      for (let i = 0; i < tokens.length; i++) {
+        value[i] = this.parseDateTime(tokens[i].trim());
+      }
+    }
+
+    return value;
+  }
+
+  parseDateTime(text): Date {
+    let date: Date;
+    let parts: string[] = text.split(' ');
+
+    if (this.timeOnly) {
+      date = new Date();
+      this.populateTime(date, parts[0], parts[1]);
+    }
+    else {
+      if (this.showTime) {
+        date = this.parseDate(parts[0], this.dateFormat);
+        this.populateTime(date, parts[1], parts[2]);
+      }
+      else {
+        date = this.parseDate(text, this.dateFormat);
+      }
+    }
+
+    return date;
+  }
+
+  populateTime(value, timeString, ampm) {
+    if (this.hourFormat == '12' && !ampm) {
+      throw 'Invalid Time';
+    }
+
+    this.pm = (ampm === 'PM' || ampm === 'pm');
+    let time = this.parseTime(timeString);
+    value.setHours(time.hour);
+    value.setMinutes(time.minute);
+    value.setSeconds(time.second);
+  }
+
+  updateUI() {
+    let val = this.value || this.defaultDate || new Date();
+    this.createMonth(val.getMonth(), val.getFullYear());
+
+    if (this.showTime || this.timeOnly) {
+      let hours = val.getHours();
+
+      if (this.hourFormat == '12') {
+        if (hours >= 12) {
+          this.currentHour = (hours == 12) ? 12 : hours - 12;
+        }
+        else {
+          this.currentHour = (hours == 0) ? 12 : hours;
+        }
+      }
+      else {
+        this.currentHour = val.getHours();
+      }
+
+      this.currentMinute = val.getMinutes();
+      this.currentSecond = val.getSeconds();
+    }
+  }
+
+  onDatePickerClick(event) {
+    this.datepickerClick = true;
+  }
+
+	/**
+	 *	getDaysInMonth() is a member function to calculate the number of days in a given month
+	 *
+	 *	@param (year int) the year
+	 *	@param (month int) the given month
+	 *
+	 *	@return (integer) number of days
+	 */
+  getDaysInMonth(year, month) {
+    return 32 - new Date(year, month, 32).getDate();
+  } // end getDaysInMonth()
+
+  /**
+	 *	selectGridCell() is a member function to put focus on the current cell of the grid.
+	 *
+	 *  @param (cellId string) this is the cell id
+   *
+	 *	@return N/A
+	 */
+  selectGridCell(cellId) {
+    const target = this.overlayViewChild.nativeElement;
+    const cells = (<HTMLElement>target).querySelectorAll('td:not(.ui-datepicker-other-month)');
+    let cellIndex = 0;
+    for (let i = 0; i < cells.length; i++) {
+      const nodeItem = cells.item(i);
+      if (nodeItem.id == cellId) {
+        cellIndex = i;
+        break;
+      }
+    }
+
+    cells[cellIndex].setAttribute('aria-selected', 'true');
+    cells[cellIndex].setAttribute('tabIndex', '0');
+    (<HTMLTableElement>this.overlayTable.nativeElement).setAttribute('aria-activedescendant', cells[cellIndex].id);
+    cells[cellIndex].querySelector('a').focus();
+  } // end focusCurrentDay()
+
+	/**
+   *	unSselectGridCell() is a member function to put focus on the current cell of the grid.
+   *
+	 *  @param (cellId string) this is the cell id
+   *
+	 *	@return N/A
+	 */
+  unSelectGridCell(cellId) {
+
+    const target = this.overlayViewChild.nativeElement;
+    const cells = (<HTMLElement>target).querySelectorAll('td:not(.ui-datepicker-other-month)');
+    let cellIndex = 0;
+    for (let i = 0; i < cells.length; i++) {
+      let nodeItem = cells.item(i);
+      if (nodeItem.id == cellId) {
+        cellIndex = i;
+        break;
+      }
+    }
+
+    cells[cellIndex].setAttribute('aria-selected', 'false');
+    cells[cellIndex].setAttribute('tabIndex', '-1');
+  } // end focusCurrentDay()
+
+
+	/**
+	 * showDaysOfNextMonth() is a member function to show the prev month
+	 *
+	 *	@param	(offset int) offset may be used to specify an offset for setting
+	 *			focus on a day the specified number of days from
+	 *			the beginning of the month.
+	 *	@return true if the nextmMonth is between the minimum and the maximum date otherwise return false
+	 */
+  showDaysOfPrevMonth(offset, e) {
+    // show the previous month
+    this.prevMonth(e);
+
+    // if offset was specified, set focus on the last day - specified offset
+    if (offset != null) {
+      const numDays = this.getDaysInMonth(this.currentYear, this.currentMonth);
+      let day = '';
+      if (e.keyCode == this.keys.pageup) {
+        if (numDays < (offset + 1)) {
+          day = 'cell' + numDays + '-' + 'date';
+        } else {
+          day = 'cell' + (offset + 1) + '-' + 'date';
+        }
+      } else {
+        day = 'cell' + (numDays - offset) + '-' + 'date';
+      }
+
+      (<HTMLTableElement>this.overlayTable.nativeElement).setAttribute('aria-activedescendant', day);
+      setTimeout(() => {
+        this.selectGridCell(day);
+      }, 0);
+    }
+    return true;
+  } // end showDaysOfPrevMonth()
+
+
+	/**
+	 * showDaysOfNextMonth() is a member function to show the next month
+	 *
+	 *	@param	(offset int) offset may be used to specify an offset for setting
+	 *			focus on a day the specified number of days from
+	 *			the beginning of the month.
+	 *	@return true if the nextmMonth is between the minimum and the maximum date otherwise return false
+	 */
+  showDaysOfNextMonth(offset, e) {
+    // show the next month
+
+    this.nextMonth(e);
+    // if offset was specified, set focus on the first day + specified offset
+    if (offset != null) {
+      // const day = 'cell' + offset + '-' + 'date';
+      const numDays = this.getDaysInMonth(this.currentYear, this.currentMonth);
+      let day = '';
+      if (e.keyCode == this.keys.pagedown) {
+        if (numDays < (offset + 1)) {
+          day = 'cell' + numDays + '-' + 'date';
+        } else {
+          day = 'cell' + (offset + 1) + '-' + 'date';
+        }
+      } else {
+        day = 'cell' + offset + '-' + 'date';
+      }
+      (<HTMLTableElement>this.overlayTable.nativeElement).setAttribute('aria-activedescendant', day);
+      setTimeout(() => {
+        this.selectGridCell(day);
+      }, 0);
+    }
+    return true;
+  } // end showDaysOfNextMonth()
+
+  /**
+	 *	showDaysOfPrevYear() is a member function to show the previous year
+	 *
+	 *	@param	(offset int) offset may be used to specify an offset for setting
+	 *			focus on a day the specified number of days from
+	 *			the beginning of the month.
+   *
+   *	@param (e obj) e is the event object associated with the event
+	 *
+	 *	@return true if the previous year is between the minimum and the maximum date otherwise return false
+	 */
+  showDaysOfPrevYear(offset, e) {
+    this.currentYear = Number(this.currentYear) - 1;
+    this.createMonth(this.currentMonth, this.currentYear);
+
+    const numDays = this.getDaysInMonth(this.currentYear, this.currentMonth);
+    let day = '';
+    if (numDays < (offset + 1)) {
+      day = 'cell' + numDays + '-' + 'date';
+    } else {
+      day = 'cell' + (offset + 1) + '-' + 'date';
+    }
+
+    (<HTMLTableElement>this.overlayTable.nativeElement).setAttribute('aria-activedescendant', day);
+    setTimeout(() => {
+      this.selectGridCell(day);
+    }, 0);
+    return true;
+  } // end showDaysOfPrevYear()
+
+	/**
+   *	showDaysOfNextYear() is a member function to show the next year
+   *
+	 *	@param	(offset int) offset may be used to specify an offset for setting
+	 *			focus on a day the specified number of days from
+	 *			the beginning of the month.
+   *
+   *	@param (e obj) e is the event object associated with the event
+	 *
+	 *	@return true if the next year is between the minimum and the maximum date otherwise return false
+	 */
+  showDaysOfNextYear(offset, e) {
+    this.currentYear = Number(this.currentYear) + 1;
+    this.createMonth(this.currentMonth, this.currentYear);
+    const numDays = this.getDaysInMonth(this.currentYear, this.currentMonth);
+    let day = '';
+    if (numDays < (offset + 1)) {
+      day = 'cell' + numDays + '-' + 'date';
+    } else {
+      day = 'cell' + (offset + 1) + '-' + 'date';
+    }
+    (<HTMLTableElement>this.overlayTable.nativeElement).setAttribute('aria-activedescendant', day);
+    setTimeout(() => {
+      this.selectGridCell(day);
+    }, 0);
+    return true;
+  } // end showDaysOfNextYear()
+
+  /**
+     *	handleKeyDown() is a member function to process keydown events for the Calendar
+     *
+     *	@param (e obj) e is the event object associated with the event
+     *
+     *	@return (boolean) false if consuming event, true if propagating
+     */
+  handleKeyDown(e) {
+    try {
+      if (!this.timeOnly && (this.overlayVisible || this.inline)) {
+        const target: HTMLDivElement = <HTMLDivElement>this.overlayViewChild.nativeElement;
+        const overlayTable: HTMLTableElement = <HTMLTableElement>this.overlayTable.nativeElement;
+        const $curCell = overlayTable.getAttribute('aria-activedescendant');
+        const $cells = (<HTMLElement>target).querySelectorAll('td:not(.ui-datepicker-other-month)');
+        const colCount = overlayTable.querySelector('tbody').rows['0'].cells.length;
+        const currCellIndex = this.nodeListIndexOfID($cells, $curCell);
+
+        const fastPrevMonthBtn: HTMLButtonElement = <HTMLButtonElement>this.fastPrevMonthBtn.nativeElement;
+        const fastNextMonthBtn: HTMLButtonElement = <HTMLButtonElement>this.fastNextMonthBtn.nativeElement;
+        const clearBtn: HTMLHRElement = this.clearBtn ? <HTMLHRElement>this.clearBtn.nativeElement : null;
+        const todayBtn: HTMLHRElement = this.todayBtn ? <HTMLHRElement>this.todayBtn.nativeElement : null;
+        const closeBtn: HTMLHRElement = this.closeBtn ? <HTMLHRElement>this.closeBtn.nativeElement : null;
+
+        const monthsNavigator: HTMLSelectElement = this.monthNavigator ? (<HTMLSelectElement>target.querySelector('.ui-datepicker-month')) : null;
+        const yearsNavigator: HTMLSelectElement = this.yearNavigator ? (<HTMLSelectElement>target.querySelector('.ui-datepicker-year')) : null;;
+
+        switch (e.keyCode) {
+          case this.keys.tab:
+            {
+              if (e.shiftKey) {
+
+                if (fastPrevMonthBtn == document.activeElement) {
+                  if (this.inline) {
+                    return true;
+                  } else {
+                  if (this.showCloseButton) {
+                      closeBtn.focus();
+                  } else if (this.showButtonBar) {
+                      clearBtn.focus();
+                  } else {
+                    this.selectGridCell(overlayTable.getAttribute('aria-activedescendant'));
+                  }
                 }
-                
-                this.datepickerClick = false;
-                this.cd.detectChanges();
-            });
+
+                } else if (this.clearBtn && clearBtn == document.activeElement) {
+                  todayBtn.focus();
+                } else if (this.monthNavigator && monthsNavigator && monthsNavigator == document.activeElement) {
+                  fastPrevMonthBtn.focus();
+                } else if (this.yearNavigator && yearsNavigator && yearsNavigator == document.activeElement) {
+                  monthsNavigator.focus();
+                } else if (this.todayBtn && todayBtn == document.activeElement) {
+                  this.selectGridCell(overlayTable.getAttribute('aria-activedescendant'));
+                } else if (this.closeBtn && closeBtn == document.activeElement) {
+                  if(this.showButtonBar){
+                    clearBtn.focus();
+                  }else{
+                    this.selectGridCell(overlayTable.getAttribute('aria-activedescendant'));
+                  }
+                } else if (fastNextMonthBtn == document.activeElement) {
+                  if (this.yearNavigator) {
+                    yearsNavigator.focus();
+                  } else if (this.monthNavigator) {
+                    monthsNavigator.focus();
+                  } else {
+                    fastPrevMonthBtn.focus();
+                  }
+                } else {
+                  // focus is on Days grid.
+                  fastNextMonthBtn.focus();
+                }
+
+              } else {
+                if (fastPrevMonthBtn == document.activeElement) {
+                  if (this.monthNavigator) {
+                    monthsNavigator.focus();
+                  } else if (this.yearNavigator) {
+                    yearsNavigator.focus();
+                  } else {
+                    fastNextMonthBtn.focus();
+                  }
+                } else if (fastNextMonthBtn == document.activeElement) {
+                  this.selectGridCell(overlayTable.getAttribute('aria-activedescendant'));
+                } else if (this.monthNavigator && monthsNavigator && monthsNavigator == document.activeElement) {
+                  yearsNavigator.focus();
+                } else if (this.yearNavigator && yearsNavigator && yearsNavigator == document.activeElement) {
+                  fastNextMonthBtn.focus();
+                } else if (this.todayBtn && todayBtn == document.activeElement) {
+                  clearBtn.focus();
+                } else if (this.clearBtn && clearBtn == document.activeElement) {
+                  if (this.inline) {
+                    return true;
+                  } else {
+                    if(this.showCloseButton){
+                      closeBtn.focus();
+                    } else {
+                    fastPrevMonthBtn.focus();
+                  }
+                  }
+                } else if (this.closeBtn && closeBtn == document.activeElement) {
+                  if (this.inline) {
+                    return true;
+                } else {
+                     fastPrevMonthBtn.focus();
+                  }
+                } else {
+                  // focus is on Days Grid
+                  if (this.inline) {
+                    return true;
+                  } else {
+                  if (this.showButtonBar) {
+                    todayBtn.focus();
+
+                  } else if(this.showCloseButton) {
+                    closeBtn.focus();
+                  } else {
+                    fastPrevMonthBtn.focus();
+                  }
+                }
+                }
+              }
+              e.stopPropagation();
+              e.preventDefault();
+              return false;
+            }
+           case this.keys.enter:
+          case this.keys.space: {
+            if (fastPrevMonthBtn == document.activeElement) {
+              fastPrevMonthBtn.click();
+              return true;
+            }
+            if (fastNextMonthBtn == document.activeElement) {
+              fastNextMonthBtn.click();
+              return true;
+            }
+
+            if(closeBtn == document.activeElement){
+              this.overlayVisible = false;
+              if (this.showOnFocus) {
+                this.escShowOnFocus = true;
+              }
+
+              this.inputfieldViewChild.nativeElement.focus();
+              e.stopPropagation();
+              e.preventDefault();
+            return true;
+          }
+            const today: Date = new Date();
+            const dateMeta = {
+              day: currCellIndex+1,
+              month: this.currentMonth,
+              year: this.currentYear,
+              today: this.isToday(today,currCellIndex+1, this.currentMonth, this.currentYear),
+              selectable: this.isSelectable(currCellIndex+1, this.currentMonth, this.currentYear)
+            };
+
+            this.onDateSelect(e, dateMeta);
+
+            return true;
+          }
+          case this.keys.esc:
+            {
+              // dismiss the dialog box
+
+              this.overlayVisible = false;
+              if (this.showOnFocus) {
+                this.escShowOnFocus = true;
+              }
+
+              this.inputfieldViewChild.nativeElement.focus();
+              e.stopPropagation();
+              e.preventDefault();
+              return false;
+            }
+          case this.keys.left:
+          case this.keys.right: {
+            if ((e.keyCode == this.keys.left && (this.locale.directionality ? this.locale.directionality : 'LTR') === 'LTR') ||
+              (e.keyCode == this.keys.right && (this.locale.directionality ? this.locale.directionality : 'LTR') === 'RTL')) {
+              if (e.ctrlKey || e.shiftKey) {
+                return true;
+              }
+              const cellIndex = currCellIndex - 1;
+              let $prevCell = null;
+              if (cellIndex >= 0) {
+                $prevCell = $cells[cellIndex];
+                this.unSelectGridCell($cells[currCellIndex].id);
+                this.selectGridCell($prevCell.id);
+              } else {
+                // move to appropriate day in previous month
+                this.showDaysOfPrevMonth(0, e);
+              }
+              e.stopPropagation();
+              e.preventDefault();
+              return false;
+            } else {
+              if (e.ctrlKey || e.shiftKey) {
+                return true;
+              }
+              const cellIndex = currCellIndex + 1;
+              let $nextCell = null;
+              if (cellIndex < $cells.length) {
+                $nextCell = $cells[cellIndex];
+                this.unSelectGridCell($cells[currCellIndex].id);
+                this.selectGridCell($nextCell.id);
+              } else {
+                this.showDaysOfNextMonth(1, e);
+              }
+              e.stopPropagation();
+              e.preventDefault();
+              return false;
+            }
+          }
+          case this.keys.up: {
+            if (monthsNavigator == document.activeElement || yearsNavigator == document.activeElement) {
+              return true;
+            }
+            if (e.ctrlKey || e.shiftKey) {
+              return true;
+            }
+
+            let cellIndex = currCellIndex - colCount;
+            let $prevCell = null;
+
+            if (cellIndex >= 0) {
+              $prevCell = $cells[cellIndex];
+              this.unSelectGridCell($cells[currCellIndex].id);
+              this.selectGridCell($prevCell.id);
+            } else {
+              // move to appropriate day in previous month
+              cellIndex = colCount - 1 - currCellIndex;
+              this.showDaysOfPrevMonth(cellIndex, e);
+            }
+            e.stopPropagation();
+            e.preventDefault();
+            return false;
+          }
+
+          case this.keys.down: {
+            if (monthsNavigator == document.activeElement || yearsNavigator == document.activeElement) {
+              return true;
+            }
+
+            if (e.ctrlKey || e.shiftKey) {
+              return true;
+            }
+
+            let cellIndex = currCellIndex + colCount;
+            let $nextCell = null;
+            if (cellIndex < $cells.length) {
+
+              $nextCell = $cells[cellIndex];
+
+
+              this.unSelectGridCell($cells[currCellIndex].id);
+              this.selectGridCell($nextCell.id);
+
+            } else {
+              cellIndex = colCount + 1 - ($cells.length - currCellIndex);
+              this.showDaysOfNextMonth(cellIndex, e);
+            }
+
+            e.stopPropagation();
+            e.preventDefault();
+            return false;
+          }
+          case this.keys.home:
+            {
+              if (e.ctrlKey || e.shiftKey) {
+                return true;
+              }
+              const $firstCell = $cells[0];
+              this.unSelectGridCell($cells[currCellIndex].id);
+              this.selectGridCell($firstCell.id);
+              e.stopPropagation();
+              e.preventDefault();
+              return false;
+            }
+          case this.keys.end:
+            {
+              if (e.ctrlKey || e.shiftKey) {
+                return true;
+              }
+              const $lastCell = $cells[$cells.length - 1];
+              this.unSelectGridCell($cells[currCellIndex].id);
+              this.selectGridCell($lastCell.id);
+              e.stopPropagation();
+              e.preventDefault();
+              return false;
+            }
+
+          case this.keys.pageup:
+            {
+              if (e.shiftKey) {
+                return true;
+              }
+              e.preventDefault();
+              let ok = false;
+
+              if (e.altKey) {
+                e.stopImmediatePropagation();
+                ok = this.showDaysOfPrevYear(currCellIndex, e);
+              } else {
+                ok = this.showDaysOfPrevMonth(currCellIndex, e);
+              }
+              e.stopPropagation();
+              return false;
+            }
+
+          case this.keys.pagedown:
+            {
+              if (e.shiftKey) {
+                return true;
+              }
+              e.preventDefault();
+              let ok = false;
+
+              if (e.altKey) {
+                e.stopImmediatePropagation();
+                ok = this.showDaysOfPrevYear(currCellIndex, e);
+              } else {
+                ok = this.showDaysOfNextMonth(currCellIndex, e);
+              }
+              e.stopPropagation();
+              return false;
+            }
+        }
+      }
+    } catch (e) {
+
+    }
+    return true;
+  }
+
+  nodeListIndexOfID(list, id) {
+    for (let i = 0; i < list.length; i++) {
+      if (list.item(i).id == id) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  /**
+	 *	handleKeyPress() is a member function to consume keypress events for browsers that
+	 *	use keypress to scroll the screen and manipulate tabs
+	 *
+	 *	@param (e obj) e is the event object associated with the event
+	 *
+	 * 	@return (boolean) false if consuming event, true if propagating
+	 */
+  handleKeyPress(e) {
+    if (e.altKey) {
+      return true;
+    }
+    switch (e.keyCode) {
+      case this.keys.tab:
+      case this.keys.enter:
+      case this.keys.space:
+      case this.keys.esc:
+      case this.keys.left:
+      case this.keys.right:
+      case this.keys.up:
+      case this.keys.down:
+      case this.keys.pageup:
+      case this.keys.pagedown:
+      case this.keys.home:
+      case this.keys.end:
+        {
+          e.stopImmediatePropagation();
+          e.stopPropagation();
+          e.preventDefault();
+          return false;
         }
     }
-    
-    unbindDocumentClickListener() {
-        if(this.documentClickListener) {
-            this.documentClickListener();
-            this.documentClickListener = null;
-        }
+    return true;
+  } // end handleGridKeyPress()
+
+  showOverlay() {
+    this.overlayVisible = true;
+    this.overlayShown = true;
+    this.overlayViewChild.nativeElement.style.zIndex = String(++DomHandler.zindex);
+
+    this.bindDocumentClickListener();
+  }
+
+  bindGridKeydownListener() {
+    if (!this.keydownListener) {
+      this.keydownListener = this.renderer.listen(document, 'keydown', (e) => {
+        this.handleKeyDown(e);
+      });
     }
-        
-    ngOnDestroy() {
-        this.unbindDocumentClickListener();
-        
-        if(!this.inline && this.appendTo) {
-            this.el.nativeElement.appendChild(this.overlayViewChild.nativeElement);
-        }
+  }
+
+  unbindGridKeydownListener() {
+    if (this.keydownListener) {
+      this.keydownListener();
+      this.keydownListener = null;
     }
+  }
+
+  alignOverlay() {
+    if (this.appendTo)
+      this.domHandler.absolutePosition(this.overlayViewChild.nativeElement, this.inputfieldViewChild.nativeElement);
+    else
+      this.domHandler.relativePosition(this.overlayViewChild.nativeElement, this.inputfieldViewChild.nativeElement);
+  }
+
+  writeValue(value: any): void {
+    this.value = value;
+    if (this.value && typeof this.value === 'string') {
+      this.value = this.parseValueFromString(this.value);
+    }
+
+    this.updateInputfield();
+    this.updateUI();
+  }
+
+  registerOnChange(fn: Function): void {
+    this.onModelChange = fn;
+  }
+
+  registerOnTouched(fn: Function): void {
+    this.onModelTouched = fn;
+  }
+
+  setDisabledState(val: boolean): void {
+    this.disabled = val;
+  }
+
+  // Ported from jquery-ui datepicker formatDate
+  formatDate(date, format) {
+    if (!date) {
+      return "";
+    }
+
+    let iFormat,
+      lookAhead = (match) => {
+        let matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
+        if (matches) {
+          iFormat++;
+        }
+        return matches;
+      },
+      formatNumber = (match, value, len) => {
+        let num = "" + value;
+        if (lookAhead(match)) {
+          while (num.length < len) {
+            num = "0" + num;
+          }
+        }
+        return num;
+      },
+      formatName = (match, value, shortNames, longNames) => {
+        return (lookAhead(match) ? longNames[value] : shortNames[value]);
+      },
+      output = "",
+      literal = false;
+
+    if (date) {
+      if (!(date instanceof Date)) {
+        date = new Date(date);
+      }
+      for (iFormat = 0; iFormat < format.length; iFormat++) {
+        if (literal) {
+          if (format.charAt(iFormat) === "'" && !lookAhead("'"))
+            literal = false;
+          else
+            output += format.charAt(iFormat);
+        }
+        else {
+          switch (format.charAt(iFormat)) {
+            case "d":
+              output += formatNumber("d", date.getDate(), 2);
+              break;
+            case "D":
+              output += formatName("D", date.getDay(), this.locale.dayNamesShort, this.locale.dayNames);
+              break;
+            case "o":
+              output += formatNumber("o",
+                Math.round((new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / 86400000), 3);
+              break;
+            case "m":
+              output += formatNumber("m", date.getMonth() + 1, 2);
+              break;
+            case "M":
+              output += formatName("M", date.getMonth(), this.locale.monthNamesShort, this.locale.monthNames);
+              break;
+            case "y":
+              output += (lookAhead("y") ? date.getFullYear() :
+                (date.getFullYear() % 100 < 10 ? "0" : "") + date.getFullYear() % 100);
+              break;
+            case "@":
+              output += date.getTime();
+              break;
+            case "!":
+              output += date.getTime() * 10000 + this.ticksTo1970;
+              break;
+            case "'":
+              if (lookAhead("'"))
+                output += "'";
+              else
+                literal = true;
+
+              break;
+            default:
+              output += format.charAt(iFormat);
+          }
+        }
+      }
+    }
+    return output;
+  }
+
+  formatTime(date) {
+    if (!date) {
+      return '';
+    }
+
+    let output = '';
+    let hours = date.getHours();
+    let minutes = date.getMinutes();
+    let seconds = date.getSeconds();
+
+    if (this.hourFormat == '12' && hours > 11 && hours != 12) {
+      hours -= 12;
+    }
+
+    output += (hours < 10) ? '0' + hours : hours;
+    output += ':';
+    output += (minutes < 10) ? '0' + minutes : minutes;
+
+    if (this.showSeconds) {
+      output += ':';
+      output += (seconds < 10) ? '0' + seconds : seconds;
+    }
+
+    if (this.hourFormat == '12') {
+      output += date.getHours() > 11 ? ' PM' : ' AM';
+    }
+
+    return output;
+  }
+
+  parseTime(value) {
+    let tokens: string[] = value.split(':');
+    let validTokenLength = this.showSeconds ? 3 : 2;
+
+    if (tokens.length !== validTokenLength) {
+      throw "Invalid time";
+    }
+
+    let h = parseInt(tokens[0]);
+    let m = parseInt(tokens[1]);
+    let s = this.showSeconds ? parseInt(tokens[2]) : null;
+
+    if (isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
+      throw "Invalid time";
+    }
+    else {
+      if (this.hourFormat == '12' && h !== 12 && this.pm) {
+        h += 12;
+      }
+
+      return { hour: h, minute: m, second: s };
+    }
+  }
+
+  // Ported from jquery-ui datepicker parseDate
+  parseDate(value, format) {
+    if (format == null || value == null) {
+      throw "Invalid arguments";
+    }
+
+    value = (typeof value === "object" ? value.toString() : value + "");
+    if (value === "") {
+      return null;
+    }
+
+    let iFormat, dim, extra,
+      iValue = 0,
+      shortYearCutoff = (typeof this.shortYearCutoff !== "string" ? this.shortYearCutoff : new Date().getFullYear() % 100 + parseInt(this.shortYearCutoff, 10)),
+      year = -1,
+      month = -1,
+      day = -1,
+      doy = -1,
+      literal = false,
+      date,
+      lookAhead = (match) => {
+        let matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
+        if (matches) {
+          iFormat++;
+        }
+        return matches;
+      },
+      getNumber = (match) => {
+        let isDoubled = lookAhead(match),
+          size = (match === "@" ? 14 : (match === "!" ? 20 :
+            (match === "y" && isDoubled ? 4 : (match === "o" ? 3 : 2)))),
+          minSize = (match === "y" ? size : 1),
+          digits = new RegExp("^\\d{" + minSize + "," + size + "}"),
+          num = value.substring(iValue).match(digits);
+        if (!num) {
+          throw "Missing number at position " + iValue;
+        }
+        iValue += num[0].length;
+        return parseInt(num[0], 10);
+      },
+      getName = (match, shortNames, longNames) => {
+        let index = -1;
+        let arr = lookAhead(match) ? longNames : shortNames;
+        let names = [];
+
+        for (let i = 0; i < arr.length; i++) {
+          names.push([i, arr[i]]);
+        }
+        names.sort((a, b) => {
+          return -(a[1].length - b[1].length);
+        });
+
+        for (let i = 0; i < names.length; i++) {
+          let name = names[i][1];
+          if (value.substr(iValue, name.length).toLowerCase() === name.toLowerCase()) {
+            index = names[i][0];
+            iValue += name.length;
+            break;
+          }
+        }
+
+        if (index !== -1) {
+          return index + 1;
+        } else {
+          throw "Unknown name at position " + iValue;
+        }
+      },
+      checkLiteral = () => {
+        if (value.charAt(iValue) !== format.charAt(iFormat)) {
+          throw "Unexpected literal at position " + iValue;
+        }
+        iValue++;
+      };
+
+    for (iFormat = 0; iFormat < format.length; iFormat++) {
+      if (literal) {
+        if (format.charAt(iFormat) === "'" && !lookAhead("'")) {
+          literal = false;
+        } else {
+          checkLiteral();
+        }
+      } else {
+        switch (format.charAt(iFormat)) {
+          case "d":
+            day = getNumber("d");
+            break;
+          case "D":
+            getName("D", this.locale.dayNamesShort, this.locale.dayNames);
+            break;
+          case "o":
+            doy = getNumber("o");
+            break;
+          case "m":
+            month = getNumber("m");
+            break;
+          case "M":
+            month = getName("M", this.locale.monthNamesShort, this.locale.monthNames);
+            break;
+          case "y":
+            year = getNumber("y");
+            break;
+          case "@":
+            date = new Date(getNumber("@"));
+            year = date.getFullYear();
+            month = date.getMonth() + 1;
+            day = date.getDate();
+            break;
+          case "!":
+            date = new Date((getNumber("!") - this.ticksTo1970) / 10000);
+            year = date.getFullYear();
+            month = date.getMonth() + 1;
+            day = date.getDate();
+            break;
+          case "'":
+            if (lookAhead("'")) {
+              checkLiteral();
+            } else {
+              literal = true;
+            }
+            break;
+          default:
+            checkLiteral();
+        }
+      }
+    }
+
+    if (iValue < value.length) {
+      extra = value.substr(iValue);
+      if (!/^\s+/.test(extra)) {
+        throw "Extra/unparsed characters found in date: " + extra;
+      }
+    }
+
+    if (year === -1) {
+      year = new Date().getFullYear();
+    } else if (year < 100) {
+      year += new Date().getFullYear() - new Date().getFullYear() % 100 +
+        (year <= shortYearCutoff ? 0 : -100);
+    }
+
+    if (doy > -1) {
+      month = 1;
+      day = doy;
+      do {
+        dim = this.getDaysCountInMonth(year, month - 1);
+        if (day <= dim) {
+          break;
+        }
+        month++;
+        day -= dim;
+      } while (true);
+    }
+
+    date = this.daylightSavingAdjust(new Date(year, month - 1, day));
+    if (date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) {
+      throw "Invalid date"; // E.g. 31/02/00
+    }
+    return date;
+  }
+
+  daylightSavingAdjust(date) {
+    if (!date) {
+      return null;
+    }
+    date.setHours(date.getHours() > 12 ? date.getHours() + 2 : 0);
+    return date;
+  }
+
+  updateFilledState() {
+    this.filled = this.inputFieldValue && this.inputFieldValue != '';
+  }
+
+  onTodayButtonClick(event) {
+    let date: Date = new Date();
+    let dateMeta = { day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), today: true, selectable: true };
+
+    this.onDateSelect(event, dateMeta);
+    this.onTodayClick.emit(event);
+  }
+
+  onClearButtonClick(event) {
+    this.updateModel(null);
+    this.updateInputfield();
+    this.overlayVisible = false;
+    this.onClearClick.emit(event);
+  }
+
+  onCloseButtonClick($event){
+    this.overlayVisible = false;
+    if (this.showOnFocus) {
+      this.escShowOnFocus = true;
+    }
+    this.inputfieldViewChild.nativeElement.focus();
+    this.onCloseClick.emit(event);
+  }
+
+  bindDocumentClickListener() {
+    if (!this.documentClickListener) {
+      this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
+        if (!this.datepickerClick && this.overlayVisible) {
+          this.overlayVisible = false;
+          this.onClose.emit(event);
+        }
+
+        this.datepickerClick = false;
+        this.cd.detectChanges();
+      });
+    }
+  }
+
+  unbindDocumentClickListener() {
+    if (this.documentClickListener) {
+      this.documentClickListener();
+      this.documentClickListener = null;
+    }
+  }
+
+  ngOnDestroy() {
+    this.unbindDocumentClickListener();
+
+    if (!this.inline && this.appendTo) {
+      this.el.nativeElement.appendChild(this.overlayViewChild.nativeElement);
+    }
+  }
 }
 
 @NgModule({
-    imports: [CommonModule,ButtonModule,SharedModule],
-    exports: [Calendar,ButtonModule,SharedModule],
-    declarations: [Calendar]
+  imports: [CommonModule, ButtonModule, SharedModule],
+  exports: [Calendar, ButtonModule, SharedModule],
+  declarations: [Calendar]
 })
 export class CalendarModule { }


### PR DESCRIPTION
Add full accessibility support to calendar component.
Demo can be found here : [https://davidkirolos.github.io/primeng/#/calendar](https://davidkirolos.github.io/primeng/#/calendar)

# Keyboard interaction

- **Left**: Move focus to the previous day. Will move to the last day of the previous month, if the current day is the first day of a month.
- **Right**: Move focus to the next day. Will move to the first day of the following month, if the current day is the last day of a month.
- **Up**: Move focus to the same day of the previous week. Will wrap to the appropriate day in the previous month.
- **Down**: Move focus to the same day of the following week. Will wrap to the appropriate day in the following month.
- **PgUp**: Move focus to the same date of the previous month. If that date does not exist, focus is placed on the last day of the month.
- **PgDn**: Move focus to the same date of the following month. If that date does not exist, focus is placed on the last day of the month.
- **Alt+PgUp**: Move focus to the same date of the previous year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
- **Alt+PgDn**: Move focus to the same date of the following year. If that date does not exist (e.g leap year), focus is placed on the last day of the month.
- **Home**: Move to the first day of the month.
- **End**: Move to the last day of the month
- **Tab / Shift+Tab**: If the datepicker is not in inline mode, navigate between calander grid and header/grid/button bar selection buttons, otherwise move to the field following/preceding the date textbox associated with the calendar
- **Enter**: Fill the date textbox with the selected date then close the calendar widget.
- **Space**: When focused on prev/next month it will load the prev/next month. 

# Special  interaction when focus on different elements
- **Key Down** / When focus is on the **input field** and calendar overlay is hidden:  This will open the calendar overlay.
- **KeyUp | KeyDown** / when focus is on **month/year** navigator: this will load the corresponding month/year.