### PR TITLE
Fixed docs class name for autocomplete list item

### DIFF
--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -478,7 +478,7 @@ export class AutoCompleteDemo &#123;
                             <td>List container of suggestions.</td>
                         </tr>
                         <tr>
-                            <td>ui-autocomplete-item</td>
+                            <td>ui-autocomplete-list-item</td>
                             <td>List item of a suggestion.</td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Fixed small mistake in the docs.

Closes #4604 