### PR TITLE
Feature #4995 - Double click expand/collapse option in a Tree

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -27,7 +27,7 @@ import {BlockableUI} from '../common/blockableui';
                     ><span [class]="getIcon()" *ngIf="node.icon||node.expandedIcon||node.collapsedIcon"></span
                     ><span class="ui-treenode-label ui-corner-all" 
                         [ngClass]="{'ui-state-highlight':isSelected()}">
-                            <span *ngIf="!tree.getTemplateForNode(node)">{{node.label}}</span>
+                            <span *ngIf="!tree.getTemplateForNode(node)" class="ui-unselectable-text">{{node.label}}</span>
                             <span *ngIf="tree.getTemplateForNode(node)">
                                 <ng-container *ngTemplateOutlet="tree.getTemplateForNode(node); context: {$implicit: node}"></ng-container>
                             </span>
@@ -63,7 +63,7 @@ import {BlockableUI} from '../common/blockableui';
                                         (click)="toggle($event)"></span
                                 ><span [class]="getIcon()" *ngIf="node.icon||node.expandedIcon||node.collapsedIcon"></span
                                 ><span class="ui-treenode-label ui-corner-all">
-                                        <span *ngIf="!tree.getTemplateForNode(node)">{{node.label}}</span>
+                                        <span *ngIf="!tree.getTemplateForNode(node)" class="ui-unselectable-text">{{node.label}}</span>
                                         <span *ngIf="tree.getTemplateForNode(node)">
                                         <ng-container *ngTemplateOutlet="tree.getTemplateForNode(node); context: {$implicit: node}"></ng-container>
                                         </span>

--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -16,12 +16,12 @@ import {BlockableUI} from '../common/blockableui';
             <li *ngIf="tree.droppableNodes" class="ui-treenode-droppoint" [ngClass]="{'ui-treenode-droppoint-active ui-state-highlight':draghoverPrev}"
             (drop)="onDropPoint($event,-1)" (dragover)="onDropPointDragOver($event)" (dragenter)="onDropPointDragEnter($event,-1)" (dragleave)="onDropPointDragLeave($event)"></li>
             <li *ngIf="!tree.horizontal" [ngClass]="['ui-treenode',node.styleClass||'', isLeaf() ? 'ui-treenode-leaf': '']">
-                <div class="ui-treenode-content" (click)="onNodeClick($event)" (contextmenu)="onNodeRightClick($event)" (touchend)="onNodeTouchEnd()"
+                <div class="ui-treenode-content" (click)="onNodeClick($event)" (dblclick)="onNodeDoubleClick($event)" (contextmenu)="onNodeRightClick($event)" (touchend)="onNodeTouchEnd()"
                     (drop)="onDropNode($event)" (dragover)="onDropNodeDragOver($event)" (dragenter)="onDropNodeDragEnter($event)" (dragleave)="onDropNodeDragLeave($event)"
-                    [ngClass]="{'ui-treenode-selectable':tree.selectionMode && node.selectable !== false,'ui-treenode-dragover':draghoverNode, 'ui-treenode-content-selected':isSelected()}" [draggable]="tree.draggableNodes" (dragstart)="onDragStart($event)" (dragend)="onDragStop($event)">
+                    [ngClass]="{'ui-treenode-selectable':(tree.selectionMode || tree.expandOnDoubleClick) && node.selectable !== false,'ui-treenode-dragover':draghoverNode, 'ui-treenode-content-selected':isSelected()}" [draggable]="tree.draggableNodes" (dragstart)="onDragStart($event)" (dragend)="onDragStop($event)">
                     <span class="ui-tree-toggler  fa fa-fw" [ngClass]="{'fa-caret-right':!node.expanded,'fa-caret-down':node.expanded}"
                             (click)="toggle($event)"></span
-                    ><div class="ui-chkbox" *ngIf="tree.selectionMode == 'checkbox'"><div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default">
+                    ><div class="ui-chkbox" *ngIf="tree.selectionMode == 'checkbox'" (click)="onCheckboxClick($event)" (dblclick)="$event.stopPropagation()"><div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default">
                         <span class="ui-chkbox-icon ui-clickable fa" 
                             [ngClass]="{'fa-check':isSelected(),'fa-minus':node.partialSelected}"></span></div></div
                     ><span [class]="getIcon()" *ngIf="node.icon||node.expandedIcon||node.collapsedIcon"></span
@@ -57,7 +57,7 @@ import {BlockableUI} from '../common/blockableui';
                         </td>
                         <td class="ui-treenode" [ngClass]="{'ui-treenode-collapsed':!node.expanded}">
                             <div class="ui-treenode-content ui-state-default ui-corner-all" 
-                                [ngClass]="{'ui-treenode-selectable':tree.selectionMode,'ui-state-highlight':isSelected()}" (click)="onNodeClick($event)" (contextmenu)="onNodeRightClick($event)"
+                                [ngClass]="{'ui-treenode-selectable':(tree.selectionMode || tree.expandOnDoubleClick) && node.selectable !== false,'ui-state-highlight':isSelected()}" (click)="onNodeClick($event)" (dblclick)="onNodeDoubleClick($event)" (contextmenu)="onNodeRightClick($event)"
                                 (touchend)="onNodeTouchEnd()">
                                 <span class="ui-tree-toggler fa fa-fw" [ngClass]="{'fa-plus':!node.expanded,'fa-minus':node.expanded}" *ngIf="!isLeaf()"
                                         (click)="toggle($event)"></span
@@ -135,7 +135,21 @@ export class UITreeNode implements OnInit {
     }
 
     onNodeClick(event: MouseEvent) {
-        this.tree.onNodeClick(event, this.node);
+        if(!this.tree.expandOnDoubleClick || !this.tree.isCheckboxSelectionMode()) {
+            this.tree.onNodeClick(event, this.node);
+        }
+    }
+
+    onCheckboxClick(event: MouseEvent) {
+        if(this.tree.expandOnDoubleClick && this.tree.isCheckboxSelectionMode()) {
+            this.tree.onNodeClick(event, this.node);
+        }
+    }
+
+    onNodeDoubleClick(event: MouseEvent) {
+        if(this.tree.expandOnDoubleClick) {
+            this.toggle(event);
+        }
     }
 
     onNodeTouchEnd() {
@@ -365,6 +379,8 @@ export class Tree implements OnInit,AfterContentInit,OnDestroy,BlockableUI {
     @Input() loadingIcon: string = 'fa-circle-o-notch';
 
     @Input() emptyMessage: string = 'No records found';
+
+    @Input() expandOnDoubleClick: boolean = false;
 
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
 

--- a/src/app/showcase/components/tree/treedemo.html
+++ b/src/app/showcase/components/tree/treedemo.html
@@ -82,6 +82,13 @@
     <h3>Horizontal Tree</h3>
     <p-tree [value]="filesTree11" layout="horizontal" selectionMode="single" [(selection)]="selectedFile3" ></p-tree>
     <div style="margin-top:8px">Selected Node: {{selectedFile3 ? selectedFile3.label : 'none'&#125;&#125;</div>
+
+    <h3>Double Click Expand</h3>
+    <p-tree [value]="filesTree12" [expandOnDoubleClick]="true"></p-tree>
+
+    <h3>Double Click Expand for Multiple Selection with Checkbox</h3>
+    <p-tree [value]="filesTree13" [expandOnDoubleClick]="true" selectionMode="checkbox" [(selection)]="selectedFiles3"></p-tree>
+    <div>Selected Nodes: <span *ngFor="let file of selectedFiles3">{{file.label&#125;&#125;</span></div>
 </div>
 
 <div class="content-section documentation">
@@ -561,6 +568,15 @@ import &#123;TreeDragDropService&#125; from 'primeng/api';
 &lt;p-tree [value]="files" layout="horizontal"&gt;&lt;/p-tree&gt;
 </code>
 </pre>
+            <h3>Expand on Double Click</h3>
+            <p>When enabled, nodes will expand/collapse and fire a onNodeExpand/onNodeCollapse event when double clicked</p>
+            <p>When used in combination with checkbox selection mode, selection can only be toggled by clicking the actual checkboxes</p>
+
+<pre>
+<code class="language-markup" pCode ngNonBindable>
+&lt;p-tree [value]="files" [expandOnDoubleClick]="true"&gt;&lt;/p-tree&gt;
+</code>
+</pre>
 
             <h3>Properties</h3>
             <div class="doc-tablewrapper">
@@ -646,6 +662,12 @@ import &#123;TreeDragDropService&#125; from 'primeng/api';
                             <td>string</td>
                             <td>fa-circle-o-notch</td>
                             <td>The icon to show while indicating data load is in progress.</td>
+                        </tr>
+                        <tr>
+                            <td>expandOnDoubleClick</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>Whether nodes should be expanded when double clicked.</td>
                         </tr>
                     </tbody>
                 </table>
@@ -846,6 +868,14 @@ import &#123;TreeDragDropService&#125; from 'primeng/api';
 &lt;h3&gt;Horizontal Tree&lt;/h3&gt;
 &lt;p-tree [value]="filesTree11" layout="horizontal" selectionMode="single" [(selection)]="selectedFile3" &gt;&lt;/p-tree&gt;
 &lt;div style="margin-top:8px"&gt;Selected Node: &#123;selectedFile3 ? selectedFile3.label : 'none'&#125;&lt;/div&gt;
+
+&lt;h3&gt;Double Click Expand&lt;/h3&gt;
+&lt;p-tree [value]="filesTree12" [expandOnDoubleClick]="true">&lt;/p-tree>
+
+&lt;h3&gt;Double Click Expand for Multiple Selection with Checkbox&lt;/h3&gt;
+&lt;p-tree [value]="filesTree13" [expandOnDoubleClick]="true" selectionMode="checkbox" [(selection)]="selectedFiles3"&gt;&lt;/p-tree&gt;
+&lt;div&gt;Selected Nodes: &lt;span *ngFor="let file of selectedFiles3"&gt;&#123;&#123;file.label&#125;&#125;&lt;/span&gt;&lt;/div&gt;
+
 </code>
 </pre>
 
@@ -869,6 +899,8 @@ export class TreeDemo implements OnInit &#123;
     filesTree9: TreeNode[];
     filesTree10: TreeNode[];
     filesTree11: TreeNode[];
+    filesTree12: TreeNode[];
+    filesTree13: TreeNode[];
 
     lazyFiles: TreeNode[];
 
@@ -881,6 +913,8 @@ export class TreeDemo implements OnInit &#123;
     selectedFiles: TreeNode[];
 
     selectedFiles2: TreeNode[];
+
+    selectedFiles3: TreeNode[];
 
     items: MenuItem[];
 
@@ -924,6 +958,8 @@ export class TreeDemo implements OnInit &#123;
                 children: files
             &#125;];
         &#125;);
+        this.nodeService.getFiles().then(files => this.filesTree12 = files);
+        this.nodeService.getFiles().then(files => this.filesTree13 = files);
 
         this.nodeService.getLazyFiles().then(files => this.lazyFiles = files);
 

--- a/src/app/showcase/components/tree/treedemo.ts
+++ b/src/app/showcase/components/tree/treedemo.ts
@@ -15,7 +15,7 @@ import {TreeDragDropService} from '../../../components/common/api';
     providers: [TreeDragDropService]
 })
 export class TreeDemo implements OnInit {
-    
+
     msgs: Message[];
 
     @ViewChild('expandingTree')
@@ -33,23 +33,27 @@ export class TreeDemo implements OnInit {
     filesTree9: TreeNode[];
     filesTree10: TreeNode[];
     filesTree11: TreeNode[];
-    
+    filesTree12: TreeNode[];
+    filesTree13: TreeNode[];
+
     lazyFiles: TreeNode[];
-    
+
     selectedFile: TreeNode;
-    
+
     selectedFile2: TreeNode;
-    
+
     selectedFile3: TreeNode;
-    
+
     selectedFiles: TreeNode[];
-    
+
     selectedFiles2: TreeNode[];
-    
+
+    selectedFiles3: TreeNode[];
+
     items: MenuItem[];
-    
+
     loading: boolean;
-        
+
     constructor(private nodeService: NodeService) { }
 
     ngOnInit() {
@@ -88,20 +92,22 @@ export class TreeDemo implements OnInit {
                 children: files
             }];
         });
+        this.nodeService.getFiles().then(files => this.filesTree12 = files);
+        this.nodeService.getFiles().then(files => this.filesTree13 = files);
 
         this.nodeService.getLazyFiles().then(files => this.lazyFiles = files);
-        
+
         this.items = [
             {label: 'View', icon: 'fa-search', command: (event) => this.viewFile(this.selectedFile2)},
             {label: 'Unselect', icon: 'fa-close', command: (event) => this.unselectFile()}
         ];
     }
-    
+
     nodeSelect(event) {
         this.msgs = [];
         this.msgs.push({severity: 'info', summary: 'Node Selected', detail: event.node.label});
     }
-    
+
     nodeUnselect(event) {
         this.msgs = [];
         this.msgs.push({severity: 'info', summary: 'Node Unselected', detail: event.node.label});
@@ -111,19 +117,19 @@ export class TreeDemo implements OnInit {
         this.msgs = [];
         this.msgs.push({severity: 'info', summary: 'Node Expanded', detail: event.node.label});
     }
-    
+
     nodeExpand(event) {
         if(event.node) {
             //in a real application, make a call to a remote url to load children of the current node and add the new nodes as children
             this.nodeService.getLazyFiles().then(nodes => event.node.children = nodes);
         }
     }
-    
+
     viewFile(file: TreeNode) {
         this.msgs = [];
         this.msgs.push({severity: 'info', summary: 'Node Selected with Right Click', detail: file.label});
     }
-    
+
     unselectFile() {
         this.selectedFile2 = null;
     }
@@ -139,7 +145,7 @@ export class TreeDemo implements OnInit {
             this.expandRecursive(node, false);
         } );
     }
-    
+
     private expandRecursive(node:TreeNode, isExpand:boolean){
         node.expanded = isExpand;
         if(node.children){


### PR DESCRIPTION
https://github.com/primefaces/primeng/issues/4995

Adds an option to Tree to expand/collapse on double clicking a node.
When the expandOnDoubleClick option is enabled together with checkbox selection mode, nodes will have to be checked by clicking on the checkboxes instead of anywhere on the line.
Also disabled text highlighting in the tree by default (can still be overwritten by implementing custom node content by usage of a template.