### PR TITLE
Protect this.value in ngDoCheck function

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -172,7 +172,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterViewChecked,DoChec
     }
     
     ngDoCheck() {
-        let valueChanges = this.valueDiffer.diff(this.value);
+        let valueChanges = this.value ? this.valueDiffer.diff(this.value) : true;
         let optionChanges = this.optionsDiffer.diff(this.options);
         
         if(valueChanges||optionChanges) {


### PR DESCRIPTION
###Defect Fixes
Protect this.value in ngDoCheck function.

If I modify  option property and then try to unselect an item I get an error in ngDoCheck
Hard to create a plunker but I can try if it is needed
