### PR TITLE
Fix doc typo: expandedRowsGroups

### DIFF
--- a/src/app/showcase/components/datatable/datatabledemo.html
+++ b/src/app/showcase/components/datatable/datatabledemo.html
@@ -1209,7 +1209,7 @@ export class DataTableDemo implements OnInit &#123;
                             <td>When enabled, adds a clickable icon at group header to expand or collapse the group.</td>
                         </tr>
                         <tr>
-                            <td>expandedRowGroups</td>
+                            <td>expandedRowsGroups</td>
                             <td>array</td>
                             <td>null</td>
                             <td>Collection of group field values to show a group as expanded by default.</td>


### PR DESCRIPTION
The property should be expandedRowsGroups not expandedRowGroups.

[issue: 1721](https://github.com/primefaces/primeng/issues/1721)