### PR TITLE
Fade animation issue with some locales

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -186,7 +186,7 @@ export class DomHandler {
         let last = +new Date();
         let opacity = 0;
         let tick = function () {
-            opacity = +element.style.opacity + (new Date().getTime() - last) / duration;
+            opacity = +element.style.opacity.replace(",", ".") + (new Date().getTime() - last) / duration;
             element.style.opacity = opacity;
             last = +new Date();
 


### PR DESCRIPTION
In Chromium with German locale element.style.opacity returns a string with a comma instead of a dot – as in "0,15" instead of "0.15". This results in a bug in the animation, making it stop after running tick() once. Replacing "," with "." fixes the problem.

See https://github.com/primefaces/primeng/pull/1491#issuecomment-342158634