### PR TITLE
Fix documentation error

### DIFF
--- a/src/app/showcase/components/listbox/listboxdemo.html
+++ b/src/app/showcase/components/listbox/listboxdemo.html
@@ -71,7 +71,7 @@ export class MyModel &#123;
 
     cities2: City[];
 
-    selectedCity1: City;
+    selectedCity1: string;
 
     selectedCity2: City;
 


### PR DESCRIPTION
When using SelectItem as listbox item, the binding of selection to ngModel will produce only string, not complex object.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.