### PR TITLE
Changed loading icon default class

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -466,7 +466,7 @@ export class ScrollableView implements AfterViewInit,AfterViewChecked,OnDestroy 
             [ngClass]="{'ui-datatable ui-widget':true,'ui-datatable-reflow':responsive,'ui-datatable-stacked':stacked,'ui-datatable-resizable':resizableColumns,'ui-datatable-scrollable':scrollable}">
             <div class="ui-datatable-loading ui-widget-overlay" *ngIf="loading"></div>
             <div class="ui-datatable-loading-content" *ngIf="loading">
-                <i [class]="'fa fa-spin fa-2x ' + loadingIcon"></i>
+                <i [class]="loadingIcon"></i>
             </div>
             <div class="ui-datatable-header ui-widget-header" *ngIf="header">
                 <ng-content select="p-header"></ng-content>


### PR DESCRIPTION
### Loading Icon
Hi I was trying to add a custom loading icon to my project using the loading property but I got some many bug's, than I notice that the loading property was concatenating the 'fa fa-spin' class with my custom icon class. 

So I remove this concatenation `"'fa fa-spni' + loading"` and left only the loading variable, because every body should be able to add a custom loading spinner icon, and also, if some one want to use the 'fa fa-spin' class he can add by himself.