### PR TITLE
fix calendar 12-hour format for switching between AM/PM

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -974,13 +974,20 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     }
     
     incrementHour(event) {
-        let newHour = this.currentHour + this.stepHour;
+        const prevHour = this.currentHour;
+        const newHour = this.currentHour + this.stepHour;
 
         if(this.validateHour(newHour)) {
             if(this.hourFormat == '24')
                 this.currentHour = (newHour >= 24) ? (newHour - 24) : newHour;        
-            else if(this.hourFormat == '12')
+            else if(this.hourFormat == '12') {
+                // Before the AM/PM break, now after
+                if (prevHour < 12 && newHour > 11) {
+                    this.pm = !this.pm;
+                }
+
                 this.currentHour = (newHour >= 13) ? (newHour - 12) : newHour;
+            }
             
             this.updateTime();
         }
@@ -989,13 +996,18 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     }
     
     decrementHour(event) {
-        let newHour = this.currentHour - this.stepHour;
+        const newHour = this.currentHour - this.stepHour;
         
         if(this.validateHour(newHour)) {
             if(this.hourFormat == '24')
                 this.currentHour = (newHour < 0) ? (24 + newHour) : newHour;        
-            else if(this.hourFormat == '12')
+            else if(this.hourFormat == '12') {
+                // If we were at noon/midnight, then switch
+                if (this.currentHour === 12) {
+                    this.pm = !this.pm;
+                }
                 this.currentHour = (newHour <= 0) ? (12 + newHour) : newHour;
+            }
                 
             this.updateTime();
         }


### PR DESCRIPTION
Addresses #3798 #4312 

The basic issue was that the 'hour' field was showing up as `0` when crossing back and forth between `12` and `1`. I was also seeing the `AM` / `PM` field not properly updating.

As a side note, this really isn't how I wanted to address this fix, but I didn't want to turn this into a refactor effort. I think the existing calendar code solves the problem of showing 12-hour time in a very inefficient way, and could gain long-term sustainability with a little bit of refactoring.

The current implementation keeps track of some offset that is calculated differently whether you are in 12 or 24-hour mode. It then sets the actual `Date` object value with the inverse calculation of the stored hour. I feel like a more proper implementation would save the `Date` value object the same and only display it differently in the input.