### PR TITLE
 schedule and scheduledemo: fix CRUD scenario. Fix linter warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,95 +1,107 @@
 {
   "name": "primeng",
-  "version": "4.2.2-SNAPSHOT",
+  "version": "5.0.3-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@angular-devkit/build-optimizer": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.21.tgz",
-      "integrity": "sha512-YK+wss6MFpLbuf1hxcgiwFJITTRcvjDq0MQkrMHbX2zonmgBT/olcvm6JoMsvrm9iQ/HETUgUY55koih/pwlJg==",
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-optimizer/-/build-optimizer-0.0.36.tgz",
+      "integrity": "sha512-EFFF7hBbVoTOzYfXuSlGhcDr8neafmwuBAIkzAekEjzik7OaTLq7LPG7As+ebed9ll+3DAGypnrpdIE1Tp/H/A==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
         "source-map": "0.5.7",
-        "typescript": "2.3.4",
+        "typescript": "2.6.2",
         "webpack-sources": "1.0.1"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+          "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/core": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.14.tgz",
-      "integrity": "sha512-DkymP3uXknGFQJKHzKeKgspEkPF6/BPP5TxLcRowYPxI2qWm7NYmC1o7JcxfIQmYbLuTpS5xjVRW9J5kx9UfOw==",
-      "dev": true
-    },
-    "@angular-devkit/schematics": {
-      "version": "0.0.24",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.0.24.tgz",
-      "integrity": "sha512-izq0ZOGxTYsPJqpABsvDf+Zlyzn6ijSyt8AXtRUjAAK7B6Iry6EGHEQ8T7YFQlsqqzUrLx4tkq/IXrTyy6aldg==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.0.22.tgz",
+      "integrity": "sha512-zxrNtTiv60liye/GGeRMnnGgLgAWoqlMTfPLMW0D1qJ4bbrPHtme010mpxS3QL4edcDtQseyXSFCnEkuo2MrRw==",
       "dev": true,
       "requires": {
-        "@angular-devkit/core": "0.0.14",
+        "source-map": "0.5.7"
+      }
+    },
+    "@angular-devkit/schematics": {
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-0.0.42.tgz",
+      "integrity": "sha512-elTiNL0Nx9oin2pfZTvMBU/d9sgutXaZe8n3xm2p7jfqQZry5MYYFES4hq+WIJjtV/X9gAniafncEpxuF7ikYw==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "0.0.22",
         "@ngtools/json-schema": "1.1.0",
+        "@schematics/schematics": "0.0.11",
         "minimist": "1.2.0",
-        "rxjs": "5.4.3"
+        "rxjs": "5.5.2"
       }
     },
     "@angular/animations": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-4.4.3.tgz",
-      "integrity": "sha1-OWxKW/sihH+eRYJFuplfnBMMDPM=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-5.0.0.tgz",
+      "integrity": "sha1-ta0ZnGf5P3WVREd+/+ZnnhVJkfs=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/cli": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.4.1.tgz",
-      "integrity": "sha512-ss/BzwThVYrN8r1oTNrz3x8MxoBHaagUhG4+XO++becRLlmSalN81pbqDbCu44g9LlC1RhAaElbmQ99XT88yWQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-1.6.2.tgz",
+      "integrity": "sha512-Qc6AD37ASJjhbYkDgWQOniEl+XDLWDydqPOZ0kPQhbrJk49PoM1HNZfCD1FmIZFTT/eFEVsaexc/rKw0KckvSA==",
       "dev": true,
       "requires": {
-        "@angular-devkit/build-optimizer": "0.0.21",
-        "@angular-devkit/schematics": "0.0.24",
+        "@angular-devkit/build-optimizer": "0.0.36",
+        "@angular-devkit/schematics": "0.0.42",
         "@ngtools/json-schema": "1.1.0",
-        "@ngtools/webpack": "1.7.0",
-        "@schematics/angular": "0.0.36",
+        "@ngtools/webpack": "1.9.2",
+        "@schematics/angular": "0.1.11",
         "autoprefixer": "6.7.7",
-        "chalk": "2.1.0",
-        "circular-dependency-plugin": "3.0.0",
+        "chalk": "2.2.2",
+        "circular-dependency-plugin": "4.3.0",
         "common-tags": "1.4.0",
-        "copy-webpack-plugin": "4.0.1",
+        "copy-webpack-plugin": "4.3.1",
         "core-object": "3.1.5",
         "css-loader": "0.28.7",
         "cssnano": "3.10.0",
         "denodeify": "1.2.1",
         "ember-cli-string-utils": "1.1.0",
         "exports-loader": "0.6.4",
-        "extract-text-webpack-plugin": "3.0.0",
-        "file-loader": "0.10.1",
+        "extract-text-webpack-plugin": "3.0.2",
+        "file-loader": "1.1.6",
         "fs-extra": "4.0.2",
-        "get-caller-file": "1.0.2",
         "glob": "7.1.2",
-        "heimdalljs": "0.2.5",
-        "heimdalljs-logger": "0.1.9",
         "html-webpack-plugin": "2.30.1",
         "istanbul-instrumenter-loader": "2.0.0",
         "karma-source-map-support": "1.2.0",
         "less": "2.7.2",
         "less-loader": "4.0.5",
         "license-webpack-plugin": "1.0.1",
+        "loader-utils": "1.1.0",
         "lodash": "4.17.4",
         "memory-fs": "0.4.1",
+        "minimatch": "3.0.4",
         "node-modules-path": "1.0.1",
         "node-sass": "4.5.3",
         "nopt": "4.0.1",
         "opn": "5.1.0",
         "portfinder": "1.0.13",
-        "postcss-loader": "1.3.3",
-        "postcss-url": "5.1.2",
+        "postcss-custom-properties": "6.2.0",
+        "postcss-loader": "2.0.9",
+        "postcss-url": "7.3.0",
         "raw-loader": "0.5.1",
         "resolve": "1.4.0",
-        "rxjs": "5.4.3",
+        "rxjs": "5.5.2",
         "sass-loader": "6.0.6",
         "semver": "5.4.1",
         "silent-error": "1.1.0",
@@ -98,112 +110,245 @@
         "style-loader": "0.13.2",
         "stylus": "0.54.5",
         "stylus-loader": "3.0.1",
-        "typescript": "2.3.4",
-        "url-loader": "0.5.9",
-        "webpack": "3.5.6",
-        "webpack-concat-plugin": "1.4.0",
+        "uglifyjs-webpack-plugin": "1.1.4",
+        "url-loader": "0.6.2",
+        "webpack": "3.10.0",
         "webpack-dev-middleware": "1.12.0",
-        "webpack-dev-server": "2.7.1",
+        "webpack-dev-server": "2.9.7",
         "webpack-merge": "4.1.0",
-        "zone.js": "0.8.17"
+        "webpack-sources": "1.0.1",
+        "webpack-subresource-integrity": "1.0.3",
+        "zone.js": "0.8.18"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.2.tgz",
+          "integrity": "sha512-LvixLAQ4MYhbf7hgL4o5PeK32gJKvVzDRiSNIApDofQvyhl8adgG2lJVXn4+ekQoK7HL9RF8lqxwerpe0x2pCw==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "circular-dependency-plugin": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-4.3.0.tgz",
+          "integrity": "sha512-L3W9L1S0wC64rq+QSaZzmWnJW7cVBgimxI2lNEFEX5biwlRG8EHRM68JFi+CX5ZkCGUWJHIpnhdVs181Zlq3wA==",
+          "dev": true
+        },
+        "extract-text-webpack-plugin": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+          "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
+          "dev": true,
+          "requires": {
+            "async": "2.5.0",
+            "loader-utils": "1.1.0",
+            "schema-utils": "0.3.0",
+            "webpack-sources": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "3.2.0",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "4.5.0"
+              }
+            }
+          }
+        },
+        "postcss-loader": {
+          "version": "2.0.9",
+          "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-2.0.9.tgz",
+          "integrity": "sha512-sgoXPtmgVT3aBAhU47Kig8oPF+mbXl8Unjvtz1Qj1q2D2EvSVJW2mKJNzxv5y/LvA9xWwuvdysvhc7Zn80UWWw==",
+          "dev": true,
+          "requires": {
+            "loader-utils": "1.1.0",
+            "postcss": "6.0.14",
+            "postcss-load-config": "1.2.0",
+            "schema-utils": "0.3.0"
+          }
+        },
+        "postcss-url": {
+          "version": "7.3.0",
+          "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-7.3.0.tgz",
+          "integrity": "sha512-VBP6uf6iL3AZra23nkPkOEkS/5azj1xf/toRrjfkolfFEgg9Gyzg9UhJZeIsz12EGKZTNVeGbPa2XtaZm/iZvg==",
+          "dev": true,
+          "requires": {
+            "mime": "1.4.1",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "postcss": "6.0.14",
+            "xxhashjs": "0.2.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "uglifyjs-webpack-plugin": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.1.4.tgz",
+          "integrity": "sha512-fRrOJ5tv6YCsJIhP9mPRnfgyo4DVNSIfNOa7Gs9aT1NNpeJc85W7GcbVxQgc+9rU3No6tnkbMqZ4xsgRBU+HGQ==",
+          "dev": true,
+          "requires": {
+            "cacache": "10.0.1",
+            "find-cache-dir": "1.0.0",
+            "schema-utils": "0.3.0",
+            "serialize-javascript": "1.4.0",
+            "source-map": "0.6.1",
+            "uglify-es": "3.2.2",
+            "webpack-sources": "1.0.1",
+            "worker-farm": "1.5.2"
+          }
+        }
       }
     },
     "@angular/common": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.4.3.tgz",
-      "integrity": "sha1-+SrGiwK+xfDm02A6hDKU3JbJYHQ=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-5.0.0.tgz",
+      "integrity": "sha1-+W1mpRe5ldG6mygwnxXC41lnWCU=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/compiler": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.4.3.tgz",
-      "integrity": "sha1-jwEWPa19s0CEl9mdOHVUtrGFrWY=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-5.0.0.tgz",
+      "integrity": "sha1-uf+/GMijnYt9rOxHMZOpDiTMK8k=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/compiler-cli": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.4.3.tgz",
-      "integrity": "sha1-GDr4HxQRhrjWYLBkKVktQLdUCko=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-5.0.0.tgz",
+      "integrity": "sha1-Dsu5N9hKT43ZTwwqR7B9LkaUyFM=",
       "dev": true,
       "requires": {
-        "@angular/tsc-wrapped": "4.4.3",
+        "chokidar": "1.7.0",
         "minimist": "1.2.0",
-        "reflect-metadata": "0.1.10"
+        "reflect-metadata": "0.1.10",
+        "tsickle": "0.24.1"
+      },
+      "dependencies": {
+        "tsickle": {
+          "version": "0.24.1",
+          "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.24.1.tgz",
+          "integrity": "sha512-XloFQZhVhgjpQsi3u2ORNRJvuID5sflOg6HfP093IqAbhE1+fIUXznULpdDwHgG4p+v8w78KdHruQtkWUKx5AQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "source-map": "0.5.7",
+            "source-map-support": "0.4.18"
+          }
+        }
       }
     },
     "@angular/core": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.4.3.tgz",
-      "integrity": "sha1-5x0rB76qy6tIq39R1OIobqXXDhU=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-5.0.0.tgz",
+      "integrity": "sha1-T5dqIl993fNJkvLK2CTJVDpG9Mg=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/forms": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-4.4.3.tgz",
-      "integrity": "sha1-JbQburWL8dqHJBHIUXwQ18U3PY4=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.0.0.tgz",
+      "integrity": "sha1-x/3fo1OWdZrphSkgowzdqMQe0d4=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/http": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/http/-/http-4.4.3.tgz",
-      "integrity": "sha1-tVftJBRKrMRLE2zUd+hNL1eAiQM=",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@angular/http/-/http-5.1.2.tgz",
+      "integrity": "sha512-LvOgVPCxOii2TH8r8UrXQJjqrbgrt/HTNOtqqT1/CmemsnbGcBiYAnt5yiZ2aYQuop4RZLhQ/UpuSMLur9XPtg==",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/language-service": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-4.4.3.tgz",
-      "integrity": "sha1-RScBGllJZ6OW7/PAXtFb1MhtUbc=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/language-service/-/language-service-5.0.0.tgz",
+      "integrity": "sha1-bMu2n0dXJw3QTsWFfTdjSy8CxAw=",
       "dev": true
     },
     "@angular/platform-browser": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.4.3.tgz",
-      "integrity": "sha1-I/mkW9Pcf0TZeHf7+OYDLez8ncs=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.0.0.tgz",
+      "integrity": "sha1-xwOPfN6AcFtiAUiXIx4YLuyXb+0=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/platform-browser-dynamic": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.4.3.tgz",
-      "integrity": "sha1-5B3dglJDJ3UxDqtZQM3Y3wYY8IQ=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-5.0.0.tgz",
+      "integrity": "sha1-iH4QbIsQOwQVz2FWpCXabYP0yJ0=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
       }
     },
     "@angular/router": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-4.4.3.tgz",
-      "integrity": "sha1-JsyUd1o4YJRq6vHC6PYPTUTpCZE=",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-5.0.0.tgz",
+      "integrity": "sha1-/ktSGmc4QIvOMPk6U0mRQMk6T3Y=",
       "dev": true,
       "requires": {
         "tslib": "1.7.1"
-      }
-    },
-    "@angular/tsc-wrapped": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.4.3.tgz",
-      "integrity": "sha1-LT84IQodTbA/yG3PHglYErhc0Rk=",
-      "dev": true,
-      "requires": {
-        "tsickle": "0.21.6"
       }
     },
     "@ngtools/json-schema": {
@@ -213,33 +358,107 @@
       "dev": true
     },
     "@ngtools/webpack": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.7.0.tgz",
-      "integrity": "sha512-WHjqE/nufok8QEFxN9XIaljBVz1dcYyI4WwGWXYOyIVnhHEhm67A15ClTXI6oZDND8ocXlPnjVzW8oexk82K4A==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-1.9.2.tgz",
+      "integrity": "sha512-jM5XMwHt94qxIe9kJS3Bmz8EfZgsC2H7fVcTSEd/dgyL5C89uZJfj5ueO9yEERpnXufvALBMfUxfODTcPX01iw==",
       "dev": true,
       "requires": {
+        "chalk": "2.2.2",
         "enhanced-resolve": "3.4.1",
         "loader-utils": "1.1.0",
         "magic-string": "0.22.4",
-        "source-map": "0.5.7"
+        "semver": "5.4.1",
+        "source-map": "0.5.7",
+        "tree-kill": "1.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.2.2.tgz",
+          "integrity": "sha512-LvixLAQ4MYhbf7hgL4o5PeK32gJKvVzDRiSNIApDofQvyhl8adgG2lJVXn4+ekQoK7HL9RF8lqxwerpe0x2pCw==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "@schematics/angular": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.0.36.tgz",
-      "integrity": "sha512-ZY3x6NaRTVD7ki1E5Kx0BfBXf8sCZZ8H+6HMP2YuiU4arVszo6Lg43r3ffTIwsP95+6ldUKqrHLeTDrttvCK6A==",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-0.1.11.tgz",
+      "integrity": "sha512-jYTantZjdYeDjxh9ZLYvGbDI0VeUxgSrcBjHvnHqMNe+YGJenY988ifWCwzjmOowj57maLrQQGrdoO7oUeNdyw==",
+      "dev": true,
+      "requires": {
+        "@angular-devkit/core": "0.0.22"
+      }
+    },
+    "@schematics/schematics": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@schematics/schematics/-/schematics-0.0.11.tgz",
+      "integrity": "sha512-HAXgAIuuAGjiIKohGlRUkmUTWYtNmclR12KHlQQxT9pHFdEb2OrpHjUp2YoV32jiU6jIZm4pf3ODwlPA0VbwnA==",
       "dev": true
     },
+    "@types/fullcalendar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/fullcalendar/-/fullcalendar-3.5.2.tgz",
+      "integrity": "sha512-g1e2KAMdvzNkxodyo8F4z9asU6YR4z9v0J5WC9kf6gmdeTN2q05cY18oVKhIxrfsQ40LGP3+UhJb0gEfK74A9g==",
+      "dev": true,
+      "requires": {
+        "@types/jquery": "3.2.17",
+        "moment": "2.20.1"
+      }
+    },
     "@types/jasmine": {
-      "version": "2.5.45",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.45.tgz",
-      "integrity": "sha1-WJKKYh0BTOarWcWpxBBx9zKLDKk=",
+      "version": "2.5.53",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.53.tgz",
+      "integrity": "sha512-2YNL0jXYuN7w07mb1sMZQ6T6zOvGi83v8UbjhBZ8mhvI1VkQ2STU9XOrTFyvWswMyh5rW1evS+e7qltYJvTqPA==",
+      "dev": true
+    },
+    "@types/jasminewd2": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jasminewd2/-/jasminewd2-2.0.2.tgz",
+      "integrity": "sha1-X2jh5pe/ELxv2Mvy4Aaj1nEsW2Q=",
+      "dev": true,
+      "requires": {
+        "@types/jasmine": "2.5.53"
+      }
+    },
+    "@types/jquery": {
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.17.tgz",
+      "integrity": "sha512-lt8i2ZqymxxN1JnWSOTPU7Xc3ze32lhASkVdsMd6/SZnb/jtBsmFEoYCBSa0tzGDSyO7ZB+4r4aihj+KTlDs5w==",
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.88",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-      "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+      "version": "6.0.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.60.tgz",
+      "integrity": "sha1-5+E068Z0rm7ZPDbHZ3ObEQ0sV/w=",
       "dev": true
     },
     "@types/q": {
@@ -476,6 +695,16 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.1.tgz",
       "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY=",
       "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.10.0"
+      }
     },
     "array-slice": {
       "version": "1.0.0",
@@ -830,12 +1059,6 @@
         "minimist": "1.2.0"
       }
     },
-    "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
-      "dev": true
-    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -1037,6 +1260,35 @@
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
       "dev": true
     },
+    "cacache": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.1.tgz",
+      "integrity": "sha512-dRHYcs9LvG9cHgdPzjiI+/eS7e1xRhULrcyOx04RZQsszNJXU2SL9CyG60yLnge282Qq5nwTv+ieK2fH+WPZmA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.1",
+        "chownr": "1.0.1",
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "lru-cache": "4.1.1",
+        "mississippi": "1.3.0",
+        "mkdirp": "0.5.1",
+        "move-concurrently": "1.0.1",
+        "promise-inflight": "1.0.1",
+        "rimraf": "2.6.2",
+        "ssri": "5.0.0",
+        "unique-filename": "1.1.0",
+        "y18n": "3.2.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        }
+      }
+    },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -1148,47 +1400,47 @@
         }
       }
     },
-    "charenc": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
-      "dev": true
-    },
     "chart.js": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.1.3.tgz",
-      "integrity": "sha1-cQAn7fwVnW+UnGU3cpQxxy1Nykk=",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.7.1.tgz",
+      "integrity": "sha512-pX1oQAY86MiuyZ2hY593Acbl4MLHKrBBhhmZ1YqSadzQbbsBE2rnd6WISoHjIsdf0WDeC0hbePYCz2ZxkV8L+g==",
       "dev": true,
       "requires": {
-        "chartjs-color": "1.0.22",
+        "chartjs-color": "2.2.0",
         "moment": "2.18.1"
-      }
-    },
-    "chartjs-color": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-1.0.22.tgz",
-      "integrity": "sha1-qZsPdNYHjw/8pBeIQz4U2BRMeiw=",
-      "dev": true,
-      "requires": {
-        "chartjs-color-string": "0.4.0",
-        "color-convert": "0.5.3"
       },
       "dependencies": {
+        "chartjs-color": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.2.0.tgz",
+          "integrity": "sha1-hKL7dVeH7YXDndbdjHsdiEKbrq4=",
+          "dev": true,
+          "requires": {
+            "chartjs-color-string": "0.5.0",
+            "color-convert": "0.5.3"
+          }
+        },
+        "chartjs-color-string": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.5.0.tgz",
+          "integrity": "sha512-amWNvCOXlOUYxZVDSa0YOab5K/lmEhbFNKI55PWc4mlv28BDzA7zaoQTGxSBgJMHIW+hGX8YUrvw/FH4LyhwSQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
         "color-convert": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
           "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=",
           "dev": true
+        },
+        "moment": {
+          "version": "2.18.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+          "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+          "dev": true
         }
-      }
-    },
-    "chartjs-color-string": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.4.0.tgz",
-      "integrity": "sha1-V3SNRTCuKNjbClSSGCugbf3y9Gg=",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
       }
     },
     "chokidar": {
@@ -1199,7 +1451,6 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1225,6 +1476,12 @@
         }
       }
     },
+    "chownr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
+      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
+      "dev": true
+    },
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
@@ -1234,12 +1491,6 @@
         "inherits": "2.0.3",
         "safe-buffer": "5.1.1"
       }
-    },
-    "circular-dependency-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-3.0.0.tgz",
-      "integrity": "sha1-m2hpLjWw41EJmNAWS2rlARvqV2A=",
-      "dev": true
     },
     "clap": {
       "version": "1.2.3",
@@ -1309,12 +1560,6 @@
       "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
       "dev": true
     },
-    "clone-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
-      "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
-      "dev": true
-    },
     "clone-deep": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
@@ -1332,17 +1577,6 @@
       "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
       "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
       "dev": true
-    },
-    "cloneable-readable": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.0.0.tgz",
-      "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "process-nextick-args": "1.0.7",
-        "through2": "2.0.3"
-      }
     },
     "co": {
       "version": "4.6.0",
@@ -1366,9 +1600,9 @@
       "dev": true
     },
     "codelyzer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-3.1.2.tgz",
-      "integrity": "sha1-n/HwQfubXuXb60W6hm368EmDrwQ=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-4.0.1.tgz",
+      "integrity": "sha512-MsOcaiLqcBK7hjHbfp9HZrflqWg5tD9A5qVSXkW208OJ8pkf63id8IiOjEiK/XU3o70W8tWbFKi1tAOwiJDMrQ==",
       "dev": true,
       "requires": {
         "app-root-path": "2.0.1",
@@ -1464,6 +1698,12 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -1511,6 +1751,17 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "typedarray": "0.0.6"
+      }
     },
     "concat-with-sourcemaps": {
       "version": "1.0.4",
@@ -1598,46 +1849,45 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
     },
-    "copy-webpack-plugin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
-      "integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
+    "copy-concurrently": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
+      "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
       "dev": true,
       "requires": {
-        "bluebird": "2.11.0",
-        "fs-extra": "0.26.7",
-        "glob": "6.0.4",
-        "is-glob": "3.1.0",
+        "aproba": "1.2.0",
+        "fs-write-stream-atomic": "1.0.10",
+        "iferr": "0.1.5",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
+    },
+    "copy-webpack-plugin": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.3.1.tgz",
+      "integrity": "sha512-xlcFiW/U7KrpS6dFuWq3r8Wb7koJx7QVc7LDFCosqkikaVSxkaYOnwDLwilbjrszZ0LYZXThDAJKcQCSrvdShQ==",
+      "dev": true,
+      "requires": {
+        "cacache": "10.0.1",
+        "find-cache-dir": "1.0.0",
+        "globby": "7.1.1",
+        "is-glob": "4.0.0",
         "loader-utils": "0.2.17",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
-        "node-dir": "0.1.17"
+        "p-limit": "1.1.0",
+        "pify": "3.0.0",
+        "serialize-javascript": "1.4.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "0.26.7",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-          "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "glob": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-          "dev": true,
-          "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "is-extglob": "2.1.1"
           }
         },
         "loader-utils": {
@@ -1651,6 +1901,12 @@
             "json5": "0.5.1",
             "object-assign": "4.1.1"
           }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -1736,12 +1992,6 @@
         "lru-cache": "4.1.1",
         "which": "1.3.0"
       }
-    },
-    "crypt": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
-      "dev": true
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -1909,6 +2159,12 @@
         "source-map": "0.5.7"
       }
     },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+      "dev": true
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -1922,6 +2178,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
       "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+      "dev": true
+    },
+    "cyclist": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
+      "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
     "d": {
@@ -1999,6 +2261,16 @@
         "clone": "1.0.2"
       }
     },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -2006,12 +2278,12 @@
       "dev": true
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.0.tgz",
+      "integrity": "sha1-mlDwS/NzJeKDtPROmFM2wlJFa9U=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
+        "globby": "4.1.0",
         "is-path-cwd": "1.0.0",
         "is-path-in-cwd": "1.0.0",
         "object-assign": "4.1.1",
@@ -2020,15 +2292,28 @@
         "rimraf": "2.6.2"
       },
       "dependencies": {
+        "glob": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
         "globby": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-4.1.0.tgz",
+          "integrity": "sha1-CA9UVJ7BuCpsYOYx/ILhIR2+lfg=",
           "dev": true,
           "requires": {
             "array-union": "1.0.2",
             "arrify": "1.0.1",
-            "glob": "7.1.2",
+            "glob": "6.0.4",
             "object-assign": "4.1.1",
             "pify": "2.3.0",
             "pinkie-promise": "2.0.1"
@@ -2136,28 +2421,30 @@
         "randombytes": "2.0.5"
       }
     },
-    "directory-encoder": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/directory-encoder/-/directory-encoder-0.7.2.tgz",
-      "integrity": "sha1-WbTiqk8lQi9sY7UntGL14tDdLFg=",
+    "dir-glob": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+      "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
       "dev": true,
       "requires": {
-        "fs-extra": "0.23.1",
-        "handlebars": "1.3.0",
-        "img-stats": "0.5.2"
+        "arrify": "1.0.1",
+        "path-type": "3.0.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "0.23.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
-          "integrity": "sha1-ZhHbpq3yq43Jxp+rN83fiBgVfj0=",
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
+            "pify": "3.0.0"
           }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
         }
       }
     },
@@ -2296,6 +2583,29 @@
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
+        }
+      }
+    },
+    "duplexify": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.1.tgz",
+      "integrity": "sha512-j5goxHTwVED1Fpe5hh3q9R93Kip0Bg2KVAt4f8CEYM3UEwYcPSvWbXaUQOzdX/HtiNomipv+gU7ASQPDbV7pGQ==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "stream-shift": "1.0.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
         }
       }
     },
@@ -2518,6 +2828,30 @@
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
+      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "es5-ext": {
@@ -2811,13 +3145,14 @@
       }
     },
     "express": {
-      "version": "4.15.5",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
-      "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
@@ -2827,22 +3162,23 @@
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.6",
+        "finalhandler": "1.1.0",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.6",
-        "serve-static": "1.12.6",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
+        "utils-merge": "1.0.1",
         "vary": "1.1.2"
       },
       "dependencies": {
@@ -2852,10 +3188,25 @@
           "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
           "dev": true
         },
-        "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg==",
+        "finalhandler": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         }
       }
@@ -2881,18 +3232,6 @@
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
           "dev": true
         }
-      }
-    },
-    "extract-text-webpack-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.0.tgz",
-      "integrity": "sha1-kMqnkHvESfM1AF46x1MrQbAN5hI=",
-      "dev": true,
-      "requires": {
-        "async": "2.5.0",
-        "loader-utils": "1.1.0",
-        "schema-utils": "0.3.0",
-        "webpack-sources": "1.0.1"
       }
     },
     "extsprintf": {
@@ -2966,12 +3305,13 @@
       }
     },
     "file-loader": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-0.10.1.tgz",
-      "integrity": "sha1-gVA0EZiR/GRB+1pkwRvJPCLd2EI=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-1.1.6.tgz",
+      "integrity": "sha512-873ztuL+/hfvXbLDJ262PGO6XjERnybJu2gW1/5j8HUfxSiFJI9Hj/DhZ50ZGRUxBvuNiazb/cM2rh9pqrxP6Q==",
       "dev": true,
       "requires": {
-        "loader-utils": "1.1.0"
+        "loader-utils": "1.1.0",
+        "schema-utils": "0.3.0"
       }
     },
     "filename-regex": {
@@ -3027,6 +3367,17 @@
         "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
+      }
+    },
+    "find-cache-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
+      "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
+      "dev": true,
+      "requires": {
+        "commondir": "1.0.1",
+        "make-dir": "1.1.0",
+        "pkg-dir": "2.0.0"
       }
     },
     "find-index": {
@@ -3116,6 +3467,16 @@
       "integrity": "sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=",
       "dev": true
     },
+    "flush-write-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.2.tgz",
+      "integrity": "sha1-yBuQ2HRnZvGmCaRoCZRsRd2K5Bc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "font-awesome": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
@@ -3136,6 +3497,12 @@
       "requires": {
         "for-in": "1.0.2"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -3165,6 +3532,16 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
     },
     "fs-access": {
       "version": "1.0.1",
@@ -3203,910 +3580,23 @@
         }
       }
     },
+    "fs-write-stream-atomic": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/fs-write-stream-atomic/-/fs-write-stream-atomic-1.0.10.tgz",
+      "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.7.0",
-        "node-pre-gyp": "0.6.36"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ajv": {
-          "version": "4.11.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "aws4": {
-          "version": "1.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "balanced-match": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "block-stream": {
-          "version": "0.0.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
-        },
-        "boom": {
-          "version": "2.10.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "brace-expansion": {
-          "version": "1.1.7",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
-        },
-        "buffer-shims": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "co": {
-          "version": "4.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.4.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "extend": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "extsprintf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "fstream": {
-          "version": "1.0.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
-        },
-        "fstream-ignore": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.1.11",
-          "bundled": true,
-          "dev": true
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "hoek": {
-          "version": "2.16.3",
-          "bundled": true,
-          "dev": true
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jodid25519": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsonify": {
-          "version": "0.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "jsprim": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "mime-db": {
-          "version": "1.27.0",
-          "bundled": true,
-          "dev": true
-        },
-        "mime-types": {
-          "version": "2.1.15",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "node-pre-gyp": {
-          "version": "0.6.36",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.2.9",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "semver": {
-          "version": "5.3.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "sshpk": {
-          "version": "1.13.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
-          "dependencies": {
-            "assert-plus": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "2.2.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
-        },
-        "tar-pack": {
-          "version": "3.4.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "uid-number": {
-          "version": "0.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "verror": {
-          "version": "1.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -4121,13 +3611,12 @@
       }
     },
     "fullcalendar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-3.5.1.tgz",
-      "integrity": "sha1-xw1kLKGNKFT7uXqbT17s72qj6IQ=",
-      "dev": true,
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-3.7.0.tgz",
+      "integrity": "sha1-dDCZQ3kKAIVkfvdnHIHIUvaLSig=",
       "requires": {
         "jquery": "3.2.1",
-        "moment": "2.18.1"
+        "moment": "2.20.1"
       }
     },
     "function-bind": {
@@ -4441,16 +3930,25 @@
       "dev": true
     },
     "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
+      "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
       "dev": true,
       "requires": {
         "array-union": "1.0.2",
+        "dir-glob": "2.0.0",
         "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "ignore": "3.3.7",
+        "pify": "3.0.0",
+        "slash": "1.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
       }
     },
     "globule": {
@@ -4539,46 +4037,48 @@
       }
     },
     "gulp-concat": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.1.tgz",
-      "integrity": "sha1-Yz0WyV2IUEYorQJmVmPO5aR5M1M=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.6.0.tgz",
+      "integrity": "sha1-WFz7EVQR80h3MTEUBWa2qBxpy5E=",
       "dev": true,
       "requires": {
         "concat-with-sourcemaps": "1.0.4",
-        "through2": "2.0.3",
-        "vinyl": "2.1.0"
+        "gulp-util": "3.0.8",
+        "through2": "0.6.5"
       },
       "dependencies": {
-        "clone": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-          "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
         },
-        "clone-stats": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
-          "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
-          "dev": true
-        },
-        "replace-ext": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
-          "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=",
-          "dev": true
-        },
-        "vinyl": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-          "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "clone": "2.1.1",
-            "clone-buffer": "1.0.0",
-            "clone-stats": "1.0.0",
-            "cloneable-readable": "1.0.0",
-            "remove-trailing-separator": "1.1.0",
-            "replace-ext": "1.0.0"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        },
+        "through2": {
+          "version": "0.6.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+          "dev": true,
+          "requires": {
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           }
         }
       }
@@ -4680,9 +4180,9 @@
       }
     },
     "gulp-uglifycss": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/gulp-uglifycss/-/gulp-uglifycss-1.0.8.tgz",
-      "integrity": "sha1-oYlcVhS0hQ6kLekZn8XE+3XSPnw=",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/gulp-uglifycss/-/gulp-uglifycss-1.0.6.tgz",
+      "integrity": "sha1-5RRTUv4KG8lGGIrR8FXdms+gmWA=",
       "dev": true,
       "requires": {
         "gulp-util": "3.0.8",
@@ -4757,47 +4257,6 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
       "integrity": "sha1-/Xqtcmvxpf0W38KbL3pmAdJxOcQ=",
       "dev": true
-    },
-    "handlebars": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-1.3.0.tgz",
-      "integrity": "sha1-npsTCpPjiUkTItl1zz7BgYw3zjQ=",
-      "dev": true,
-      "requires": {
-        "optimist": "0.3.7",
-        "uglify-js": "2.3.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true,
-          "optional": true
-        },
-        "source-map": {
-          "version": "0.1.43",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        },
-        "uglify-js": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
-          "integrity": "sha1-+gmEdwtCi3qbKoBY9GNV0U/vIRo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "async": "0.2.10",
-            "optimist": "0.3.7",
-            "source-map": "0.1.43"
-          }
-        }
-      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -4913,25 +4372,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
-    },
-    "heimdalljs": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/heimdalljs/-/heimdalljs-0.2.5.tgz",
-      "integrity": "sha1-aqVDCO7nk7ZCz/nPlHgURfN3MKw=",
-      "dev": true,
-      "requires": {
-        "rsvp": "3.2.1"
-      }
-    },
-    "heimdalljs-logger": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/heimdalljs-logger/-/heimdalljs-logger-0.1.9.tgz",
-      "integrity": "sha1-12raTkW3u294b8nAEKaOsuL68XY=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "heimdalljs": "0.2.5"
-      }
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -5215,6 +4655,18 @@
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
+    "iferr": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
+      "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
+      "dev": true
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
     "image-size": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz",
@@ -5222,14 +4674,21 @@
       "dev": true,
       "optional": true
     },
-    "img-stats": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/img-stats/-/img-stats-0.5.2.tgz",
-      "integrity": "sha1-wgNJbELy2esuWrgjL6dWurMsnis=",
+    "import-local": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
       "dev": true,
       "requires": {
-        "xmldom": "0.1.27"
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "in-publish": {
       "version": "2.0.0",
@@ -5330,9 +4789,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A=",
       "dev": true
     },
     "is-absolute": {
@@ -5380,6 +4839,18 @@
       "requires": {
         "builtin-modules": "1.1.1"
       }
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-directory": {
       "version": "0.3.1",
@@ -5501,6 +4972,15 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
     "is-relative": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
@@ -5524,6 +5004,12 @@
       "requires": {
         "html-comment-regex": "1.1.1"
       }
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5847,8 +5333,7 @@
     "jquery": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz",
-      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c=",
-      "dev": true
+      "integrity": "sha1-XE2d5lKvbNCncBVKYxu6ErAVx4c="
     },
     "js-base64": {
       "version": "2.3.2",
@@ -5929,15 +5414,6 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
-    },
-    "jsonfile": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
-      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -6075,6 +5551,12 @@
         "source-map-support": "0.4.18"
       }
     },
+    "killable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+      "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -6082,15 +5564,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "1.1.5"
-      }
-    },
-    "klaw": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11"
       }
     },
     "lazy-cache": {
@@ -6508,6 +5981,23 @@
         "vlq": "0.2.2"
       }
     },
+    "make-dir": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
+      "dev": true,
+      "requires": {
+        "pify": "3.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        }
+      }
+    },
     "make-error": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.0.tgz",
@@ -6531,17 +6021,6 @@
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
       "dev": true
-    },
-    "md5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-      "dev": true,
-      "requires": {
-        "charenc": "0.0.2",
-        "crypt": "0.0.2",
-        "is-buffer": "1.1.5"
-      }
     },
     "md5.js": {
       "version": "1.3.4",
@@ -6722,6 +6201,35 @@
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
       "dev": true
     },
+    "mississippi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-1.3.0.tgz",
+      "integrity": "sha1-0gFYPrEjJ+PFwWQqQEqcrPlONPU=",
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "duplexify": "3.5.1",
+        "end-of-stream": "1.4.0",
+        "flush-write-stream": "1.0.2",
+        "from2": "2.3.0",
+        "parallel-transform": "1.1.0",
+        "pump": "1.0.3",
+        "pumpify": "1.3.5",
+        "stream-each": "1.2.2",
+        "through2": "2.0.3"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        }
+      }
+    },
     "mixin-object": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
@@ -6758,10 +6266,23 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
-      "dev": true
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
+      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg=="
+    },
+    "move-concurrently": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
+      "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "copy-concurrently": "1.0.5",
+        "fs-write-stream-atomic": "1.0.10",
+        "mkdirp": "0.5.1",
+        "rimraf": "2.6.2",
+        "run-queue": "1.0.3"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -6822,6 +6343,11 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
+    "ng2-logger": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ng2-logger/-/ng2-logger-1.0.3.tgz",
+      "integrity": "sha1-G0SvP+nxS7J4CaQ2U3XT8lkhNng="
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -6829,15 +6355,6 @@
       "dev": true,
       "requires": {
         "lower-case": "1.1.4"
-      }
-    },
-    "node-dir": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
-      "dev": true,
-      "requires": {
-        "minimatch": "3.0.4"
       }
     },
     "node-forge": {
@@ -7032,19 +6549,20 @@
       }
     },
     "npm": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-5.4.2.tgz",
-      "integrity": "sha512-F6LLCAHriKyKQ9Ff03UKCjkXZoRBp281I42K42+VeHfjAXZ3TJdg3RccinzoCFV1kDxCedVm7AstIpb1Uf5UkQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-5.0.1.tgz",
+      "integrity": "sha512-QGwOzpe5Exdh/k0tM9SbYIKEo73XICxkNAV7K9ACokKKTO1yZsIIXglmxxP+FJHhbm8Zbd23HauhyA05eG/Xug==",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "abbrev": "1.1.0",
-        "ansi-regex": "3.0.0",
+        "ansi-regex": "2.1.1",
         "ansicolors": "0.3.2",
         "ansistyles": "0.1.3",
-        "aproba": "1.1.2",
+        "aproba": "1.1.1",
         "archy": "1.0.0",
         "bluebird": "3.5.0",
-        "cacache": "9.2.9",
+        "cacache": "9.2.6",
         "call-limit": "1.1.0",
         "chownr": "1.0.1",
         "cmd-shim": "2.0.2",
@@ -7056,19 +6574,19 @@
         "editor": "1.0.0",
         "fs-vacuum": "1.2.10",
         "fs-write-stream-atomic": "1.0.10",
+        "fstream": "1.0.11",
+        "fstream-npm": "1.2.1",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
         "has-unicode": "2.0.1",
-        "hosted-git-info": "2.5.0",
+        "hosted-git-info": "2.4.2",
         "iferr": "0.1.5",
         "imurmurhash": "0.1.4",
         "inflight": "1.0.6",
         "inherits": "2.0.3",
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
-        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
-        "libnpx": "9.6.0",
         "lockfile": "1.0.3",
         "lodash._baseindexof": "3.1.0",
         "lodash._baseuniq": "4.6.0",
@@ -7081,69 +6599,86 @@
         "lodash.union": "4.6.0",
         "lodash.uniq": "4.5.0",
         "lodash.without": "4.4.0",
-        "lru-cache": "4.1.1",
-        "meant": "1.0.0",
+        "lru-cache": "4.0.2",
         "mississippi": "1.3.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
-        "node-gyp": "3.6.2",
+        "node-gyp": "3.6.1",
         "nopt": "4.0.1",
-        "normalize-package-data": "2.4.0",
+        "normalize-package-data": "2.3.8",
         "npm-cache-filename": "1.0.2",
         "npm-install-checks": "3.0.0",
-        "npm-lifecycle": "1.0.2",
-        "npm-package-arg": "5.1.2",
-        "npm-packlist": "1.1.8",
-        "npm-registry-client": "8.4.0",
+        "npm-package-arg": "5.0.1",
+        "npm-registry-client": "8.3.0",
         "npm-user-validate": "1.0.0",
-        "npmlog": "4.1.2",
+        "npmlog": "4.1.0",
         "once": "1.4.0",
         "opener": "1.4.3",
         "osenv": "0.1.4",
-        "pacote": "6.0.2",
+        "pacote": "2.7.26",
         "path-is-inside": "1.0.2",
         "promise-inflight": "1.0.1",
         "read": "1.0.7",
         "read-cmd-shim": "1.0.1",
         "read-installed": "4.0.3",
-        "read-package-json": "2.0.12",
-        "read-package-tree": "5.1.6",
-        "readable-stream": "2.3.3",
+        "read-package-json": "2.0.5",
+        "read-package-tree": "5.1.5",
+        "readable-stream": "2.2.9",
         "readdir-scoped-modules": "1.0.2",
         "request": "2.81.0",
         "retry": "0.10.1",
         "rimraf": "2.6.1",
-        "safe-buffer": "5.1.1",
-        "semver": "5.4.1",
+        "safe-buffer": "5.0.1",
+        "semver": "5.3.0",
         "sha": "2.0.1",
         "slide": "1.1.6",
         "sorted-object": "2.0.1",
         "sorted-union-stream": "2.1.3",
-        "ssri": "4.1.6",
-        "strip-ansi": "4.0.0",
-        "tar": "4.0.1",
+        "ssri": "4.1.4",
+        "strip-ansi": "3.0.1",
+        "tar": "2.2.1",
         "text-table": "0.2.0",
         "uid-number": "0.0.6",
         "umask": "1.1.0",
         "unique-filename": "1.1.0",
         "unpipe": "1.0.0",
-        "update-notifier": "2.2.0",
-        "uuid": "3.1.0",
+        "update-notifier": "2.1.0",
+        "uuid": "3.0.1",
         "validate-npm-package-license": "3.0.1",
         "validate-npm-package-name": "3.0.0",
-        "which": "1.3.0",
-        "worker-farm": "1.5.0",
+        "which": "1.2.14",
         "wrappy": "1.0.2",
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "jsonparse": "1.3.0",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.0",
+              "bundled": true,
+              "dev": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true,
+              "dev": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true,
           "dev": true
         },
         "ansi-regex": {
-          "version": "3.0.0",
+          "version": "2.1.1",
           "bundled": true,
           "dev": true
         },
@@ -7158,7 +6693,7 @@
           "dev": true
         },
         "aproba": {
-          "version": "1.1.2",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true
         },
@@ -7173,7 +6708,7 @@
           "dev": true
         },
         "cacache": {
-          "version": "9.2.9",
+          "version": "9.2.6",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -7181,38 +6716,17 @@
             "chownr": "1.0.1",
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "lru-cache": "4.1.1",
+            "lru-cache": "4.0.2",
             "mississippi": "1.3.0",
             "mkdirp": "0.5.1",
             "move-concurrently": "1.0.1",
             "promise-inflight": "1.0.1",
             "rimraf": "2.6.1",
-            "ssri": "4.1.6",
+            "ssri": "4.1.4",
             "unique-filename": "1.1.0",
             "y18n": "3.2.1"
           },
           "dependencies": {
-            "lru-cache": {
-              "version": "4.1.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
-              },
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
             "y18n": {
               "version": "3.2.1",
               "bundled": true,
@@ -7248,21 +6762,6 @@
             "wcwidth": "1.0.1"
           },
           "dependencies": {
-            "strip-ansi": {
-              "version": "3.0.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "ansi-regex": "2.1.1"
-              },
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
             "wcwidth": {
               "version": "1.0.1",
               "bundled": true,
@@ -7355,7 +6854,72 @@
             "graceful-fs": "4.1.11",
             "iferr": "0.1.5",
             "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.2.9"
+          }
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-npm": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fstream-ignore": "1.0.5",
+            "inherits": "2.0.3"
+          },
+          "dependencies": {
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              },
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "brace-expansion": "1.1.7"
+                  },
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.7",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "balanced-match": "0.4.2",
+                        "concat-map": "0.0.1"
+                      },
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.4.2",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
         },
         "glob": {
@@ -7381,20 +6945,20 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.8",
+                  "version": "1.1.7",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "0.4.2",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
                     "balanced-match": {
-                      "version": "1.0.0",
+                      "version": "0.4.2",
                       "bundled": true,
                       "dev": true
                     },
@@ -7425,7 +6989,7 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "2.5.0",
+          "version": "2.4.2",
           "bundled": true,
           "dev": true
         },
@@ -7464,11 +7028,11 @@
           "dev": true,
           "requires": {
             "glob": "7.1.2",
-            "npm-package-arg": "5.1.2",
+            "npm-package-arg": "5.0.1",
             "promzard": "0.3.0",
             "read": "1.0.7",
-            "read-package-json": "2.0.12",
-            "semver": "5.4.1",
+            "read-package-json": "2.0.5",
+            "semver": "5.3.0",
             "validate-npm-package-license": "3.0.1",
             "validate-npm-package-name": "3.0.0"
           },
@@ -7483,459 +7047,10 @@
             }
           }
         },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true,
-              "dev": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "lazy-property": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
-        },
-        "libnpx": {
-          "version": "9.6.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "dotenv": "4.0.0",
-            "npm-package-arg": "5.1.2",
-            "rimraf": "2.6.1",
-            "safe-buffer": "5.1.1",
-            "update-notifier": "2.2.0",
-            "which": "1.3.0",
-            "y18n": "3.2.1",
-            "yargs": "8.0.2"
-          },
-          "dependencies": {
-            "dotenv": {
-              "version": "4.0.0",
-              "bundled": true,
-              "dev": true
-            },
-            "y18n": {
-              "version": "3.2.1",
-              "bundled": true,
-              "dev": true
-            },
-            "yargs": {
-              "version": "8.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "camelcase": "4.1.0",
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "os-locale": "2.1.0",
-                "read-pkg-up": "2.0.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "7.0.0"
-              },
-              "dependencies": {
-                "camelcase": {
-                  "version": "4.1.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "cliui": {
-                  "version": "3.2.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "string-width": "1.0.2",
-                    "strip-ansi": "3.0.1",
-                    "wrap-ansi": "2.1.0"
-                  },
-                  "dependencies": {
-                    "string-width": {
-                      "version": "1.0.2",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
-                      },
-                      "dependencies": {
-                        "code-point-at": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "is-fullwidth-code-point": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "number-is-nan": "1.0.1"
-                          },
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "2.1.1"
-                      },
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1"
-                      }
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "dev": true
-                },
-                "os-locale": {
-                  "version": "2.1.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "execa": "0.7.0",
-                    "lcid": "1.0.0",
-                    "mem": "1.1.0"
-                  },
-                  "dependencies": {
-                    "execa": {
-                      "version": "0.7.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
-                      },
-                      "dependencies": {
-                        "cross-spawn": {
-                          "version": "5.1.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "lru-cache": "4.1.1",
-                            "shebang-command": "1.2.0",
-                            "which": "1.3.0"
-                          },
-                          "dependencies": {
-                            "shebang-command": {
-                              "version": "1.2.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "shebang-regex": "1.0.0"
-                              },
-                              "dependencies": {
-                                "shebang-regex": {
-                                  "version": "1.0.0",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "get-stream": {
-                          "version": "3.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "npm-run-path": {
-                          "version": "2.0.2",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "path-key": "2.0.1"
-                          },
-                          "dependencies": {
-                            "path-key": {
-                              "version": "2.0.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "p-finally": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "signal-exit": {
-                          "version": "3.0.2",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "strip-eof": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "lcid": {
-                      "version": "1.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "invert-kv": "1.0.0"
-                      },
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    },
-                    "mem": {
-                      "version": "1.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "mimic-fn": "1.1.0"
-                      },
-                      "dependencies": {
-                        "mimic-fn": {
-                          "version": "1.1.0",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "find-up": "2.1.0",
-                    "read-pkg": "2.0.0"
-                  },
-                  "dependencies": {
-                    "find-up": {
-                      "version": "2.1.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "locate-path": "2.0.0"
-                      },
-                      "dependencies": {
-                        "locate-path": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "p-locate": "2.0.0",
-                            "path-exists": "3.0.0"
-                          },
-                          "dependencies": {
-                            "p-locate": {
-                              "version": "2.0.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "p-limit": "1.1.0"
-                              },
-                              "dependencies": {
-                                "p-limit": {
-                                  "version": "1.1.0",
-                                  "bundled": true,
-                                  "dev": true
-                                }
-                              }
-                            },
-                            "path-exists": {
-                              "version": "3.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "load-json-file": "2.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "2.0.0"
-                      },
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "graceful-fs": "4.1.11",
-                            "parse-json": "2.2.0",
-                            "pify": "2.3.0",
-                            "strip-bom": "3.0.0"
-                          },
-                          "dependencies": {
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "bundled": true,
-                              "dev": true,
-                              "requires": {
-                                "error-ex": "1.3.1"
-                              },
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.1",
-                                  "bundled": true,
-                                  "dev": true,
-                                  "requires": {
-                                    "is-arrayish": "0.2.1"
-                                  },
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "bundled": true,
-                                      "dev": true
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true,
-                              "dev": true
-                            },
-                            "strip-bom": {
-                              "version": "3.0.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "2.0.0",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "pify": "2.3.0"
-                          },
-                          "dependencies": {
-                            "pify": {
-                              "version": "2.3.0",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "dev": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "string-width": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
-                  },
-                  "dependencies": {
-                    "is-fullwidth-code-point": {
-                      "version": "2.0.0",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "dev": true
-                },
-                "yargs-parser": {
-                  "version": "7.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "camelcase": "4.1.0"
-                  }
-                }
-              }
-            }
-          }
         },
         "lockfile": {
           "version": "1.0.3",
@@ -8017,7 +7132,7 @@
           "dev": true
         },
         "lru-cache": {
-          "version": "4.1.1",
+          "version": "4.0.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8036,11 +7151,6 @@
               "dev": true
             }
           }
-        },
-        "meant": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
         },
         "mississippi": {
           "version": "1.3.0",
@@ -8065,7 +7175,7 @@
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.2.9",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
@@ -8083,7 +7193,7 @@
               "requires": {
                 "end-of-stream": "1.0.0",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.2.9",
                 "stream-shift": "1.0.0"
               },
               "dependencies": {
@@ -8126,7 +7236,7 @@
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.2.9"
               }
             },
             "from2": {
@@ -8135,7 +7245,7 @@
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.2.9"
               }
             },
             "parallel-transform": {
@@ -8145,7 +7255,7 @@
               "requires": {
                 "cyclist": "0.2.2",
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.2.9"
               },
               "dependencies": {
                 "cyclist": {
@@ -8195,7 +7305,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.2.9",
                 "xtend": "4.0.1"
               },
               "dependencies": {
@@ -8228,7 +7338,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "1.1.2",
+            "aproba": "1.1.1",
             "copy-concurrently": "1.0.3",
             "fs-write-stream-atomic": "1.0.10",
             "mkdirp": "0.5.1",
@@ -8241,7 +7351,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aproba": "1.1.2",
+                "aproba": "1.1.1",
                 "fs-write-stream-atomic": "1.0.10",
                 "iferr": "0.1.5",
                 "mkdirp": "0.5.1",
@@ -8254,13 +7364,13 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aproba": "1.1.2"
+                "aproba": "1.1.1"
               }
             }
           }
         },
         "node-gyp": {
-          "version": "3.6.2",
+          "version": "3.6.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8270,45 +7380,34 @@
             "minimatch": "3.0.4",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
-            "npmlog": "4.1.2",
+            "npmlog": "4.1.0",
             "osenv": "0.1.4",
             "request": "2.81.0",
             "rimraf": "2.6.1",
             "semver": "5.3.0",
             "tar": "2.2.1",
-            "which": "1.3.0"
+            "which": "1.2.14"
           },
           "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
-              }
-            },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.8",
+                  "version": "1.1.7",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "0.4.2",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
                     "balanced-match": {
-                      "version": "1.0.0",
+                      "version": "0.4.2",
                       "bundled": true,
                       "dev": true
                     },
@@ -8328,31 +7427,6 @@
               "requires": {
                 "abbrev": "1.1.0"
               }
-            },
-            "semver": {
-              "version": "5.3.0",
-              "bundled": true,
-              "dev": true
-            },
-            "tar": {
-              "version": "2.2.1",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
-              },
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "inherits": "2.0.3"
-                  }
-                }
-              }
             }
           }
         },
@@ -8366,13 +7440,13 @@
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.3.8",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
+            "hosted-git-info": "2.4.2",
             "is-builtin-module": "1.0.0",
-            "semver": "5.4.1",
+            "semver": "5.3.0",
             "validate-npm-package-license": "3.0.1"
           },
           "dependencies": {
@@ -8403,105 +7477,36 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "semver": "5.4.1"
-          }
-        },
-        "npm-lifecycle": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "slide": "1.1.6",
-            "uid-number": "0.0.6",
-            "umask": "1.1.0",
-            "which": "1.3.0"
+            "semver": "5.3.0"
           }
         },
         "npm-package-arg": {
-          "version": "5.1.2",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "hosted-git-info": "2.5.0",
+            "hosted-git-info": "2.4.2",
             "osenv": "0.1.4",
-            "semver": "5.4.1",
+            "semver": "5.3.0",
             "validate-npm-package-name": "3.0.0"
           }
         },
-        "npm-packlist": {
-          "version": "1.1.8",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ignore-walk": "3.0.0",
-            "npm-bundled": "1.0.3"
-          },
-          "dependencies": {
-            "ignore-walk": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minimatch": "3.0.4"
-              },
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "brace-expansion": "1.1.8"
-                  },
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "balanced-match": "1.0.0",
-                        "concat-map": "0.0.1"
-                      },
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "bundled": true,
-                          "dev": true
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "bundled": true,
-                          "dev": true
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "npm-bundled": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
         "npm-registry-client": {
-          "version": "8.4.0",
+          "version": "8.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
             "concat-stream": "1.6.0",
             "graceful-fs": "4.1.11",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npmlog": "4.1.2",
+            "normalize-package-data": "2.3.8",
+            "npm-package-arg": "5.0.1",
+            "npmlog": "4.1.0",
             "once": "1.4.0",
             "request": "2.81.0",
             "retry": "0.10.1",
-            "semver": "5.4.1",
+            "semver": "5.3.0",
             "slide": "1.1.6",
-            "ssri": "4.1.6"
+            "ssri": "4.1.4"
           },
           "dependencies": {
             "concat-stream": {
@@ -8510,7 +7515,7 @@
               "dev": true,
               "requires": {
                 "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.2.9",
                 "typedarray": "0.0.6"
               },
               "dependencies": {
@@ -8529,7 +7534,7 @@
           "dev": true
         },
         "npmlog": {
-          "version": "4.1.2",
+          "version": "4.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -8545,7 +7550,7 @@
               "dev": true,
               "requires": {
                 "delegates": "1.0.0",
-                "readable-stream": "2.3.3"
+                "readable-stream": "2.2.9"
               },
               "dependencies": {
                 "delegates": {
@@ -8565,14 +7570,14 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "aproba": "1.1.2",
+                "aproba": "1.1.1",
                 "console-control-strings": "1.1.0",
                 "has-unicode": "2.0.1",
                 "object-assign": "4.1.1",
                 "signal-exit": "3.0.2",
                 "string-width": "1.0.2",
                 "strip-ansi": "3.0.1",
-                "wide-align": "1.1.2"
+                "wide-align": "1.1.0"
               },
               "dependencies": {
                 "object-assign": {
@@ -8617,23 +7622,8 @@
                     }
                   }
                 },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
                 "wide-align": {
-                  "version": "1.1.2",
+                  "version": "1.1.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -8684,53 +7674,53 @@
           }
         },
         "pacote": {
-          "version": "6.0.2",
+          "version": "2.7.26",
           "bundled": true,
           "dev": true,
           "requires": {
             "bluebird": "3.5.0",
-            "cacache": "9.2.9",
+            "cacache": "9.2.6",
             "glob": "7.1.2",
-            "lru-cache": "4.1.1",
-            "make-fetch-happen": "2.5.0",
+            "lru-cache": "4.0.2",
+            "make-fetch-happen": "2.4.10",
             "minimatch": "3.0.4",
             "mississippi": "1.3.0",
-            "normalize-package-data": "2.4.0",
-            "npm-package-arg": "5.1.2",
-            "npm-packlist": "1.1.8",
-            "npm-pick-manifest": "1.0.4",
+            "normalize-package-data": "2.3.8",
+            "npm-package-arg": "5.0.1",
+            "npm-pick-manifest": "1.0.3",
             "osenv": "0.1.4",
             "promise-inflight": "1.0.1",
             "promise-retry": "1.1.1",
             "protoduck": "4.0.0",
-            "safe-buffer": "5.1.1",
-            "semver": "5.4.1",
-            "ssri": "4.1.6",
-            "tar": "4.0.1",
+            "safe-buffer": "5.0.1",
+            "semver": "5.3.0",
+            "ssri": "4.1.4",
+            "tar-fs": "1.15.2",
+            "tar-stream": "1.5.4",
             "unique-filename": "1.1.0",
-            "which": "1.3.0"
+            "which": "1.2.14"
           },
           "dependencies": {
             "make-fetch-happen": {
-              "version": "2.5.0",
+              "version": "2.4.10",
               "bundled": true,
               "dev": true,
               "requires": {
-                "agentkeepalive": "3.3.0",
-                "cacache": "9.2.9",
+                "agentkeepalive": "3.1.0",
+                "cacache": "9.2.6",
                 "http-cache-semantics": "3.7.3",
-                "http-proxy-agent": "2.0.0",
-                "https-proxy-agent": "2.1.0",
-                "lru-cache": "4.1.1",
+                "http-proxy-agent": "1.0.0",
+                "https-proxy-agent": "1.0.0",
+                "lru-cache": "4.0.2",
                 "mississippi": "1.3.0",
-                "node-fetch-npm": "2.0.2",
+                "node-fetch-npm": "2.0.1",
                 "promise-retry": "1.1.1",
-                "socks-proxy-agent": "3.0.0",
-                "ssri": "4.1.6"
+                "socks-proxy-agent": "2.1.0",
+                "ssri": "4.1.4"
               },
               "dependencies": {
                 "agentkeepalive": {
-                  "version": "3.3.0",
+                  "version": "3.1.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -8760,36 +7750,28 @@
                   "dev": true
                 },
                 "http-proxy-agent": {
-                  "version": "2.0.0",
+                  "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.8"
+                    "agent-base": "2.1.1",
+                    "debug": "2.6.8",
+                    "extend": "3.0.1"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "2.1.1",
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "extend": "3.0.1",
+                        "semver": "5.0.3"
                       },
                       "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
+                        "semver": {
+                          "version": "5.0.3",
                           "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
+                          "dev": true
                         }
                       }
                     },
@@ -8807,40 +7789,37 @@
                           "dev": true
                         }
                       }
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "https-proxy-agent": {
-                  "version": "2.1.0",
+                  "version": "1.0.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "4.1.1",
-                    "debug": "2.6.8"
+                    "agent-base": "2.1.1",
+                    "debug": "2.6.8",
+                    "extend": "3.0.1"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "2.1.1",
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "extend": "3.0.1",
+                        "semver": "5.0.3"
                       },
                       "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
+                        "semver": {
+                          "version": "5.0.3",
                           "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
+                          "dev": true
                         }
                       }
                     },
@@ -8858,17 +7837,22 @@
                           "dev": true
                         }
                       }
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
                     }
                   }
                 },
                 "node-fetch-npm": {
-                  "version": "2.0.2",
+                  "version": "2.0.1",
                   "bundled": true,
                   "dev": true,
                   "requires": {
                     "encoding": "0.1.12",
-                    "json-parse-better-errors": "1.0.1",
-                    "safe-buffer": "5.1.1"
+                    "json-parse-helpfulerror": "1.0.3",
+                    "safe-buffer": "5.0.1"
                   },
                   "dependencies": {
                     "encoding": {
@@ -8876,56 +7860,63 @@
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "iconv-lite": "0.4.18"
+                        "iconv-lite": "0.4.17"
                       },
                       "dependencies": {
                         "iconv-lite": {
-                          "version": "0.4.18",
+                          "version": "0.4.17",
                           "bundled": true,
                           "dev": true
                         }
                       }
                     },
-                    "json-parse-better-errors": {
-                      "version": "1.0.1",
+                    "json-parse-helpfulerror": {
+                      "version": "1.0.3",
                       "bundled": true,
-                      "dev": true
+                      "dev": true,
+                      "requires": {
+                        "jju": "1.3.0"
+                      },
+                      "dependencies": {
+                        "jju": {
+                          "version": "1.3.0",
+                          "bundled": true,
+                          "dev": true
+                        }
+                      }
                     }
                   }
                 },
                 "socks-proxy-agent": {
-                  "version": "3.0.0",
+                  "version": "2.1.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "agent-base": "4.1.1",
+                    "agent-base": "2.1.1",
+                    "extend": "3.0.1",
                     "socks": "1.1.10"
                   },
                   "dependencies": {
                     "agent-base": {
-                      "version": "4.1.1",
+                      "version": "2.1.1",
                       "bundled": true,
                       "dev": true,
                       "requires": {
-                        "es6-promisify": "5.0.0"
+                        "extend": "3.0.1",
+                        "semver": "5.0.3"
                       },
                       "dependencies": {
-                        "es6-promisify": {
-                          "version": "5.0.0",
+                        "semver": {
+                          "version": "5.0.3",
                           "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "es6-promise": "4.1.1"
-                          },
-                          "dependencies": {
-                            "es6-promise": {
-                              "version": "4.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
+                          "dev": true
                         }
                       }
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "dev": true
                     },
                     "socks": {
                       "version": "1.1.10",
@@ -8957,20 +7948,20 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "1.1.7"
               },
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.8",
+                  "version": "1.1.7",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "balanced-match": "1.0.0",
+                    "balanced-match": "0.4.2",
                     "concat-map": "0.0.1"
                   },
                   "dependencies": {
                     "balanced-match": {
-                      "version": "1.0.0",
+                      "version": "0.4.2",
                       "bundled": true,
                       "dev": true
                     },
@@ -8984,12 +7975,12 @@
               }
             },
             "npm-pick-manifest": {
-              "version": "1.0.4",
+              "version": "1.0.3",
               "bundled": true,
               "dev": true,
               "requires": {
-                "npm-package-arg": "5.1.2",
-                "semver": "5.4.1"
+                "npm-package-arg": "5.0.1",
+                "semver": "5.3.0"
               }
             },
             "promise-retry": {
@@ -9017,6 +8008,72 @@
               },
               "dependencies": {
                 "genfun": {
+                  "version": "4.0.1",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
+            },
+            "tar-fs": {
+              "version": "1.15.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "chownr": "1.0.1",
+                "mkdirp": "0.5.1",
+                "pump": "1.0.2",
+                "tar-stream": "1.5.4"
+              },
+              "dependencies": {
+                "pump": {
+                  "version": "1.0.2",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "end-of-stream": "1.4.0",
+                    "once": "1.4.0"
+                  },
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "once": "1.4.0"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "1.5.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "bl": "1.2.1",
+                "end-of-stream": "1.4.0",
+                "readable-stream": "2.2.9",
+                "xtend": "4.0.1"
+              },
+              "dependencies": {
+                "bl": {
+                  "version": "1.2.1",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "readable-stream": "2.2.9"
+                  }
+                },
+                "end-of-stream": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "once": "1.4.0"
+                  }
+                },
+                "xtend": {
                   "version": "4.0.1",
                   "bundled": true,
                   "dev": true
@@ -9065,9 +8122,9 @@
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.11",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.5",
             "readdir-scoped-modules": "1.0.2",
-            "semver": "5.4.1",
+            "semver": "5.3.0",
             "slide": "1.1.6",
             "util-extend": "1.0.3"
           },
@@ -9080,55 +8137,64 @@
           }
         },
         "read-package-json": {
-          "version": "2.0.12",
+          "version": "2.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
-            "json-parse-better-errors": "1.0.1",
-            "normalize-package-data": "2.4.0",
-            "slash": "1.0.0"
+            "json-parse-helpfulerror": "1.0.3",
+            "normalize-package-data": "2.3.8"
           },
           "dependencies": {
-            "json-parse-better-errors": {
-              "version": "1.0.1",
+            "json-parse-helpfulerror": {
+              "version": "1.0.3",
               "bundled": true,
-              "dev": true
-            },
-            "slash": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true
+              "dev": true,
+              "requires": {
+                "jju": "1.3.0"
+              },
+              "dependencies": {
+                "jju": {
+                  "version": "1.3.0",
+                  "bundled": true,
+                  "dev": true
+                }
+              }
             }
           }
         },
         "read-package-tree": {
-          "version": "5.1.6",
+          "version": "5.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
             "once": "1.4.0",
-            "read-package-json": "2.0.12",
+            "read-package-json": "2.0.5",
             "readdir-scoped-modules": "1.0.2"
           }
         },
         "readable-stream": {
-          "version": "2.3.3",
+          "version": "2.2.9",
           "bundled": true,
           "dev": true,
           "requires": {
+            "buffer-shims": "1.0.0",
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
             "isarray": "1.0.0",
             "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
+            "string_decoder": "1.0.0",
             "util-deprecate": "1.0.2"
           },
           "dependencies": {
+            "buffer-shims": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true
+            },
             "core-util-is": {
               "version": "1.0.2",
               "bundled": true,
@@ -9145,11 +8211,11 @@
               "dev": true
             },
             "string_decoder": {
-              "version": "1.0.3",
+              "version": "1.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "buffer-shims": "1.0.0"
               }
             },
             "util-deprecate": {
@@ -9192,11 +8258,11 @@
             "oauth-sign": "0.8.2",
             "performance-now": "0.2.0",
             "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
+            "safe-buffer": "5.0.1",
             "stringstream": "0.0.5",
             "tough-cookie": "2.3.2",
             "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "uuid": "3.0.1"
           },
           "dependencies": {
             "aws-sign2": {
@@ -9352,7 +8418,7 @@
               "requires": {
                 "assert-plus": "0.2.0",
                 "jsprim": "1.4.0",
-                "sshpk": "1.13.1"
+                "sshpk": "1.13.0"
               },
               "dependencies": {
                 "assert-plus": {
@@ -9397,7 +8463,7 @@
                   }
                 },
                 "sshpk": {
-                  "version": "1.13.1",
+                  "version": "1.13.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
@@ -9407,6 +8473,7 @@
                     "dashdash": "1.14.1",
                     "ecc-jsbn": "0.1.1",
                     "getpass": "0.1.7",
+                    "jodid25519": "1.0.2",
                     "jsbn": "0.1.1",
                     "tweetnacl": "0.14.5"
                   },
@@ -9453,6 +8520,15 @@
                       "dev": true,
                       "requires": {
                         "assert-plus": "1.0.0"
+                      }
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "0.1.1"
                       }
                     },
                     "jsbn": {
@@ -9516,6 +8592,11 @@
               "bundled": true,
               "dev": true
             },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true,
+              "dev": true
+            },
             "stringstream": {
               "version": "0.0.5",
               "bundled": true,
@@ -9541,7 +8622,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "5.0.1"
               }
             }
           }
@@ -9560,12 +8641,12 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true
         },
         "semver": {
-          "version": "5.4.1",
+          "version": "5.3.0",
           "bundled": true,
           "dev": true
         },
@@ -9575,7 +8656,7 @@
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
-            "readable-stream": "2.3.3"
+            "readable-stream": "2.2.9"
           }
         },
         "slide": {
@@ -9641,7 +8722,7 @@
               "bundled": true,
               "dev": true,
               "requires": {
-                "readable-stream": "2.3.3",
+                "readable-stream": "2.2.9",
                 "stream-shift": "1.0.0"
               },
               "dependencies": {
@@ -9655,60 +8736,38 @@
           }
         },
         "ssri": {
-          "version": "4.1.6",
+          "version": "4.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "5.0.1"
           }
         },
         "strip-ansi": {
-          "version": "4.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "bundled": true,
-              "dev": true
-            }
+            "ansi-regex": "2.1.1"
           }
         },
         "tar": {
-          "version": "4.0.1",
+          "version": "2.2.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "chownr": "1.0.1",
-            "minipass": "2.2.1",
-            "minizlib": "1.0.3",
-            "mkdirp": "0.5.1",
-            "yallist": "3.0.2"
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
           },
           "dependencies": {
-            "minipass": {
-              "version": "2.2.1",
+            "block-stream": {
+              "version": "0.0.9",
               "bundled": true,
               "dev": true,
               "requires": {
-                "yallist": "3.0.2"
+                "inherits": "2.0.3"
               }
-            },
-            "minizlib": {
-              "version": "1.0.3",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "minipass": "2.2.1"
-              }
-            },
-            "yallist": {
-              "version": "3.0.2",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -9751,40 +8810,74 @@
           "dev": true
         },
         "update-notifier": {
-          "version": "2.2.0",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "boxen": "1.1.0",
+            "boxen": "1.0.0",
             "chalk": "1.1.3",
-            "configstore": "3.1.0",
-            "import-lazy": "2.1.0",
+            "configstore": "3.0.0",
             "is-npm": "1.0.0",
             "latest-version": "3.1.0",
+            "lazy-req": "2.0.0",
             "semver-diff": "2.1.0",
             "xdg-basedir": "3.0.0"
           },
           "dependencies": {
             "boxen": {
-              "version": "1.1.0",
+              "version": "1.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "ansi-align": "2.0.0",
+                "ansi-align": "1.1.0",
                 "camelcase": "4.1.0",
                 "chalk": "1.1.3",
                 "cli-boxes": "1.0.0",
-                "string-width": "2.1.0",
+                "string-width": "2.0.0",
                 "term-size": "0.1.1",
                 "widest-line": "1.0.0"
               },
               "dependencies": {
                 "ansi-align": {
-                  "version": "2.0.0",
+                  "version": "1.1.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
-                    "string-width": "2.1.0"
+                    "string-width": "1.0.2"
+                  },
+                  "dependencies": {
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true,
+                          "dev": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "dev": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true,
+                              "dev": true
+                            }
+                          }
+                        }
+                      }
+                    }
                   }
                 },
                 "camelcase": {
@@ -9798,26 +8891,18 @@
                   "dev": true
                 },
                 "string-width": {
-                  "version": "2.1.0",
+                  "version": "2.0.0",
                   "bundled": true,
                   "dev": true,
                   "requires": {
                     "is-fullwidth-code-point": "2.0.0",
-                    "strip-ansi": "4.0.0"
+                    "strip-ansi": "3.0.1"
                   },
                   "dependencies": {
                     "is-fullwidth-code-point": {
                       "version": "2.0.0",
                       "bundled": true,
                       "dev": true
-                    },
-                    "strip-ansi": {
-                      "version": "4.0.0",
-                      "bundled": true,
-                      "dev": true,
-                      "requires": {
-                        "ansi-regex": "3.0.0"
-                      }
                     }
                   }
                 },
@@ -9847,8 +8932,8 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "lru-cache": "4.1.1",
-                            "which": "1.3.0"
+                            "lru-cache": "4.0.2",
+                            "which": "1.2.14"
                           }
                         },
                         "is-stream": {
@@ -9920,21 +9005,6 @@
                               "dev": true
                             }
                           }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "bundled": true,
-                          "dev": true,
-                          "requires": {
-                            "ansi-regex": "2.1.1"
-                          },
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "bundled": true,
-                              "dev": true
-                            }
-                          }
                         }
                       }
                     }
@@ -9970,28 +9040,6 @@
                   "dev": true,
                   "requires": {
                     "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "ansi-regex": "2.1.1"
-                  },
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "bundled": true,
-                      "dev": true
-                    }
                   }
                 },
                 "supports-color": {
@@ -10002,15 +9050,15 @@
               }
             },
             "configstore": {
-              "version": "3.1.0",
+              "version": "3.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
                 "dot-prop": "4.1.1",
                 "graceful-fs": "4.1.11",
-                "make-dir": "1.0.0",
+                "mkdirp": "0.5.1",
                 "unique-string": "1.0.0",
-                "write-file-atomic": "2.1.0",
+                "write-file-atomic": "1.3.4",
                 "xdg-basedir": "3.0.0"
               },
               "dependencies": {
@@ -10024,21 +9072,6 @@
                   "dependencies": {
                     "is-obj": {
                       "version": "1.0.1",
-                      "bundled": true,
-                      "dev": true
-                    }
-                  }
-                },
-                "make-dir": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "pify": "2.3.0"
-                  },
-                  "dependencies": {
-                    "pify": {
-                      "version": "2.3.0",
                       "bundled": true,
                       "dev": true
                     }
@@ -10058,13 +9091,18 @@
                       "dev": true
                     }
                   }
+                },
+                "write-file-atomic": {
+                  "version": "1.3.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "imurmurhash": "0.1.4",
+                    "slide": "1.1.6"
+                  }
                 }
               }
-            },
-            "import-lazy": {
-              "version": "2.1.0",
-              "bundled": true,
-              "dev": true
             },
             "is-npm": {
               "version": "1.0.0",
@@ -10085,9 +9123,9 @@
                   "dev": true,
                   "requires": {
                     "got": "6.7.1",
-                    "registry-auth-token": "3.3.1",
+                    "registry-auth-token": "3.3.0",
                     "registry-url": "3.1.0",
-                    "semver": "5.4.1"
+                    "semver": "5.3.0"
                   },
                   "dependencies": {
                     "got": {
@@ -10102,7 +9140,7 @@
                         "is-retry-allowed": "1.1.0",
                         "is-stream": "1.1.0",
                         "lowercase-keys": "1.0.0",
-                        "safe-buffer": "5.1.1",
+                        "safe-buffer": "5.0.1",
                         "timed-out": "4.0.1",
                         "unzip-response": "2.0.1",
                         "url-parse-lax": "1.0.0"
@@ -10153,6 +9191,11 @@
                           "bundled": true,
                           "dev": true
                         },
+                        "safe-buffer": {
+                          "version": "5.0.1",
+                          "bundled": true,
+                          "dev": true
+                        },
                         "timed-out": {
                           "version": "4.0.1",
                           "bundled": true,
@@ -10181,12 +9224,12 @@
                       }
                     },
                     "registry-auth-token": {
-                      "version": "3.3.1",
+                      "version": "3.3.0",
                       "bundled": true,
                       "dev": true,
                       "requires": {
                         "rc": "1.2.1",
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "5.0.1"
                       },
                       "dependencies": {
                         "rc": {
@@ -10194,14 +9237,14 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "deep-extend": "0.4.2",
+                            "deep-extend": "0.4.1",
                             "ini": "1.3.4",
                             "minimist": "1.2.0",
                             "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
-                              "version": "0.4.2",
+                              "version": "0.4.1",
                               "bundled": true,
                               "dev": true
                             },
@@ -10216,6 +9259,11 @@
                               "dev": true
                             }
                           }
+                        },
+                        "safe-buffer": {
+                          "version": "5.0.1",
+                          "bundled": true,
+                          "dev": true
                         }
                       }
                     },
@@ -10232,14 +9280,14 @@
                           "bundled": true,
                           "dev": true,
                           "requires": {
-                            "deep-extend": "0.4.2",
+                            "deep-extend": "0.4.1",
                             "ini": "1.3.4",
                             "minimist": "1.2.0",
                             "strip-json-comments": "2.0.1"
                           },
                           "dependencies": {
                             "deep-extend": {
-                              "version": "0.4.2",
+                              "version": "0.4.1",
                               "bundled": true,
                               "dev": true
                             },
@@ -10261,12 +9309,17 @@
                 }
               }
             },
+            "lazy-req": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true
+            },
             "semver-diff": {
               "version": "2.1.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "semver": "5.4.1"
+                "semver": "5.3.0"
               }
             },
             "xdg-basedir": {
@@ -10277,7 +9330,7 @@
           }
         },
         "uuid": {
-          "version": "3.1.0",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true
         },
@@ -10328,7 +9381,7 @@
           }
         },
         "which": {
-          "version": "1.3.0",
+          "version": "1.2.14",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -10337,37 +9390,6 @@
           "dependencies": {
             "isexe": {
               "version": "2.0.0",
-              "bundled": true,
-              "dev": true
-            }
-          }
-        },
-        "worker-farm": {
-          "version": "1.5.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "errno": "0.1.4",
-            "xtend": "4.0.1"
-          },
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "prr": "0.0.0"
-              },
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "bundled": true,
-                  "dev": true
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.1",
               "bundled": true,
               "dev": true
             }
@@ -10456,6 +9478,12 @@
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
     "object.defaults": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
@@ -10535,15 +9563,6 @@
       "dev": true,
       "requires": {
         "is-wsl": "1.1.0"
-      }
-    },
-    "optimist": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
-      "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
-      "dev": true,
-      "requires": {
-        "wordwrap": "0.0.3"
       }
     },
     "options": {
@@ -10660,6 +9679,17 @@
       "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
       "dev": true
     },
+    "parallel-transform": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.1.0.tgz",
+      "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
+      "dev": true,
+      "requires": {
+        "cyclist": "0.2.2",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
     "param-case": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
@@ -10668,12 +9698,6 @@
       "requires": {
         "no-case": "2.3.2"
       }
-    },
-    "parchment": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.0.tgz",
-      "integrity": "sha1-x5OHqA/Er0uolHuU/FWoNfYoUKU=",
-      "dev": true
     },
     "parse-asn1": {
       "version": "5.1.0",
@@ -10887,6 +9911,26 @@
         "pinkie": "2.0.4"
       }
     },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
     "portfinder": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
@@ -10971,6 +10015,70 @@
       "requires": {
         "postcss": "5.2.17",
         "postcss-value-parser": "3.3.0"
+      }
+    },
+    "postcss-custom-properties": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-6.2.0.tgz",
+      "integrity": "sha512-eNR2h9T9ciKMoQEORrPjH33XeN/nuvVuxArOKmHtsFbGbNss631tgTrKou3/pmjAZbA4QQkhLIkPQkIk3WW+8w==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "postcss": "6.0.14"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
+          "dev": true,
+          "requires": {
+            "chalk": "2.3.0",
+            "source-map": "0.6.1",
+            "supports-color": "4.5.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "postcss-discard-comments": {
@@ -11059,18 +10167,6 @@
       "requires": {
         "cosmiconfig": "2.2.2",
         "object-assign": "4.1.1"
-      }
-    },
-    "postcss-loader": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
-      "integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
-      "dev": true,
-      "requires": {
-        "loader-utils": "1.1.0",
-        "object-assign": "4.1.1",
-        "postcss": "5.2.17",
-        "postcss-load-config": "1.2.0"
       }
     },
     "postcss-merge-idents": {
@@ -11403,21 +10499,6 @@
         "uniqs": "2.0.0"
       }
     },
-    "postcss-url": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-url/-/postcss-url-5.1.2.tgz",
-      "integrity": "sha1-mLMWW+jVkkccsMqt3iwNH4MvEz4=",
-      "dev": true,
-      "requires": {
-        "directory-encoder": "0.7.2",
-        "js-base64": "2.3.2",
-        "mime": "1.4.1",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "path-is-absolute": "1.0.1",
-        "postcss": "5.2.17"
-      }
-    },
     "postcss-value-parser": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -11464,9 +10545,9 @@
       "dev": true
     },
     "prismjs": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.8.1.tgz",
-      "integrity": "sha1-vQzcMumlYcHIw8lzN2Wn8ew7VO4=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.6.0.tgz",
+      "integrity": "sha1-EY2V+3pm26InLjQ7NF9SNmWds2U=",
       "dev": true,
       "requires": {
         "clipboard": "1.7.1"
@@ -11494,13 +10575,19 @@
         "asap": "2.0.6"
       }
     },
+    "promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
+      "dev": true
+    },
     "protractor": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.1.2.tgz",
       "integrity": "sha1-myIXQXCaTGLVzVPGqt1UpxE36V8=",
       "dev": true,
       "requires": {
-        "@types/node": "6.0.88",
+        "@types/node": "6.0.60",
         "@types/q": "0.0.32",
         "@types/selenium-webdriver": "2.53.42",
         "blocking-proxy": "0.0.5",
@@ -11566,7 +10653,7 @@
           "requires": {
             "adm-zip": "0.4.7",
             "chalk": "1.1.3",
-            "del": "2.2.2",
+            "del": "2.2.0",
             "glob": "7.1.2",
             "ini": "1.3.4",
             "minimist": "1.2.0",
@@ -11588,13 +10675,13 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "dev": true,
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.5.2"
       }
     },
     "prr": {
@@ -11620,6 +10707,38 @@
         "create-hash": "1.1.3",
         "parse-asn1": "5.1.0",
         "randombytes": "2.0.5"
+      }
+    },
+    "pump": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+      "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "once": "1.4.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        }
+      }
+    },
+    "pumpify": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.5.tgz",
+      "integrity": "sha1-G2ccYZlAq8rqwK0OOjwWS+dgmTs=",
+      "dev": true,
+      "requires": {
+        "duplexify": "3.5.1",
+        "inherits": "2.0.3",
+        "pump": "1.0.3"
       }
     },
     "punycode": {
@@ -11675,17 +10794,17 @@
       "dev": true
     },
     "quill": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.2.tgz",
-      "integrity": "sha512-Tudr3tPSPr64J+Fnr8hsNKbi5e2xueyLROmemOIsIsUIeX+WU7LtA22HWRRHr2gGasqxhah2NzFGe9N32eJkMg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.1.8.tgz",
+      "integrity": "sha1-xIqntvDjX9oW3cQceWFl6+RLaSs=",
       "dev": true,
       "requires": {
         "clone": "2.1.1",
         "deep-equal": "1.0.1",
         "eventemitter3": "2.0.3",
         "extend": "3.0.1",
-        "parchment": "1.1.0",
-        "quill-delta": "3.6.1"
+        "parchment": "1.0.7",
+        "quill-delta": "3.4.3"
       },
       "dependencies": {
         "clone": {
@@ -11699,18 +10818,24 @@
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
           "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo=",
           "dev": true
+        },
+        "parchment": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.0.7.tgz",
+          "integrity": "sha1-R9lToQp3WU+rl/fKlrOjgsgYKdg=",
+          "dev": true
+        },
+        "quill-delta": {
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.4.3.tgz",
+          "integrity": "sha1-K4zDAPjJjVsXnvP9H/S1IvhXodM=",
+          "dev": true,
+          "requires": {
+            "deep-equal": "1.0.1",
+            "extend": "3.0.1",
+            "fast-diff": "1.1.1"
+          }
         }
-      }
-    },
-    "quill-delta": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.1.tgz",
-      "integrity": "sha512-jSD448mqyDevX0FhdjNppMLHl67vXEzZEDjQrtkfDXI6s6e3WJkJOZpYiVhqxLl4HcYNeAhFT+fhAeX8ef7Cew==",
-      "dev": true,
-      "requires": {
-        "deep-equal": "1.0.1",
-        "extend": "3.0.1",
-        "fast-diff": "1.1.1"
       }
     },
     "randomatic": {
@@ -12066,6 +11191,15 @@
         "path-parse": "1.0.5"
       }
     },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
+      }
+    },
     "resolve-dir": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
@@ -12075,6 +11209,12 @@
         "expand-tilde": "1.2.2",
         "global-modules": "0.2.3"
       }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
@@ -12104,16 +11244,19 @@
         "inherits": "2.0.3"
       }
     },
-    "rsvp": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.2.1.tgz",
-      "integrity": "sha1-B8tKXfJa3Z6Cbrxn3Mn9idsn2Eo=",
-      "dev": true
+    "run-queue": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
+      "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
+      "dev": true,
+      "requires": {
+        "aproba": "1.2.0"
+      }
     },
     "rxjs": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
+      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.4"
@@ -12267,9 +11410,9 @@
       }
     },
     "send": {
-      "version": "0.15.6",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
-      "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+      "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "dev": true,
       "requires": {
         "debug": "2.6.9",
@@ -12280,25 +11423,23 @@
         "etag": "1.8.1",
         "fresh": "0.5.2",
         "http-errors": "1.6.2",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "ms": "2.0.0",
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.3.4",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-          "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
-          "dev": true
-        }
       }
     },
     "sequencify": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz",
       "integrity": "sha1-kM/xnQLgcCf9dn9erT57ldHnOAw=",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.4.0.tgz",
+      "integrity": "sha1-fJWFFNtqwkQ6irwGLcn3iGp/YAU=",
       "dev": true
     },
     "serve-index": {
@@ -12328,15 +11469,15 @@
       }
     },
     "serve-static": {
-      "version": "1.12.6",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
-      "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "dev": true,
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.6"
+        "send": "0.16.1"
       }
     },
     "set-blocking": {
@@ -12431,6 +11572,12 @@
       "requires": {
         "debug": "2.6.9"
       }
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
     },
     "sntp": {
       "version": "2.0.2",
@@ -12774,6 +11921,15 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "ssri": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-5.0.0.tgz",
+      "integrity": "sha512-728D4yoQcQm1ooZvSbywLkV1RjfITZXh0oWrhM/lnsx3nAHx7LsRGJWB/YyvoceAYRq98xqbstiN4JBv1/wNHg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -12806,6 +11962,27 @@
       "integrity": "sha1-pB6tGm1ggc63n2WwYZAbbY89HQ8=",
       "dev": true
     },
+    "stream-each": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
+      "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "1.4.0",
+        "stream-shift": "1.0.0"
+      },
+      "dependencies": {
+        "end-of-stream": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+          "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+          "dev": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        }
+      }
+    },
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
@@ -12819,20 +11996,17 @@
         "xtend": "4.0.1"
       }
     },
+    "stream-shift": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
+      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "dev": true
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
     },
     "string-width": {
       "version": "1.0.2",
@@ -12843,6 +12017,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -13098,6 +12281,12 @@
         "punycode": "1.4.1"
       }
     },
+    "tree-kill": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.0.tgz",
+      "integrity": "sha512-DlX6dR0lOIRDFxI0mjL9IYg6OTncLm/Zt+JiBhE5OlFcAR8yc9S7FFXU9so0oda47frdM/JFsk7UjNt9vscKcg==",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -13111,9 +12300,9 @@
       "dev": true
     },
     "ts-node": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.2.2.tgz",
-      "integrity": "sha1-u9KOOK9Kqj6WB2xGbhsiAZfBo84=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-3.2.0.tgz",
+      "integrity": "sha1-mBTwwBQXhJAM8S/vEZetS39NI9E=",
       "dev": true,
       "requires": {
         "arrify": "1.0.1",
@@ -13124,19 +12313,8 @@
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18",
         "tsconfig": "6.0.0",
-        "v8flags": "3.0.1",
+        "v8flags": "2.1.1",
         "yn": "2.0.0"
-      },
-      "dependencies": {
-        "v8flags": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
-          "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
-          "dev": true,
-          "requires": {
-            "homedir-polyfill": "1.0.1"
-          }
-        }
       }
     },
     "tsconfig": {
@@ -13157,18 +12335,6 @@
         }
       }
     },
-    "tsickle": {
-      "version": "0.21.6",
-      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
-      "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
-      "dev": true,
-      "requires": {
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "source-map": "0.5.7",
-        "source-map-support": "0.4.18"
-      }
-    },
     "tslib": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
@@ -13176,38 +12342,21 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.3.2.tgz",
-      "integrity": "sha1-5WRZ+wlacwfxA7hAUhdPXju+9u0=",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.7.0.tgz",
+      "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "colors": "1.1.2",
+        "commander": "2.11.0",
         "diff": "3.3.1",
         "glob": "7.1.2",
-        "optimist": "0.6.1",
+        "minimatch": "3.0.4",
         "resolve": "1.4.0",
         "semver": "5.4.1",
         "tslib": "1.7.1",
         "tsutils": "2.9.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
-          "dev": true
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.10",
-            "wordwrap": "0.0.3"
-          }
-        }
       }
     },
     "tsutils": {
@@ -13251,11 +12400,41 @@
         "mime-types": "2.1.17"
       }
     },
-    "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "typescript": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
+      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "dev": true
+    },
+    "uglify-es": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
+      "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "uglify-js": {
       "version": "3.1.2",
@@ -13377,6 +12556,24 @@
       "integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
       "dev": true
     },
+    "unique-filename": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.0.tgz",
+      "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
+      "dev": true,
+      "requires": {
+        "unique-slug": "2.0.0"
+      }
+    },
+    "unique-slug": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.0.tgz",
+      "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "0.1.4"
+      }
+    },
     "unique-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz",
@@ -13420,21 +12617,14 @@
       }
     },
     "url-loader": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
-      "integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.6.2.tgz",
+      "integrity": "sha512-h3qf9TNn53BpuXTTcpC+UehiRrl0Cv45Yr/xWayApjw6G8Bg2dGke7rIwDQ39piciWCWrC+WiqLjOh3SUp9n0Q==",
       "dev": true,
       "requires": {
         "loader-utils": "1.1.0",
-        "mime": "1.3.6"
-      },
-      "dependencies": {
-        "mime": {
-          "version": "1.3.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-          "integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA=",
-          "dev": true
-        }
+        "mime": "1.4.1",
+        "schema-utils": "0.3.0"
       }
     },
     "url-parse": {
@@ -13509,16 +12699,15 @@
       "dev": true
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
       "dev": true
     },
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-      "dev": true
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "v8flags": {
       "version": "2.1.1",
@@ -13770,9 +12959,9 @@
       }
     },
     "webpack": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.5.6.tgz",
-      "integrity": "sha512-sXnxfx6KoZVrFAGLjdhCCwDtDwkYMfwm8mJjkQv3thr5pjTlbxopVlr/kJwc9Bz317gL+gNjvz++ir9TgG1MDg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.10.0.tgz",
+      "integrity": "sha512-fxxKXoicjdXNUMY7LIdY89tkJJJ0m1Oo8PQutZ5rLgWbV5QVKI15Cn7+/IHnRTd3vfKfiwBx6SBqlorAuNA8LA==",
       "dev": true,
       "requires": {
         "acorn": "5.1.2",
@@ -13791,7 +12980,7 @@
         "mkdirp": "0.5.1",
         "node-libs-browser": "2.0.0",
         "source-map": "0.5.7",
-        "supports-color": "4.4.0",
+        "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.4.0",
@@ -13911,9 +13100,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -13957,60 +13146,29 @@
         }
       }
     },
-    "webpack-concat-plugin": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/webpack-concat-plugin/-/webpack-concat-plugin-1.4.0.tgz",
-      "integrity": "sha512-Ym9Qm5Sw9oXJYChNJk09I/yaXDaV3UDxsa07wcCvILzIeSJTnSUZjhS4y2YkULzgE8VHOv9X04KtlJPZGwXqMg==",
+    "webpack-core": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "integrity": "sha1-/FcViMhVjad76e+23r3Fo7FyvcI=",
       "dev": true,
       "requires": {
-        "md5": "2.2.1",
-        "uglify-js": "2.8.29"
+        "source-list-map": "0.1.8",
+        "source-map": "0.4.4"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+        "source-list-map": {
+          "version": "0.1.8",
+          "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
+          "integrity": "sha1-xVCyq1Qn9rPyH1r+rYjE9Vh7IQY=",
           "dev": true
         },
-        "cliui": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "center-align": "0.1.3",
-            "right-align": "0.1.3",
-            "wordwrap": "0.0.2"
-          }
-        },
-        "uglify-js": {
-          "version": "2.8.29",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-          "dev": true,
-          "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
-          }
-        },
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-          "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
+            "amdefine": "1.0.1"
           }
         }
       }
@@ -14029,24 +13187,28 @@
       }
     },
     "webpack-dev-server": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.7.1.tgz",
-      "integrity": "sha1-IVgPWgjNBlxxFEz29hw0W8pZqLg=",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.7.tgz",
+      "integrity": "sha512-Pu7uoQFgQj5RE5wmlfkpYSzihMKxulwEuO2xCsaMnAnyRSApwoVi3B8WCm9XbigyWTHaIMzYGkB90Vr6leAeTQ==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
+        "array-includes": "3.0.3",
         "bonjour": "3.5.0",
         "chokidar": "1.7.0",
         "compression": "1.7.1",
         "connect-history-api-fallback": "1.3.0",
+        "debug": "3.1.0",
         "del": "3.0.0",
-        "express": "4.15.5",
+        "express": "4.16.2",
         "html-entities": "1.2.1",
         "http-proxy-middleware": "0.17.4",
+        "import-local": "0.1.1",
         "internal-ip": "1.2.0",
         "ip": "1.1.5",
+        "killable": "1.0.0",
         "loglevel": "1.5.0",
-        "opn": "4.0.2",
+        "opn": "5.1.0",
         "portfinder": "1.0.13",
         "selfsigned": "1.10.1",
         "serve-index": "1.9.0",
@@ -14054,7 +13216,7 @@
         "sockjs-client": "1.1.4",
         "spdy": "3.4.7",
         "strip-ansi": "3.0.1",
-        "supports-color": "3.2.3",
+        "supports-color": "4.5.0",
         "webpack-dev-middleware": "1.12.0",
         "yargs": "6.6.0"
       },
@@ -14064,6 +13226,15 @@
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "del": {
           "version": "3.0.0",
@@ -14079,21 +13250,47 @@
             "rimraf": "2.6.2"
           }
         },
-        "opn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+        "globby": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+          "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
           "requires": {
+            "array-union": "1.0.2",
+            "glob": "7.1.2",
             "object-assign": "4.1.1",
+            "pify": "2.3.0",
             "pinkie-promise": "2.0.1"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+              "dev": true
+            }
           }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         },
         "yargs": {
           "version": "6.6.0",
@@ -14144,6 +13341,15 @@
       "requires": {
         "source-list-map": "2.0.0",
         "source-map": "0.5.7"
+      }
+    },
+    "webpack-subresource-integrity": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-1.0.3.tgz",
+      "integrity": "sha1-wGBtQAkLBwzeQovsjfNgMhbkcus=",
+      "dev": true,
+      "requires": {
+        "webpack-core": "0.6.9"
       }
     },
     "websocket-driver": {
@@ -14210,6 +13416,16 @@
       "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
       "dev": true
     },
+    "worker-farm": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
+      "integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
+      "dev": true,
+      "requires": {
+        "errno": "0.1.4",
+        "xtend": "4.0.1"
+      }
+    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -14264,12 +13480,6 @@
       "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8=",
       "dev": true
     },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
-      "dev": true
-    },
     "xmlhttprequest-ssl": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
@@ -14281,6 +13491,15 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
       "dev": true
+    },
+    "xxhashjs": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.1.tgz",
+      "integrity": "sha1-m76b6JYUKXbfo0wGGy0GjEPTDeA=",
+      "dev": true,
+      "requires": {
+        "cuint": "0.2.2"
+      }
     },
     "y18n": {
       "version": "3.2.1",
@@ -14357,9 +13576,9 @@
       "dev": true
     },
     "zone.js": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.17.tgz",
-      "integrity": "sha1-TF5RhahX2o2nk9rzkZNxxaNrKgs=",
+      "version": "0.8.18",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.18.tgz",
+      "integrity": "sha512-knKOBQM0oea3/x9pdyDuDi7RhxDlJhOIkeixXSiTKWLgs4LpK37iBc+1HaHwzlciHUKT172CymJFKo8Xgh+44Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@angular/animations": "5.0.0",
-    "@angular/cli": "1.5.0",
+    "@angular/cli": "^1.6.2",
     "@angular/common": "5.0.0",
     "@angular/compiler": "5.0.0",
     "@angular/compiler-cli": "5.0.0",
@@ -30,13 +30,13 @@
     "@types/fullcalendar": "^3.5.2",
     "@types/jasmine": "2.5.53",
     "@types/jasminewd2": "2.0.2",
+    "@types/jquery": "^3.2.17",
     "@types/node": "6.0.60",
     "chart.js": "2.7.1",
     "codelyzer": "4.0.1",
     "core-js": "2.5.1",
     "del": "2.2.0",
     "font-awesome": "4.7.0",
-    "fullcalendar": "^3.6.0",
     "gulp": "^3.9.1",
     "gulp-concat": "2.6.0",
     "gulp-flatten": "^0.2.0",
@@ -65,8 +65,9 @@
     "zone.js": "0.8.18"
   },
   "dependencies": {
+    "fullcalendar": "3.7.0",
     "jquery": "^3.2.1",
-    "moment": "^2.18.1",
+    "moment": "^2.20.1",
     "ng2-logger": "^1.0.3",
     "uuid": "^3.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@angular/platform-browser": "5.0.0",
     "@angular/platform-browser-dynamic": "5.0.0",
     "@angular/router": "5.0.0",
+    "@types/fullcalendar": "^3.5.2",
     "@types/jasmine": "2.5.53",
     "@types/jasminewd2": "2.0.2",
     "@types/node": "6.0.60",
@@ -35,7 +36,7 @@
     "core-js": "2.5.1",
     "del": "2.2.0",
     "font-awesome": "4.7.0",
-    "fullcalendar": "^3.5.0",
+    "fullcalendar": "^3.6.0",
     "gulp": "^3.9.1",
     "gulp-concat": "2.6.0",
     "gulp-flatten": "^0.2.0",
@@ -46,14 +47,12 @@
     "intl": "1.2.5",
     "jasmine-core": "2.6.4",
     "jasmine-spec-reporter": "4.1.1",
-    "jquery": "3.2.1",
     "karma": "1.7.1",
     "karma-chrome-launcher": "2.1.1",
     "karma-cli": "1.0.1",
+    "karma-coverage-istanbul-reporter": "1.3.0",
     "karma-jasmine": "1.1.0",
     "karma-jasmine-html-reporter": "0.2.2",
-    "karma-coverage-istanbul-reporter": "1.3.0",
-    "moment": "2.18.1",
     "npm": "5.0.1",
     "prismjs": "1.6.0",
     "protractor": "5.1.2",
@@ -64,5 +63,11 @@
     "typescript": "~2.4.2",
     "web-animations-js": "2.3.1",
     "zone.js": "0.8.18"
+  },
+  "dependencies": {
+    "jquery": "^3.2.1",
+    "moment": "^2.18.1",
+    "ng2-logger": "^1.0.3",
+    "uuid": "^3.1.0"
   }
 }

--- a/src/app/components/schedule/schedule.ts
+++ b/src/app/components/schedule/schedule.ts
@@ -1,4 +1,5 @@
-import {NgModule,Component,ElementRef,OnDestroy,DoCheck,OnChanges,Input,Output,EventEmitter,IterableDiffers,OnInit,AfterViewChecked,SimpleChanges} from '@angular/core';
+import {NgModule, Component, ElementRef, OnDestroy, DoCheck, OnChanges, Input, Output, EventEmitter,
+    IterableDiffers, OnInit, AfterViewChecked, SimpleChanges} from '@angular/core';
 import {CommonModule} from '@angular/common';
 
 declare var jQuery: any;
@@ -7,133 +8,133 @@ declare var jQuery: any;
     selector: 'p-schedule',
     template: '<div [ngStyle]="style" [class]="styleClass"></div>'
 })
-export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChecked {
-    
+export class Schedule implements DoCheck, OnDestroy, OnInit, OnChanges, AfterViewChecked {
+
     @Input() events: any[];
-    
+
     @Input() header: any;
 
     @Input() style: any;
 
     @Input() styleClass: string;
-    
+
     @Input() rtl: boolean;
-    
+
     @Input() weekends: boolean;
-    
+
     @Input() hiddenDays: number[];
-        
+
     @Input() fixedWeekCount: boolean;
-    
+
     @Input() weekNumbers: boolean;
-    
+
     @Input() businessHours: any;
-    
+
     @Input() height: any;
-    
+
     @Input() contentHeight: any;
-    
+
     @Input() aspectRatio: number = 1.35;
-    
+
     @Input() eventLimit: any;
-    
+
     @Input() defaultDate: any;
-    
+
     @Input() editable: boolean;
-    
+
     @Input() droppable: boolean;
-    
+
     @Input() eventStartEditable: boolean;
-    
+
     @Input() eventDurationEditable: boolean;
-    
+
     @Input() defaultView: string = 'month';
-    
+
     @Input() allDaySlot: boolean = true;
 
     @Input() allDayText: string = 'all-day';
 
     @Input() slotDuration: any = '00:30:00';
-    
+
     @Input() slotLabelInterval: any;
-    
+
     @Input() snapDuration: any;
-    
+
     @Input() scrollTime: any = '06:00:00';
-    
+
     @Input() minTime: any = '00:00:00';
-        
+
     @Input() maxTime: any = '24:00:00';
-    
+
     @Input() slotEventOverlap: boolean = true;
-    
+
     @Input() nowIndicator: boolean;
-    
+
     @Input() dragRevertDuration: number = 500;
-    
+
     @Input() dragOpacity: number = .75;
-    
+
     @Input() dragScroll: boolean = true;
-    
+
     @Input() eventOverlap: any;
-        
+
     @Input() eventConstraint: any;
-    
+
     @Input() locale: string;
 
     @Input() timezone: boolean | string = false;
-    
-    @Input() timeFormat:string | null = null;
+
+    @Input() timeFormat: string | null = null;
 
     @Input() eventRender: Function;
-    
+
     @Input() dayRender: Function;
-    
+
     @Input() navLinks: boolean;
-    
+
     @Input() options: any;
-    
+
     @Output() onDayClick: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onDrop: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onEventClick: EventEmitter<any> = new EventEmitter();
-        
+
     @Output() onEventMouseover: EventEmitter<any> = new EventEmitter();
-            
+
     @Output() onEventMouseout: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onEventDragStart: EventEmitter<any> = new EventEmitter();
 
     @Output() onEventDragStop: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onEventDrop: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onEventResizeStart: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onEventResizeStop: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onEventResize: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onViewRender: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onViewDestroy: EventEmitter<any> = new EventEmitter();
-        
+
     initialized: boolean;
-    
+
     stopNgOnChangesPropagation: boolean;
-    
+
     differ: any;
-    
+
     schedule: any;
-    
+
     config: any;
 
     constructor(public el: ElementRef, differs: IterableDiffers) {
         this.differ = differs.find([]).create(null);
         this.initialized = false;
     }
-    
+
     ngOnInit() {
         this.config = {
             theme: true,
@@ -227,7 +228,7 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
             },
             eventDrop: (event, delta, revertFunc, jsEvent, ui, view) => {
                 this._updateEvent(event);
-                
+
                 this.onEventDrop.emit({
                     'event': event,
                     'delta': delta,
@@ -252,7 +253,7 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
             },
             eventResize: (event, delta, revertFunc, jsEvent, ui, view) => {
                 this._updateEvent(event);
-                
+
                 this.onEventResize.emit({
                     'event': event,
                     'delta': delta,
@@ -264,7 +265,7 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
             viewRender: (view, element) => {
                 this.onViewRender.emit({
                     'view': view,
-                    'element': element                    
+                    'element': element
                 });
             },
             viewDestroy: (view, element) => {
@@ -274,30 +275,30 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
               });
             }
         };
-                
-        if(this.options) {
-            for(let prop in this.options) {
+
+        if (this.options) {
+            for (const prop in this.options) {
                 this.config[prop] = this.options[prop];
             }
         }
     }
-    
+
     ngAfterViewChecked() {
-        if(!this.initialized && this.el.nativeElement.offsetParent) {
+        if (!this.initialized && this.el.nativeElement.offsetParent) {
             this.initialize();
         }
     }
-    
+
     ngOnChanges(changes: SimpleChanges) {
-        if(this.schedule) {
-            let options = {};
-            for(let change in changes) {
-                if(change !== 'events') {
+        if (this.schedule) {
+            const options = {};
+            for (const change in changes) {
+                if (change !== 'events') {
                     options[change] = changes[change].currentValue;
-                }   
+                }
             }
-            
-            if(Object.keys(options).length) {
+
+            if (Object.keys(options).length) {
                 this.schedule.fullCalendar('option', options);
             }
         }
@@ -306,19 +307,19 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
     initialize() {
         this.schedule = jQuery(this.el.nativeElement.children[0]);
         this.schedule.fullCalendar(this.config);
-        if(this.events) {
+        if (this.events) {
             this.schedule.fullCalendar('addEventSource', this.events);
         }
         this.initialized = true;
     }
-     
+
     ngDoCheck() {
-        let changes = this.differ.diff(this.events);
-        
-        if(this.schedule && changes) {
+        const changes = this.differ.diff(this.events);
+
+        if (this.schedule && changes) {
             this.schedule.fullCalendar('removeEventSources');
-            
-            if(this.events) {
+
+            if (this.events) {
                 this.schedule.fullCalendar('addEventSource', this.events);
             }
         }
@@ -329,52 +330,52 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
         this.initialized = false;
         this.schedule = null;
     }
-    
+
     gotoDate(date: any) {
         this.schedule.fullCalendar('gotoDate', date);
     }
-    
+
     prev() {
         this.schedule.fullCalendar('prev');
     }
-    
+
     next() {
         this.schedule.fullCalendar('next');
     }
-    
+
     prevYear() {
         this.schedule.fullCalendar('prevYear');
     }
-    
+
     nextYear() {
         this.schedule.fullCalendar('nextYear');
     }
-    
+
     today() {
         this.schedule.fullCalendar('today');
     }
-    
+
     incrementDate(duration: any) {
         this.schedule.fullCalendar('incrementDate', duration);
     }
-     
+
     changeView(viewName: string) {
-        this.schedule.fullCalendar('changeView', viewName);   
+        this.schedule.fullCalendar('changeView', viewName);
     }
-    
+
     getDate() {
         return this.schedule.fullCalendar('getDate');
     }
-   
+
     updateEvent(event: any) {
         this.schedule.fullCalendar('updateEvent', event);
     }
- 
+
     _findEvent(id: string) {
         let event;
-        if(this.events) {
-            for(let e of this.events) {
-                if(e.id === id) {
+        if (this.events) {
+            for (const e of this.events) {
+                if (e.id === id) {
                     event = e;
                     break;
                 }
@@ -382,14 +383,14 @@ export class Schedule implements DoCheck,OnDestroy,OnInit,OnChanges,AfterViewChe
         }
         return event;
     }
-    
+
     _updateEvent(event: any) {
-        let sourceEvent = this._findEvent(event.id);
-        if(sourceEvent) {
+        const sourceEvent = this._findEvent(event.id);
+        if (sourceEvent) {
             sourceEvent.start = event.start.format();
-            if(event.end) {
+            if (event.end) {
                 sourceEvent.end = event.end.format();
-            }    
+            }
         }
     }
 }

--- a/src/app/showcase/app.component.ts
+++ b/src/app/showcase/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import {trigger,state,style,transition,animate} from '@angular/animations';
+import {trigger, state, style, transition, animate} from '@angular/animations';
 
 @Component({
   selector: 'app-root',
@@ -19,17 +19,17 @@ import {trigger,state,style,transition,animate} from '@angular/animations';
   ],
 })
 export class AppComponent {
-    
+
     menuActive: boolean;
-    
+
     activeMenuId: string;
-    
+
     changeTheme(event: Event, theme: string) {
-        let themeLink: HTMLLinkElement = <HTMLLinkElement> document.getElementById('theme-css');
+        const themeLink: HTMLLinkElement = <HTMLLinkElement> document.getElementById('theme-css');
         themeLink.href = 'assets/components/themes/' + theme + '/theme.css';
         event.preventDefault();
     }
-    
+
     onMenuButtonClick(event: Event) {
         this.menuActive = !this.menuActive;
         event.preventDefault();

--- a/src/app/showcase/components/schedule/scheduledemo.html
+++ b/src/app/showcase/components/schedule/scheduledemo.html
@@ -6,7 +6,53 @@
 </div>
 
 <div class="content-section implementation">
-    <p-schedule [events]="events" [header]="header" defaultDate="2017-02-01" [eventLimit]="4" [editable]="true"></p-schedule>
+    <p-schedule [events]="events" [header]="header" defaultDate="2017-02-01" [eventLimit]="4" [editable]="true" [eventRender]="eventRender" [defaultView]="defaultView" [timeFormat]="timeFormat" (onDayClick)="handleDayClick($event)"
+        (onEventClick)="handleEventClick($event)" (onEventResize)="handleEventResize($event)" (onEventDrop)="handleEventDrop($event)"></p-schedule>
+
+    <!-- Creation dialog -->
+    <p-dialog header="Creation" [(visible)]="creationDialogVisible" [responsive]="true" showEffect="fade" [modal]="false" [contentStyle]="{'overflow':'visible'}"
+        [style]="{'overflow':'visible'}" [resizable]="false">
+        <div class="ui-grid ui-grid-responsive ui-fluid" *ngIf="event">
+            <div class="ui-grid-row">
+                <div class="ui-grid-col-4">
+                    <label for="title">Title</label>
+                </div>
+                <div class="ui-grid-col-8">
+                    <input pInputText id="title" [(ngModel)]="event.title" (keyup.enter)="createEvent()" />
+                </div>
+            </div>
+        </div>
+        <p-footer>
+            <div class="ui-dialog-buttonpane ui-helper-clearfix">
+                <button type="button" pButton icon="fa-check" (click)="createEvent()" label="Add" [disabled]="!event?.title"></button>
+            </div>
+        </p-footer>
+    </p-dialog>
+
+    <!-- Modification dialog -->
+    <p-dialog header="" [(visible)]="modificationDialogVisible" [responsive]="true" showEffect="fade" [modal]="false" [contentStyle]="{'overflow':'visible'}"
+        [style]="{'overflow':'visible'}" [resizable]="false">
+        <div class="ui-grid ui-grid-responsive ui-fluid" *ngIf="modificationDialogVisible">
+            <div class="ui-grid-row">
+                <div class="ui-grid-col-6">
+                    <label for="title">Title:</label>
+                </div>
+                <div class="ui-grid-col-2">
+                    <input pInputText id="title" [(ngModel)]="event.title" (keyup.enter)="modifyEvent()"
+                    />
+                </div>
+                <div class="ui-grid-col-4">
+                    <button type="button" pButton icon="fa-edit" (click)="modifyEvent()" label="Modifier" [disabled]="!event?.title"></button>
+                </div>
+            </div>
+            <p-footer>
+                <div class="ui-dialog-buttonpane ui-helper-clearfix">
+                    <button type="button" pButton icon="fa-close" (click)="deleteEvent()" label="Remove event" [disabled]="!event?.id"></button>
+                </div>
+            </p-footer>
+        </div>
+    </p-dialog>
+
 </div>
 
 <div class="content-section documentation">

--- a/src/app/showcase/components/schedule/scheduledemo.ts
+++ b/src/app/showcase/components/schedule/scheduledemo.ts
@@ -1,5 +1,11 @@
-import {Component,OnInit} from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import {EventService} from '../../service/eventservice';
+
+import { v1 } from 'uuid';
+import {Moment} from 'moment';
+import moment from 'moment/src/moment';
+import {EventObject, ViewObject} from 'fullcalendar';
+import { Log, Level } from 'ng2-logger';
 
 @Component({
     templateUrl: './scheduledemo.html',
@@ -7,7 +13,7 @@ import {EventService} from '../../service/eventservice';
         .ui-grid-row div {
           padding: 4px 10px
         }
-        
+
         .ui-grid-row div label {
           font-weight: bold;
         }
@@ -15,21 +21,183 @@ import {EventService} from '../../service/eventservice';
 })
 export class ScheduleDemo implements OnInit {
 
-    events: any[];
-    
-    header: any;
-            
-    constructor(private eventService: EventService) { }
+   // The list of event in the fullCalendar library
+   events: MyEvent[];
+
+   header: any;
+   event: MyEvent;
+
+   creationDialogVisible: boolean = false;
+   modificationDialogVisible: boolean = false;
+
+   // Fullcalendar configuration
+   // the rendering function
+   eventRender: (event: MyEvent, element) => void ;
+   defaultView: string;
+   timeFormat: string;
+   log = Log.create('ScheduleDemo');
+
+    constructor(private eventService: EventService) {
+        this.log.data('constructor');
+        this.defaultView = 'agendaWeek';
+        this.timeFormat = 'HH:mm';
+    }
 
     ngOnInit() {
-        this.eventService.getEvents().then(events => {this.events = events;});
-        
+        this.eventService.getEvents().then(events => {this.events = events; });
+
         this.header = {
-			left: 'prev,next today',
-			center: 'title',
-			right: 'month,agendaWeek,agendaDay'
-		};
+            left: 'prev,next today',
+            center: 'title',
+            right: 'month,agendaWeek,agendaDay'
+        };
+
+        // Custom rendering of the sessions
+        this.eventRender = (event: EventObject, element: JQuery) => {
+            // Example for adding html code after the title
+            // element.append('<ul><li>custo</li></ul>');
+            // Example for changing the element css
+            // element.css('border-color', 'red');
+        };
+
     }
+
+    /**
+     * This function should be called when a click occurs on an event in order to put in place the current
+     *   fullcalendar event values into the dialog fields
+     * @param fullCalendarEvent
+     * @param {ViewObject} view
+     */
+    synchronizeFullCalendarToAngular(fullCalendarEvent: any, view: ViewObject): void {
+        this.event = new MyEvent();
+        this.event.title = fullCalendarEvent.title;
+        const start = fullCalendarEvent.start;
+        const end = fullCalendarEvent.end;
+        if (end) {
+            this.event.end = end.format();
+        }
+
+        this.event.id = fullCalendarEvent.id;
+        this.event.start = start.format();
+    }
+
+
+    /**
+     * Handle day click:
+     *   Create a new angular event
+     * @param {{date: moment.Moment}} event
+     */
+        handleDayClick(event: any): void {
+        this.event = new MyEvent();
+        // generates a unique id for each event or else events are mixed together by fullcalendar when they are moved close to one another
+        this.event.id = v1();
+        if (event.date.hasTime()) {
+            this.event.allDay = false;
+            this.event.start = event.date.format('YYYY-MM-DD HH:mm');
+            // Creates 3-hour event by default
+            this.event.end = event.date.add(3, 'hours').format('YYYY-MM-DD HH:mm');
+        } else {
+            this.event.allDay = true;
+            this.event.start = event.date.format('YYYY-MM-DD');
+        }
+        this.creationDialogVisible = true;
+    }
+
+    /**
+     * Handle event click:
+     *   load the useful data to angular component into "this.event" and show the dialog
+     * @param e {
+     *            calEvent:Object, // the fullcalendar event (= session)
+     *            jsEvent:n.Event,
+     *            view:Et.function.e.constructor
+     *          }
+     *
+     */
+    handleEventClick(e): void {
+        this.log.data('handleEventClick for id ' + e.calEvent.id);
+        this.synchronizeFullCalendarToAngular(e.calEvent, e.view);
+        this.modificationDialogVisible = true;
+    }
+
+
+    /**
+     * Handle event duration change through resizing:
+     *   load the useful data to angular component in "this" and update the mongo DB
+     * @param e : {
+     *              delta:Ab,
+     *              event:Object,  // the fullcalendar event (= session)
+     *              jsEvent:n.Event,
+     *              revertFunc:function (),
+     *              view:Et.function.e.constructor
+     *            }
+     */
+    handleEventResize(e): void {
+        this.log.data('handleEventResize for _id ' + e.event._id + ' and id ' + e.event.id);
+    }
+
+    /**
+     * Handle event drop after being dragged (ie event was moved in time):
+     *   load the useful data to angular component in "this" and update the mongo DB
+     * @param e : {
+     *              delta:Ab,
+     *              event:Object,  // the fullcalendar event (= session)
+     *              jsEvent:n.Event,
+     *              revertFunc:function (),
+     *              view:Et.function.e.constructor
+     *            }
+     */
+    handleEventDrop(e): void {
+        this.log.data('handleEventDrop for _id ' + e.event._id + ' and id ' + e.event.id);
+    }
+
+    /**
+     * Create an event based on this.event content (the content is filled by handleDayClick)
+     */
+    createEvent(): void {
+        this.log.data('createEvent with id ' + this.event.id + ' and title: ' + this.event.title);
+        this.creationDialogVisible = false;
+        this.events.push(this.event);
+    }
+
+   /**
+     * Update the event title in fullcalendar EventObject
+     */
+    modifyEvent(): void {
+        this.log.data('Modifying event id ' + this.event.id + ' with new title: ' + this.event.title);
+        // As of fullcalendar 3.6.0, updating an event won't refresh fullcalendar display
+        /*
+        this.events.map(
+            (event: EventObject) => {
+                if (event.id === this.event.id) {
+                    event.title = this.event.title;
+                }
+            }
+        );
+        */
+        // See also this discussion https://github.com/angular-ui/ui-calendar/issues/167
+        // For the changes to appear, we need to remove the event an put it back with the new values
+        this.events = this.events.filter(
+            (event: EventObject) => {
+                return event.id !== this.event.id;
+             });
+        this.events.push(this.event);
+        this.modificationDialogVisible = false;
+        this.event = null;
+    }
+
+    /**
+     * Remove an event
+     */
+    deleteEvent(): void {
+        this.modificationDialogVisible = false;
+        this.events = this.events.filter(
+            (event: EventObject) => {
+                return event.id !== this.event.id;
+             });
+        this.event = null;
+    }
+
+
 }
 
 export class MyEvent {
@@ -37,5 +205,5 @@ export class MyEvent {
     title: string;
     start: string;
     end: string;
-    allDay: boolean = true;
+    allDay: boolean = false;
 }

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,7 @@
     ],
     "curly": true,
     "eofline": true,
-    "forin": true,
+    "forin": false,
     "import-blacklist": [
       true,
       "rxjs"
@@ -57,7 +57,7 @@
     "no-empty-interface": true,
     "no-eval": true,
     "no-inferrable-types": [
-      true,
+      false,
       "ignore-params"
     ],
     "no-misused-new": true,


### PR DESCRIPTION
###Defect Fixes
The running demo at https://www.primefaces.org/primeng/#/schedule doesn't offer CRUD functionality (CReate Update Delete). It used to be working back when the project was using angular 2 a few month ago, although I don't think that all the functionalities were there either. The code in the PR adds basic functionality to the demo: 
- create events
- delete events
- update events (change title)

I have also fixed the linter warnings with visual studio code auto-fix in schedule.ts and by de-activating a few rules in tslint.json

Defect ref:
https://github.com/primefaces/primeng/issues/4697
