### PR TITLE
Css fix for some Android.

### DIFF
--- a/src/app/components/button/button.css
+++ b/src/app/components/button/button.css
@@ -33,6 +33,7 @@ p-button {
 .ui-button-text-empty .ui-button-text { 
     padding: .25em; 
     text-indent: -9999999px; 
+    overflow: hidden;
 }
 
 .ui-button-text-icon-left .ui-button-text { 

--- a/src/app/components/dropdown/dropdown.css
+++ b/src/app/components/dropdown/dropdown.css
@@ -36,6 +36,7 @@
 .ui-dropdown-item-empty,
 .ui-dropdown-label-empty {
     text-indent: -9999px;   
+    overflow: hidden;
 }
 
 .ui-dropdown.ui-state-disabled .ui-dropdown-trigger,

--- a/src/app/components/menu/menu.css
+++ b/src/app/components/menu/menu.css
@@ -122,6 +122,7 @@
     border-width: 0 0 0 1px;
     width: 1px;
     text-indent: -9999999px;
+    overflow: hidden;
 }
 
 .ui-menubar:not(.ui-megamenu-vertical) .ui-menubar-root-list > .ui-menu-separator::before {


### PR DESCRIPTION
## description
Optimize brower's painting process.
For instance, my case is Android 4.4.2 (Device published by SHARP) .

## detail
Use `text-ident: -supersize px`(and complex some animation, like fade-in, fade-out...) some browser paint all position, solemnly. It makes more slow performance.