### PR TITLE
#4957 TurboTable: Annoying resizing behavior when reorderableColumns="true"

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1434,7 +1434,7 @@ export class Table implements OnInit, AfterContentInit {
     }
 
     onColumnDragStart(event, columnElement) {
-        if (this.domHandler.hasClass(event.target, 'ui-column-resizer')) {
+        if (this.domHandler.hasClass(event.target, 'ui-column-resizer') || this.resizeHelperViewChild.nativeElement.style.display === 'block') {
             event.preventDefault();
             return;
         }


### PR DESCRIPTION
In p-table when reorderableColumns="true" and reorderableColumns="true" dragging the column resizer also calls the drag listener.