### PR TITLE
Travis configuration for running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+sudo: false
+node_js:
+   - node
+
+before_install:
+   - export CHROME_BIN=chromium-browser
+   - export DISPLAY=:99.0
+   - sh -e /etc/init.d/xvfb start
+
+script: # the build step
+   - node_modules/.bin/ng test --colors=false --progress=false --single-run
+
+
+cache:
+  yarn: true
+  directories:
+     - ./node_modules
+     - ./.chrome/chromium
+


### PR DESCRIPTION
This configuration file sets Travis up to execute primeng tests. In order to execute tests automatically on commits and pull requests, it needs to be enabled on https://travis-ci.org by a github repository admin. (Travis is free of charge for open source projects).