### PR TITLE
Fix small typo in the input text showcase

### DIFF
--- a/src/app/showcase/components/inputtext/inputtextdemo.html
+++ b/src/app/showcase/components/inputtext/inputtextdemo.html
@@ -133,7 +133,7 @@ import &#123;InputTextModule&#125; from 'primeng/primeng';
 <code class="language-markup" pCode ngNonBindable>
 &lt;h3 class="first"&gt;Basic&lt;/h3&gt;
 &lt;input id="input" type="text" size="30" pInputText [(ngModel)]="text"&gt; 
-&lt;span id="text"&gt;&#123;text&#125;&#125;&lt;/span&gt;
+&lt;span id="text"&gt;&#123;&#123;text&#125;&#125;&lt;/span&gt;
 
 &lt;h3&gt;Float Label&lt;/h3&gt;
 &lt;span class="ui-float-label"&gt;


### PR DESCRIPTION
In the input text documentation under the source tab there is written **{text}}** instead of **{{text}}**