### PR TITLE
Fix virtualScrollCallback not triggering for ui virtualization

### DIFF
--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -1155,7 +1155,13 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 if(this.lazy)
                     this.onLazyLoad.emit(this.createLazyLoadMetadata());
                 else
+                {
                     this.updateDataToRender(this.filteredValue||this.value);
+                  
+                    if(this.virtualScrollCallback){
+                      virtualScrollCallback();
+                    }
+                }
             }, this.virtualScrollDelay);
         });
     }

--- a/src/app/components/datatable/datatable.ts
+++ b/src/app/components/datatable/datatable.ts
@@ -1157,10 +1157,7 @@ export class DataTable implements AfterViewChecked,AfterViewInit,AfterContentIni
                 else
                 {
                     this.updateDataToRender(this.filteredValue||this.value);
-                  
-                    if(this.virtualScrollCallback){
-                      virtualScrollCallback();
-                    }
+                    this.handleDataChange();
                 }
             }, this.virtualScrollDelay);
         });


### PR DESCRIPTION
virtualScrollCallback is used to set scrollTable.style.top.
virtualScrollCallback currently only gets called on data change, which only happens on lazy load.
It should also trigger when rendering data has been updated.

This fix just showcases the problem and is probably not production-ready, however it does fix the issue.

Other things that don't work properly, but that are not included in this PR:
- Filtering does not reduce the totalRecords, allowing you to scroll as if there is no filtering
- It seems to randomly glitch out and keep showing the same records over and over

###Defect Fixes
#4964 dataTable virtualisation without lazy does not update scrollTable.top.y