### PR TITLE
Add dropdown appendTo to paginator and data components

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -478,7 +478,7 @@ export class ScrollableView implements AfterViewInit,AfterViewChecked,OnDestroy 
             
             <p-paginator [rows]="rows" [first]="first" [totalRecords]="totalRecords" [pageLinkSize]="pageLinks" styleClass="ui-paginator-bottom" [alwaysShow]="alwaysShowPaginator"
                 (onPageChange)="onPageChange($event)" [rowsPerPageOptions]="rowsPerPageOptions" *ngIf="paginator && (paginatorPosition === 'bottom' || paginatorPosition =='both')"
-                [templateLeft]="paginatorLeftTemplate" [templateRight]="paginatorRightTemplate"></p-paginator>
+                [templateLeft]="paginatorLeftTemplate" [templateRight]="paginatorRightTemplate" [dropdownAppendTo]="paginatorDropdownAppendTo"></p-paginator>
             <div class="ui-datatable-footer ui-widget-header" *ngIf="footer">
                 <ng-content select="p-footer"></ng-content>
             </div>
@@ -493,6 +493,8 @@ export class ScrollableView implements AfterViewInit,AfterViewChecked,OnDestroy 
 export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentInit,OnInit,OnDestroy,BlockableUI {
 
     @Input() paginator: boolean;
+
+    @Input() paginatorDropdownAppendTo: any;
 
     @Input() rows: number;
 

--- a/src/app/components/paginator/paginator.ts
+++ b/src/app/components/paginator/paginator.ts
@@ -34,7 +34,7 @@ import {SharedModule} from '../common/shared';
                 <span class="fa fa-step-forward"></span>
             </a>
             <p-dropdown [options]="rowsPerPageItems" [(ngModel)]="rows" *ngIf="rowsPerPageOptions" 
-                (onChange)="onRppChange($event)" [lazy]="false" [autoWidth]="false"></p-dropdown>
+                (onChange)="onRppChange($event)" [lazy]="false" [autoWidth]="false" [appendTo]="dropdownAppendTo"></p-dropdown>
             <div class="ui-paginator-right-content" *ngIf="templateRight">
                 <p-templateLoader [template]="templateRight" [data]="paginatorState"></p-templateLoader>
             </div>
@@ -56,6 +56,8 @@ export class Paginator implements OnInit {
     @Input() templateLeft: TemplateRef<any>;
     
     @Input() templateRight: TemplateRef<any>;
+
+    @Input() dropdownAppendTo: any;
 
     pageLinks: number[];
 


### PR DESCRIPTION
### Defect Fixes
I've noticed that when adding tables to modals, the paginator seems to calculate the direction it should drop in (down or up) based purely on screen height. This can sometimes result in a paginator dropdown which still drops down and makes your modal scroll.  
I have attached a repo plunkr of the issue here: http://plnkr.co/edit/gvesU2PhChbN321tMeER?p=preview


I have attempted to fix this by adding appendTo support to the paginator dropdown. I believe if you append the paginator dropdown directly to the body you can at least have it float over the bottom of the modal instead of being stuck inside of it to scroll. This was my personal take on a solution to this issue. If there are other/better ways to fix this, I am open to all suggestions. 