### PR TITLE
Removed non-functional template code.

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -489,7 +489,7 @@ export class ScrollableView implements AfterViewInit,AfterViewChecked,OnDestroy 
             </div>
             
             <ng-template [ngIf]="scrollable">
-                <div class="ui-datatable-scrollable-wrapper ui-helper-clearfix" [ngClass]="{'max-height':scrollHeight}">
+                <div class="ui-datatable-scrollable-wrapper ui-helper-clearfix">
                     <div *ngIf="hasFrozenColumns()" [pScrollableView]="frozenColumns" frozen="true"
                         [headerColumnGroup]="frozenHeaderColumnGroup" [footerColumnGroup]="frozenFooterColumnGroup"
                         [ngStyle]="{'width':this.frozenWidth}" class="ui-datatable-scrollable-view ui-datatable-frozen-view"></div>


### PR DESCRIPTION
Removed [ngClass] property, 'max-height' from .ui-datatable-scrollable-wrapper. This looks like it was originally intended to be [ngStyle], as it is adding a style (max-height), not a class. The scrollHeight property is already correctly added as a max-height style on another element, .ui-datatable-scrollable-body.

Issue: #4213 