### PR TITLE
Add onYearChange to Calendar

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1006,11 +1006,13 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     onMonthDropdownChange(m: string) {
         this.currentMonth = parseInt(m);
+        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
         this.createMonth(this.currentMonth, this.currentYear);
     }
     
     onYearDropdownChange(y: string) {
         this.currentYear = parseInt(y);
+        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
         this.createMonth(this.currentMonth, this.currentYear);
     }
     

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -265,6 +265,8 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     @Output() onMonthChange: EventEmitter<any> = new EventEmitter();
     
+    @Output() onYearChange: EventEmitter<any> = new EventEmitter();
+    
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     
     _locale: LocaleSettings = {
@@ -1012,7 +1014,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     onYearDropdownChange(y: string) {
         this.currentYear = parseInt(y);
-        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
+        this.onYearChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
         this.createMonth(this.currentMonth, this.currentYear);
     }
     

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -603,6 +603,13 @@ export class MyModel &#123;
                                 event.year: New year
                             </td>
                             <td>Callback to invoke when a month is changed using the navigators.</td>
+                        </tr>                        
+                        <tr>
+                            <td>onYearChange</td>
+                            <td>event.month: New month <br />
+                                event.year: New year
+                            </td>
+                            <td>Callback to invoke when a year is changed using the navigators.</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
onMonthChange emitted when year and month dropdowns are changed

Attempt to resolve comment from previous PR relating to this issue
https://github.com/primefaces/primeng/pull/5264#issuecomment-370665886

###Defect Fixes
#4708 - Calendar onMonthChange is not triggered when change in yearNavigator or monthNavigator