### PR TITLE
Small fix in the documentation for the Tree API

### DIFF
--- a/src/app/showcase/components/tree/treedemo.html
+++ b/src/app/showcase/components/tree/treedemo.html
@@ -603,7 +603,7 @@ import &#123;TreeDragDropService&#125; from 'primeng/primeng';
                             <td>Context menu instance.</td>
                         </tr>
                         <tr>
-                            <td>orientation</td>
+                            <td>layout</td>
                             <td>string</td>
                             <td>vertical</td>
                             <td>Defines the orientation of the tree, valid values are 'vertical' and 'horizontal'.</td>


### PR DESCRIPTION
The documentation of the Tree API shows a wrong name for the attribute that sets the horizontal/vertical orientation of the tree. The attribute name is "layout", not "orientation".