### PR TITLE
Adjust site.css to show last items of sidebar.

### DIFF
--- a/src/assets/showcase/css/site.css
+++ b/src/assets/showcase/css/site.css
@@ -186,7 +186,7 @@ body {
     position: fixed;
     left: 0;
     top: 70px;
-    height: 100%;
+    height: calc(100% - 70px);
     background-color: #ffffff;
     overflow-x: hidden;
     overflow-y: auto;


### PR DESCRIPTION
The last items of sidebar were not be visible because 100% value on height property.

###Defect Fixes
When height property was 100% without subtract top property value, the last items of sidebar was hidden.