### PR TITLE
Make configurable Messages's icon.

### DIFF
--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -36,6 +36,18 @@ export class Messages implements OnDestroy {
     
     @Input() styleClass: string;
 
+    @Input() icons: {
+      success: string,
+      info: string,
+      error: string,
+      warn: string,
+    } = {
+      success: 'fa-check',
+      info: 'fa-info-circle',
+      error: 'fa-close',
+      warn: 'fa-warning',
+    };
+
     @Output() valueChange: EventEmitter<Message[]> = new EventEmitter<Message[]>();
 
     subscription: Subscription;
@@ -77,19 +89,19 @@ export class Messages implements OnDestroy {
             let msg = this.value[0];
             switch(msg.severity) {
                 case 'success':
-                    icon = 'fa-check';
+                    icon = this.icons.success;
                 break;
 
                 case 'info':
-                    icon = 'fa-info-circle';
+                    icon = this.icons.info;
                 break;
 
                 case 'error':
-                    icon = 'fa-close';
+                    icon = this.icons.error;
                 break;
 
                 case 'warn':
-                    icon = 'fa-warning';
+                    icon = this.icons.warn;
                 break;
 
                 default:


### PR DESCRIPTION
# description
Adding `icons` input interface to `Messages` component, for overwrite serverity icons;

# why
In my case, serverity `error` icon looks like the close button.
So I want to custom message icon like following:
![image](https://user-images.githubusercontent.com/10954150/36585301-a93a0928-18c0-11e8-8aee-310d732be443.png)
