### PR TITLE
Fix issue #4645: update localization documentation

### DIFF
--- a/src/app/showcase/components/schedule/scheduledemo.html
+++ b/src/app/showcase/components/schedule/scheduledemo.html
@@ -165,8 +165,28 @@ export class MyModel &#123;
 &lt;p-schedule [events]="events" locale="es"&gt;&lt;/p-schedule&gt;
 </code>
 </pre>
-
             <p>Visit the <a href="https://fullcalendar.io/docs/text/locale/">fullcalendar documentation</a> to get the available locales.</p>
+            <p>Activating fullcalendar i18n functionalities requires installing jquery-datepicker and loading the locale definitions for the target language</p>
+            <ul><li>Install jquery-datepicker module:</li></ul>
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+npm i jquery-datepicker --save
+</code>
+</pre>
+            <ul><li>Add required scripts in .angular-cli.json in the "scripts" section:</li>
+            <ul><li>Between moment.js and fullcalendar.js:</li></ul></ul>
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+"../node_modules/moment/locale/es.js",
+"../node_modules/jquery-datepicker/jquery-datepicker.min.js",
+</code>
+</pre>
+            <ul><ul><li>After fullcalendar.js:</li></ul></ul>
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+"../node_modules/fullcalendar/dist/locale/es.js",
+</code>
+</pre>
 
             <h3>Properties</h3>
             <div class="doc-tablewrapper">


### PR DESCRIPTION
This fixes issue https://github.com/primefaces/primeng/issues/4645
It updates the schedule documentation by adding the instructions required to activate the fullcalendar i18n functionality as per https://fullcalendar.io/docs/text/locale/
