### PR TITLE
Add table sort compareFunction feature

### DIFF
--- a/src/app/components/common/shared.ts
+++ b/src/app/components/common/shared.ts
@@ -41,6 +41,7 @@ export class Column implements AfterContentInit{
     @Input() field: string;
     @Input() colId: string;
     @Input() sortField: string;
+    @Input() compareFunction: (a: any, b: any) => number;
     @Input() filterField: string;
     @Input() header: string;
     @Input() footer: string;

--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -1243,6 +1243,8 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                         result = 1;
                     else if (value1 == null && value2 == null)
                         result = 0;
+                    else if (this.sortColumn.compareFunction)
+                        result = this.sortColumn.compareFunction(value1, value2);
                     else if (typeof value1 === 'string' && typeof value2 === 'string')
                         result = value1.localeCompare(value2);
                     else
@@ -1273,10 +1275,17 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
     }
 
     multisortField(data1,data2,multiSortMeta,index) {
+        const column = this.columns.find(col => col.field === multiSortMeta[index].field);
         let value1 = this.resolveFieldData(data1, multiSortMeta[index].field);
         let value2 = this.resolveFieldData(data2, multiSortMeta[index].field);
         let result = null;
 
+        if (column.compareFunction) {
+            const compareResult = column.compareFunction(value1, value2);
+            if (compareResult !== 0) {
+                return multiSortMeta[index].order * compareResult;
+            }
+        }
         if (typeof value1 == 'string' || value1 instanceof String) {
             if (value1.localeCompare && (value1 != value2)) {
                 return (multiSortMeta[index].order * value1.localeCompare(value2));

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -481,7 +481,7 @@ export class Table implements OnInit, AfterContentInit {
         }
         else if (this.value) {
             this.value.sort((data1, data2) => {
-                const column = this.columns.find(col => col.field === this.sortField);
+                const column = this.columns ? this.columns.find(col => col.field === this.sortField) : null;
                 let value1 = this.objectUtils.resolveFieldData(data1, this.sortField);
                 let value2 = this.objectUtils.resolveFieldData(data2, this.sortField);
                 let result = null;
@@ -492,7 +492,7 @@ export class Table implements OnInit, AfterContentInit {
                     result = 1;
                 else if (value1 == null && value2 == null)
                     result = 0;
-                else if (column.compareFunction)
+                else if (column && column.compareFunction)
                     result = column.compareFunction(value1, value2);
                 else if (typeof value1 === 'string' && typeof value2 === 'string')
                     result = value1.localeCompare(value2);
@@ -531,12 +531,12 @@ export class Table implements OnInit, AfterContentInit {
     }
 
     multisortField(data1, data2, multiSortMeta, index) {
-        const column = this.columns.find(col => col.field === multiSortMeta[index].field);
+        const column = this.columns ? this.columns.find(col => col.field === multiSortMeta[index].field) : null;
         let value1 = this.objectUtils.resolveFieldData(data1, multiSortMeta[index].field);
         let value2 = this.objectUtils.resolveFieldData(data2, multiSortMeta[index].field);
         let result = null;
 
-        if (column.compareFunction) {
+        if (column && column.compareFunction) {
             const compareResult = column.compareFunction(value1, value2);
             if (compareResult !== 0) {
                 return multiSortMeta[index].order * compareResult;

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -481,6 +481,7 @@ export class Table implements OnInit, AfterContentInit {
         }
         else if (this.value) {
             this.value.sort((data1, data2) => {
+                const column = this.columns.find(col => col.field === this.sortField);
                 let value1 = this.objectUtils.resolveFieldData(data1, this.sortField);
                 let value2 = this.objectUtils.resolveFieldData(data2, this.sortField);
                 let result = null;
@@ -491,6 +492,8 @@ export class Table implements OnInit, AfterContentInit {
                     result = 1;
                 else if (value1 == null && value2 == null)
                     result = 0;
+                else if (column.compareFunction)
+                    result = column.compareFunction(value1, value2);
                 else if (typeof value1 === 'string' && typeof value2 === 'string')
                     result = value1.localeCompare(value2);
                 else
@@ -528,10 +531,17 @@ export class Table implements OnInit, AfterContentInit {
     }
 
     multisortField(data1, data2, multiSortMeta, index) {
+        const column = this.columns.find(col => col.field === multiSortMeta[index].field);
         let value1 = this.objectUtils.resolveFieldData(data1, multiSortMeta[index].field);
         let value2 = this.objectUtils.resolveFieldData(data2, multiSortMeta[index].field);
         let result = null;
 
+        if (column.compareFunction) {
+            const compareResult = column.compareFunction(value1, value2);
+            if (compareResult !== 0) {
+                return multiSortMeta[index].order * compareResult;
+            }
+        }
         if (typeof value1 == 'string' || value1 instanceof String) {
             if (value1.localeCompare && (value1 != value2)) {
                 return (multiSortMeta[index].order * value1.localeCompare(value2));

--- a/src/app/showcase/components/datatable/datatabledemo.html
+++ b/src/app/showcase/components/datatable/datatabledemo.html
@@ -119,6 +119,12 @@ export class DataTableDemo implements OnInit &#123;
                             <td>Property of a row data used for sorting, defaults to field.</td>
                         </tr>
                         <tr>
+                            <td>compareFunction</td>
+                            <td>function</td>
+                            <td>null</td>
+                            <td>Compare function to use for sorting on this column (like Array.prototype.sort)</td>
+                        </tr>
+                        <tr>
                             <td>filterField</td>
                             <td>string</td>
                             <td>null</td>

--- a/src/app/showcase/components/datatable/datatablesortdemo.html
+++ b/src/app/showcase/components/datatable/datatablesortdemo.html
@@ -14,7 +14,7 @@
         <p-column field="vin" header="Vin" [sortable]="true"></p-column>
         <p-column field="year" header="Year" [sortable]="true"></p-column>
         <p-column field="brand" header="Brand" [sortable]="true"></p-column>
-        <p-column field="color" header="Color" [sortable]="true"></p-column>
+        <p-column field="color" header="Color" [sortable]="true" [compareFunction]="compareColors"></p-column>
       <p-footer>
         <button type="button" label="Sort by Year" (click)="changeSort($event)" pButton [ngStyle]="{'display':'flex'}"></button>
       </p-footer>
@@ -25,7 +25,7 @@
         <p-column field="vin" header="Vin" [sortable]="true"></p-column>
         <p-column field="year" header="Year" [sortable]="true"></p-column>
         <p-column field="brand" header="Brand" [sortable]="true"></p-column>
-        <p-column field="color" header="Color" [sortable]="true"></p-column>
+        <p-column field="color" header="Color" [sortable]="true" [compareFunction]="compareColors"></p-column>
     </p-dataTable>
 </div>
 
@@ -58,6 +58,11 @@ export class DataTableSortDemo implements OnInit &#123;
           this.sortF = event.field;
         &#125;
     &#125;
+
+    compareColors(color1, color2) &#123;
+        const colorOrder = [ 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'White', 'Gray', 'Black' ];
+        return colorOrder.indexOf(color1) - colorOrder.indexOf(color2);
+    &#125;
 &#125;
 </code>
 </pre>
@@ -75,7 +80,7 @@ export class DataTableSortDemo implements OnInit &#123;
     &lt;p-column field="vin" header="Vin" [sortable]="true"&gt;&lt;/p-column&gt;
     &lt;p-column field="year" header="Year" [sortable]="true"&gt;&lt;/p-column&gt;
     &lt;p-column field="brand" header="Brand" [sortable]="true"&gt;&lt;/p-column&gt;
-    &lt;p-column field="color" header="Color" [sortable]="true"&gt;&lt;/p-column&gt;
+    &lt;p-column field="color" header="Color" [sortable]="true" [compareFunction]="compareColor"&gt;&lt;/p-column&gt;
     &lt;p-footer&gt;
       &lt;button type="button" label="Sort by Year" (click)="changeSort($event)" pButton&gt;&lt;/button&gt;
     &lt;/p-footer&gt;
@@ -86,7 +91,7 @@ export class DataTableSortDemo implements OnInit &#123;
     &lt;p-column field="vin" header="Vin" [sortable]="true"&gt;&lt;/p-column&gt;
     &lt;p-column field="year" header="Year" [sortable]="true"&gt;&lt;/p-column&gt;
     &lt;p-column field="brand" header="Brand" [sortable]="true"&gt;&lt;/p-column&gt;
-    &lt;p-column field="color" header="Color" [sortable]="true"&gt;&lt;/p-column&gt;
+    &lt;p-column field="color" header="Color" [sortable]="true" [compareFunction]="compareColor"&gt;&lt;/p-column&gt;
 &lt;/p-dataTable&gt;
 </code>
 </pre>

--- a/src/app/showcase/components/datatable/datatablesortdemo.ts
+++ b/src/app/showcase/components/datatable/datatablesortdemo.ts
@@ -29,4 +29,9 @@ export class DataTableSortDemo implements OnInit {
           this.sortF = event.field;
         }
     }
+
+    compareColors(color1, color2) {
+        const colorOrder = [ 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'White', 'Gray', 'Black' ];
+        return colorOrder.indexOf(color1) - colorOrder.indexOf(color2);
+    }
 }

--- a/src/app/showcase/components/table/tabledemo.html
+++ b/src/app/showcase/components/table/tabledemo.html
@@ -735,6 +735,21 @@ this.multiSortMeta.push(&#123;field: 'brand', order: -1&#125;);
 </code>
 </pre>
 
+            <p>For custom sort ordering, a compare function can be provided via the compareFunction property on the column.</p>
+<pre>
+<code class="language-typescript" pCode ngNonBindable>
+cols = [
+    ...
+    &#123; field: 'color', header: 'Color', compareFunction: compareColors &#125;
+];
+
+function compareColors(color1, color2) &#123;
+    const order = [ 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet' ];
+    return order.indexOf(color1) - order.indexOf(color2);
+&#125;
+</code>
+</pre>
+
             <p>See the <a [routerLink]="['/table/sort']">live example.</a></p>
 
             <h3>Filtering</h3>

--- a/src/app/showcase/components/table/tablesortdemo.html
+++ b/src/app/showcase/components/table/tablesortdemo.html
@@ -76,9 +76,14 @@ export class TableSortDemo implements OnInit &#123;
             &#123; field: 'vin', header: 'Vin' &#125;,
             &#123; field: 'year', header: 'Year' &#125;,
             &#123; field: 'brand', header: 'Brand' &#125;,
-            &#123; field: 'color', header: 'Color' &#125;
+            &#123; field: 'color', header: 'Color', compareFunction: compareColors &#125;
         ];
     &#125;
+&#125;
+
+function compareColors(color1, color2) &#123;
+    const colorOrder = [ 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'White', 'Gray', 'Black' ];
+    return colorOrder.indexOf(color1) - colorOrder.indexOf(color2);
 &#125;
 </code>
 </pre>   

--- a/src/app/showcase/components/table/tablesortdemo.ts
+++ b/src/app/showcase/components/table/tablesortdemo.ts
@@ -23,7 +23,13 @@ export class TableSortDemo implements OnInit {
             { field: 'vin', header: 'Vin' },
             { field: 'year', header: 'Year' },
             { field: 'brand', header: 'Brand' },
-            { field: 'color', header: 'Color' }
+            { field: 'color', header: 'Color', compareFunction: compareColors }
         ];
     }
+
+}
+
+function compareColors(color1, color2) {
+    const colorOrder = [ 'Red', 'Orange', 'Yellow', 'Green', 'Blue', 'White', 'Gray', 'Black' ];
+    return colorOrder.indexOf(color1) - colorOrder.indexOf(color2);
 }


### PR DESCRIPTION
This allows a compareFunction property to be provided for a table column (working the same way as with Array.prototype.sort), to allow customization of the sort ordering. Implemented for both single-column and multi-column sorting.

Also added this to both the old datatable and the new turbo table.