### PR TITLE
Dropdown do not close on enter if no match

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -581,9 +581,11 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             
             //enter
             case 13:
-                this.hide();
-
-                event.preventDefault();
+                let selectedItemIndex = this.selectedOption ? this.findOptionIndex(this.selectedOption.value, this.optionsToDisplay) : -1;
+                if (selectedItemIndex !== -1) {
+                    this.hide();
+                    event.preventDefault();
+                }
             break;
             
             //escape and tab


### PR DESCRIPTION
Proposal:
When using the filter option, if all options are filtered, and so
no match found, I believe that keyboard enter key shouldn't close the
dropdown.
It give the wrong feeling that a new value had been selected where it's
not the case.

This is a solution to not close the dropdown in such a case.