### PR TITLE
Fix #4659

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -52,7 +52,7 @@ export class Tooltip implements OnDestroy {
     
     @HostListener('mouseenter', ['$event']) 
     onMouseEnter(e: Event) {
-        if(this.tooltipEvent === 'hover') {
+        if(this.tooltipEvent === 'hover' && !this.active) {
             if(this.hideTimeout) {
                 clearTimeout(this.hideTimeout);
                 this.destroy();
@@ -64,7 +64,7 @@ export class Tooltip implements OnDestroy {
     
     @HostListener('mouseleave', ['$event'])
     onMouseLeave(e: Event) {
-        if(this.tooltipEvent === 'hover') {
+        if(this.tooltipEvent === 'hover' && this.active) {
             this.deactivate(true);
         }
     }


### PR DESCRIPTION
###Defect Fixes
#4659

The problem gets caused by multiple enter events. More than one tooltip element gets created but not all will be deleted on mouseleave. My solution simply checks if the tooltip is already active so a tooltip will be created only once.  