### PR TITLE
fix(calendar): use ng-container instead of span

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -72,7 +72,7 @@ export interface LocaleSettings {
                                 <a class="ui-state-default" href="#" *ngIf="date.otherMonth ? showOtherMonths : true" 
                                     [ngClass]="{'ui-state-active':isSelected(date), 'ui-state-highlight':date.today, 'ui-state-disabled':!date.selectable}"
                                     (click)="onDateSelect($event,date)">
-                                    <span *ngIf="!dateTemplate">{{date.day}}</span>
+                                    <ng-container *ngIf="!dateTemplate">{{date.day}}</ng-container>
                                     <ng-template [pTemplateWrapper]="dateTemplate" [item]="date" *ngIf="dateTemplate"></ng-template>
                                 </a>
                             </td>


### PR DESCRIPTION
I'm sumitting a small fix.
Following modification in primeng introduce date template in calendar component:
89e7d3aee0d4ca1dea870af01458d36b62d88513

In our app we don't use date template but upgrading primeng we had a regression on the display:
![calendar](https://user-images.githubusercontent.com/10905922/30862337-032a1fcc-a2ce-11e7-9f83-f771e19b9913.png)

Not completly sure why, it's seems than the new `span` level introduced by 89e7d3aee0d4ca1dea870af01458d36b62d88513 for the 'no custom template case' didn't do any good.

I believe that's not our app, as we don't have many style on calendar, but primeng css rules for `.ui-datepicker-calendar td a` and `.ui-datepicker-calendar td span` that are applied two times now (once for the `a` and once for the new `span`).

Anyway, angular `ng-container` are here for that. It's good to used them, and recommended by angular doc, instead of adding span or div each time.

Moreover for us it does the trick and will prevent regression for others to.