### PR TITLE
Edited emptyMessage as InnerHTML for datatable

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -219,7 +219,7 @@ export class ColumnFooters {
 
         <tr *ngIf="dt.isEmpty()" class="ui-widget-content ui-datatable-emptymessage-row" [style.visibility]="dt.loading ? 'hidden' : 'visible'">
             <td [attr.colspan]="dt.visibleColumns().length" class="ui-datatable-emptymessage">
-                <span *ngIf="!dt.emptyMessageTemplate">{{dt.emptyMessage}}</span>
+                <span *ngIf="!dt.emptyMessageTemplate"><div [innerHTML]=\"dt.emptyMessage\"></div></span>
                 <p-templateLoader [template]="dt.emptyMessageTemplate"></p-templateLoader>
             </td>
         </tr>


### PR DESCRIPTION
Have edited the EmptyMessage config as innerHTML so that if any styling required for empty message can be done.