### PR TITLE
Fix typo "optionField" dropdown showcase

### DIFF
--- a/src/app/showcase/components/dropdown/dropdowndemo.html
+++ b/src/app/showcase/components/dropdown/dropdowndemo.html
@@ -447,7 +447,7 @@ clearFilter(dropdown: Dropdown) &#123;
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;h3 class="first"&gt;Single&lt;/h3&gt;
-&lt;p-dropdown [options]="cities" [(ngModel)]="selectedCity" placeholder="Select a City" optionField="name"&gt;&lt;/p-dropdown&gt;
+&lt;p-dropdown [options]="cities" [(ngModel)]="selectedCity" placeholder="Select a City" optionLabel="name"&gt;&lt;/p-dropdown&gt;
 &lt;p&gt;Selected City: {{selectedCity ? selectedCity.name : 'none'}}&lt;/p&gt;
 
 &lt;h3&gt;Editable&lt;/h3&gt;


### PR DESCRIPTION
Fix typo in dropdown showcase. Change "optionField" to "optionLabel" as featured on 4,3 release.