### PR TITLE
allow custom filtering using the same mechanism as custom sort

### DIFF
--- a/src/app/components/common/filtermetadata.ts
+++ b/src/app/components/common/filtermetadata.ts
@@ -1,4 +1,5 @@
 export interface FilterMetadata {
+    field?: string;
     value?: any;
     matchMode?: string;
 }

--- a/src/app/components/common/shared.ts
+++ b/src/app/components/common/shared.ts
@@ -86,6 +86,7 @@ export class Column implements AfterContentInit{
     @Input() filterMaxlength: number;
     @Input() frozen: boolean;
     @Output() sortFunction: EventEmitter<any> = new EventEmitter();
+    @Output() filterFunction: EventEmitter<any> = new EventEmitter();
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     @ContentChild(TemplateRef) template: TemplateRef<any>;
     

--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -1750,13 +1750,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     }
     
     isFilterBlank(filter: any): boolean {
-        if(filter !== null && filter !== undefined) {
-            if((typeof filter === 'string' && filter.trim().length == 0) || (filter instanceof Array && filter.length == 0))
-                return true;
-            else
-                return false;
-        }
-        return true;
+        return filter === null && filter === undefined;
     }
 
     _filter() {
@@ -1788,7 +1782,12 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                         dataFieldValue = this.resolveFieldData(this.value[i], filterField);
                         let filterConstraint = this.filterConstraints[filterMatchMode];
 
-                        if(!filterConstraint(dataFieldValue, filterValue)) {
+                        if (filterMatchMode === 'custom') {
+                            this.columns[0].filterFunction.emit({
+                                value: filterValue,
+                                field: filterField
+                            });
+                        } else if(!filterConstraint(dataFieldValue, filterValue)) {
                             localMatch = false;
                         }
 

--- a/src/app/showcase/components/datatable/datatabledemo.html
+++ b/src/app/showcase/components/datatable/datatabledemo.html
@@ -149,6 +149,12 @@ export class DataTableDemo implements OnInit &#123;
                             <td>Sort function for custom sorting.</td>
                         </tr>
                         <tr>
+                            <td>filterFunction</td>
+                            <td>function</td>
+                            <td>null</td>
+                            <td>Filter function for custom filtering.</td>
+                        </tr>
+                        <tr>
                             <td>editable</td>
                             <td>boolean</td>
                             <td>false</td>


### PR DESCRIPTION
###Defect Fixes
Fixes defect #3521 

Replicates the custom sortFunction mechanism with a filterFunction.

Note that is also now allows a blank string to be a filter, this is how you would clear your fliter function.

Usage: 

`<p-column *ngFor="let columnDef of columnDefs" [filter]='columnDef.filter' filterMatchMode='custom' (filterFunction)='onFilter($event)'>`

which will then call an 

`onFilter(filterMeta: FilterMetadata)`

method on the component.  

FilterMetadata looks like this:

```
export interface FilterMetadata {
    field?: string;
    value?: any;
    matchMode?: string;
}
```

