### PR TITLE
TurboTable with virtualScroll not display records when totalRecords is set after ngOnInit

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1805,6 +1805,7 @@ export class ScrollableView implements AfterViewInit,OnDestroy {
         }
 
         if(this.dt.virtualScroll) {
+            this.virtualScrollerViewChild.nativeElement.style.height = this.dt.totalRecords * this.dt.virtualRowHeight + 'px';            
             let viewport = this.domHandler.getOuterHeight(this.scrollBodyViewChild.nativeElement);
             let tableHeight = this.domHandler.getOuterHeight(this.scrollTableViewChild.nativeElement);
             let pageHeight = 28 * this.dt.rows;


### PR DESCRIPTION
###Defect Fixes
In all my projects, where are datatables with virtualscroll,  totalRecords it's initialized dynamically when records and total of records are received from server request. Without this feature I cannot migrate to TurboTable. In present turbotable run only if totalRecords are initialized static or in ngOnInit.