### PR TITLE
#5280 #5288 #5286 #5285 Fix DropwDown clear button

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -44,7 +44,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
             <label [ngClass]="{'ui-dropdown-label ui-inputtext ui-corner-all ui-placeholder':true,'ui-dropdown-label-empty': (placeholder == null || placeholder.length === 0)}" *ngIf="!editable && (label == null)">{{placeholder||'empty'}}</label>
             <input #editableInput type="text" [attr.aria-label]="selectedOption ? selectedOption.label : ' '" class="ui-dropdown-label ui-inputtext ui-corner-all" *ngIf="editable" [disabled]="disabled" [attr.placeholder]="placeholder"
                         (click)="onEditableInputClick($event)" (input)="onEditableInputChange($event)" (focus)="onEditableInputFocus($event)" (blur)="onInputBlur($event)">
-            <i class="ui-dropdown-clear-icon fa fa-close" (click)="clear($event)" *ngIf="value != null"></i>
+            <i class="ui-dropdown-clear-icon fa fa-close" (click)="clear($event)" *ngIf="clearButton && value != null"></i>
             <div class="ui-dropdown-trigger ui-state-default ui-corner-right">
                 <span class="ui-clickable" [ngClass]="dropdownIcon"></span>
             </div>
@@ -105,132 +105,132 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     @Input() scrollHeight: string = '200px';
 
     @Input() filter: boolean;
-    
+
     @Input() name: string;
 
     @Input() style: any;
-    
+
     @Input() panelStyle: any;
 
     @Input() styleClass: string;
-    
+
     @Input() panelStyleClass: string;
-    
+
     @Input() disabled: boolean;
-    
+
     @Input() readonly: boolean;
-    
+
     @Input() autoWidth: boolean = true;
-    
+
     @Input() required: boolean;
-    
+
     @Input() editable: boolean;
-    
+
     @Input() appendTo: any;
 
     @Input() tabindex: number;
-    
+
     @Input() placeholder: string;
-    
+
     @Input() filterPlaceholder: string;
 
     @Input() inputId: string;
-    
+
     @Input() dataKey: string;
-    
+
     @Input() filterBy: string = 'label';
-    
+
     @Input() lazy: boolean = true;
-    
+
     @Input() autofocus: boolean;
-    
+
     @Input() resetFilterOnHide: boolean = false;
-    
+
     @Input() dropdownIcon: string = 'fa fa-fw fa-caret-down';
-    
+
     @Input() optionLabel: string;
 
     @Input() autoDisplayFirst: boolean = true;
 
+    @Input() clearButton: boolean = false;
+
     @Input() group: boolean;
 
     @Input() emptyFilterMessage: string = 'No results found';
-    
+
     @Output() onChange: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onFocus: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onBlur: EventEmitter<any> = new EventEmitter();
-    
+
     @ViewChild('container') containerViewChild: ElementRef;
-    
+
     @ViewChild('panel') panelViewChild: ElementRef;
-    
+
     @ViewChild('itemswrapper') itemsWrapperViewChild: ElementRef;
 
     @ViewChild('filter') filterViewChild: ElementRef;
-    
+
     @ViewChild('in') focusViewChild: ElementRef;
-    
+
     @ViewChild('editableInput') editableInputViewChild: ElementRef;
-    
+
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
-    
+
     public itemTemplate: TemplateRef<any>;
 
     public groupTemplate: TemplateRef<any>;
 
     public selectedItemTemplate: TemplateRef<any>;
-    
+
     selectedOption: any;
-    
+
     _options: any[];
-    
+
     value: any;
-    
+
     onModelChange: Function = () => {};
-    
+
     onModelTouched: Function = () => {};
 
     optionsToDisplay: any[];
-    
+
     hover: boolean;
-    
+
     focus: boolean;
 
     filled: boolean;
-    
+
     public panelVisible: boolean = false;
-    
+
     public shown: boolean;
-    
+
     public documentClickListener: any;
-    
+
     public optionsChanged: boolean;
-    
+
     public panel: HTMLDivElement;
-    
+
     public container: HTMLDivElement;
-    
+
     public itemsWrapper: HTMLDivElement;
-    
+
     public initialized: boolean;
-    
+
     public selfClick: boolean;
-    
+
     public itemClick: boolean;
 
-    public clearClick: boolean;
-    
     public hoveredItem: any;
-    
+
     public selectedOptionUpdated: boolean;
-    
+
     public filterValue: string;
-    
+
     constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, private cd: ChangeDetectorRef,
                 public objectUtils: ObjectUtils, public zone: NgZone) {}
-    
+
     ngAfterContentInit() {
         this.templates.forEach((item) => {
             switch(item.getType()) {
@@ -245,19 +245,19 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                 case 'group':
                     this.groupTemplate = item.template;
                 break;
-                
+
                 default:
                     this.itemTemplate = item.template;
                 break;
             }
         });
     }
-    
+
     ngOnInit() {
         this.optionsToDisplay = this.options;
         this.updateSelectedOption(null);
     }
-    
+
     @Input() get options(): any[] {
         return this._options;
     }
@@ -268,24 +268,24 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         this.optionsToDisplay = this._options;
         this.updateSelectedOption(this.value);
         this.optionsChanged = true;
-        
+
         if(this.filterValue && this.filterValue.length) {
             this.activateFilter();
         }
     }
-    
+
     ngAfterViewInit() {
         this.container = <HTMLDivElement> this.containerViewChild.nativeElement;
         this.panel = <HTMLDivElement> this.panelViewChild.nativeElement;
         this.itemsWrapper = <HTMLDivElement> this.itemsWrapperViewChild.nativeElement;
-        
+
         if(this.editable) {
             this.updateEditableLabel();
         }
-        
+
         this.updateDimensions();
         this.initialized = true;
-        
+
         if(this.appendTo) {
             if(this.appendTo === 'body')
                 document.body.appendChild(this.panel);
@@ -293,17 +293,17 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                 this.domHandler.appendChild(this.panel, this.appendTo);
         }
     }
-    
+
     get label(): string {
         return (this.selectedOption ? this.selectedOption.label : null);
     }
-    
+
     updateEditableLabel(): void {
         if(this.editableInputViewChild && this.editableInputViewChild.nativeElement) {
             this.editableInputViewChild.nativeElement.value = (this.selectedOption ? this.selectedOption.label : this.value||'');
         }
     }
-    
+
     onItemClick(event, option) {
         this.itemClick = true;
         this.selectItem(event, option);
@@ -311,12 +311,12 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         this.filled = true;
         this.hide();
     }
-    
+
     selectItem(event, option) {
         if(this.selectedOption != option) {
             this.selectedOption = option;
             this.value = option.value;
-            
+
             this.onModelChange(this.value);
             this.updateEditableLabel();
             this.onChange.emit({
@@ -325,16 +325,16 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             });
         }
     }
-    
+
     ngAfterViewChecked() {
         if(this.shown) {
             this.onShow();
             this.shown = false;
         }
-        
+
         if(this.optionsChanged && this.panelVisible) {
             this.optionsChanged = false;
-            
+
             this.zone.runOutsideAngular(() => {
                 setTimeout(() => {
                     this.updateDimensions();
@@ -342,7 +342,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                 }, 1);
             });
         }
-        
+
         if(this.selectedOptionUpdated && this.itemsWrapper) {
             let selectedItem = this.domHandler.findSingle(this.panel, 'li.ui-state-highlight');
             if(selectedItem) {
@@ -351,27 +351,27 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             this.selectedOptionUpdated = false;
         }
     }
-    
+
     writeValue(value: any): void {
         if(this.filter) {
             this.resetFilter();
         }
-        
+
         this.value = value;
         this.updateSelectedOption(value);
         this.updateEditableLabel();
         this.updateFilledState();
         this.cd.markForCheck();
     }
-    
+
     resetFilter(): void {
         if(this.filterViewChild && this.filterViewChild.nativeElement) {
             this.filterViewChild.nativeElement.value = '';
         }
-        
+
         this.optionsToDisplay = this.options;
     }
-    
+
     updateSelectedOption(val: any): void {
         this.selectedOption = this.findOption(val, this.optionsToDisplay);
         if(this.autoDisplayFirst && !this.placeholder && !this.selectedOption && this.optionsToDisplay && this.optionsToDisplay.length && !this.editable) {
@@ -379,7 +379,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         }
         this.selectedOptionUpdated = true;
     }
-    
+
     registerOnChange(fn: Function): void {
         this.onModelChange = fn;
     }
@@ -387,11 +387,11 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     registerOnTouched(fn: Function): void {
         this.onModelTouched = fn;
     }
-    
+
     setDisabledState(val: boolean): void {
         this.disabled = val;
     }
-    
+
     updateDimensions() {
         if(this.autoWidth) {
             let select = this.domHandler.findSingle(this.el.nativeElement, 'select');
@@ -400,17 +400,17 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             }
         }
     }
-    
+
     onMouseclick(event) {
         if(this.disabled||this.readonly) {
             return;
         }
-        
+
         this.selfClick = true;
-        
-        if(!this.itemClick && !this.clearClick) {
+
+        if(!this.itemClick) {
             this.focusViewChild.nativeElement.focus();
-            
+
             if(this.panelVisible)
                 this.hide();
             else {
@@ -424,17 +424,17 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             }
         }
     }
-    
+
     onEditableInputClick(event) {
         this.itemClick = true;
         this.bindDocumentClickListener();
     }
-    
+
     onEditableInputFocus(event) {
         this.focus = true;
         this.hide();
     }
-    
+
     onEditableInputChange(event) {
         this.value = event.target.value;
         this.updateSelectedOption(this.value);
@@ -444,56 +444,56 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             value: this.value
         });
     }
-    
+
     onShow() {
         this.bindDocumentClickListener();
 
         if(this.options && this.options.length) {
             this.alignPanel();
-            
+
             let selectedListItem = this.domHandler.findSingle(this.itemsWrapper, '.ui-dropdown-item.ui-state-highlight');
             if(selectedListItem) {
                 this.domHandler.scrollInView(this.itemsWrapper, selectedListItem);
             }
         }
     }
-    
+
     show() {
         if(this.appendTo) {
             this.panel.style.minWidth = this.domHandler.getWidth(this.container) + 'px';
         }
-        
+
         this.panel.style.zIndex = String(++DomHandler.zindex);
         this.panelVisible = true;
         this.shown = true;
     }
-    
+
     hide() {
         this.panelVisible = false;
-        
+
         if(this.filter && this.resetFilterOnHide) {
             this.resetFilter();
         }
     }
-    
+
     alignPanel() {
         if(this.appendTo)
             this.domHandler.absolutePosition(this.panel, this.container);
         else
             this.domHandler.relativePosition(this.panel, this.container);
     }
-    
+
     onInputFocus(event) {
         this.focus = true;
         this.onFocus.emit(event);
     }
-    
+
     onInputBlur(event) {
         this.focus = false;
         this.onModelTouched();
         this.onBlur.emit(event);
     }
-    
+
     onKeydown(event) {
         if(this.readonly || !this.optionsToDisplay || this.optionsToDisplay.length === null) {
             return;
@@ -508,7 +508,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                 else {
                     if(this.group) {
                         let selectedItemIndex = this.selectedOption ? this.findOptionGroupIndex(this.selectedOption.value, this.optionsToDisplay) : -1;
-                        
+
                         if(selectedItemIndex !== -1) {
                             let nextItemIndex = selectedItemIndex.itemIndex + 1;
                             if(nextItemIndex < (this.optionsToDisplay[selectedItemIndex.groupIndex].items.length)) {
@@ -536,11 +536,11 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                         }
                     }
                 }
-                
+
                 event.preventDefault();
-                
+
             break;
-            
+
             //up
             case 38:
                 if(this.group) {
@@ -580,16 +580,16 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                     event.preventDefault();
                 }
             break;
-            
+
             //enter
             case 13:
                 if (!this.filter || (this.optionsToDisplay && this.optionsToDisplay.length > 0)) {
                     this.hide();
                 }
-                
+
                 event.preventDefault();
             break;
-            
+
             //escape and tab
             case 27:
             case 9:
@@ -597,7 +597,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             break;
         }
     }
-    
+
     findOptionIndex(val: any, opts: any[]): number {
         let index: number = -1;
         if(opts) {
@@ -608,7 +608,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                 }
             }
         }
-        
+
         return index;
     }
 
@@ -633,7 +633,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             return -1;
         }
     }
-    
+
     findOption(val: any, opts: any[], inGroup?: boolean): SelectItem {
         if(this.group && !inGroup) {
             let opt: SelectItem;
@@ -652,7 +652,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             return (index != -1) ? opts[index] : null;
         }
     }
-    
+
     onFilter(event): void {
         let inputValue = event.target.value.toLowerCase();
         if(inputValue && inputValue.length) {
@@ -663,10 +663,10 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             this.filterValue = null;
             this.optionsToDisplay = this.options;
         }
-        
+
         this.optionsChanged = true;
     }
-    
+
     activateFilter() {
         let searchFields: string[] = this.filterBy.split(',');
         if(this.options && this.options.length) {
@@ -692,14 +692,14 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             this.optionsChanged = true;
         }
     }
-    
+
     applyFocus(): void {
         if(this.editable)
             this.domHandler.findSingle(this.el.nativeElement, '.ui-dropdown-label.ui-inputtext').focus();
         else
             this.domHandler.findSingle(this.el.nativeElement, 'input[readonly]').focus();
     }
-    
+
     bindDocumentClickListener() {
         if(!this.documentClickListener) {
             this.documentClickListener = this.renderer.listen('document', 'click', () => {
@@ -707,15 +707,14 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
                     this.panelVisible = false;
                     this.unbindDocumentClickListener();
                 }
-                
+
                 this.selfClick = false;
                 this.itemClick = false;
-                this.clearClick = false;
                 this.cd.markForCheck();
             });
         }
     }
-    
+
     unbindDocumentClickListener() {
         if(this.documentClickListener) {
             this.documentClickListener();
@@ -728,19 +727,23 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     }
 
     clear(event: Event) {
-        this.clearClick = true;
+        event.stopPropagation();
         this.value = null;
         this.onModelChange(this.value);
         this.updateSelectedOption(this.value);
         this.updateEditableLabel();
         this.updateFilledState();
+        this.onChange.emit({
+            originalEvent: event,
+            value: this.value
+        });
     }
-    
+
     ngOnDestroy() {
         this.initialized = false;
-        
+
         this.unbindDocumentClickListener();
-        
+
         if(this.appendTo) {
             this.el.nativeElement.appendChild(this.panel);
         }

--- a/src/app/showcase/components/dropdown/dropdowndemo.html
+++ b/src/app/showcase/components/dropdown/dropdowndemo.html
@@ -9,11 +9,11 @@
     <h3 class="first">Single</h3>
     <p-dropdown [options]="cities" [(ngModel)]="selectedCity" placeholder="Select a City" optionLabel="name"></p-dropdown>
     <p>Selected City: {{selectedCity ? selectedCity.name : 'none'}}</p>
-    
+
     <h3>Editable</h3>
     <p-dropdown [options]="cars" [(ngModel)]="selectedCar1" [style]="{'width':'150px'}" editable="true" placeholder="Select a Brand"></p-dropdown>
     <p>Selected Car: {{selectedCar1 || 'none'}}</p>
-    
+
     <h3>Content with Filters</h3>
     <p-dropdown [options]="cars" [(ngModel)]="selectedCar2" [style]="{'width':'150px'}" filter="true">
         <ng-template let-item pTemplate="selectedItem">
@@ -37,6 +37,10 @@
         </ng-template>
     </p-dropdown>
     <p>Selected Car: {{selectedCar3 || 'none'}}</p>
+
+    <h3>With clear button</h3>
+    <p-dropdown [options]="cars" [(ngModel)]="selectedCar4" [style]="{'width':'150px'}" [clearButton]="true" placeholder="Select a Car"></p-dropdown>
+    <p>Selected Car: {{selectedCar4 || 'none'}}</p>
 </div>
 
 <div class="content-section documentation">
@@ -51,7 +55,7 @@ import &#123;DropdownModule&#125; from 'primeng/dropdown';
 
             <h3>Getting Started</h3>
             <p>Dropdown requires a value to bind and a collection of options. There are two alternatives of how to define the options property; one way is providing a collection of SelectItem
-            instances whereas other way is providing an array of arbitrary objects along with the optionLabel property to specify the field name of the option. SelectItem API is designed to have more control on how 
+            instances whereas other way is providing an array of arbitrary objects along with the optionLabel property to specify the field name of the option. SelectItem API is designed to have more control on how
             the options are displayed such as grouping and disabling however in most cases an arbitrary object collection will suffice. Example below demonstrates both cases.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
@@ -73,11 +77,11 @@ interface City &#123;
 export class MyModel &#123;
 
     cities1: SelectItem[];
-    
+
     cities2: City[];
 
     selectedCity1: City;
-    
+
     selectedCity2: City;
 
     constructor() &#123;
@@ -90,7 +94,7 @@ export class MyModel &#123;
             &#123;label:'Istanbul', value:&#123;id:4, name: 'Istanbul', code: 'IST'&#125;&#125;,
             &#123;label:'Paris', value:&#123;id:5, name: 'Paris', code: 'PRS'&#125;&#125;
         ];
-        
+
         //An array of cities
         this.cities2 = [
             &#123;name: 'New York', code: 'NY'&#125;,
@@ -138,7 +142,7 @@ import &#123;SelectItem&#125; from 'primeng/api';
 import &#123;SelectItemGroup&#125; from 'primeng/api';
 
 export class GroupDemo &#123;
-    
+
     selectedCar: string;
 
     groupedCars: SelectItemGroup[];
@@ -146,7 +150,7 @@ export class GroupDemo &#123;
     constructor() &#123;
         this.groupedCars = [
             &#123;
-                label: 'Germany', 
+                label: 'Germany',
                 items: [
                     &#123;label: 'Audi', value: 'Audi'&#125;,
                     &#123;label: 'BMW', value: 'BMW'&#125;,
@@ -154,7 +158,7 @@ export class GroupDemo &#123;
                 ]
             &#125;,
             &#123;
-                label: 'USA', 
+                label: 'USA',
                 items: [
                     &#123;label: 'Cadillac', value: 'Cadillac'&#125;,
                     &#123;label: 'Ford', value: 'Ford'&#125;,
@@ -162,7 +166,7 @@ export class GroupDemo &#123;
                 ]
             &#125;,
             &#123;
-                label: 'Japan', 
+                label: 'Japan',
                 items: [
                     &#123;label: 'Honda', value: 'Honda'&#125;,
                     &#123;label: 'Toyota', value: 'Toyota'&#125;
@@ -176,19 +180,19 @@ export class GroupDemo &#123;
 
             <h3>Custom Content</h3>
             <p>Both the selected option and the options list can be templated to provide customization on the default behavior which is displaying label property of an option. Use
-                "selectedItem" template to customize the selected label display and the "item" template to change the content of the options in the dropdown panel. In addition when grouping is enabled, "group" template is available 
-                to customize the option groups. All templates get the option instance as the default local template variable. 
+                "selectedItem" template to customize the selected label display and the "item" template to change the content of the options in the dropdown panel. In addition when grouping is enabled, "group" template is available
+                to customize the option groups. All templates get the option instance as the default local template variable.
             </p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-dropdown [options]="cars" [(ngModel)]="selectedCar" [style]="&#123;'width':'150px'&#125;"&gt;
-     &lt;ng-template let-item pTemplate="selectedItem"&gt; 
-        &lt;img src="assets/showcase/images/demo/car/&#123;&#123;item.label&#125;&#125;.png" style="width:16px;vertical-align:middle" /&gt; 
+     &lt;ng-template let-item pTemplate="selectedItem"&gt;
+        &lt;img src="assets/showcase/images/demo/car/&#123;&#123;item.label&#125;&#125;.png" style="width:16px;vertical-align:middle" /&gt;
         &lt;span style="vertical-align:middle"&gt;&#123;&#123;item.label&#125;&#125;&lt;/span&gt;
-    &lt;/ng-template&gt; 
-    &lt;ng-template let-car pTemplate="item"&gt; 
+    &lt;/ng-template&gt;
+    &lt;ng-template let-car pTemplate="item"&gt;
         &lt;div class="ui-helper-clearfix" style="position: relative;height:25px;"&gt;
-        &lt;img src="assets/showcase/images/demo/car/&#123;&#123;car.label&#125;&#125;.png" style="width:24px;position:absolute;top:1px;left:5px"/&gt; 
+        &lt;img src="assets/showcase/images/demo/car/&#123;&#123;car.label&#125;&#125;.png" style="width:24px;position:absolute;top:1px;left:5px"/&gt;
         &lt;div style="font-size:14px;float:right;margin-top:4px"&gt;&#123;&#123;car.label&#125;&#125;&lt;/div&gt; &lt;/div&gt;
     &lt;/ng-template&gt;
 &lt;/p-dropdown&gt;
@@ -386,6 +390,12 @@ export class MyModel &#123;
                             <td>Text to display when filtering does not return any results.</td>
                         </tr>
                         <tr>
+                            <td>clearButton</td>
+                            <td>boolean</td>
+                            <td>true</td>
+                            <td>When present, it specifies that show clear button if one value is selected</td>
+                        </tr>
+                        <tr>
                             <td>autoDisplayFirst</td>
                             <td>boolean</td>
                             <td>true</td>
@@ -432,7 +442,7 @@ export class MyModel &#123;
                     </tbody>
                 </table>
             </div>
-            
+
             <h3>Methods</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">
@@ -452,7 +462,7 @@ export class MyModel &#123;
                     </tbody>
                 </table>
             </div>
-            
+
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-dropdown #dd [options]="cars" [(ngModel)]="selectedCar" filter="true"&gt;&lt;/p-dropdown&gt;
@@ -580,7 +590,7 @@ export class DropdownDemo &#123;
     selectedCar1: string;
 
     selectedCar2: string = 'BMW';
-    
+
     selectedCar3: string;
 
     groupedCars: SelectItemGroup[];
@@ -609,7 +619,7 @@ export class DropdownDemo &#123;
 
         this.groupedCars = [
             &#123;
-                label: 'Germany', value: 'germany.png', 
+                label: 'Germany', value: 'germany.png',
                 items: [
                     &#123;label: 'Audi', value: 'Audi'&#125;,
                     &#123;label: 'BMW', value: 'BMW'&#125;,
@@ -617,7 +627,7 @@ export class DropdownDemo &#123;
                 ]
             &#125;,
             &#123;
-                label: 'USA', value: 'usa.png', 
+                label: 'USA', value: 'usa.png',
                 items: [
                     &#123;label: 'Cadillac', value: 'Cadillac'&#125;,
                     &#123;label: 'Ford', value: 'Ford'&#125;,
@@ -625,7 +635,7 @@ export class DropdownDemo &#123;
                 ]
             &#125;,
             &#123;
-                label: 'Japan', value: 'japan.png', 
+                label: 'Japan', value: 'japan.png',
                 items: [
                     &#123;label: 'Honda', value: 'Honda'&#125;,
                     &#123;label: 'Toyota', value: 'Toyota'&#125;

--- a/src/app/showcase/components/dropdown/dropdowndemo.ts
+++ b/src/app/showcase/components/dropdown/dropdowndemo.ts
@@ -21,8 +21,10 @@ export class DropdownDemo {
     selectedCar1: string;
 
     selectedCar2: string = 'BMW';
-    
+
     selectedCar3: string;
+
+    selectedCar4: string;
 
     groupedCars: SelectItemGroup[];
 
@@ -50,7 +52,7 @@ export class DropdownDemo {
 
         this.groupedCars = [
             {
-                label: 'Germany', value: 'germany.png', 
+                label: 'Germany', value: 'germany.png',
                 items: [
                     {label: 'Audi', value: 'Audi'},
                     {label: 'BMW', value: 'BMW'},
@@ -58,7 +60,7 @@ export class DropdownDemo {
                 ]
             },
             {
-                label: 'USA', value: 'usa.png', 
+                label: 'USA', value: 'usa.png',
                 items: [
                     {label: 'Cadillac', value: 'Cadillac'},
                     {label: 'Ford', value: 'Ford'},
@@ -66,7 +68,7 @@ export class DropdownDemo {
                 ]
             },
             {
-                label: 'Japan', value: 'japan.png', 
+                label: 'Japan', value: 'japan.png',
                 items: [
                     {label: 'Honda', value: 'Honda'},
                     {label: 'Toyota', value: 'Toyota'}


### PR DESCRIPTION
Include fixes to:
#5280 
#5288
#5286
#5285 

- Prevent the clear button event propagation and removed the condition inside onMouseClick
- Emit onChange event when clear button is clicked
- Added clearButton parameter to show/hide the clear button
- A lot of spaces that WebStorm removes following TSLint.