### PR TITLE
Scoping for MessageService FIx for 4347  & 4572 

### DIFF
--- a/src/app/components/common/message.ts
+++ b/src/app/components/common/message.ts
@@ -1,4 +1,5 @@
 export interface Message {
+    key?: string;
     severity?: string;
     summary?: string;
     detail?: string;

--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -28,7 +28,7 @@ import {BlockableUI} from '../common/blockableui';
                 (dragenter)="onDragEnter($event)" (dragleave)="onDragLeave($event)" (drop)="onDrop($event)">
                 <p-progressBar [value]="progress" [showValue]="false" *ngIf="hasFiles()"></p-progressBar>
                 
-                <p-messages [value]="msgs"></p-messages>
+                <p-messages [value]="msgs" [key]="key"></p-messages>
                 
                 <div class="ui-fileupload-files" *ngIf="hasFiles()">
                     <div *ngIf="!fileTemplate">
@@ -104,6 +104,8 @@ export class FileUpload implements OnInit,AfterViewInit,AfterContentInit,OnDestr
     @Input() mode: string = 'advanced';
 
     @Input() customUpload: boolean;
+
+    @Input() key: string;
 
     @Output() onBeforeUpload: EventEmitter<any> = new EventEmitter();
 
@@ -241,6 +243,7 @@ export class FileUpload implements OnInit,AfterViewInit,AfterContentInit,OnDestr
     validate(file: File): boolean {
         if(this.accept && !this.isFileTypeValid(file)) {
             this.msgs.push({
+                key: this.key,
                 severity: 'error',
                 summary: this.invalidFileTypeMessageSummary.replace('{0}', file.name),
                 detail: this.invalidFileTypeMessageDetail.replace('{0}', this.accept)
@@ -250,6 +253,7 @@ export class FileUpload implements OnInit,AfterViewInit,AfterContentInit,OnDestr
 
         if(this.maxFileSize  && file.size > this.maxFileSize) {
             this.msgs.push({
+                key: this.key,
                 severity: 'error',
                 summary: this.invalidFileSizeMessageSummary.replace('{0}', file.name),
                 detail: this.invalidFileSizeMessageDetail.replace('{0}', this.formatSize(this.maxFileSize))

--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -28,13 +28,24 @@ import {Subscription}   from 'rxjs/Subscription';
 })
 export class Messages implements OnDestroy {
 
-    @Input() value: Message[];
+    private _value: Message[];
+
+    get value(){
+      return this._value;
+    }
+
+    @Input()
+    set value(value: Message[]){
+      this._value = value ? value.filter((m) => this.key === m.key): value ;
+    }
 
     @Input() closable: boolean = true;
 
     @Input() style: any;
-    
+
     @Input() styleClass: string;
+
+    @Input() key: string;
 
     @Output() valueChange: EventEmitter<Message[]> = new EventEmitter<Message[]>();
 
@@ -43,11 +54,17 @@ export class Messages implements OnDestroy {
     constructor(@Optional() public messageService: MessageService) {
         if(messageService) {
             this.subscription = messageService.messageObserver.subscribe((messages: any) => {
-                if(messages) {
-                    if(messages instanceof Array)
-                        this.value = this.value ? [...this.value, ...messages] : [...messages];
-                    else
+                if (messages) {
+                    if (messages instanceof Array){
+                      messages =  messages.filter((m) => this.key === m.key);
+                      this.value = this.value ? [...this.value, ...messages] : [...messages];
+                    }
+
+                    else {
+                      if (this.key === messages.key)
                         this.value = this.value ? [...this.value, ...[messages]]: [messages];
+                    }
+
                 }
                 else {
                     this.value = null;

--- a/src/app/showcase/components/fileupload/fileuploaddemo.html
+++ b/src/app/showcase/components/fileupload/fileuploaddemo.html
@@ -8,20 +8,39 @@
 
 <div class="content-section implementation">
     <p-growl [value]="msgs"></p-growl>
-        
+
     <h3 class="first">Advanced</h3>
-    <p-fileUpload name="demo[]" url="./upload.php" (onUpload)="onUpload($event)" 
-            multiple="multiple" accept="image/*" maxFileSize="1000000"> 
+    <p-fileUpload name="demo[]" url="./upload.php" (onUpload)="onUpload($event)"
+            multiple="multiple" accept="image/*" maxFileSize="1000000">
             <ng-template pTemplate="content">
                 <ul *ngIf="uploadedFiles.length">
                     <li *ngFor="let file of uploadedFiles">{{file.name}} - {{file.size}} bytes</li>
                 </ul>
-            </ng-template>    
+            </ng-template>
     </p-fileUpload>
-    
+
+  <h3 class="first">Multiple Advanced with KEY for error message</h3>
+  <p-fileUpload name="demo[]" url="./upload.php" (onUpload)="onUpload($event)"
+                multiple="multiple" accept="image/*" maxFileSize="1" [key]="'upload1'">
+    <ng-template pTemplate="content">
+      <ul *ngIf="uploadedFiles.length">
+        <li *ngFor="let file of uploadedFiles">{{file.name}} - {{file.size}} bytes</li>
+      </ul>
+    </ng-template>
+  </p-fileUpload>
+
+  <p-fileUpload name="demo[]" url="./upload.php" (onUpload)="onUpload($event)"
+                multiple="multiple" accept="image/*" maxFileSize="1" [key]="'upload2'">
+    <ng-template pTemplate="content">
+      <ul *ngIf="uploadedFiles.length">
+        <li *ngFor="let file of uploadedFiles">{{file.name}} - {{file.size}} bytes</li>
+      </ul>
+    </ng-template>
+  </p-fileUpload>
+
     <h3>Basic</h3>
     <p-fileUpload mode="basic" name="demo[]" url="./upload.php" accept="image/*" maxFileSize="1000000" (onUpload)="onBasicUpload($event)"></p-fileUpload>
-    
+
     <h3>Basic with Auto</h3>
     <p-fileUpload #fubauto mode="basic" name="demo[]" url="./upload.php" accept="image/*" maxFileSize="1000000" (onUpload)="onBasicUploadAuto($event)" auto="true" chooseLabel="Browse"></p-fileUpload>
 </div>
@@ -54,7 +73,7 @@ import &#123;FileUploadModule&#125; from 'primeng/fileupload';
 
             <h3>DragDrop</h3>
             <p>File selection can also be done by dragging and dropping one or more to the content section of the component.</p>
-            
+
             <h3>Auto Uploads</h3>
             <p>When auto property is enabled, upload begins as soon as file selection is completed or a file is dropped on the drop area.</p>
 <pre>
@@ -83,16 +102,16 @@ import &#123;FileUploadModule&#125; from 'primeng/fileupload';
 </code>
 </pre>
 
-            <p>In order to customize the default messages use invalidFileSizeMessageSummary and invalidFileSizeMessageDetail options. 
+            <p>In order to customize the default messages use invalidFileSizeMessageSummary and invalidFileSizeMessageDetail options.
             In summary &#123;0&#125; placeholder refers to the filename and in detail, file size.</p>
             <ul>
                 <li>invalidFileSizeMessageSummary: '&#123;0&#125;: Invalid file size, '</li>
                 <li>invalidFileSizeMessageDetail: string = 'maximum upload size is &#123;0&#125;.'</li>
             </ul>
-            
+
             <h3>Templating</h3>
             <p>File list UI is customizable using a ng-template called "file" that gets the <a href="https://www.w3.org/TR/FileAPI/">File</a> instance as the implicit variable.
-                Second ng-template named "content" can be used to place custom content inside the content section which would be useful to implement a user interface to manage the uploaded files such as removing them.  
+                Second ng-template named "content" can be used to place custom content inside the content section which would be useful to implement a user interface to manage the uploaded files such as removing them.
                 Third and final ng-template option is "toolbar" to display custom content at toolbar.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
@@ -100,13 +119,13 @@ import &#123;FileUploadModule&#125; from 'primeng/fileupload';
         accept="image/*" maxFileSize="1000000"&gt;
         &lt;ng-template pTemplate="toolbar"&gt;
             &lt;div&gt;Upload 3 Files&lt;/div&gt;
-        &lt;/ng-template&gt;  
+        &lt;/ng-template&gt;
         &lt;ng-template let-file pTemplate="file"&gt;
             &lt;div&gt;Custom UI to display a file&lt;/div&gt;
-        &lt;/ng-template&gt; 
+        &lt;/ng-template&gt;
         &lt;ng-template pTemplate="content"&gt;
             &lt;div&gt;Custom UI to manage uploaded files&lt;/div&gt;
-        &lt;/ng-template&gt;  
+        &lt;/ng-template&gt;
 &lt;/p-fileUpload&gt;
 </code>
 </pre>
@@ -114,7 +133,7 @@ import &#123;FileUploadModule&#125; from 'primeng/fileupload';
             <h3>Request Customization</h3>
             <p>XHR request to upload the files can be customized using the onBeforeUpload callback that passes
                 the xhr instance and FormData object as event parameters.</p>
-                
+
             <h3>Basic UI</h3>
             <p>FileUpload basic mode provides a simpler UI as an alternative to advanced mode.</p>
 <pre>
@@ -137,7 +156,7 @@ myUploader(event) &#123;
 &#125;
 </code>
 </pre>
-            
+
             <h3>Properties</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">
@@ -366,7 +385,7 @@ myUploader(event) &#123;
                     </tbody>
                 </table>
             </div>
-            
+
             <h3>Methods</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">
@@ -431,15 +450,15 @@ myUploader(event) &#123;
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-growl [value]="msgs"&gt;&lt;/p-growl&gt;
-    
+
 &lt;h3 class="first"&gt;Advanced&lt;/h3&gt;
-&lt;p-fileUpload name="demo[]" url="./upload.php" (onUpload)="onUpload($event)" 
+&lt;p-fileUpload name="demo[]" url="./upload.php" (onUpload)="onUpload($event)"
         multiple="multiple" accept="image/*" maxFileSize="1000000"&gt;
     &lt;ng-template pTemplate="content"&gt;
         &lt;ul *ngIf="uploadedFiles.length"&gt;
             &lt;li *ngFor="let file of uploadedFiles"&gt;&#123;&#123;file.name&#125;&#125; - &#123;&#123;file.size&#125;&#125; bytes&lt;/li&gt;
         &lt;/ul&gt;
-    &lt;/ng-template&gt;        
+    &lt;/ng-template&gt;
 &lt;/p-fileUpload&gt;
 
 &lt;h3&gt;Basic&lt;/h3&gt;
@@ -455,14 +474,14 @@ myUploader(event) &#123;
 export class FileUploadDemo &#123;
 
     msgs: Message[];
-    
+
     uploadedFiles: any[] = [];
 
     onUpload(event) &#123;
         for(let file of event.files) &#123;
             this.uploadedFiles.push(file);
         &#125;
-    
+
         this.msgs = [];
         this.msgs.push(&#123;severity: 'info', summary: 'File Uploaded', detail: ''&#125;);
     &#125;

--- a/src/app/showcase/components/messages/messagesdemo.html
+++ b/src/app/showcase/components/messages/messagesdemo.html
@@ -17,22 +17,33 @@
         <button type="button" pButton (click)="showMultiple()" label="Multiple"></button>
         <button type="button" pButton (click)="clear()" icon="fa-close" style="float:right" label="Clear"></button>
     </div>
-    
+
     <h3>Message Service</h3>
     <button type="button" pButton (click)="showViaService()" label="Use Service"></button>
-    
+
+  <h3>Multiple component with Message Service and key</h3>
+  <p-messages [key]="'key1'"></p-messages>
+  <p-messages [key]="'key2'"></p-messages>
+  <button type="button" pButton (click)="showViaServiceWithKey('key1')" label="Use Service with key 1"></button>
+  <button type="button" pButton (click)="showViaServiceWithKey('key2')" label="Use Service with key 2"></button>
+
+  <button type="button" pButton (click)="showMultipleViaServiceWithKey('key1')" label="Multiple via Service with key 1"></button>
+  <button type="button" pButton (click)="showMultipleViaServiceWithKey('key2')" label="Multiple via Service with key 2"></button>
+
+
+
     <h3>Inline Message CSS</h3>
     <p>p-message component is used to display inline messages mostly within forms.</p>
     <p-message severity="info" text="PrimeNG Rocks"></p-message>
-    <p-message severity="success" text="Record Saved"></p-message>  
-    <p-message severity="warn" text="Are you sure?"></p-message>  
+    <p-message severity="success" text="Record Saved"></p-message>
+    <p-message severity="warn" text="Are you sure?"></p-message>
     <p-message severity="error" text="Field is required"></p-message>
-    
+
     <div style="margin-top:30px">
         <input type="text" pInputText placeholder="Username" class="ng-dirty ng-invalid">
         <p-message severity="error" text="Field is required"></p-message>
     </div>
-    
+
     <div style="margin-top:30px">
         <input type="text" pInputText placeholder="Email" class="ng-dirty ng-invalid">
         <p-message severity="error"></p-message>
@@ -52,14 +63,14 @@ import &#123;MessageModule&#125; from 'primeng/message';
 
             <h3>Getting Started</h3>
             <p>A single message is specified by Message interface in PrimeNG that defines the id, severity, summary and detail as the properties.
-                Messages to display can either be defined using the value property which should an array of Message instances or using 
+                Messages to display can either be defined using the value property which should an array of Message instances or using
                 a MessageService are defined using the value property which should an array of Message instances.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-messages [(value)]="msgs"&gt;&lt;/p-messages&gt;
 </code>
 </pre>
-            
+
             <h3>Message Array</h3>
             <p>A binding to the value property is required to provide messages to the component.</p>
 <pre>
@@ -85,9 +96,9 @@ hide() &#123;
 
             <h3>Message Service</h3>
             <p>MessageService alternative does not require a value binding to an array.
-            In order to use this service, import the class and define it as a provider in a component higher up in the component tree such as application instance itself 
+            In order to use this service, import the class and define it as a provider in a component higher up in the component tree such as application instance itself
             so that descandant components can have it injected.</p>
-            
+
 <pre>
 <code class="language-typescript" pCode ngNonBindable>
 import &#123;MessageService&#125; from 'primeng/components/common/messageservice';
@@ -115,7 +126,7 @@ import &#123;MessageService&#125; from 'primeng/components/common/messageservice
             this.messageService.addAll([&#123;severity:'success', summary:'Service Message', detail:'Via MessageService'&#125;,
                             &#123;severity:'info', summary:'Info Message', detail:'Via MessageService'&#125;]);
         &#125;
-        
+
         clear() &#123;
             this.messageService.clear();
         &#125;
@@ -147,7 +158,7 @@ import &#123;MessageService&#125; from 'primeng/components/common/messageservice
                 <li>warn</li>
                 <li>error</li>
             </ul>
-            
+
             <h3>Message Component</h3>
             <p>Message component is useful in cases where messages need to be displayed related to an element such as forms. It has two property, severity and text of the message.</p>
 <pre>
@@ -155,8 +166,8 @@ import &#123;MessageService&#125; from 'primeng/components/common/messageservice
 &lt;h3&gt;Inline Message CSS&lt;/h3&gt;
 &lt;p&gt;CSS helpers to display inline messages mostly within forms.&lt;/p&gt;
 &lt;p-message severity="info" text="PrimeNG Rocks"&gt;&lt;/p-message&gt;
-&lt;p-message severity="success" text="Record Saved"&gt;&lt;/p-message&gt;  
-&lt;p-message severity="warn" text="Are you sure?"&gt;&lt;/p-message&gt;  
+&lt;p-message severity="success" text="Record Saved"&gt;&lt;/p-message&gt;
+&lt;p-message severity="warn" text="Are you sure?"&gt;&lt;/p-message&gt;
 &lt;p-message severity="error" text="Field is required"&gt;&lt;/p-message&gt;
 </code>
 </pre>
@@ -281,8 +292,8 @@ import &#123;MessageService&#125; from 'primeng/components/common/messageservice
 &lt;h3&gt;Inline Message CSS&lt;/h3&gt;
 &lt;p&gt;CSS helpers to display inline messages mostly within forms.&lt;/p&gt;
 &lt;p-message severity="info" text="PrimeNG Rocks"&gt;&lt;/p-message&gt;
-&lt;p-message severity="success" text="Record Saved"&gt;&lt;/p-message&gt;  
-&lt;p-message severity="warn" text="Are you sure?"&gt;&lt;/p-message&gt;  
+&lt;p-message severity="success" text="Record Saved"&gt;&lt;/p-message&gt;
+&lt;p-message severity="warn" text="Are you sure?"&gt;&lt;/p-message&gt;
 &lt;p-message severity="error" text="Field is required"&gt;&lt;/p-message&gt;
 
 &lt;div style="margin-top:30px"&gt;
@@ -311,7 +322,7 @@ import &#123;MessageService&#125; from 'primeng/components/common/messageservice
 export class GrowlDemo &#123;
 
     msgs: Message[] = [];
-    
+
     constructor(private messageService: MessageService) &#123;&#125;
 
     showSuccess() &#123;
@@ -340,7 +351,7 @@ export class GrowlDemo &#123;
         this.msgs.push(&#123;severity:'info', summary:'Message 2', detail:'PrimeUI rocks'&#125;);
         this.msgs.push(&#123;severity:'info', summary:'Message 3', detail:'PrimeFaces rocks'&#125;);
     &#125;
-    
+
     showViaService() &#123;
         this.messageService.add(&#123;severity:'success', summary:'Service Message', detail:'Via MessageService'&#125;);
     &#125;

--- a/src/app/showcase/components/messages/messagesdemo.ts
+++ b/src/app/showcase/components/messages/messagesdemo.ts
@@ -9,9 +9,9 @@ import {MessageService} from '../../../components/common/messageservice';
 export class MessagesDemo {
 
     msgs: Message[] = [];
-    
+
     constructor(private messageService: MessageService) {}
-    
+
     showSuccess() {
         this.msgs = [];
         this.msgs.push({severity:'success', summary:'Success Message', detail:'Order submitted'});
@@ -38,10 +38,20 @@ export class MessagesDemo {
         this.msgs.push({severity:'info', summary:'Message 2', detail:'PrimeUI rocks'});
         this.msgs.push({severity:'info', summary:'Message 3', detail:'PrimeFaces rocks'});
     }
-    
+
     showViaService() {
         this.messageService.add({severity:'success', summary:'Service Message', detail:'Via MessageService'});
     }
+
+    showViaServiceWithKey(key: string){
+      this.messageService.add({severity:'success', summary:'Service Message', detail:'Via MessageService with key ' +key,key:key});
+    }
+
+  showMultipleViaServiceWithKey(key: string){
+    this.messageService.addAll([{severity:'success', summary:'Service Message 1', detail:'PrimeNG rocks with key ' +key,key:key},
+      {severity:'success', summary:'Service Message 1', detail:'PrimeUI rocks with key ' +key,key:key},
+      {severity:'success', summary:'Service Message 1', detail:'PrimeFaces rocks with key ' +key,key:key}]);
+  }
 
     clear() {
         this.msgs = [];


### PR DESCRIPTION
This fix add a key on p-message and p-growl.

-  allow to have a scope for message service as we have for p-confirm-dialog (see issue [4347](https://github.com/primefaces/primeng/issues/4347))
- the key is used in p-fileUpload to allow multiple file upload components (advanced mode) with independant error message in case of invalid File Type or Invalid File size  (see issue [4572](https://github.com/primefaces/primeng/issues/4572))



