### PR TITLE
 Fixed splitbutton display in IE 11, Firefox 57 and Edge

### DIFF
--- a/src/app/components/button/button.css
+++ b/src/app/components/button/button.css
@@ -32,8 +32,7 @@ p-button {
 .ui-button-icon-only .ui-button-text,
 .ui-button-text-empty .ui-button-text { 
     padding: .25em; 
-    text-indent: -9999999px; 
-    overflow: hidden;
+    text-indent: -9999999px;
 }
 
 .ui-button-text-icon-left .ui-button-text { 

--- a/src/app/components/button/button.css
+++ b/src/app/components/button/button.css
@@ -32,7 +32,7 @@ p-button {
 .ui-button-icon-only .ui-button-text,
 .ui-button-text-empty .ui-button-text { 
     padding: .25em; 
-    text-indent: -9999999px;
+    text-indent: -9999999px; 
 }
 
 .ui-button-text-icon-left .ui-button-text { 


### PR DESCRIPTION
Setting overflow: hidden in the previous change caused splitbuttons to display incorrectly in all browsers except Google Chrome.

The bug can be seen on https://www.primefaces.org/primeng/#/splitbutton