### PR TITLE
Default to an empty label instead of text that says ui-btn when btn.label is falsey.

### DIFF
--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -31,7 +31,7 @@ export class Button implements AfterViewInit, OnDestroy {
         
         let labelElement = document.createElement("span");
         labelElement.className = 'ui-button-text ui-clickable';
-        labelElement.appendChild(document.createTextNode(this.label||'ui-btn'));
+        labelElement.appendChild(document.createTextNode(this.label||''));
         this.el.nativeElement.appendChild(labelElement);
         this.initialized = true;
     }


### PR DESCRIPTION
### Defect Fixes
This fixes the fact that the button text defaults to ui-btn instead of just being empty when a label isn't set.
https://github.com/primefaces/primeng/issues/4252