### PR TITLE
feat(dropdown): option to ignore keyboard events

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -40,7 +40,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
                 [style.display]="panelVisible ? 'block' : 'none'" [ngStyle]="panelStyle" [class]="panelStyleClass">
                 <div *ngIf="filter" class="ui-dropdown-filter-container" (input)="onFilter($event)" (click)="$event.stopPropagation()">
                     <input #filter type="text" autocomplete="off" class="ui-dropdown-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [attr.placeholder]="filterPlaceholder"
-                    (keydown.enter)="$event.preventDefault()" (keydown)="onKeydown($event)">
+                    (keydown)="onKeydown($event)">
                     <span class="fa fa-search"></span>
                 </div>
                 <div #itemswrapper class="ui-dropdown-items-wrapper" [style.max-height]="scrollHeight||'auto'">
@@ -114,6 +114,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     @Input() autofocus: boolean;
     
     @Input() resetFilterOnHide: boolean = false;
+
+    @Input() keydownEnable: boolean = true;
     
     @Output() onChange: EventEmitter<any> = new EventEmitter();
     
@@ -437,7 +439,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     }
     
     onKeydown(event) {
-        if(this.readonly) {
+        if(this.readonly || !this.keydownEnable) {
             return;
         }
         


### PR DESCRIPTION

Following update to PrimeNG 4.2, I have issue with keydown events on dropdown.

I propose to add an option to disable them entirely.
