### PR TITLE
Make ObjectUtils.equals() work with frozen objects (fix #4600)

### DIFF
--- a/src/app/components/utils/objectutils.spec.ts
+++ b/src/app/components/utils/objectutils.spec.ts
@@ -2,17 +2,17 @@ import { ObjectUtils } from './objectutils';
 import { inject, TestBed } from '@angular/core/testing';
 
 describe('ObjectUtils Suite', () => {
-    
+
     let objectUtils: ObjectUtils = null;
-    
+
     beforeEach(() => TestBed.configureTestingModule({
         providers: [ ObjectUtils ]
     }));
-    
+
     beforeEach(inject([ObjectUtils], s => {
         objectUtils = s;
     }));
-    
+
     let data: any = [
         {brand: "VW", year: 2012, color: {name:"Orange"}, vin: "dsad231ff"},
         {brand: "Audi", year: 2011, color: {name:"Black"}, vin: "gwregre345"},
@@ -25,7 +25,7 @@ describe('ObjectUtils Suite', () => {
         {brand: "Ford", year: 2000, color: {name:"White"}, vin: "h54hw5"},
         {brand: "Fiat", year: 2013, color: {name:"Yellow"}, vin: "245t2s"}
     ];
-    
+
     it('Should resolve field data', () => {
         let obj = {
             firstname: 'Silvio',
@@ -37,44 +37,78 @@ describe('ObjectUtils Suite', () => {
                 city: 'Corleone'
             }
         }
-        
+
         expect(objectUtils.resolveFieldData(obj, 'firstname')).toBe('Silvio');
         expect(objectUtils.resolveFieldData(obj, 'lastname')).toBe('Andolini');
         expect(objectUtils.resolveFieldData(obj, 'address.city')).toBe('Corleone');
         expect(objectUtils.resolveFieldData(obj, 'address.country.name')).toBe('Italy');
         expect(objectUtils.resolveFieldData(obj, 'age')).toBeUndefined();
     });
-    
+
     it('Should run single field correctly', () => {
         let result = objectUtils.filter(data, ['brand'], 'b');
         expect(result[0].brand).toBe('BMW');
     });
-    
+
     it('Should run multiple filter correctly', () => {
         let result = objectUtils.filter(data, ['brand','color.name'], 'w');
         expect(result[0].brand).toBe('VW');
         expect(result[1].brand).toBe('BMW');
         expect(result[2].brand).toBe('Ford');
     });
-    
+
     it('Should relocate an item in array', () => {
         let arr: string[] = ['New York', 'Istanbul', 'Paris', 'Barcelona', 'London'];
         objectUtils.reorderArray(arr, 3, 1);
         expect(arr).toEqual(['New York', 'Barcelona', 'Istanbul', 'Paris', 'London']);
     });
-    
+
     it('Should inject an item as indexed', () => {
         let sourceArr: string[] = ['New York', 'Istanbul', 'Paris', 'Barcelona', 'London'];
         let arr: string[] = [];
-        
+
         objectUtils.insertIntoOrderedArray('Istanbul', 1, arr, sourceArr);
         expect(arr).toEqual(['Istanbul']);
-        
+
         objectUtils.insertIntoOrderedArray('Paris', 2, arr, sourceArr);
         objectUtils.insertIntoOrderedArray('New York', 0, arr, sourceArr);
         objectUtils.insertIntoOrderedArray('London', 4, arr, sourceArr);
         objectUtils.insertIntoOrderedArray('Barcelona', 3, arr, sourceArr);
         expect(arr).toEqual(['New York', 'Istanbul', 'Paris', 'Barcelona', 'London']);
+    });
+
+    it('Should check if simple objects are equal', () => {
+      const [data0, data1] = data.slice(0, 2);
+      expect(objectUtils.equals(data0, data0)).toBe(true);
+      expect(objectUtils.equals(data0, Object.assign({}, data0))).toBe(true);
+      expect(objectUtils.equals(data0, data1)).toBe(false);
+    });
+
+    it('Should check if nested objects are equal', () => {
+      const arr = [1, 2, [3, 4]];
+      expect(objectUtils.equals(arr, Object.assign({}, arr))).toBe(true);
+      const arr2 = [1, 2, [3, 4, 5]];
+      expect(objectUtils.equals(arr, arr2)).toBe(false);
+      const obj = {a: 1, b: {c: 3, d: 4}};
+      expect(objectUtils.equals(obj, Object.assign({}, obj))).toBe(true);
+      const obj2 = {a: 1, b: {c: 3, d: 5}};
+      expect(objectUtils.equals(obj, obj2)).toBe(false);
+    });
+
+    it('Should not cause stack overflow comparing recursive objects', () => {
+      const obj1 = {p: null};
+      const obj2 = {p: null};
+      obj1['p'] = obj1;
+      obj2['p'] = obj2;
+      expect(objectUtils.equals(obj1, obj2)).toBe(false);
+    });
+
+    it('Should be able to compare frozen nested objects', () => {
+      const obj1 = {a: 1, b: {c: 3, d: 4}};
+      const obj2 = {a: 1, b: {c: 3, d: 4}};
+      Object.preventExtensions(obj1);
+      Object.preventExtensions(obj2);
+      expect(objectUtils.equals(obj1, obj2)).toBe(true);
     });
 
 });

--- a/src/app/components/utils/objectutils.ts
+++ b/src/app/components/utils/objectutils.ts
@@ -3,15 +3,15 @@ import {SelectItem} from '../common/selectitem';
 
 @Injectable()
 export class ObjectUtils {
-    
+
     public equals(obj1: any, obj2: any, field?: string): boolean {
-        if(field)
+        if (field)
             return (this.resolveFieldData(obj1, field) === this.resolveFieldData(obj2, field));
         else
             return this.equalsByValue(obj1, obj2);
     }
-    
-    public equalsByValue(obj1: any, obj2: any): boolean {
+
+    public equalsByValue(obj1: any, obj2: any, visited?: any[]): boolean {
         if (obj1 == null && obj2 == null) {
             return true;
         }
@@ -20,21 +20,25 @@ export class ObjectUtils {
         }
 
         if (obj1 == obj2) {
-            delete obj1._$visited;
             return true;
         }
 
         if (typeof obj1 == 'object' && typeof obj2 == 'object') {
-            obj1._$visited = true;
+            if (visited) {
+                if (visited.includes(obj1)) return false;
+            } else {
+                visited = [];
+            }
+            visited.push(obj1);
+
             for (var p in obj1) {
-                if (p === "_$visited") continue;
                 if (obj1.hasOwnProperty(p) !== obj2.hasOwnProperty(p)) {
                     return false;
                 }
 
                 switch (typeof (obj1[p])) {
                     case 'object':
-                        if (obj1[p] && obj1[p]._$visited || !this.equals(obj1[p], obj2[p])) return false;
+                        if (!this.equalsByValue(obj1[p], obj2[p], visited)) return false;
                         break;
 
                     case 'function':
@@ -57,7 +61,7 @@ export class ObjectUtils {
 
         return false;
     }
-    
+
     resolveFieldData(data: any, field: string): any {
         if(data && field) {
             if(field.indexOf('.') == -1) {
@@ -79,12 +83,12 @@ export class ObjectUtils {
             return null;
         }
     }
-    
+
     filter(value: any[], fields: any[], filterValue: string) {
         let filteredItems: any[] = [];
-        
+
         if(value) {
-            for(let item of value) {                
+            for(let item of value) {
                 for(let field of fields) {
                     if(String(this.resolveFieldData(item, field)).toLowerCase().indexOf(filterValue.toLowerCase()) > -1) {
                         filteredItems.push(item);
@@ -93,10 +97,10 @@ export class ObjectUtils {
                 }
             }
         }
-        
+
         return filteredItems;
     }
-    
+
     reorderArray(value: any[], from: number, to: number) {
         let target: number;
         if(value && (from !== to)) {
@@ -109,7 +113,7 @@ export class ObjectUtils {
             value.splice(to, 0, value.splice(from, 1)[0]);
         }
     }
-    
+
     generateSelectItems(val: any[], field: string): SelectItem[] {
         let selectItems: SelectItem[];
         if(val && val.length) {
@@ -118,10 +122,10 @@ export class ObjectUtils {
                 selectItems.push({label: this.resolveFieldData(item, field), value: item});
             }
         }
-        
+
         return selectItems;
     }
-    
+
     insertIntoOrderedArray(item: any, index: number, arr: any[], sourceArr: any[]): void {
         if(arr.length > 0) {
             let injected = false;
@@ -133,7 +137,7 @@ export class ObjectUtils {
                     break;
                 }
             }
-            
+
             if(!injected) {
                 arr.push(item);
             }
@@ -142,10 +146,10 @@ export class ObjectUtils {
             arr.push(item);
         }
     }
-    
+
     findIndexInList(item: any, list: any): number {
         let index: number = -1;
-        
+
         if(list) {
             for(let i = 0; i < list.length; i++) {
                 if(list[i] == item) {
@@ -154,7 +158,7 @@ export class ObjectUtils {
                 }
             }
         }
-        
+
         return index;
     }
 }


### PR DESCRIPTION
In order to avoid infinite recursion, the method added a "visited" flag as property to the compared objects. This caused the method to raise an error when "frozen" (read only) objects were compared that cannot be extended. This fix uses a stack to memorize visited objects instead of setting a property on the objects, and therefore allows frozen objects to be compared as well.

In real life, this can happen when feeding a PrimeNG data table with data queried using the Apollo GraphQL client (see issue #4600).

This fix also adds some unit tests to confirm proper behavior of ObjectUtils.equals().