### PR TITLE
allow configuration of csv linebreak character

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -573,6 +573,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     @Input() contextMenu: any;
     
     @Input() csvSeparator: string = ',';
+
+    @Input() csvLinebreak: string = '\n';
     
     @Input() exportFilename: string = 'download';
     
@@ -2524,7 +2526,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
         
         //body
         data.forEach((record, i) => {
-            csv += '\n';
+            csv += this.csvLinebreak;
             for(let i = 0; i < this.columns.length; i++) {
                 let column = this.columns[i];
                 if(column.exportable && column.field) {

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -107,6 +107,8 @@ export class Table implements OnInit, AfterContentInit, AfterViewInit {
 
     @Input() csvSeparator: string = ',';
 
+    @Input() csvLinebreak: string = '\n';
+
     @Input() exportFilename: string = 'download';
 
     @Input() filters: { [s: string]: FilterMetadata; } = {};
@@ -842,7 +844,7 @@ export class Table implements OnInit, AfterContentInit, AfterViewInit {
 
         //body
         data.forEach((record, i) => {
-            csv += '\n';
+            csv += this.csvLinebreak;
             for (let i = 0; i < this.columns.length; i++) {
                 let column = this.columns[i];
                 if (column.exportable !== false && column.field) {

--- a/src/app/showcase/components/datatable/datatabledemo.html
+++ b/src/app/showcase/components/datatable/datatabledemo.html
@@ -1456,6 +1456,12 @@ export class DataTableDemo implements OnInit &#123;
                             <td>Character to use as the csv separator.</td>
                         </tr>
                         <tr>
+                            <td>csvLinebreak</td>
+                            <td>string</td>
+                            <td>LF</td>
+                            <td>Character to use as the csv row separator (default is Linux - LF only).</td>
+                        </tr>
+                        <tr>
                             <td>exportFilename</td>
                             <td>string</td>
                             <td>download</td>


### PR DESCRIPTION
###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

This is a quite small feature. It simply adds the possibility to configure the used linebreak character when exporting to csv. The default is still the existing Linux style (LF only), but could be changed to windows style (CR/LF), Mac OS style (CR only) or something exotic (pipe sign '|') if desired.