### PR TITLE
Add emptyMessage to Dropdown/Multiselect & add emptyMessageTemplate to Dropdown/Multiselect/Autocomplete

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -41,7 +41,10 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                         <span *ngIf="!itemTemplate">{{field ? option[field] : option}}</span>
                         <ng-template *ngIf="itemTemplate" [pTemplateWrapper]="itemTemplate" [item]="option" [index]="idx"></ng-template>
                     </li>
-                    <li *ngIf="noResults && emptyMessage" class="ui-autocomplete-list-item ui-corner-all">{{emptyMessage}}</li>
+                    <li *ngIf="noResults && emptyMessage && !emptyMessageTemplate" class="ui-autocomplete-list-item ui-corner-all">{{emptyMessage}}</li>
+                    <li *ngIf="noResults && emptyMessageTemplate">
+                        <ng-template [pTemplateWrapper]="emptyMessageTemplate"></ng-template>
+                    </li>
                 </ul>
             </div>
         </span>
@@ -53,131 +56,133 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
     providers: [DomHandler,ObjectUtils,AUTOCOMPLETE_VALUE_ACCESSOR]
 })
 export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,ControlValueAccessor {
-    
+
     @Input() minLength: number = 1;
-    
+
     @Input() delay: number = 300;
-    
+
     @Input() style: any;
-    
+
     @Input() styleClass: string;
-    
+
     @Input() inputStyle: any;
 
     @Input() inputId: string;
-    
+
     @Input() inputStyleClass: string;
-    
+
     @Input() placeholder: string;
-    
+
     @Input() readonly: boolean;
-        
+
     @Input() disabled: boolean;
-    
+
     @Input() maxlength: number;
-    
+
     @Input() required: boolean;
-    
+
     @Input() size: number;
-    
+
     @Input() appendTo: any;
-    
+
     @Input() autoHighlight: boolean;
-    
+
     @Input() forceSelection: boolean;
-        
+
     @Input() type: string = 'text';
 
     @Output() completeMethod: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onSelect: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onUnselect: EventEmitter<any> = new EventEmitter();
 
     @Output() onFocus: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onBlur: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onDropdownClick: EventEmitter<any> = new EventEmitter();
-	
+
 	@Output() onClear: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onKeyUp: EventEmitter<any> = new EventEmitter();
-    
+
     @Input() field: string;
-    
+
     @Input() scrollHeight: string = '200px';
-    
+
     @Input() dropdown: boolean;
-    
+
     @Input() dropdownMode: string = 'blank';
-    
+
     @Input() multiple: boolean;
 
     @Input() tabindex: number;
-    
+
     @Input() dataKey: string;
-    
+
     @Input() emptyMessage: string;
-    
+
     @Input() immutable: boolean = true;
-    
+
     @ViewChild('in') inputEL: ElementRef;
-    
+
     @ViewChild('multiIn') multiInputEL: ElementRef;
-    
+
     @ViewChild('panel') panelEL: ElementRef;
-    
+
     @ViewChild('multiContainer') multiContainerEL: ElementRef;
 
     @ViewChild('ddBtn') dropdownButton: ElementRef;
-        
+
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
-    
+
     itemTemplate: TemplateRef<any>;
-    
+
     selectedItemTemplate: TemplateRef<any>;
-    
+
+    emptyMessageTemplate: TemplateRef<any>;
+
     value: any;
-    
+
     _suggestions: any[];
-    
+
     onModelChange: Function = () => {};
-    
+
     onModelTouched: Function = () => {};
-    
+
     timeout: any;
-            
+
     panelVisible: boolean = false;
-    
+
     documentClickListener: any;
-    
+
     suggestionsUpdated: boolean;
-    
+
     highlightOption: any;
-    
+
     highlightOptionChanged: boolean;
-    
+
     focus: boolean = false;
-        
+
     filled: boolean;
-    
+
     inputClick: boolean;
-    
+
     inputKeyDown: boolean;
-    
+
     noResults: boolean;
-    
+
     differ: any;
-    
+
     inputFieldValue: string = null;
-    
+
     loading: boolean;
-        
+
     constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public objectUtils: ObjectUtils, public cd: ChangeDetectorRef, public differs: IterableDiffers) {
         this.differ = differs.find([]).create(null);
     }
-    
+
     @Input() get suggestions(): any[] {
         return this._suggestions;
     }
@@ -188,7 +193,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
             this.handleSuggestionsChange();
         }
     }
-    
+
     ngDoCheck() {
         if(!this.immutable) {
             let changes = this.differ.diff(this.suggestions);
@@ -197,7 +202,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
             }
         }
     }
-    
+
     handleSuggestionsChange() {
         if(this.panelEL && this.panelEL.nativeElement && this.loading) {
             this.highlightOption = null;
@@ -205,15 +210,15 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 this.noResults = false;
                 this.show();
                 this.suggestionsUpdated = true;
-                
+
                 if(this.autoHighlight) {
                     this.highlightOption = this._suggestions[0];
                 }
             }
             else {
                 this.noResults = true;
-                
-                if(this.emptyMessage) {    
+
+                if(this.emptyMessage || this.emptyMessageTemplate) {
                     this.show();
                     this.suggestionsUpdated = true;
                 }
@@ -222,10 +227,10 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 }
             }
         }
-        
+
         this.loading = false;
     }
-        
+
     ngAfterContentInit() {
         this.templates.forEach((item) => {
             switch(item.getType()) {
@@ -236,14 +241,18 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 case 'selectedItem':
                     this.selectedItemTemplate = item.template;
                 break;
-                
+
+                case 'emptyMessage':
+                    this.emptyMessageTemplate = item.template;
+                break;
+
                 default:
                     this.itemTemplate = item.template;
                 break;
             }
         });
     }
-    
+
     ngAfterViewInit() {
         if(this.appendTo) {
             if(this.appendTo === 'body')
@@ -252,14 +261,14 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 this.domHandler.appendChild(this.panelEL.nativeElement, this.appendTo);
         }
     }
-    
+
     ngAfterViewChecked() {
         //Use timeouts as since Angular 4.2, AfterViewChecked is broken and not called after panel is updated
         if(this.suggestionsUpdated && this.panelEL.nativeElement && this.panelEL.nativeElement.offsetParent) {
             setTimeout(() => this.align(), 1);
             this.suggestionsUpdated = false;
         }
-        
+
         if(this.highlightOptionChanged) {
             setTimeout(() => {
                 let listItem = this.domHandler.findSingle(this.panelEL.nativeElement, 'li.ui-state-highlight');
@@ -270,13 +279,13 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
             this.highlightOptionChanged = false;
         }
     }
-    
+
     writeValue(value: any) : void {
         this.value = value;
         this.filled = this.value && this.value != '';
         this.updateInputField();
     }
-    
+
     registerOnChange(fn: Function): void {
         this.onModelChange = fn;
     }
@@ -284,7 +293,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
     registerOnTouched(fn: Function): void {
         this.onModelTouched = fn;
     }
-    
+
     setDisabledState(val: boolean): void {
         this.disabled = val;
     }
@@ -293,7 +302,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
         if(!this.inputKeyDown) {
             return;
         }
-      
+
         if(this.timeout) {
             clearTimeout(this.timeout);
         }
@@ -302,12 +311,12 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
         if(!this.multiple) {
             this.onModelChange(value);
         }
-        
+
         if(value.length === 0) {
            this.hide();
            this.onClear.emit(event);
         }
-        
+
         if(value.length >= this.minLength) {
             this.timeout = setTimeout(() => {
                 this.search(event, value);
@@ -320,27 +329,27 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
         this.updateFilledState();
         this.inputKeyDown = false;
     }
-    
+
     onInputClick(event: MouseEvent) {
         if(this.documentClickListener) {
             this.inputClick = true;
         }
     }
-    
+
     search(event: any, query: string) {
         //allow empty string but not undefined or null
        if(query === undefined || query === null) {
            return;
        }
-       
+
        this.loading = true;
-       
+
        this.completeMethod.emit({
            originalEvent: event,
            query: query
        });
     }
-            
+
     selectItem(option: any, focus: boolean = true) {
         if(this.multiple) {
             this.multiInputEL.nativeElement.value = '';
@@ -355,15 +364,15 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
             this.value = option;
             this.onModelChange(this.value);
         }
-        
+
         this.onSelect.emit(option);
         this.updateFilledState();
-        
+
         if(focus) {
             this.focusInput();
-        }    
+        }
     }
-    
+
     show() {
         if(this.multiInputEL || this.inputEL) {
             let hasFocus = this.multiple ? document.activeElement == this.multiInputEL.nativeElement : document.activeElement == this.inputEL.nativeElement ;
@@ -375,44 +384,44 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 this.panelEL.nativeElement.style.zIndex = ++DomHandler.zindex;
                 this.domHandler.fadeIn(this.panelEL.nativeElement, 200);
                 this.bindDocumentClickListener();
-            }   
+            }
         }
     }
-    
+
     align() {
         if(this.appendTo)
             this.domHandler.absolutePosition(this.panelEL.nativeElement, (this.multiple ? this.multiContainerEL.nativeElement : this.inputEL.nativeElement));
         else
             this.domHandler.relativePosition(this.panelEL.nativeElement, (this.multiple ? this.multiContainerEL.nativeElement : this.inputEL.nativeElement));
     }
-    
+
     hide() {
         this.panelVisible = false;
         this.unbindDocumentClickListener();
     }
-    
+
     handleDropdownClick(event) {
         this.focusInput();
         let queryValue = this.multiple ? this.multiInputEL.nativeElement.value : this.inputEL.nativeElement.value;
-        
+
         if(this.dropdownMode === 'blank')
             this.search(event, '');
         else if(this.dropdownMode === 'current')
             this.search(event, queryValue);
-        
+
         this.onDropdownClick.emit({
             originalEvent: event,
             query: queryValue
         });
     }
-    
+
     focusInput() {
         if(this.multiple)
             this.multiInputEL.nativeElement.focus();
         else
             this.inputEL.nativeElement.focus();
     }
-    
+
     removeItem(item: any) {
         let itemIndex = this.domHandler.index(item);
         let removedValue = this.value[itemIndex];
@@ -420,11 +429,11 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
         this.onUnselect.emit(removedValue);
         this.onModelChange(this.value);
     }
-        
+
     onKeydown(event) {
         if(this.panelVisible) {
             let highlightItemIndex = this.findOptionIndex(this.highlightOption);
-            
+
             switch(event.which) {
                 //down
                 case 40:
@@ -438,10 +447,10 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                     else {
                         this.highlightOption = this.suggestions[0];
                     }
-                    
+
                     event.preventDefault();
                 break;
-                
+
                 //up
                 case 38:
                     if(highlightItemIndex > 0) {
@@ -449,10 +458,10 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                         this.highlightOption = this.suggestions[prevItemIndex];
                         this.highlightOptionChanged = true;
                     }
-                    
+
                     event.preventDefault();
                 break;
-                
+
                 //enter
                 case 13:
                     if(this.highlightOption) {
@@ -461,14 +470,14 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                     }
                     event.preventDefault();
                 break;
-                
+
                 //escape
                 case 27:
                     this.hide();
                     event.preventDefault();
                 break;
 
-                
+
                 //tab
                 case 9:
                     if(this.highlightOption) {
@@ -482,7 +491,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 this.search(event,event.target.value);
             }
         }
-        
+
         if(this.multiple) {
             switch(event.which) {
                 //backspace
@@ -499,25 +508,25 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
 
         this.inputKeyDown = true;
     }
-    
+
     onKeyup(event) {
         this.onKeyUp.emit(event);
     }
-    
+
     onInputFocus(event) {
         this.focus = true;
         this.onFocus.emit(event);
     }
-    
+
     onInputBlur(event) {
         this.focus = false;
         this.onModelTouched();
         this.onBlur.emit(event);
-        
+
         if(this.forceSelection && this.suggestions) {
             let valid = false;
             let inputValue = event.target.value.trim();
-            
+
             if(this.suggestions)  {
                 for(let suggestion of this.suggestions) {
                     let itemValue = this.field ? this.objectUtils.resolveFieldData(suggestion, this.field) : suggestion;
@@ -528,7 +537,7 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                     }
                 }
             }
-            
+
             if(!valid) {
                 if(this.multiple) {
                     this.multiInputEL.nativeElement.value = '';
@@ -537,12 +546,12 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                     this.value = null;
                     this.inputEL.nativeElement.value = '';
                 }
-                
+
                 this.onModelChange(this.value);
             }
         }
     }
-                
+
     isSelected(val: any): boolean {
         let selected: boolean = false;
         if(this.value && this.value.length) {
@@ -555,8 +564,8 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
         }
         return selected;
     }
-    
-    findOptionIndex(option): number {        
+
+    findOptionIndex(option): number {
         let index: number = -1;
         if(this.suggestions) {
             for(let i = 0; i < this.suggestions.length; i++) {
@@ -566,39 +575,39 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 }
             }
         }
-                
+
         return index;
     }
-    
+
     updateFilledState() {
         if(this.multiple)
             this.filled = (this.value && this.value.length) || (this.multiInputEL && this.multiInputEL.nativeElement && this.multiInputEL.nativeElement.value != '');
         else
             this.filled = (this.inputFieldValue && this.inputFieldValue != '') || (this.inputEL && this.inputEL.nativeElement && this.inputEL.nativeElement.value != '');;
     }
-    
+
     updateInputField() {
         let formattedValue = this.value ? (this.field ? this.objectUtils.resolveFieldData(this.value, this.field)||'' : this.value) : '';
         this.inputFieldValue = formattedValue;
-        
+
         if(this.inputEL && this.inputEL.nativeElement) {
             this.inputEL.nativeElement.value = formattedValue;
         }
-        
+
         this.updateFilledState();
     }
-    
+
     bindDocumentClickListener() {
         if(!this.documentClickListener) {
             this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
                 if(event.which === 3) {
                     return;
                 }
-                
+
                 if(!this.inputClick && !this.isDropdownClick(event)) {
                     this.hide();
                 }
-                    
+
                 this.inputClick = false;
                 this.cd.markForCheck();
             });
@@ -614,14 +623,14 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
             return false;
         }
     }
-        
+
     unbindDocumentClickListener() {
         if(this.documentClickListener) {
             this.documentClickListener();
             this.documentClickListener = null;
         }
     }
-    
+
     ngOnDestroy() {
         this.unbindDocumentClickListener();
 

--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -20,6 +20,11 @@
                 <div style="font-size:18px;float:right;margin:10px 10px 0 0">{{brand}}</div>
             </div>
         </ng-template>
+        <ng-template pTemplate="emptyMessage">
+            <div style="padding: 5px; font-weight: bold;">
+                No matching brands found
+            </div>
+        </ng-template>
     </p-autoComplete>
     <span style="margin-left:50px">Brand: {{brand||'none'}}</span>
 

--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -214,6 +214,18 @@ export class AutoCompleteDemo &#123;
 </code>
 </pre>
 
+            <p>In case more control is necessary than the emptyMessage property provides, the emptyMessage template can be specified:</p>
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+&lt;p-autoComplete [(ngModel)]="brand" [suggestions]="filteredBrands" (completeMethod)="filterBrands($event)"&gt;
+    &lt;ng-template pTemplate="emptyMessage"&gt;
+        &lt;div class="ui-helper-clearfix" style="padding: 5px; font-weight: bold;"&gt;
+            No matching items found
+        &lt;/div&gt;
+    &lt;/ng-template&gt;
+&lt;/p-autoComplete&gt;
+</code>
+</pre>
             <h3>Properties</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">

--- a/src/app/showcase/components/dropdown/dropdowndemo.html
+++ b/src/app/showcase/components/dropdown/dropdowndemo.html
@@ -9,11 +9,11 @@
     <h3 class="first">Single</h3>
     <p-dropdown [options]="cities" [(ngModel)]="selectedCity" placeholder="Select a City" optionLabel="name"></p-dropdown>
     <p>Selected City: {{selectedCity ? selectedCity.name : 'none'}}</p>
-    
+
     <h3>Editable</h3>
     <p-dropdown [options]="cars" [(ngModel)]="selectedCar" [style]="{'width':'150px'}" editable="true" placeholder="Select a Brand"></p-dropdown>
     <p>Selected Car: {{selectedCar || 'none'}}</p>
-    
+
     <h3>Content with Filters</h3>
     <p-dropdown [options]="cars" [(ngModel)]="selectedCar2" [style]="{'width':'150px'}" filter="true">
         <ng-template let-car pTemplate="item">
@@ -21,6 +21,11 @@
                 <img src="assets/showcase/images/demo/car/{{car.label}}.png" style="width:24px;position:absolute;top:1px;left:5px"/>
                 <div style="font-size:14px;float:right;margin-top:4px">{{car.label}}</div>
             </div>
+        </ng-template>
+        <ng-template pTemplate="emptyMessage">
+          <div style="padding: 5px; font-weight: bold;">
+              No matching cars found
+          </div>
         </ng-template>
     </p-dropdown>
     <p>Selected Car: {{selectedCar2||'none'}}</p>
@@ -38,7 +43,7 @@ import &#123;DropdownModule&#125; from 'primeng/primeng';
 
             <h3>Getting Started</h3>
             <p>Dropdown requires a value to bind and a collection of options. There are two alternatives of how to define the options property; one way is providing a collection of SelectItem
-            instances whereas other way is providing an array of arbitrary objects along with the optionLabel property to specify the field name of the option. SelectItem API is designed to have more control on how 
+            instances whereas other way is providing an array of arbitrary objects along with the optionLabel property to specify the field name of the option. SelectItem API is designed to have more control on how
             the options are displayed such as grouping and disabling however in most cases an arbitrary object collection will suffice. Example below demonstrates both cases.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
@@ -60,11 +65,11 @@ interface City &#123;
 export class MyModel &#123;
 
     cities1: SelectItem[];
-    
+
     cities2: City[];
 
     selectedCity1: City;
-    
+
     selectedCity2: City;
 
     constructor() &#123;
@@ -77,7 +82,7 @@ export class MyModel &#123;
             &#123;label:'Istanbul', value:&#123;id:4, name: 'Istanbul', code: 'IST'&#125;&#125;,
             &#123;label:'Paris', value:&#123;id:5, name: 'Paris', code: 'PRS'&#125;&#125;
         ];
-        
+
         //An array of cities
         this.cities2 = [
             &#123;name: 'New York', code: 'NY'&#125;,
@@ -344,7 +349,7 @@ export class MyModel &#123;
                     </tbody>
                 </table>
             </div>
-            
+
             <h3>Methods</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">
@@ -364,7 +369,7 @@ export class MyModel &#123;
                     </tbody>
                 </table>
             </div>
-            
+
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-dropdown #dd [options]="cars" [(ngModel)]="selectedCar" filter="true"&gt;&lt;/p-dropdown&gt;

--- a/src/app/showcase/components/dropdown/dropdowndemo.html
+++ b/src/app/showcase/components/dropdown/dropdowndemo.html
@@ -130,6 +130,19 @@ export class MyModel &#123;
 </code>
 </pre>
 
+            <p>In case more control is necessary than the emptyMessage property provides, the emptyMessage template can be specified:</p>
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+&lt;p-dropdown [options]="cars" [(ngModel)]="selectedCar" [style]="&#123;'width':'150px'&#125;"&gt;
+    &lt;ng-template pTemplate="emptyMessage"&gt;
+        &lt;div class="ui-helper-clearfix" style="padding: 5px; font-weight: bold;"&gt;
+            No matching items found
+        &lt;/div&gt;
+    &lt;/ng-template&gt;
+&lt;/p-dropdown&gt;
+</code>
+</pre>
+
 <pre>
 <code class="language-typescript" pCode ngNonBindable>
 import &#123;SelectItem&#125; from 'primeng/primeng'
@@ -313,6 +326,12 @@ export class MyModel &#123;
                             <td>string</td>
                             <td>fa fa-fw fa-caret-down</td>
                             <td>Icon class of the dropdown icon.</td>
+                        </tr>
+                        <tr>
+                            <td>emptyMessage</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Message to display when there are no results from filter.</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/app/showcase/components/multiselect/multiselectdemo.html
+++ b/src/app/showcase/components/multiselect/multiselectdemo.html
@@ -114,7 +114,19 @@ export class MyModel &#123;
 </code>
 </pre>
 
-
+            <p>In case more control is necessary than the emptyMessage property provides, the emptyMessage template can be specified:</p>
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+&lt;p-multiSelect [options]="cars" [(ngModel)]="selectedCars2" [panelStyle]="&#123;minWidth:'12em'}"&gt;
+    &lt;ng-template pTemplate="emptyMessage"&gt;
+        &lt;div class="ui-helper-clearfix" style="padding: 5px; font-weight: bold;"&gt;
+            No matching items found
+        &lt;/div&gt;
+    &lt;/ng-template&gt;
+&lt;/p-multiSelect&gt;
+&lt;p&gt;Selected Cars: &#123;&#123;selectedCars2&#125;&#125;&lt;/p&gt;
+</code>
+</pre>
             <h3>Properties</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">
@@ -252,6 +264,12 @@ export class MyModel &#123;
                             <td>string</td>
                             <td>fa fa-fw fa-caret-down</td>
                             <td>Icon class of the dropdown icon.</td>
+                        </tr>
+                        <tr>
+                            <td>emptyMessage</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Message to display when there are no results from filter.</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/app/showcase/components/multiselect/multiselectdemo.html
+++ b/src/app/showcase/components/multiselect/multiselectdemo.html
@@ -7,14 +7,19 @@
 
 <div class="content-section implementation">
     <h3 class="first">Basic</h3>
-    <p-multiSelect [options]="cars" [(ngModel)]="selectedCars1" [panelStyle]="{minWidth:'12em'}"></p-multiSelect>
+    <p-multiSelect [options]="cars" [(ngModel)]="selectedCars1" [panelStyle]="{minWidth:'12em'}" emptyMessage="No results found"></p-multiSelect>
     <p>Selected Cars: {{selectedCars1}}</p>
-    
+
     <h3>Template</h3>
     <p-multiSelect [options]="cars" [(ngModel)]="selectedCars2" [panelStyle]="{minWidth:'12em'}">
         <ng-template let-car pTemplate="item">
             <img src="assets/showcase/images/demo/car/{{car.label}}.png" style="width:24px;display:inline-block;vertical-align:middle"/>
             <div style="font-size:14px;float:right;margin-top:4px">{{car.label}}</div>
+        </ng-template>
+        <ng-template pTemplate="emptyMessage">
+            <div style="padding: 5px; font-weight: bold;">
+                No matching cars found
+            </div>
         </ng-template>
     </p-multiSelect>
     <p>Selected Cars: {{selectedCars2}}</p>
@@ -32,7 +37,7 @@ import &#123;MultiSelectModule&#125; from 'primeng/primeng';
 
             <h3>Getting Started</h3>
             <p>MultiSelect requires a value to bind and a collection of options. There are two alternatives of how to define the options property; one way is providing a collection of SelectItem
-            instances whereas other way is providing an array of arbitrary objects along with the optionLabel property to specify the field name of the option. SelectItem API is designed to have more control on how 
+            instances whereas other way is providing an array of arbitrary objects along with the optionLabel property to specify the field name of the option. SelectItem API is designed to have more control on how
             the options are displayed such as grouping and disabling however in most cases an arbitrary object collection will suffice. Example below demonstrates both cases.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
@@ -54,11 +59,11 @@ interface City &#123;&#123;
 export class MyModel &#123;
 
     cities1: SelectItem[];
-    
+
     cities2: City[];
 
     selectedCities1: City[];
-    
+
     selectedCities2: City[];
 
     constructor() &#123;
@@ -70,7 +75,7 @@ export class MyModel &#123;
             &#123;label:'Istanbul', value:&#123;id:4, name: 'Istanbul', code: 'IST'&#125;&#125;
             &#123;label:'Paris', value:&#123;id:5, name: 'Paris', code: 'PRS'&#125;&#125;
         ];
-        
+
         //An array of cities
         this.cities2 = [
             &#123;name: 'New York', code: 'NY'&#125;,
@@ -92,7 +97,7 @@ export class MyModel &#123;
 &lt;p-multiSelect [options]="cities" formControlName="selectedCities"&gt;&lt;/p-multiSelect&gt;
 </code>
 </pre>
-        
+
             <h3>Templating</h3>
             <p>Label of a selectitem is displayed by default next to the checkbox in the overlay panel and it is possible to customize
             the content using templating. The ngTemplate receives the selectitem as the implicit variable along with the index of the option.</p>
@@ -108,8 +113,8 @@ export class MyModel &#123;
 &lt;p&gt;Selected Cars: &#123;&#123;selectedCars2&#125;&#125;&lt;/p&gt;
 </code>
 </pre>
-        
-        
+
+
             <h3>Properties</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">


### PR DESCRIPTION
Implemented `emptyMessage` property in Dropdown and Multiselect, and added `emptyMessageTemplate` to Dropdown, Multiselect, and Autocomplete. Added documentation for new properties and templates to all three components.

Requested by my own issue #4635.