### PR TITLE
InputMask component's value not synced

### DIFF
--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -596,7 +596,8 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
     }
     
     updateModel(e) {
-        this.onModelChange(this.unmask ? this.getUnmaskedValue() : e.target.value);
+        this.value = this.unmask ? this.getUnmaskedValue() : e.target.value;
+        this.onModelChange(this.value);
     }
     
     updateFilledState() {


### PR DESCRIPTION
# description
When updating model value, synchronize component's `value` with model.

# why
InputMask.value same with initialized value, and not updated after component was initialized.
So, cannot get current, latest value from my component.