### PR TITLE
Update paginator.ts

### DIFF
--- a/src/app/components/paginator/paginator.ts
+++ b/src/app/components/paginator/paginator.ts
@@ -34,7 +34,7 @@ import {SharedModule} from '../common/shared';
                 <span class="fa fa-step-forward"></span>
             </a>
             <p-dropdown [options]="rowsPerPageItems" [(ngModel)]="rows" *ngIf="rowsPerPageOptions" 
-                (onChange)="onRppChange($event)" [lazy]="false" [autoWidth]="false" [appendTo]="dropdownAppendTo"></p-dropdown>
+                (onChange)="onRppChange($event)" [lazy]="false" [showClear]="false" [autoWidth]="false" [appendTo]="dropdownAppendTo"></p-dropdown>
             <div class="ui-paginator-right-content" *ngIf="templateRight">
                 <ng-container *ngTemplateOutlet="templateRight; context: {$implicit: paginatorState}"></ng-container>
             </div>


### PR DESCRIPTION
Do not show clear button on "rowsPerPageItems" drop-down since it doesn't make any sense

###Defect Fixes
Fixed an issue when clear button is displayed on "rowsPerPageItems" drop-down in Paginator component after upgrading PrimeNg to 5.2.1