### PR TITLE
Pass previousindex to onchange event of tabview

### DIFF
--- a/src/app/components/tabview/tabview.ts
+++ b/src/app/components/tabview/tabview.ts
@@ -213,11 +213,13 @@ export class TabView implements AfterContentInit,BlockableUI {
         
         if(!tab.selected) {
             let selectedTab: TabPanel = this.findSelectedTab();
+            let previousIndex = this.findTabIndex(selectedTab);
+            let nextIndex = this.findTabIndex(tab);
             if(selectedTab) {
                 selectedTab.selected = false
             }
             tab.selected = true;
-            this.onChange.emit({originalEvent: event, index: this.findTabIndex(tab)});
+            this.onChange.emit({originalEvent: event, index: nextIndex , previousIndex });
         }
         
         if(event) {


### PR DESCRIPTION
Does not fix any issues.

This just adds another member (previous tab index) to the event object passed to the onchange event emitter in the tabview. The parent component can then use this previous index to know which was the previous tab.