### PR TITLE
Fixed a bug with the Multiselect 'selectedItemsLabel' option.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "primeng",
-  "version": "5.2.2-SNAPSHOT",
+  "version": "5.2.4-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -75,13 +75,13 @@ export const MULTISELECT_VALUE_ACCESSOR: any = {
 export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterViewChecked,OnDestroy,ControlValueAccessor {
 
     @Input() scrollHeight: string = '200px';
-    
+
     @Input() defaultLabel: string = 'Choose';
 
     @Input() style: any;
 
     @Input() styleClass: string;
-    
+
     @Input() panelStyle: any;
 
     @Input() panelStyleClass: string;
@@ -89,87 +89,87 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     @Input() inputId: string;
 
     @Input() disabled: boolean;
-    
+
     @Input() filter: boolean = true;
 
     @Input() filterPlaceHolder: string;
-    
+
     @Input() overlayVisible: boolean;
 
     @Input() tabindex: number;
-    
+
     @Input() appendTo: any;
-    
+
     @Input() dataKey: string;
-    
+
     @Input() displaySelectedLabel: boolean = true;
-    
+
     @Input() maxSelectedLabels: number = 3;
-    
+
     @Input() selectedItemsLabel: string = '{0} items selected';
-    
+
     @Input() showToggleAll: boolean = true;
-    
+
     @Input() resetFilterOnHide: boolean = false;
-    
+
     @Input() dropdownIcon: string = 'fa fa-fw fa-caret-down';
-    
+
     @Input() optionLabel: string;
-        
+
     @ViewChild('container') containerViewChild: ElementRef;
-    
+
     @ViewChild('panel') panelViewChild: ElementRef;
-    
+
     @ViewChild('filterInput') filterInputChild: ElementRef;
-    
+
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
-        
+
     @Output() onChange: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onFocus: EventEmitter<any> = new EventEmitter();
 
     @Output() onBlur: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onPanelShow: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onPanelHide: EventEmitter<any> = new EventEmitter();
-    
+
     public value: any[];
-    
+
     public onModelChange: Function = () => {};
-    
+
     public onModelTouched: Function = () => {};
-    
+
     public valuesAsString: string;
-        
+
     public focus: boolean;
 
     filled: boolean;
-    
+
     public documentClickListener: any;
-    
+
     public container: HTMLDivElement;
-    
+
     public panel: HTMLDivElement;
-        
+
     public selfClick: boolean;
-    
+
     public panelClick: boolean;
-    
+
     public filterValue: string;
-    
+
     public visibleOptions: SelectItem[];
-    
+
     public filtered: boolean;
-            
+
     public itemTemplate: TemplateRef<any>;
-    
+
     public focusedItemCheckbox: HTMLInputElement;
-    
+
     _options: any[];
-    
+
     constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public objectUtils: ObjectUtils, private cd: ChangeDetectorRef) {}
-    
+
     @Input() get options(): any[] {
         return this._options;
     }
@@ -179,41 +179,41 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
         this._options = opts;
         this.updateLabel();
     }
-    
+
     ngOnInit() {
         this.updateLabel();
     }
-    
+
     ngAfterContentInit() {
         this.templates.forEach((item) => {
             switch(item.getType()) {
                 case 'item':
                     this.itemTemplate = item.template;
                 break;
-                
+
                 default:
                     this.itemTemplate = item.template;
                 break;
             }
         });
     }
-    
+
     ngAfterViewInit() {
         this.container = <HTMLDivElement> this.containerViewChild.nativeElement;
-        this.panel = <HTMLDivElement> this.panelViewChild.nativeElement; 
-        
+        this.panel = <HTMLDivElement> this.panelViewChild.nativeElement;
+
         if(this.appendTo) {
             if(this.appendTo === 'body')
                 document.body.appendChild(this.panel);
             else
                 this.domHandler.appendChild(this.panel, this.appendTo);
         }
-        
+
         if(this.overlayVisible) {
             this.show();
         }
     }
-    
+
     ngAfterViewChecked() {
         if(this.filtered) {
             if(this.appendTo)
@@ -224,7 +224,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
             this.filtered = false;
         }
     }
-        
+
     writeValue(value: any) : void {
         this.value = value;
         this.updateLabel();
@@ -235,7 +235,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     updateFilledState() {
         this.filled = (this.valuesAsString != null && this.valuesAsString.length > 0);
     }
-    
+
     registerOnChange(fn: Function): void {
         this.onModelChange = fn;
     }
@@ -243,31 +243,31 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     registerOnTouched(fn: Function): void {
         this.onModelTouched = fn;
     }
-    
+
     setDisabledState(val: boolean): void {
         this.disabled = val;
     }
-    
+
     onItemClick(event, value) {
         let selectionIndex = this.findSelectionIndex(value);
         if(selectionIndex != -1)
             this.value = this.value.filter((val,i) => i!=selectionIndex);
         else
             this.value = [...this.value||[],value];
-        
+
         this.onModelChange(this.value);
         this.onChange.emit({originalEvent: event, value: this.value, itemValue: value});
         this.updateLabel();
         this.updateFilledState();
-    }   
-    
+    }
+
     isSelected(value) {
         return this.findSelectionIndex(value) != -1;
     }
-    
+
     findSelectionIndex(val: any): number {
         let index = -1;
-        
+
         if(this.value) {
             for(let i = 0; i < this.value.length; i++) {
                 if(this.objectUtils.equals(this.value[i], val, this.dataKey)) {
@@ -276,10 +276,10 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                 }
             }
         }
-        
+
         return index;
     }
-    
+
     toggleAll(event, checkbox) {
         if(checkbox.checked) {
             this.value = [];
@@ -290,28 +290,28 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                 this.value = [];
                 for(let i = 0; i < opts.length; i++) {
                     this.value.push(opts[i].value);
-                } 
+                }
             }
         }
-        
+
         checkbox.checked = !checkbox.checked;
         this.onModelChange(this.value);
         this.onChange.emit({originalEvent: event, value: this.value});
         this.updateLabel();
-    } 
-    
+    }
+
     isAllChecked() {
         if(this.filterValue && this.filterValue.trim().length)
             return this.value&&this.visibleOptions&&this.visibleOptions.length&&(this.value.length == this.visibleOptions.length);
         else
             return this.value&&this.options&&(this.value.length == this.options.length);
-    } 
-    
+    }
+
     show() {
         this.overlayVisible = true;
         this.panel.style.zIndex = String(++DomHandler.zindex);
         this.bindDocumentClickListener();
-        
+
         if(this.appendTo)
             this.domHandler.absolutePosition(this.panel, this.container);
         else
@@ -320,7 +320,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
         this.domHandler.fadeIn(this.panel, 250);
         this.onPanelShow.emit();
     }
-    
+
     hide() {
         this.overlayVisible = false;
         this.unbindDocumentClickListener();
@@ -330,18 +330,18 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
         }
         this.onPanelHide.emit();
     }
-    
+
     close(event) {
         this.hide();
         event.preventDefault();
         event.stopPropagation();
     }
-         
+
     onMouseclick(event,input) {
         if(this.disabled) {
             return;
         }
-        
+
         if(!this.panelClick) {
             if(this.overlayVisible) {
                 this.hide();
@@ -351,21 +351,21 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                 this.show();
             }
         }
-        
+
         this.selfClick = true;
     }
-    
+
     onInputFocus(event) {
         this.focus = true;
         this.onFocus.emit({originalEvent: event});
     }
-    
+
     onInputBlur(event) {
         this.focus = false;
         this.onBlur.emit({originalEvent: event});
         this.onModelTouched();
     }
-    
+
     onInputKeydown(event) {
         switch(event.which) {
             //down
@@ -373,10 +373,10 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                 if(!this.overlayVisible && event.altKey) {
                     this.show();
                 }
-                
+
                 event.preventDefault();
             break;
-            
+
             //escape and tab
             case 27:
             case 9:
@@ -384,7 +384,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
             break;
         }
     }
-    
+
     updateLabel() {
         if(this.value && this.options && this.value.length && this.displaySelectedLabel) {
             let label = '';
@@ -397,33 +397,34 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                     label = label + itemLabel;
                 }
             }
-            
+
             if(this.value.length <= this.maxSelectedLabels) {
                 this.valuesAsString = label;
             }
             else {
-                let pattern = /{(.*?)}/,
-                newSelectedItemsLabel = this.selectedItemsLabel.replace(this.selectedItemsLabel.match(pattern)[0], this.value.length + '');
-                this.valuesAsString = newSelectedItemsLabel;
+                let pattern = /{(.*?)}/;
+                if (pattern.test(this.selectedItemsLabel)) {
+                    this.valuesAsString = this.selectedItemsLabel.replace(this.selectedItemsLabel.match(pattern)[0], this.value.length + '');
+                }
             }
         }
         else {
             this.valuesAsString = this.defaultLabel;
         }
     }
-    
+
     findLabelByValue(val: any): string {
         let label = null;
         for(let i = 0; i < this.options.length; i++) {
             let option = this.options[i];
             if(val == null && option.value == null || this.objectUtils.equals(val, option.value, this.dataKey)) {
                 label = option.label;
-                break; 
+                break;
             }
         }
         return label;
     }
-    
+
     onFilter(event) {
         this.filterValue = event.target.value.trim().toLowerCase();
         this.visibleOptions = [];
@@ -435,7 +436,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
         }
         this.filtered = true;
     }
-        
+
     isItemVisible(option: SelectItem): boolean {
         if(this.filterValue && this.filterValue.trim().length) {
             for(let i = 0; i < this.visibleOptions.length; i++) {
@@ -448,7 +449,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
             return true;
         }
     }
-    
+
     getVisibleOptions(): SelectItem[] {
         if(this.filterValue && this.filterValue.trim().length) {
             let items = [];
@@ -464,31 +465,31 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
             return this.options;
         }
     }
-    
+
     bindDocumentClickListener() {
         if(!this.documentClickListener) {
             this.documentClickListener = this.renderer.listen('document', 'click', () => {
                 if(!this.selfClick && !this.panelClick && this.overlayVisible) {
                     this.hide();
                 }
-                
+
                 this.selfClick = false;
                 this.panelClick = false;
                 this.cd.markForCheck();
             });
-        }        
+        }
     }
-    
+
     unbindDocumentClickListener() {
         if(this.documentClickListener) {
             this.documentClickListener();
             this.documentClickListener = null;
-        }        
+        }
     }
 
     ngOnDestroy() {
         this.unbindDocumentClickListener();
-        
+
         if(this.appendTo) {
             this.container.appendChild(this.panel);
         }


### PR DESCRIPTION
setting a 'selectedItemsLabel' required that the user supply '{}' in the desired label or an error occurred, since the regex assumed it would always find the '{}'. This fix first searches the label for the regex before grabbing the first matching instance of the regex

###Defect Fixes
This is associated with issue #4905 