### PR TITLE
Update datatable.ts

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -1301,7 +1301,13 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         let value2 = this.resolveFieldData(data2, multiSortMeta[index].field);
         let result = null;
 
-        if (typeof value1 == 'string' || value1 instanceof String) {
+        if (value1 == null && value2 != null)
+          result = -1;
+        else if (value1 != null && value2 == null)
+            result = 1;
+        else if (value1 == null && value2 == null)
+            result = 0;
+        else if (typeof value1 == 'string' || value1 instanceof String) {
             if (value1.localeCompare && (value1 != value2)) {
                 return (multiSortMeta[index].order * value1.localeCompare(value2));
             }


### PR DESCRIPTION
Fix for multiple fields sort when a field's value is null.
It was already fixed for single field sorting, see issue #681