### PR TITLE
#5356 - PrimeNG DialogBox Property

### DIFF
--- a/src/app/showcase/components/dialog/dialogdemo.html
+++ b/src/app/showcase/components/dialog/dialogdemo.html
@@ -181,7 +181,7 @@ export class ModelComponent &#123;
                             <td>minHeight</td>
                             <td>number</td>
                             <td>150</td>
-                            <td>Minimum width of a resizable dialog.</td>
+                            <td>Minimum height of a resizable dialog.</td>
                         </tr>
                         <tr>
                             <td>width</td>


### PR DESCRIPTION
###Defect Fixes
The documentation of dialog 
There was  word width instead height in minHeight property documentation