### PR TITLE
Css fix for some Android.

### DIFF
--- a/src/app/components/accordion/accordion.spec.ts
+++ b/src/app/components/accordion/accordion.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Accordion } from './accordion';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Accordion', () => {
+  
+  let accordion: Accordion;
+  let fixture: ComponentFixture<Accordion>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Accordion
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Accordion);
+    accordion = fixture.componentInstance;
+  });
+});

--- a/src/app/components/autocomplete/autocomplete.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { AutoComplete } from './autocomplete';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('AutoComplete', () => {
+  
+  let autocomplete: AutoComplete;
+  let fixture: ComponentFixture<AutoComplete>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        AutoComplete
+      ]
+    });
+    
+    fixture = TestBed.createComponent(AutoComplete);
+    autocomplete = fixture.componentInstance;
+  });
+});

--- a/src/app/components/blockui/blockui.spec.ts
+++ b/src/app/components/blockui/blockui.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BlockUI } from './blockui';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('BlockUI', () => {
+  
+  let blockui: BlockUI;
+  let fixture: ComponentFixture<BlockUI>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        BlockUI
+      ]
+    });
+    
+    fixture = TestBed.createComponent(BlockUI);
+    blockui = fixture.componentInstance;
+  });
+});

--- a/src/app/components/breadcrumb/breadcrumb.spec.ts
+++ b/src/app/components/breadcrumb/breadcrumb.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Breadcrumb } from './breadcrumb';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Breadcrumb', () => {
+  
+  let breadcrumb: Breadcrumb;
+  let fixture: ComponentFixture<Breadcrumb>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Breadcrumb
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Breadcrumb);
+    breadcrumb = fixture.componentInstance;
+  });
+});

--- a/src/app/components/button/button.css
+++ b/src/app/components/button/button.css
@@ -33,6 +33,7 @@ p-button {
 .ui-button-text-empty .ui-button-text { 
     padding: .25em; 
     text-indent: -9999999px; 
+    overflow: hidden;
 }
 
 .ui-button-text-icon-left .ui-button-text { 

--- a/src/app/components/button/button.spec.ts
+++ b/src/app/components/button/button.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Button } from './button';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Button', () => {
+  
+  let button: Button;
+  let fixture: ComponentFixture<Button>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Button
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Button);
+    button = fixture.componentInstance;
+  });
+});

--- a/src/app/components/calendar/calendar.spec.ts
+++ b/src/app/components/calendar/calendar.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Calendar } from './calendar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Calendar', () => {
+  
+  let calendar: Calendar;
+  let fixture: ComponentFixture<Calendar>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Calendar
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Calendar);
+    calendar = fixture.componentInstance;
+  });
+});

--- a/src/app/components/captcha/captcha.spec.ts
+++ b/src/app/components/captcha/captcha.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Captcha } from './captcha';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Captcha', () => {
+  
+  let captcha: Captcha;
+  let fixture: ComponentFixture<Captcha>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Captcha
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Captcha);
+    captcha = fixture.componentInstance;
+  });
+});

--- a/src/app/components/card/card.spec.ts
+++ b/src/app/components/card/card.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Card } from './card';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Card', () => {
+  
+  let card: Card;
+  let fixture: ComponentFixture<Card>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Card
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Card);
+    card = fixture.componentInstance;
+  });
+});

--- a/src/app/components/carousel/carousel.spec.ts
+++ b/src/app/components/carousel/carousel.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Carousel } from './carousel';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Carousel', () => {
+  
+  let carousel: Carousel;
+  let fixture: ComponentFixture<Carousel>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Carousel
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Carousel);
+    carousel = fixture.componentInstance;
+  });
+});

--- a/src/app/components/chart/chart.spec.ts
+++ b/src/app/components/chart/chart.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { UIChart } from './chart';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('UIChart', () => {
+  
+  let chart: UIChart;
+  let fixture: ComponentFixture<UIChart>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        UIChart
+      ]
+    });
+    
+    fixture = TestBed.createComponent(UIChart);
+    chart = fixture.componentInstance;
+  });
+});

--- a/src/app/components/checkbox/checkbox.spec.ts
+++ b/src/app/components/checkbox/checkbox.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Checkbox } from './checkbox';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Checkbox', () => {
+  
+  let checkbox: Checkbox;
+  let fixture: ComponentFixture<Checkbox>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Checkbox
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Checkbox);
+    checkbox = fixture.componentInstance;
+  });
+});

--- a/src/app/components/chips/chips.spec.ts
+++ b/src/app/components/chips/chips.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Chips } from './chips';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Chips', () => {
+  
+  let chips: Chips;
+  let fixture: ComponentFixture<Chips>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Chips
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Chips);
+    chips = fixture.componentInstance;
+  });
+});

--- a/src/app/components/codehighlighter/codehighlighter.spec.ts
+++ b/src/app/components/codehighlighter/codehighlighter.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { CodeHighlighter } from './codehighlighter';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('CodeHighlighter', () => {
+  
+  let codehighlighter: CodeHighlighter;
+  let fixture: ComponentFixture<CodeHighlighter>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        CodeHighlighter
+      ]
+    });
+    
+    fixture = TestBed.createComponent(CodeHighlighter);
+    codehighlighter = fixture.componentInstance;
+  });
+});

--- a/src/app/components/colorpicker/colorpicker.spec.ts
+++ b/src/app/components/colorpicker/colorpicker.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ColorPicker } from './colorpicker';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('ColorPicker', () => {
+  
+  let colorpicker: ColorPicker;
+  let fixture: ComponentFixture<ColorPicker>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        ColorPicker
+      ]
+    });
+    
+    fixture = TestBed.createComponent(ColorPicker);
+    colorpicker = fixture.componentInstance;
+  });
+});

--- a/src/app/components/confirmdialog/confirmdialog.spec.ts
+++ b/src/app/components/confirmdialog/confirmdialog.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ConfirmDialog } from './confirmdialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('ConfirmDialog', () => {
+  
+  let confirmdialog: ConfirmDialog;
+  let fixture: ComponentFixture<ConfirmDialog>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        ConfirmDialog
+      ]
+    });
+    
+    fixture = TestBed.createComponent(ConfirmDialog);
+    confirmdialog = fixture.componentInstance;
+  });
+});

--- a/src/app/components/contextmenu/contextmenu.spec.ts
+++ b/src/app/components/contextmenu/contextmenu.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ContextMenu } from './contextmenu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Accordion', () => {
+  
+  let contextmenu: ContextMenu;
+  let fixture: ComponentFixture<ContextMenu>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        ContextMenu
+      ]
+    });
+    
+    fixture = TestBed.createComponent(ContextMenu);
+    contextmenu = fixture.componentInstance;
+  });
+});

--- a/src/app/components/datagrid/datagrid.spec.ts
+++ b/src/app/components/datagrid/datagrid.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DataGrid } from './datagrid';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('DataGrid', () => {
+  
+  let datagrid: DataGrid;
+  let fixture: ComponentFixture<DataGrid>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        DataGrid
+      ]
+    });
+    
+    fixture = TestBed.createComponent(DataGrid);
+    datagrid = fixture.componentInstance;
+  });
+});

--- a/src/app/components/datalist/datalist.spec.ts
+++ b/src/app/components/datalist/datalist.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DataList } from './datalist';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('DataList', () => {
+  
+  let datalist: DataList;
+  let fixture: ComponentFixture<DataList>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        DataList
+      ]
+    });
+    
+    fixture = TestBed.createComponent(DataList);
+    datalist = fixture.componentInstance;
+  });
+});

--- a/src/app/components/datascroller/datascroller.spec.ts
+++ b/src/app/components/datascroller/datascroller.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DataScroller } from './datascroller';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('DataScroller', () => {
+  
+  let datascroller: DataScroller;
+  let fixture: ComponentFixture<DataScroller>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        DataScroller
+      ]
+    });
+    
+    fixture = TestBed.createComponent(DataScroller);
+    datascroller = fixture.componentInstance;
+  });
+});

--- a/src/app/components/datatable/datatable.spec.ts
+++ b/src/app/components/datatable/datatable.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DataTable } from './datatable';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('DataTable', () => {
+  
+  let datatable: DataTable;
+  let fixture: ComponentFixture<DataTable>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        DataTable
+      ]
+    });
+    
+    fixture = TestBed.createComponent(DataTable);
+    datatable = fixture.componentInstance;
+  });
+});

--- a/src/app/components/dragdrop/dragdrop.spec.ts
+++ b/src/app/components/dragdrop/dragdrop.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Draggable } from './dragdrop';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Draggable', () => {
+  
+  let draggable: Draggable;
+  let fixture: ComponentFixture<Draggable>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Draggable
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Draggable);
+    draggable = fixture.componentInstance;
+  });
+});

--- a/src/app/components/dropdown/dropdown.css
+++ b/src/app/components/dropdown/dropdown.css
@@ -36,6 +36,7 @@
 .ui-dropdown-item-empty,
 .ui-dropdown-label-empty {
     text-indent: -9999px;   
+    overflow: hidden;
 }
 
 .ui-dropdown.ui-state-disabled .ui-dropdown-trigger,

--- a/src/app/components/dropdown/dropdown.spec.ts
+++ b/src/app/components/dropdown/dropdown.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Dropdown } from './dropdown';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Dropdown', () => {
+  
+  let dropdown: Dropdown;
+  let fixture: ComponentFixture<Dropdown>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Dropdown
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Dropdown);
+    dropdown = fixture.componentInstance;
+  });
+});

--- a/src/app/components/editor/editor.spec.ts
+++ b/src/app/components/editor/editor.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Editor } from './editor';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Editor', () => {
+  
+  let editor: Editor;
+  let fixture: ComponentFixture<Editor>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Editor
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Editor);
+    editor = fixture.componentInstance;
+  });
+});

--- a/src/app/components/fileupload/fileupload.spec.ts
+++ b/src/app/components/fileupload/fileupload.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FileUpload } from './fileupload';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('FileUpload', () => {
+  
+  let fileupload: FileUpload;
+  let fixture: ComponentFixture<FileUpload>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        FileUpload
+      ]
+    });
+    
+    fixture = TestBed.createComponent(FileUpload);
+    fileupload = fixture.componentInstance;
+  });
+});

--- a/src/app/components/galleria/galleria.spec.ts
+++ b/src/app/components/galleria/galleria.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Galleria } from './galleria';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Galleria', () => {
+  
+  let galleria: Galleria;
+  let fixture: ComponentFixture<Galleria>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Galleria
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Galleria);
+    galleria = fixture.componentInstance;
+  });
+});

--- a/src/app/components/gmap/gmap.spec.ts
+++ b/src/app/components/gmap/gmap.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { GMap } from './gmap';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('GMap', () => {
+  
+  let gmap: GMap;
+  let fixture: ComponentFixture<GMap>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        GMap
+      ]
+    });
+    
+    fixture = TestBed.createComponent(GMap);
+    gmap = fixture.componentInstance;
+  });
+});

--- a/src/app/components/growl/growl.spec.ts
+++ b/src/app/components/growl/growl.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Growl } from './growl';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Growl', () => {
+  
+  let growl: Growl;
+  let fixture: ComponentFixture<Growl>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Growl
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Growl);
+    growl = fixture.componentInstance;
+  });
+});

--- a/src/app/components/inplace/inplace.spec.ts
+++ b/src/app/components/inplace/inplace.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Inplace } from './inplace';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Inplace', () => {
+  
+  let inplace: Inplace;
+  let fixture: ComponentFixture<Inplace>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Inplace
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Inplace);
+    inplace = fixture.componentInstance;
+  });
+});

--- a/src/app/components/inputmask/inputmask.spec.ts
+++ b/src/app/components/inputmask/inputmask.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { InputMask } from './inputmask';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('InputMask', () => {
+  
+  let inputmask: InputMask;
+  let fixture: ComponentFixture<InputMask>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        InputMask
+      ]
+    });
+    
+    fixture = TestBed.createComponent(InputMask);
+    inputmask = fixture.componentInstance;
+  });
+});

--- a/src/app/components/inputswitch/inputswitch.spec.ts
+++ b/src/app/components/inputswitch/inputswitch.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { InputSwitch } from './inputswitch';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('InputSwitch', () => {
+  
+  let inputswitch: InputSwitch;
+  let fixture: ComponentFixture<InputSwitch>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        InputSwitch
+      ]
+    });
+    
+    fixture = TestBed.createComponent(InputSwitch);
+    inputswitch = fixture.componentInstance;
+  });
+});

--- a/src/app/components/inputtext/inputtext.spec.ts
+++ b/src/app/components/inputtext/inputtext.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { InputText } from './inputtext';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('InputText', () => {
+  
+  let inputtext: InputText;
+  let fixture: ComponentFixture<InputText>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        InputText
+      ]
+    });
+    
+    fixture = TestBed.createComponent(InputText);
+    inputtext = fixture.componentInstance;
+  });
+});

--- a/src/app/components/inputtextarea/inputtextarea.spec.ts
+++ b/src/app/components/inputtextarea/inputtextarea.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { InputTextarea } from './inputtextarea';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('InputTextarea', () => {
+  
+  let inputtextarea: InputTextarea;
+  let fixture: ComponentFixture<InputTextarea>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        InputTextarea
+      ]
+    });
+    
+    fixture = TestBed.createComponent(InputTextarea);
+    inputtextarea = fixture.componentInstance;
+  });
+});

--- a/src/app/components/keyfilter/keyfilter.spec.ts
+++ b/src/app/components/keyfilter/keyfilter.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { KeyFilter } from './keyfilter';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('KeyFilter', () => {
+  
+  let keyfilter: KeyFilter;
+  let fixture: ComponentFixture<KeyFilter>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        KeyFilter
+      ]
+    });
+    
+    fixture = TestBed.createComponent(KeyFilter);
+    keyfilter = fixture.componentInstance;
+  });
+});

--- a/src/app/components/lightbox/lightbox.spec.ts
+++ b/src/app/components/lightbox/lightbox.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Lightbox } from './lightbox';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Lightbox', () => {
+  
+  let lightbox: Lightbox;
+  let fixture: ComponentFixture<Lightbox>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Lightbox
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Lightbox);
+    lightbox = fixture.componentInstance;
+  });
+});

--- a/src/app/components/listbox/listbox.spec.ts
+++ b/src/app/components/listbox/listbox.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Listbox } from './listbox';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Listbox', () => {
+  
+  let listbox: Listbox;
+  let fixture: ComponentFixture<Listbox>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Listbox
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Listbox);
+    listbox = fixture.componentInstance;
+  });
+});

--- a/src/app/components/megamenu/megamenu.spec.ts
+++ b/src/app/components/megamenu/megamenu.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MegaMenu } from './megamenu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('MegaMenu', () => {
+  
+  let megamenu: MegaMenu;
+  let fixture: ComponentFixture<MegaMenu>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        MegaMenu
+      ]
+    });
+    
+    fixture = TestBed.createComponent(MegaMenu);
+    megamenu = fixture.componentInstance;
+  });
+});

--- a/src/app/components/menu/menu.css
+++ b/src/app/components/menu/menu.css
@@ -122,6 +122,7 @@
     border-width: 0 0 0 1px;
     width: 1px;
     text-indent: -9999999px;
+    overflow: hidden;
 }
 
 .ui-menubar:not(.ui-megamenu-vertical) .ui-menubar-root-list > .ui-menu-separator::before {

--- a/src/app/components/menu/menu.spec.ts
+++ b/src/app/components/menu/menu.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Menu } from './menu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Menu', () => {
+  
+  let menu: Menu;
+  let fixture: ComponentFixture<Menu>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Menu
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Menu);
+    menu = fixture.componentInstance;
+  });
+});

--- a/src/app/components/menubar/menubar.spec.ts
+++ b/src/app/components/menubar/menubar.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Menubar } from './menubar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Menubar', () => {
+  
+  let menubar: Menubar;
+  let fixture: ComponentFixture<Menubar>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Menubar
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Menubar);
+    menubar = fixture.componentInstance;
+  });
+});

--- a/src/app/components/message/message.spec.ts
+++ b/src/app/components/message/message.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { UIMessage } from './message';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('UIMessage', () => {
+  
+  let message: UIMessage;
+  let fixture: ComponentFixture<UIMessage>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        UIMessage
+      ]
+    });
+    
+    fixture = TestBed.createComponent(UIMessage);
+    message = fixture.componentInstance;
+  });
+});

--- a/src/app/components/messages/messages.spec.ts
+++ b/src/app/components/messages/messages.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Messages } from './messages';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Messages', () => {
+  
+  let messages: Messages;
+  let fixture: ComponentFixture<Messages>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Messages
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Messages);
+    messages = fixture.componentInstance;
+  });
+});

--- a/src/app/components/multiselect/multiselect.spec.ts
+++ b/src/app/components/multiselect/multiselect.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { MultiSelect } from './multiselect';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('MultiSelect', () => {
+  
+  let multiselect: MultiSelect;
+  let fixture: ComponentFixture<MultiSelect>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        MultiSelect
+      ]
+    });
+    
+    fixture = TestBed.createComponent(MultiSelect);
+    multiselect = fixture.componentInstance;
+  });
+});

--- a/src/app/components/orderlist/orderlist.spec.ts
+++ b/src/app/components/orderlist/orderlist.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { OrderList } from './orderlist';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('OrderList', () => {
+  
+  let orderlist: OrderList;
+  let fixture: ComponentFixture<OrderList>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        OrderList
+      ]
+    });
+    
+    fixture = TestBed.createComponent(OrderList);
+    orderlist = fixture.componentInstance;
+  });
+});

--- a/src/app/components/organizationchart/organizationchart.spec.ts
+++ b/src/app/components/organizationchart/organizationchart.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { OrganizationChart } from './organizationchart';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('OrganizationChart', () => {
+  
+  let organizationchart: OrganizationChart;
+  let fixture: ComponentFixture<OrganizationChart>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        OrganizationChart
+      ]
+    });
+    
+    fixture = TestBed.createComponent(OrganizationChart);
+    organizationchart = fixture.componentInstance;
+  });
+});

--- a/src/app/components/overlaypanel/overlaypanel.spec.ts
+++ b/src/app/components/overlaypanel/overlaypanel.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { OverlayPanel } from './overlaypanel';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('OverlayPanel', () => {
+  
+  let overlaypanel: OverlayPanel;
+  let fixture: ComponentFixture<OverlayPanel>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        OverlayPanel
+      ]
+    });
+    
+    fixture = TestBed.createComponent(OverlayPanel);
+    overlaypanel = fixture.componentInstance;
+  });
+});

--- a/src/app/components/paginator/paginator.spec.ts
+++ b/src/app/components/paginator/paginator.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Paginator } from './paginator';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Paginator', () => {
+  
+  let paginator: Paginator;
+  let fixture: ComponentFixture<Paginator>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Paginator
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Paginator);
+    paginator = fixture.componentInstance;
+  });
+});

--- a/src/app/components/panelmenu/panelmenu.spec.ts
+++ b/src/app/components/panelmenu/panelmenu.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { PanelMenu } from './panelmenu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('PanelMenu', () => {
+  
+  let panelmenu: PanelMenu;
+  let fixture: ComponentFixture<PanelMenu>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        PanelMenu
+      ]
+    });
+    
+    fixture = TestBed.createComponent(PanelMenu);
+    panelmenu = fixture.componentInstance;
+  });
+});

--- a/src/app/components/password/password.spec.ts
+++ b/src/app/components/password/password.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Password } from './password';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Password', () => {
+  
+  let password: Password;
+  let fixture: ComponentFixture<Password>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Password
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Password);
+    password = fixture.componentInstance;
+  });
+});

--- a/src/app/components/picklist/picklist.spec.ts
+++ b/src/app/components/picklist/picklist.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { PickList } from './picklist';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('PickList', () => {
+  
+  let picklist: PickList;
+  let fixture: ComponentFixture<PickList>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        PickList
+      ]
+    });
+    
+    fixture = TestBed.createComponent(PickList);
+    picklist = fixture.componentInstance;
+  });
+});

--- a/src/app/components/progressbar/progressbar.spec.ts
+++ b/src/app/components/progressbar/progressbar.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ProgressBar } from './progressbar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('ProgressBar', () => {
+  
+  let progressbar: ProgressBar;
+  let fixture: ComponentFixture<ProgressBar>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        ProgressBar
+      ]
+    });
+    
+    fixture = TestBed.createComponent(ProgressBar);
+    progressbar = fixture.componentInstance;
+  });
+});

--- a/src/app/components/progressspinner/progressspinner.spec.ts
+++ b/src/app/components/progressspinner/progressspinner.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ProgressSpinner } from './progressspinner';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('ProgressSpinner', () => {
+  
+  let progressspinner: ProgressSpinner;
+  let fixture: ComponentFixture<ProgressSpinner>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        ProgressSpinner
+      ]
+    });
+    
+    fixture = TestBed.createComponent(ProgressSpinner);
+    progressspinner = fixture.componentInstance;
+  });
+});

--- a/src/app/components/radiobutton/radiobutton.spec.ts
+++ b/src/app/components/radiobutton/radiobutton.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { RadioButton } from './radiobutton';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('RadioButton', () => {
+  
+  let radiobutton: RadioButton;
+  let fixture: ComponentFixture<RadioButton>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        RadioButton
+      ]
+    });
+    
+    fixture = TestBed.createComponent(RadioButton);
+    radiobutton = fixture.componentInstance;
+  });
+});

--- a/src/app/components/rating/rating.spec.ts
+++ b/src/app/components/rating/rating.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Rating } from './rating';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Rating', () => {
+  
+  let rating: Rating;
+  let fixture: ComponentFixture<Rating>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Rating
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Rating);
+    rating = fixture.componentInstance;
+  });
+});

--- a/src/app/components/schedule/schedule.spec.ts
+++ b/src/app/components/schedule/schedule.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Schedule } from './schedule';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Schedule', () => {
+  
+  let schedule: Schedule;
+  let fixture: ComponentFixture<Schedule>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Schedule
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Schedule);
+    schedule = fixture.componentInstance;
+  });
+});

--- a/src/app/components/scrollpanel/scrollpanel.spec.ts
+++ b/src/app/components/scrollpanel/scrollpanel.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { ScrollPanel } from './scrollpanel';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('ScrollPanel', () => {
+  
+  let scrollpanel: ScrollPanel;
+  let fixture: ComponentFixture<ScrollPanel>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        ScrollPanel
+      ]
+    });
+    
+    fixture = TestBed.createComponent(ScrollPanel);
+    scrollpanel = fixture.componentInstance;
+  });
+});

--- a/src/app/components/selectbutton/selectbutton.spec.ts
+++ b/src/app/components/selectbutton/selectbutton.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed, ComponentFixture, tick, fakeAsync } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SelectButton } from './selectbutton';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('SelectButton', () => {
+  
+  let selectButton: SelectButton;
+  let fixture: ComponentFixture<SelectButton>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        SelectButton
+      ]
+    });
+    
+    fixture = TestBed.createComponent(SelectButton);
+    selectButton = fixture.componentInstance;
+  });
+  
+  it('should display the label', () => {
+    selectButton.options = [{label: 'Apartment', value: 'Apartment'},{label: 'House', value: 'House'},{label: 'Studio', value: 'Studio'}];
+    fixture.detectChanges();
+    const labelEl = fixture.debugElement.query(By.css('.ui-selectbutton')).children[0];
+    expect(labelEl.nativeElement.querySelector('.ui-button-text').textContent).toContain('Apartment')
+  });
+  
+  
+  it('should display the active when click', fakeAsync(() => {
+    selectButton.options = [{label: 'Apartment', value: 'Apartment'},{label: 'House', value: 'House'},{label: 'Studio', value: 'Studio'}];
+    fixture.detectChanges();
+  
+    const activeEl = fixture.nativeElement.querySelector('.ui-selectbutton').children[0];
+    activeEl.click();
+  
+    fixture.detectChanges();
+    
+    const active = fixture.nativeElement.querySelector('.ui-state-active').children[0];
+    expect(active.textContent).toContain('Apartment');
+  }));
+});

--- a/src/app/components/sidebar/sidebar.spec.ts
+++ b/src/app/components/sidebar/sidebar.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Sidebar } from './sidebar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Sidebar', () => {
+  
+  let sidebar: Sidebar;
+  let fixture: ComponentFixture<Sidebar>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Sidebar
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Sidebar);
+    sidebar = fixture.componentInstance;
+  });
+});

--- a/src/app/components/slidemenu/slidemenu.spec.ts
+++ b/src/app/components/slidemenu/slidemenu.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SlideMenu } from './slidemenu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('SlideMenu', () => {
+  
+  let slidemenu: SlideMenu;
+  let fixture: ComponentFixture<SlideMenu>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        SlideMenu
+      ]
+    });
+    
+    fixture = TestBed.createComponent(SlideMenu);
+    slidemenu = fixture.componentInstance;
+  });
+});

--- a/src/app/components/slider/slider.spec.ts
+++ b/src/app/components/slider/slider.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Slider } from './slider';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Slider', () => {
+  
+  let slider: Slider;
+  let fixture: ComponentFixture<Slider>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Slider
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Slider);
+    slider = fixture.componentInstance;
+  });
+});

--- a/src/app/components/spinner/spinner.spec.ts
+++ b/src/app/components/spinner/spinner.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Spinner } from './spinner';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Spinner', () => {
+  
+  let spinner: Spinner;
+  let fixture: ComponentFixture<Spinner>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Spinner
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Spinner);
+    spinner = fixture.componentInstance;
+  });
+});

--- a/src/app/components/splitbutton/splitbutton.spec.ts
+++ b/src/app/components/splitbutton/splitbutton.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { SplitButton } from './splitbutton';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('SplitButton', () => {
+  
+  let splitbutton: SplitButton;
+  let fixture: ComponentFixture<SplitButton>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        SplitButton
+      ]
+    });
+    
+    fixture = TestBed.createComponent(SplitButton);
+    splitbutton = fixture.componentInstance;
+  });
+});

--- a/src/app/components/steps/steps.spec.ts
+++ b/src/app/components/steps/steps.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Steps } from './steps';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Steps', () => {
+  
+  let steps: Steps;
+  let fixture: ComponentFixture<Steps>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Steps
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Steps);
+    steps = fixture.componentInstance;
+  });
+});

--- a/src/app/components/tabmenu/tabmenu.spec.ts
+++ b/src/app/components/tabmenu/tabmenu.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TabMenu } from './tabmenu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('TabMenu', () => {
+  
+  let tabmenu: TabMenu;
+  let fixture: ComponentFixture<TabMenu>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        TabMenu
+      ]
+    });
+    
+    fixture = TestBed.createComponent(TabMenu);
+    tabmenu = fixture.componentInstance;
+  });
+});

--- a/src/app/components/tabview/tabview.spec.ts
+++ b/src/app/components/tabview/tabview.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TabView } from './tabview';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('TabView', () => {
+  
+  let tabview: TabView;
+  let fixture: ComponentFixture<TabView>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        TabView
+      ]
+    });
+    
+    fixture = TestBed.createComponent(TabView);
+    tabview = fixture.componentInstance;
+  });
+});

--- a/src/app/components/terminal/terminal.spec.ts
+++ b/src/app/components/terminal/terminal.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Terminal } from './terminal';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Terminal', () => {
+  
+  let terminal: Terminal;
+  let fixture: ComponentFixture<Terminal>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Terminal
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Terminal);
+    terminal = fixture.componentInstance;
+  });
+});

--- a/src/app/components/tieredmenu/tieredmenu.spec.ts
+++ b/src/app/components/tieredmenu/tieredmenu.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TieredMenu } from './tieredmenu';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('TieredMenu', () => {
+  
+  let tieredmenu: TieredMenu;
+  let fixture: ComponentFixture<TieredMenu>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        TieredMenu
+      ]
+    });
+    
+    fixture = TestBed.createComponent(TieredMenu);
+    tieredmenu = fixture.componentInstance;
+  });
+});

--- a/src/app/components/toolbar/toolbar.spec.ts
+++ b/src/app/components/toolbar/toolbar.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Toolbar } from './toolbar';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Toolbar', () => {
+  
+  let toolbar: Toolbar;
+  let fixture: ComponentFixture<Toolbar>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Toolbar
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Toolbar);
+    toolbar = fixture.componentInstance;
+  });
+});

--- a/src/app/components/tooltip/tooltip.spec.ts
+++ b/src/app/components/tooltip/tooltip.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Tooltip } from './tooltip';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Tooltip', () => {
+  
+  let tooltip: Tooltip;
+  let fixture: ComponentFixture<Tooltip>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Tooltip
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Tooltip);
+    tooltip = fixture.componentInstance;
+  });
+});

--- a/src/app/components/tree/tree.spec.ts
+++ b/src/app/components/tree/tree.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Tree } from './tree';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('Tree', () => {
+  
+  let tree: Tree;
+  let fixture: ComponentFixture<Tree>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        Tree
+      ]
+    });
+    
+    fixture = TestBed.createComponent(Tree);
+    tree = fixture.componentInstance;
+  });
+});

--- a/src/app/components/treetable/treetable.spec.ts
+++ b/src/app/components/treetable/treetable.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TreeTable } from './treetable';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('TreeTable', () => {
+  
+  let treetable: TreeTable;
+  let fixture: ComponentFixture<TreeTable>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        TreeTable
+      ]
+    });
+    
+    fixture = TestBed.createComponent(TreeTable);
+    treetable = fixture.componentInstance;
+  });
+});

--- a/src/app/components/tristatecheckbox/tristatecheckbox.spec.ts
+++ b/src/app/components/tristatecheckbox/tristatecheckbox.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TriStateCheckbox } from './tristatecheckbox';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('TriStateCheckbox', () => {
+  
+  let tristate: TriStateCheckbox;
+  let fixture: ComponentFixture<TriStateCheckbox>;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        NoopAnimationsModule
+      ],
+      declarations: [
+        TriStateCheckbox
+      ]
+    });
+    
+    fixture = TestBed.createComponent(TriStateCheckbox);
+    tristate = fixture.componentInstance;
+  });
+});


### PR DESCRIPTION
## description
Optimize brower's painting process.
For instance, my case is Android 4.4.2 (Device published by SHARP) .

## detail
Use `text-ident: -supersize px`(and complex some animation, like fade-in, fade-out...) some browser paint all position, solemnly. It makes more slow performance.