### PR TITLE
Fix 5080

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -7,6 +7,7 @@ import {SharedModule,PrimeTemplate} from '../common/shared';
 import {DomHandler} from '../dom/domhandler';
 import {ObjectUtils} from '../utils/objectutils';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
+import { SelectItemGroup } from '../common/selectitemgroup';
 
 export const DROPDOWN_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -630,23 +631,12 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         }
     }
     
-    findOption(val: any, opts: any[], mayRecur=true): SelectItem {
-        if(this.group && mayRecur) {
-            let opt: SelectItem;
-            if(opts && opts.length) {
-                for(let optgroup of opts) {
-                    opt = this.findOption(val, optgroup.items, false);
-                    if(opt) {
-                        break;
-                    }
-                }
-            }
-            return opt;
-        }
-        else {
-            let index: number = this.findOptionIndex(val, opts);
-            return (index != -1) ? opts[index] : null;
-        }
+    findOption(val: any, opts: any[]): SelectItem {
+        const searchable = (this.group)
+        ? opts.reduce((a, opt: SelectItemGroup) => a.concat(opt.items), [])
+        : opts;
+        const index: number = this.findOptionIndex(val, searchable);
+        return (index !== -1) ? searchable[index] : null;
     }
     
     onFilter(event): void {

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -630,12 +630,12 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         }
     }
     
-    findOption(val: any, opts: any[]): SelectItem {
-        if(this.group) {
+    findOption(val: any, opts: any[], mayRecur=true): SelectItem {
+        if(this.group && mayRecur) {
             let opt: SelectItem;
             if(opts && opts.length) {
                 for(let optgroup of opts) {
-                    opt = this.findOption(val, optgroup.items);
+                    opt = this.findOption(val, optgroup.items, false);
                     if(opt) {
                         break;
                     }


### PR DESCRIPTION
Trying to fix behaviour of Dropdown when used with [group]=true


- As described in #5080 , the grouped dropdown was not able to update it gui after the value had been set programatically.
- when the options were being set asynchronously (i.e. [options]="groupedOptions$ | async" ), a previously selected option - even though still present in the new list of options would - disappear, and the placeholder would appear instead.

re https://github.com/primefaces/primeng/issues/5080


###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.