### PR TITLE
Make forceSelection="false" work

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -511,7 +511,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
         this.onModelTouched();
         this.onBlur.emit(event);
         
-        if(this.forceSelection && this.suggestions) {
+        if(this.forceSelection && this.forceSelection !== 'false' && this.suggestions) {
             let valid = false;
             let inputValue = event.target.value.trim();
             


### PR DESCRIPTION
Setting forceSelection="false" attribute for <p-autoComplete> does now work, bringing it in line with the documentation for the forceSelection property at https://www.primefaces.org/primeng/#/autocomplete

Fixes https://github.com/primefaces/primeng/issues/4389