### PR TITLE
Listen mouseup not only on header

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -149,7 +149,9 @@ export class Dialog implements AfterViewInit,AfterViewChecked,OnDestroy {
     
     id: string = `ui-dialog-${idx++}`;
                 
-    constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public zone: NgZone) {}
+    constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public zone: NgZone) {
+        renderer.listen("body", "mouseup", event => this.endDrag(event));
+    }
     
     @Input() get visible(): boolean {
         return this._visible;


### PR DESCRIPTION
This fixes the same problem as #2550

You should listen mouseup on full browser, not only on header of the dialog to stop dragging. Sometimes mouseup invokes on different places if you move fast.
