### PR TITLE
Fix for "Datascroller lazy load implementation broken #3906"

### DIFF
--- a/src/app/components/datascroller/datascroller.ts
+++ b/src/app/components/datascroller/datascroller.ts
@@ -12,7 +12,7 @@ import {DomHandler} from '../dom/domhandler';
         </div>
         <div #content class="ui-datascroller-content ui-widget-content" [ngStyle]="{'max-height': scrollHeight}">
             <ul class="ui-datascroller-list">
-                <li *ngFor="let item of dataToRender;trackBy: trackBy">
+            <li *ngFor="let item of dataToRender;trackBy: trackBy">
                     <ng-template [pTemplateWrapper]="itemTemplate" [item]="item"></ng-template>
                 </li>
             </ul>
@@ -29,46 +29,50 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
     @Input() rows: number;
 
     @Input() lazy: boolean;
-    
+
     @Output() onLazyLoad: EventEmitter<any> = new EventEmitter();
 
     @Input() style: any;
 
     @Input() styleClass: string;
-    
+
     @Input() buffer: number = 0.9;
-    
+
     @Input() inline: boolean;
-    
+
     @Input() scrollHeight: any;
-    
+
     @Input() loader: any;
-    
+
     @Input() trackBy: Function = (index: number, item: any) => item;
-    
+
     @Input() immutable: boolean = true;
-    
+
     @ViewChild('content') contentViewChild: ElementRef;
-        
+
     @ContentChild(Header) header;
 
     @ContentChild(Footer) footer;
-    
+
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
-    
+
     public _value: any[];
-    
+
     public itemTemplate: TemplateRef<any>;
 
     public dataToRender: any[] = [];
 
     public first: number = 0;
-    
+
     scrollFunction: any;
-    
+
     contentElement: HTMLDivElement;
 
-    differ: any;
+   differ: any;
+
+   public isLoadComplete = true;
+
+   public isNoMoreData = false;
 
     constructor(public el: ElementRef, public renderer: Renderer2, public domHandler: DomHandler, public differs: IterableDiffers) {
         this.differ = differs.find([]).create(null);
@@ -78,7 +82,7 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
         if(this.lazy) {
             this.load();
         }
-        
+
         if(this.loader) {
             this.scrollFunction = this.renderer.listen(this.loader, 'click', () => {
                 this.load();
@@ -88,56 +92,56 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
             this.bindScrollListener();
         }
     }
-    
+
     ngAfterContentInit() {
         this.templates.forEach((item) => {
             switch(item.getType()) {
                 case 'item':
                     this.itemTemplate = item.template;
                 break;
-                
+
                 default:
                     this.itemTemplate = item.template;
                 break;
             }
         });
     }
-    
+
     @Input() get value(): any[] {
         return this._value;
     }
 
     set value(val:any[]) {
-        this._value = val;
-        
-        if(this.immutable) {
-            this.handleDataChange();
-        }
-    }
-    
-    handleDataChange() {
-        if(this.lazy)
-            this.dataToRender = this.value;
-        else
-            this.load();
-    }
-    
-    ngDoCheck() {
-        if(!this.immutable) {
-            let changes = this.differ.diff(this.value);
-            if(changes) {
-                this.handleDataChange();
-            }
-        }
-    }
-        
+      this._value = val;
+
+      if(this.immutable) {
+          this.handleDataChange();
+      }
+  }
+
+  handleDataChange() {
+      if(this.lazy)
+          this.dataToRender = this.value;
+      else
+          this.load();
+  }
+
+  ngDoCheck() {
+      if(!this.immutable) {
+          let changes = this.differ.diff(this.value);
+          if(changes) {
+              this.handleDataChange();
+          }
+      }
+  }
+
     load() {
         if(this.lazy) {
             this.onLazyLoad.emit({
                 first: this.first,
                 rows: this.rows
             });
-            
+
             this.first = this.first + this.rows;
         }
         else {
@@ -149,59 +153,66 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
 
                     this.dataToRender.push(this.value[i]);
                 }
-                
+
                 this.first = this.first + this.rows;
             }
         }
     }
-     
+
     reset() {
         this.first = 0;
         this.dataToRender = [];
         this.load();
+        this.isLoadComplete = true;
+        this.isNoMoreData = false;
     }
 
     isEmpty() {
         return !this.dataToRender||(this.dataToRender.length == 0);
     }
-    
+
     createLazyLoadMetadata(): any {
         return {
             first: this.first,
             rows: this.rows
         };
     }
-    
+
     bindScrollListener() {
         if(this.inline) {
             this.contentElement = this.contentViewChild.nativeElement;
-            
-            this.scrollFunction = this.renderer.listen(this.contentElement, 'scroll', () => {
-                let scrollTop = this.contentElement.scrollTop;
-                let scrollHeight = this.contentElement.scrollHeight;
-                let viewportHeight = this.contentElement.clientHeight;
 
-                if((scrollTop >= ((scrollHeight * this.buffer) - (viewportHeight)))) {
-                    this.load();
+            this.scrollFunction = this.renderer.listen(this.contentElement, 'scroll', () => {
+                if(!this.isNoMoreData && (!this.lazy || this.isLoadComplete)){
+                    let scrollTop = this.contentElement.scrollTop;
+                    let scrollHeight = this.contentElement.scrollHeight;
+                    let viewportHeight = this.contentElement.clientHeight;
+                    if((scrollTop >= ((scrollHeight * this.buffer) - (viewportHeight)))) {
+                        this.isLoadComplete = false;
+                        this.load();
+                    }
                 }
             });
         }
         else {
             this.scrollFunction = this.renderer.listen('window', 'scroll', () => {
-                let docBody = document.body;
-                let docElement = document.documentElement;
-                let scrollTop = (window.pageYOffset||document.documentElement.scrollTop);
-                let winHeight = docElement.clientHeight;
-                let docHeight = Math.max(docBody.scrollHeight, docBody.offsetHeight, winHeight, docElement.scrollHeight, docElement.offsetHeight);
-                            
-                if(scrollTop >= ((docHeight * this.buffer) - winHeight)) {
-                    this.load();
+                if(!this.isNoMoreData && (!this.lazy || this.isLoadComplete)){
+                    let docBody = document.body;
+                    let docElement = document.documentElement;
+                    let scrollTop = (window.pageYOffset||document.documentElement.scrollTop);
+                    let winHeight = docElement.clientHeight;
+                    let docHeight = Math.max(docBody.scrollHeight, docBody.offsetHeight, winHeight, docElement.scrollHeight, docElement.offsetHeight);
+
+                    if(scrollTop >= ((docHeight * this.buffer) - winHeight)) {
+                        this.isLoadComplete = false;
+                        this.load();
+                    }
                 }
             });
         }
-        
+
     }
-    
+
     ngOnDestroy() {
         //unbind
         if(this.scrollFunction) {

--- a/src/app/components/datascroller/datascroller.ts
+++ b/src/app/components/datascroller/datascroller.ts
@@ -12,7 +12,7 @@ import {DomHandler} from '../dom/domhandler';
         </div>
         <div #content class="ui-datascroller-content ui-widget-content" [ngStyle]="{'max-height': scrollHeight}">
             <ul class="ui-datascroller-list">
-            <li *ngFor="let item of dataToRender;trackBy: trackBy">
+                <li *ngFor="let item of dataToRender;trackBy: trackBy">
                     <ng-template [pTemplateWrapper]="itemTemplate" [item]="item"></ng-template>
                 </li>
             </ul>
@@ -68,11 +68,11 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
 
     contentElement: HTMLDivElement;
 
-   differ: any;
+    differ: any;
 
-   public isLoadComplete = true;
+    public isLoadComplete = true;
 
-   public isNoMoreData = false;
+    public isNoMoreData = false;
 
     constructor(public el: ElementRef, public renderer: Renderer2, public domHandler: DomHandler, public differs: IterableDiffers) {
         this.differ = differs.find([]).create(null);
@@ -187,6 +187,7 @@ export class DataScroller implements AfterViewInit,DoCheck,OnDestroy {
                     let scrollTop = this.contentElement.scrollTop;
                     let scrollHeight = this.contentElement.scrollHeight;
                     let viewportHeight = this.contentElement.clientHeight;
+
                     if((scrollTop >= ((scrollHeight * this.buffer) - (viewportHeight)))) {
                         this.isLoadComplete = false;
                         this.load();


### PR DESCRIPTION
Added two properties to datascroller component that allow to correctly wait for external data load callbacks ( see issue #3906): 

1. isDataLoaded - when set to true, allows receiving next portion of data, when set to false outside component, means component is waiting for data to load, should be set back to true after data finished loading (for example, inside subscribe event of data loading method)

2. isNoMoredata - set outside component to true means all data was loaded, and we reached the end of data, so no need to fire load()
