### PR TITLE
#2993 - Spinner: decimals are separated by the thousand separator

### DIFF
--- a/src/app/components/spinner/spinner.spec.ts
+++ b/src/app/components/spinner/spinner.spec.ts
@@ -64,4 +64,15 @@ describe('Spinner', () => {
         expect(spinner.value).toEqual(0.75);
         expect(spinner.valueAsString).toEqual('0.75');
     });
+
+    it('Should display the formated value with thousand and decimal separator when input is filled by value 1234.1234', () => {
+        spinner.precision = 4;
+        const spinnerInput = <any>spinner.inputfieldViewChild.nativeElement;
+        spinnerInput.value = '1234.1234';
+        triggerEvent(spinnerInput, 'keyup');
+
+        fixture.detectChanges();
+
+        expect(spinner.valueAsString).toEqual('1,234.1234');
+    });
 });

--- a/src/app/components/spinner/spinner.ts
+++ b/src/app/components/spinner/spinner.ts
@@ -262,7 +262,9 @@ export class Spinner implements OnInit,ControlValueAccessor {
             let textValue = String(this.value).replace('.', this.decimalSeparator);
             
             if(this.formatInput) {
-                textValue = textValue.replace(/\B(?=(\d{3})+(?!\d))/g, this.thousandSeparator);
+                let parts = textValue.split(this.decimalSeparator);
+                parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, this.thousandSeparator);
+                textValue = parts.join(this.decimalSeparator);
             }
             
             this.valueAsString = textValue;


### PR DESCRIPTION
The error: If decimal part was more than three digits than the decimal part was formated with thousand separator. After this bug fix only integer part is formated with thousand separator