### PR TITLE
Fixed angular formGroup example

### DIFF
--- a/src/app/showcase/components/checkbox/checkboxdemo.html
+++ b/src/app/showcase/components/checkbox/checkboxdemo.html
@@ -109,7 +109,7 @@ export class ModelComponent &#123;
 &lt;p-checkbox formControlName="cities"&gt;&lt;/p-checkbox&gt;
 
 &lt;!-- Correct --&gt;
-&lt;p-checkbox [formControl]="myFormGroup.get['cities']"&gt;&lt;/p-checkbox&gt;
+&lt;p-checkbox [formControl]="myFormGroup.get('cities')"&gt;&lt;/p-checkbox&gt;
 </code>
 </pre>
 


### PR DESCRIPTION
.get['cities'] should be .get('cities') according to https://angular.io/guide/reactive-forms#inspect-formcontrol-properties
I've tested this and can aprove this.