### PR TITLE
Default to no button text when label is not set.

### DIFF
--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -31,7 +31,7 @@ export class Button implements AfterViewInit, OnDestroy {
         
         let labelElement = document.createElement("span");
         labelElement.className = 'ui-button-text ui-clickable';
-        labelElement.appendChild(document.createTextNode(this.label||'ui-btn'));
+        labelElement.appendChild(document.createTextNode(this.label||''));
         this.el.nativeElement.appendChild(labelElement);
         this.initialized = true;
     }


### PR DESCRIPTION
This is a pull request to fix the issue demonstrated by this Plunkr.
http://plnkr.co/edit/dSx8dBkXUQJXWtZHIOvc?p=preview

I've modified this line:
https://github.com/primefaces/primeng/blob/d06afd823cbac923b5cf3042b33efa64ba4ba53e/src/app/components/button/button.ts#L34
To allow for situations in which an end user would prefer to just have a button without a label so that they may edit the actual HTML inside of the button tag.


It is currently known by issue https://github.com/primefaces/primeng/issues/1657 that you can currently hide this text with the following styling 
```
.ui-button-text-only .ui-button-text{
    display: none !important;
}
```
but this seems like it should be unnecessary. 