### PR TITLE
#5369 Fix AutoComplete ui-state-filled management

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -491,9 +491,10 @@ export class AutoComplete implements AfterViewInit,AfterViewChecked,DoCheck,Cont
                 case 8:
                     if(this.value && this.value.length && !this.multiInputEL.nativeElement.value) {
                         this.value = [...this.value];
-                        let removedValue = this.value.pop();
-                        this.onUnselect.emit(removedValue);
+                        const removedValue = this.value.pop();
                         this.onModelChange(this.value);
+                        this.updateFilledState();
+                        this.onUnselect.emit(removedValue);
                     }
                 break;
             }


### PR DESCRIPTION
#5369

- When remove items through backspace the ui-state-filled css class now is removed