### PR TITLE
Added `onMonthChange` output event to calendar component

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -254,6 +254,8 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     @Output() onTodayClick: EventEmitter<any> = new EventEmitter();
     
     @Output() onClearClick: EventEmitter<any> = new EventEmitter();
+     
+    @Output() onMonthChange: EventEmitter<any> = new EventEmitter();
     
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     
@@ -555,6 +557,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             this.currentMonth--;
         }
         
+        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
         this.createMonth(this.currentMonth, this.currentYear);
         event.preventDefault();
     }
@@ -577,6 +580,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             this.currentMonth++;
         }
         
+        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
         this.createMonth(this.currentMonth, this.currentYear);
         event.preventDefault();
     }


### PR DESCRIPTION
###Feature Request
I added an output event to the calendar component that will fire when the user changes the date inside the calendar using the previous and next buttons.

#### The Problem
In my application only 14 specific dates in the calendar should be selectable. There is only an input for black listing dates. I would have to input all possible dates that are not my 14....forever/eternity.

#### The Solution
I created an event that lets the parent know when the calendar view has changed months and provides the current month and year. The parent can then use that data to create a small list of unavailable dates inside that scope and update the disabled dates input property.