### PR TITLE
Fix #4872 - Add same table border of DataTable to TurboTable

### DIFF
--- a/src/app/components/table/table.css
+++ b/src/app/components/table/table.css
@@ -12,6 +12,8 @@
 .ui-table .ui-table-tbody > tr > td,
 .ui-table .ui-table-tfoot > tr > td {
     padding: .25em .5em;
+    border-width: 1px;
+    border-style: solid;
 }
 
 .ui-table .ui-sortable-column {
@@ -61,7 +63,7 @@
 
 .ui-table-scrollable-body > table > .ui-table-tbody > tr:first-child > td {
     border-top: 0 none;
-} 
+}
 
 .ui-table-virtual-table {
     position: absolute;


### PR DESCRIPTION
#4872

Added same table border of DataTable to TurboTable because the default styles are not shown properly.