### PR TITLE
reorderableColumns not work in scrollable dataTable

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -2230,7 +2230,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         
             if(allowDrop) {
                 this.objectUtils.reorderArray(this.columns, dragIndex, dropIndex);
-				this.scrollableColumns = this.columns;
+				        this.scrollableColumns = this.columns;
 				
                 this.onColReorder.emit({
                     dragIndex: dragIndex,

--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -2230,7 +2230,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         
             if(allowDrop) {
                 this.objectUtils.reorderArray(this.columns, dragIndex, dropIndex);
-
+				this.scrollableColumns = this.columns;
+				
                 this.onColReorder.emit({
                     dragIndex: dragIndex,
                     dropIndex: dropIndex,


### PR DESCRIPTION
###Defect Fixes
using scrollable attribute break the reorderableColumns behavior in dataTable