### PR TITLE
Wrong return value in calendar

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1331,7 +1331,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         this.createMonth(val.getMonth(), val.getFullYear());
         
         if(this.showTime||this.timeOnly) {
-            let hours = (this.utc) ? val.getUTCHours : val.getHours();
+            let hours = (this.utc) ? val.getUTCHours() : val.getHours();
             
             if(this.hourFormat == '12') {
                 this.pm = hours > 11;


### PR DESCRIPTION
Change code to invoke function instead of return it.

### Defect Fixes

Example:
`<p-calendar [timeOnly]="true" hourFormat="12" [utc]="true"></p-calendar>`

If `timeOnly` is true then the hours column displays the following text instead of the hours:
```function getUTCHours() { [native code] }```

The method was being returned instead of invoked.
Bug is only present for 12 hour time (24 hour code is OK).