### PR TITLE
Emmit move events on drag and drop in picklist component

### DIFF
--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -551,12 +551,25 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     }
     
     insert(fromIndex, fromList, toIndex, toList) {
+        const elementtomove = fromList[fromIndex];
+
         if(toIndex === null)
             toList.push(fromList.splice(fromIndex, 1)[0]);
         else
             toList.splice(toIndex, 0, fromList.splice(fromIndex, 1)[0]);
+
+        if (fromList === this.target) {
+            this.onMoveToSource.emit({
+                items: [elementtomove]
+            });
+        }
+        else {
+            this.onMoveToTarget.emit({
+                items: [elementtomove]
+            });
+        }
     }
-    
+        
     onListMouseMove(event: MouseEvent, listType: number) {
         if(this.dragging) {
             let moveListType = (listType == 0 ? this.listViewSourceChild : this.listViewTargetChild);


### PR DESCRIPTION
###Defect Fixes
When you move an element the move events are not triggered (onMoveToSource, onMoveToTarget).

PS
Not sure if this is the best way to do it. 
Also I have notice that multiselect is not working with drag and drop, not sure if this is as designed or it is a bug.
