### PR TITLE
Correct example code.

### DIFF
--- a/src/app/showcase/components/datatable/datatabledemo.html
+++ b/src/app/showcase/components/datatable/datatabledemo.html
@@ -1830,7 +1830,7 @@ update(dt: DataTable) &#123;
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;h3 class="first"&gt;Basic&lt;/h3&gt;
-&lt;p-dataTable [value]="cars" [loading]="true"&gt;
+&lt;p-dataTable [value]="cars" [loading]="loading"&gt;
     &lt;p-column field="vin" header="Vin"&gt;&lt;/p-column&gt;
     &lt;p-column field="year" header="Year"&gt;&lt;/p-column&gt;
     &lt;p-column field="brand" header="Brand"&gt;&lt;/p-column&gt;


### PR DESCRIPTION
Fix error in example code of the simple table example.

###Defect Fixes
When using the code of the example without modifying - the loading circle does never disappears, because the binding is fixed to true. Although in the running code sample the binding is correct.