### PR TITLE
Checkbox demo syntax error fix

### DIFF
--- a/src/app/showcase/components/checkbox/checkboxdemo.html
+++ b/src/app/showcase/components/checkbox/checkboxdemo.html
@@ -109,7 +109,7 @@ export class ModelComponent &#123;
 &lt;p-checkbox formControlName="cities"&gt;&lt;/p-checkbox&gt;
 
 &lt;!-- Correct --&gt;
-&lt;p-checkbox [formControl]="myFormGroup.get['cities']"&gt;&lt;/p-checkbox&gt;
+&lt;p-checkbox [formControl]="myFormGroup.get('cities')"&gt;&lt;/p-checkbox&gt;
 </code>
 </pre>
 


### PR DESCRIPTION
I believe this is a typo - myFormGroup.get is a method, not an array.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.