### PR TITLE
DropDown - Add clear button flag property whether to show it

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -44,7 +44,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
             <label [ngClass]="{'ui-dropdown-label ui-inputtext ui-corner-all ui-placeholder':true,'ui-dropdown-label-empty': (placeholder == null || placeholder.length === 0)}" *ngIf="!editable && (label == null)">{{placeholder||'empty'}}</label>
             <input #editableInput type="text" [attr.aria-label]="selectedOption ? selectedOption.label : ' '" class="ui-dropdown-label ui-inputtext ui-corner-all" *ngIf="editable" [disabled]="disabled" [attr.placeholder]="placeholder"
                         (click)="onEditableInputClick($event)" (input)="onEditableInputChange($event)" (focus)="onEditableInputFocus($event)" (blur)="onInputBlur($event)">
-            <i class="ui-dropdown-clear-icon fa fa-close" (click)="clear($event)" *ngIf="value != null"></i>
+            <i class="ui-dropdown-clear-icon fa fa-close" (click)="clear($event)" *ngIf="clearButton && value != null"></i>
             <div class="ui-dropdown-trigger ui-state-default ui-corner-right">
                 <span class="ui-clickable" [ngClass]="dropdownIcon"></span>
             </div>
@@ -146,6 +146,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     
     @Input() resetFilterOnHide: boolean = false;
     
+    @Input() clearButton: boolean = true;
+
     @Input() dropdownIcon: string = 'fa fa-fw fa-caret-down';
     
     @Input() optionLabel: string;

--- a/src/app/showcase/components/dropdown/dropdowndemo.html
+++ b/src/app/showcase/components/dropdown/dropdowndemo.html
@@ -374,6 +374,12 @@ export class MyModel &#123;
                             <td>Clears the filter value when hiding the dropdown.</td>
                         </tr>
                         <tr>
+                            <td>clearButton</td>
+                            <td>boolean</td>
+                            <td>true</td>
+                            <td>Whether to show clear button which reset selected value.</td>
+                        </tr>
+                        <tr>
                             <td>dropdownIcon</td>
                             <td>string</td>
                             <td>fa fa-fw fa-caret-down</td>


### PR DESCRIPTION
Add property to be able show or hide the clear selected button:
default behavior:
<img width="97" alt="2018-03-08 14_26_54-primeng" src="https://user-images.githubusercontent.com/5566282/37151677-3a7292a2-22df-11e8-9685-abee88f4c5c8.png">

using `<p-dropdown [clearButton]="false"...`:
<img width="95" alt="2018-03-08 14_24_59-primeng" src="https://user-images.githubusercontent.com/5566282/37151680-3e7c38ee-22df-11e8-9518-3b51718634ce.png">

additionally add documentation explanation:
![image](https://user-images.githubusercontent.com/5566282/37151970-52e067be-22e0-11e8-9a9f-2529a996d875.png)

