### PR TITLE
RTL Support for Scrolling Table

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1853,11 +1853,20 @@ export class ScrollableView implements AfterViewInit,OnDestroy {
     }
 
     alignScrollBar() {
-        if(!this.frozen) {
-            let scrollBarWidth = this.hasVerticalOverflow() ? this.domHandler.calculateScrollbarWidth() : 0;
-            this.scrollHeaderBoxViewChild.nativeElement.style.marginRight = scrollBarWidth + 'px';
-            if(this.scrollFooterBoxViewChild && this.scrollFooterBoxViewChild.nativeElement) {
-                this.scrollFooterBoxViewChild.nativeElement.style.marginRight = scrollBarWidth + 'px';
+        if (!this.frozen) {
+            const scrollBarWidth = this.hasVerticalOverflow() ? this.domHandler.calculateScrollbarWidth() : 0;
+            const isRTL = window.getComputedStyle(this.el.nativeElement).getPropertyValue('direction') === 'rtl';
+            if (isRTL) {
+                this.scrollHeaderBoxViewChild.nativeElement.style.marginLeft = scrollBarWidth + 'px';
+            } else {
+                this.scrollHeaderBoxViewChild.nativeElement.style.marginRight = scrollBarWidth + 'px';
+            }
+            if (this.scrollFooterBoxViewChild && this.scrollFooterBoxViewChild.nativeElement) {
+                if (isRTL) {
+                    this.scrollFooterBoxViewChild.nativeElement.style.marginLeft = scrollBarWidth + 'px';
+                } else {
+                    this.scrollFooterBoxViewChild.nativeElement.style.marginRight = scrollBarWidth + 'px';
+                }
             }
         }
     }


### PR DESCRIPTION
Table header nested under `direction: rtl` ancestor behave currently unexpected:
![2018-03-14 10_54_16-primeng](https://user-images.githubusercontent.com/5566282/37392170-15a14c70-2776-11e8-9e73-3fc76d5debb2.png)

After fix:
![2018-03-14 10_53_36-primeng](https://user-images.githubusercontent.com/5566282/37392175-1849bb60-2776-11e8-83d6-af15bb82d993.png)