### PR TITLE
Add method to reset resizable DataTable columns

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -795,6 +795,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     
     columnsSubscription: Subscription;
     
+    columnWidths: string[];
+    
     totalRecordsChanged: boolean;
     
     anchorRowIndex: number;
@@ -2087,9 +2089,21 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     initResizableColumns() {
         this.tbody = this.domHandler.findSingle(this.el.nativeElement, 'tbody.ui-datatable-data');
         this.resizerHelper = this.domHandler.findSingle(this.el.nativeElement, 'div.ui-column-resizer-helper');
+        const columns = this.domHandler.find(this.el.nativeElement, 'th.ui-resizable-column');
+        this.columnWidths = [];
+        for(let i = 0; i < columns.length; i++) {
+            this.columnWidths.push(columns[i].style.width);
+        }
         this.fixColumnWidths();
     }
-    
+
+    resetResizableColumns() {
+        const columns = this.domHandler.find(this.el.nativeElement, 'th.ui-resizable-column');
+        for(let i = 0; i < columns.length; i++) {
+            columns[i].style.width = this.columnWidths[i];
+        }
+    }
+
     onDocumentMouseMove(event) {
         if(this.columnResizing) {
             this.onColumnResize(event);

--- a/src/app/showcase/components/datatable/datatablecolresizedemo.html
+++ b/src/app/showcase/components/datatable/datatablecolresizedemo.html
@@ -3,15 +3,16 @@
 <div class="content-section introduction">
     <div>
         <span class="feature-title">DataTable</span>
-        <span>Columns can be resized using drag drop by setting the resizableColumns to true. There are two resize modes; "fit" and "expand". Fit is the default one and 
+        <span>Columns can be resized using drag drop by setting the resizableColumns to true. There are two resize modes; "fit" and "expand". Fit is the default one and
         the overall table width does not change when a column is resized. In "expand" mode, table width also changes along with the column width. onColumnResize
-        is a callback that passes the resized column header as a parameter.</span>
+        is a callback that passes the resized column header as a parameter. resetResizableColumns is a method that restores the original column widths before any resizing.</span>
     </div>
 </div>
 
 <div class="content-section implementation">
     <h3 class="first">Fit Mode</h3>
-    <p-dataTable [value]="cars" resizableColumns="true">
+    <button pButton type="button" (click)="dtfm.resetResizableColumns()" style="float:right" icon="fa-undo"></button>
+    <p-dataTable [value]="cars" resizableColumns="true" #dtfm>
         <p-column field="vin" header="Vin"></p-column>
         <p-column field="year" header="Year"></p-column>
         <p-column field="brand" header="Brand"></p-column>
@@ -19,7 +20,8 @@
     </p-dataTable>
 
     <h3>Expand Mode</h3>
-    <p-dataTable [value]="cars" resizableColumns="true" columnResizeMode="expand">
+    <button pButton type="button" (click)="dtem.resetResizableColumns()" icon="fa-undo" style="float:right"></button>
+    <p-dataTable [value]="cars" resizableColumns="true" columnResizeMode="expand" #dtem>
         <p-column field="vin" header="Vin"></p-column>
         <p-column field="year" header="Year"></p-column>
         <p-column field="brand" header="Brand"></p-column>
@@ -47,7 +49,7 @@ export class DataTableColResizeDemo implements OnInit &#123;
     &#125;
 &#125;
 </code>
-</pre>            
+</pre>
         </p-tabPanel>
 
         <p-tabPanel header="datatablecolresizedemo.html">
@@ -58,7 +60,8 @@ export class DataTableColResizeDemo implements OnInit &#123;
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;h3 class="first"&gt;Fit Mode&lt;/h3&gt;
-&lt;p-dataTable [value]="cars" resizableColumns="true"&gt;
+&lt;button pButton type="button" (click)="dtfm.resetResizableColumns()" icon="fa-undo" style="float:right"&gt;&lt;/button&gt;
+&lt;p-dataTable [value]="cars" resizableColumns="true" #dtfm&gt;
     &lt;p-column field="vin" header="Vin"&gt;&lt;/p-column&gt;
     &lt;p-column field="year" header="Year"&gt;&lt;/p-column&gt;
     &lt;p-column field="brand" header="Brand"&gt;&lt;/p-column&gt;
@@ -66,7 +69,8 @@ export class DataTableColResizeDemo implements OnInit &#123;
 &lt;/p-dataTable&gt;
 
 &lt;h3&gt;Expand Mode&lt;/h3&gt;
-&lt;p-dataTable [value]="cars" resizableColumns="true" columnResizeMode="expand"&gt;
+&lt;button pButton type="button" (click)="dtem.resetResizableColumns()" icon="fa-undo" style="float:right"&gt;&lt;/button&gt;
+&lt;p-dataTable [value]="cars" resizableColumns="true" columnResizeMode="expand" #dtem&gt;
     &lt;p-column field="vin" header="Vin"&gt;&lt;/p-column&gt;
     &lt;p-column field="year" header="Year"&gt;&lt;/p-column&gt;
     &lt;p-column field="brand" header="Brand"&gt;&lt;/p-column&gt;


### PR DESCRIPTION
This is a proposed sultion for #4149 : The DataTable currently is lacking a method to reset manually resized column widths. This patch adds a method resetResizableColumns() to the DataTable that does just that.