### PR TITLE
Add tooltip on menu items

### DIFF
--- a/src/app/components/common/menuitem.ts
+++ b/src/app/components/common/menuitem.ts
@@ -21,4 +21,16 @@ export interface MenuItem {
     title?: string;
     id?: string;
     automationId?: any;
+    toolTipMessage?: string;
+    toolTipPosition?: string;
+    toolTipEvent?: string;
+    toolTipPositionStyle?: string;
+    toolTipDisabled?: boolean;
+    toolTipAppendTo?: string;
+    toolTipHideDelay?: number;
+    toolTipShowDelay?: number;
+    tooltipLife?: number;
+    toolTipStyleClass?: string;
+    toolTipEscape?: boolean;
+    toolTipZIndex?: string;
 }

--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -3,6 +3,7 @@ import {CommonModule} from '@angular/common';
 import {DomHandler} from '../dom/domhandler';
 import {MenuItem} from '../common/menuitem';
 import {RouterModule} from '@angular/router';
+import {TooltipModule} from '../tooltip/tooltip';
 
 @Component({
     selector: '[pMenuItemContent]',
@@ -23,7 +24,7 @@ import {RouterModule} from '@angular/router';
 export class MenuItemContent {
 
     @Input("pMenuItemContent") item: MenuItem;
-    
+
     constructor(@Inject(forwardRef(() => Menu)) public menu: Menu) {}
 }
 
@@ -38,12 +39,34 @@ export class MenuItemContent {
                     <li class="ui-submenu-header ui-widget-header ui-corner-all" [attr.data-automationid]="submenu.automationId" *ngIf="!submenu.separator" [ngClass]="{'ui-helper-hidden': submenu.visible === false}">{{submenu.label}}</li>
                     <ng-template ngFor let-item [ngForOf]="submenu.items">
                         <li class="ui-menu-separator ui-widget-content" *ngIf="item.separator" [ngClass]="{'ui-helper-hidden': (item.visible === false || submenu.visible === false)}"></li>
-                        <li class="ui-menuitem ui-widget ui-corner-all" *ngIf="!item.separator" [pMenuItemContent]="item" [ngClass]="{'ui-helper-hidden': (item.visible === false || submenu.visible === false)}"></li>
+                        <li class="ui-menuitem ui-widget ui-corner-all" *ngIf="!item.separator" [pMenuItemContent]="item" [ngClass]="{'ui-helper-hidden': (item.visible === false || submenu.visible === false)}" [pTooltip]="child.toolTipMessage"
+                            [tooltipPosition]="item.toolTipPosition ? item.toolTipPosition : 'right'"
+                            [tooltipEvent]="item.toolTipEvent ? item.toolTipEvent : 'hover'"
+                            [appendTo]="item.toolTipAppendTo ? item.toolTipAppendTo : 'body'"
+                            [positionStyle]="item.toolTipPositionStyle ? item.toolTipPositionStyle : 'absolute'"
+                            [tooltipStyleClass]="item.toolTipStyleClass"
+                            [tooltipZIndex]="item.toolTipZIndex ? item.toolTipZIndex : 'auto'"
+                            [tooltipDisabled]="item.toolTipDisabled ? item.toolTipDisabled : false"
+                            [escape]="item.toolTipEscape ? item.toolTipEscape : true"
+                            [showDelay]="item.toolTipShowDelay"
+                            [hideDelay]="item.toolTipHideDelay"
+                            [life]="item.toolTipLife"></li>
                     </ng-template>
                 </ng-template>
                 <ng-template ngFor let-item [ngForOf]="model" *ngIf="!hasSubMenu()">
                     <li class="ui-menu-separator ui-widget-content" *ngIf="item.separator" [ngClass]="{'ui-helper-hidden': item.visible === false}"></li>
-                    <li class="ui-menuitem ui-widget ui-corner-all" *ngIf="!item.separator" [pMenuItemContent]="item" [ngClass]="{'ui-helper-hidden': item.visible === false}"></li>
+                    <li class="ui-menuitem ui-widget ui-corner-all" *ngIf="!item.separator" [pMenuItemContent]="item" [ngClass]="{'ui-helper-hidden': item.visible === false}" [pTooltip]="child.toolTipMessage"
+                        [tooltipPosition]="item.toolTipPosition ? item.toolTipPosition : 'right'"
+                        [tooltipEvent]="item.toolTipEvent ? item.toolTipEvent : 'hover'"
+                        [appendTo]="item.toolTipAppendTo ? item.toolTipAppendTo : 'body'"
+                        [positionStyle]="item.toolTipPositionStyle ? item.toolTipPositionStyle : 'absolute'"
+                        [tooltipStyleClass]="item.toolTipStyleClass"
+                        [tooltipZIndex]="item.toolTipZIndex ? item.toolTipZIndex : 'auto'"
+                        [tooltipDisabled]="item.toolTipDisabled ? item.toolTipDisabled : false"
+                        [escape]="item.toolTipEscape ? item.toolTipEscape : true"
+                        [showDelay]="item.toolTipShowDelay"
+                        [hideDelay]="item.toolTipHideDelay"
+                        [life]="item.toolTipLife"></li>
                 </ng-template>
             </ul>
         </div>
@@ -60,28 +83,28 @@ export class Menu implements AfterViewInit,OnDestroy {
     @Input() style: any;
 
     @Input() styleClass: string;
-    
+
     @Input() appendTo: any;
 
     @Input() autoZIndex: boolean = true;
-    
+
     @Input() baseZIndex: number = 0;
-    
+
     @ViewChild('container') containerViewChild: ElementRef;
-    
+
     container: HTMLDivElement;
-    
+
     documentClickListener: any;
-    
+
     preventDocumentDefault: any;
 
     onResizeTarget: any;
-    
+
     constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2) {}
 
     ngAfterViewInit() {
         this.container = <HTMLDivElement> this.containerViewChild.nativeElement;
-        
+
         if(this.popup) {
             if(this.appendTo) {
                 if(this.appendTo === 'body')
@@ -89,7 +112,7 @@ export class Menu implements AfterViewInit,OnDestroy {
                 else
                     this.domHandler.appendChild(this.container, this.appendTo);
             }
-            
+
             this.documentClickListener = this.renderer.listen('document', 'click', () => {
                 if(!this.preventDocumentDefault) {
                     this.hide();
@@ -98,13 +121,13 @@ export class Menu implements AfterViewInit,OnDestroy {
             });
         }
     }
-    
+
     toggle(event) {
         if(this.container.offsetParent)
             this.hide();
         else
             this.show(event);
-            
+
         this.preventDocumentDefault = true;
     }
 
@@ -113,7 +136,7 @@ export class Menu implements AfterViewInit,OnDestroy {
             this.domHandler.absolutePosition(this.container, this.onResizeTarget);
         }
     }
-    
+
     show(event) {
         let target = event.currentTarget;
         this.onResizeTarget = event.currentTarget;
@@ -129,45 +152,45 @@ export class Menu implements AfterViewInit,OnDestroy {
             this.containerViewChild.nativeElement.style.zIndex = String(this.baseZIndex + (++DomHandler.zindex));
         }
     }
-    
+
     hide() {
         this.container.style.display = 'none';
     }
-    
+
     itemClick(event, item: MenuItem) {
         if(item.disabled) {
             event.preventDefault();
             return;
         }
-        
+
         if(!item.url) {
             event.preventDefault();
         }
-        
+
         if(item.command) {
             item.command({
                 originalEvent: event,
                 item: item
             });
         }
-        
+
         if(this.popup) {
             this.hide();
         }
     }
-    
+
     ngOnDestroy() {
         if(this.popup) {
             if(this.documentClickListener) {
                 this.documentClickListener();
             }
-            
+
             if(this.appendTo) {
                 this.el.nativeElement.appendChild(this.container);
             }
         }
     }
-    
+
     hasSubMenu(): boolean {
         if(this.model) {
             for(var item of this.model) {
@@ -181,7 +204,7 @@ export class Menu implements AfterViewInit,OnDestroy {
 }
 
 @NgModule({
-    imports: [CommonModule,RouterModule],
+    imports: [CommonModule,RouterModule,TooltipModule],
     exports: [Menu,RouterModule],
     declarations: [Menu,MenuItemContent]
 })

--- a/src/app/components/menubar/menubar.ts
+++ b/src/app/components/menubar/menubar.ts
@@ -4,6 +4,7 @@ import { DomHandler } from '../dom/domhandler';
 import { MenuItem } from '../common/menuitem';
 import { Location } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import {TooltipModule} from '../tooltip/tooltip';
 
 @Component({
     selector: 'p-menubarSub',
@@ -14,7 +15,19 @@ import { RouterModule } from '@angular/router';
                 <li *ngIf="child.separator" class="ui-menu-separator ui-widget-content" [ngClass]="{'ui-helper-hidden': child.visible === false}">
                 <li *ngIf="!child.separator" #listItem [ngClass]="{'ui-menuitem ui-corner-all':true,
                         'ui-menu-parent':child.items,'ui-menuitem-active':listItem==activeItem,'ui-helper-hidden': child.visible === false}"
-                        (mouseenter)="onItemMouseEnter($event,listItem,child)" (mouseleave)="onItemMouseLeave($event)" (click)="onItemMenuClick($event, listItem, child)">
+                        (mouseenter)="onItemMouseEnter($event,listItem,child)" (mouseleave)="onItemMouseLeave($event)" (click)="onItemMenuClick($event, listItem, child)"
+                        [pTooltip]="child.toolTipMessage"
+                        [tooltipPosition]="child.toolTipPosition ? child.toolTipPosition : 'right'"
+                        [tooltipEvent]="child.toolTipEvent ? child.toolTipEvent : 'hover'"
+                        [appendTo]="child.toolTipAppendTo ? child.toolTipAppendTo : 'body'"
+                        [positionStyle]="child.toolTipPositionStyle ? child.toolTipPositionStyle : 'absolute'"
+                        [tooltipStyleClass]="child.toolTipStyleClass"
+                        [tooltipZIndex]="child.toolTipZIndex ? child.toolTipZIndex : 'auto'"
+                        [tooltipDisabled]="child.toolTipDisabled ? child.toolTipDisabled : false"
+                        [escape]="child.toolTipEscape ? child.toolTipEscape : true"
+                        [showDelay]="child.toolTipShowDelay"
+                        [hideDelay]="child.toolTipHideDelay"
+                        [life]="child.toolTipLife">
                     <a *ngIf="!child.routerLink" [href]="child.url||'#'" [attr.data-automationid]="child.automationId" [attr.target]="child.target" [attr.title]="child.title" [attr.id]="child.id" (click)="itemClick($event, child)"
                          [ngClass]="{'ui-menuitem-link ui-corner-all':true,'ui-state-disabled':child.disabled}" [ngStyle]="child.style" [class]="child.styleClass">
                         <span class="ui-menuitem-icon fa fa-fw" *ngIf="child.icon" [ngClass]="child.icon"></span>
@@ -50,13 +63,13 @@ export class MenubarSub implements OnDestroy {
     documentClickListener: any;
 
     menuClick: boolean;
-  
+
     menuHoverActive: boolean = false;
 
     activeItem: any;
 
     hideTimeout: any;
-    
+
     activeMenu: any;
 
     constructor(public domHandler: DomHandler, public renderer: Renderer2) { }
@@ -67,7 +80,7 @@ export class MenubarSub implements OnDestroy {
             if (menuitem.disabled) {
                 return;
             }
-            
+
             this.activeItem = this.activeMenu ? (this.activeMenu.isEqualNode(item)? null: item) : item;
             let nextElement = <HTMLLIElement>item.children[0].nextElementSibling;
             if (nextElement) {
@@ -131,7 +144,7 @@ export class MenubarSub implements OnDestroy {
                     sublist.style.left = this.domHandler.getOuterWidth(item.children[0]) + 'px';
                 }
             }
-  
+
             this.activeMenu = this.activeMenu ? (this.activeMenu.isEqualNode(item)? null: item) : item;
         }
     }
@@ -212,7 +225,7 @@ export class Menubar {
 }
 
 @NgModule({
-    imports: [CommonModule, RouterModule],
+    imports: [CommonModule, RouterModule, TooltipModule],
     exports: [Menubar, RouterModule],
     declarations: [Menubar, MenubarSub]
 })

--- a/src/app/showcase/components/menubar/menubardemo.ts
+++ b/src/app/showcase/components/menubar/menubardemo.ts
@@ -14,10 +14,13 @@ export class MenubarDemo {
                 label: 'File',
                 icon: 'fa-file-o',
                 items: [{
-                        label: 'New', 
+                        label: 'New',
                         icon: 'fa-plus',
                         items: [
-                            {label: 'Project'},
+                            {
+                                label: 'Project',
+                                toolTipMessage: 'Test ToolTip'
+                            },
                             {label: 'Other'},
                         ]
                     },
@@ -42,11 +45,11 @@ export class MenubarDemo {
                         label: 'Contents'
                     },
                     {
-                        label: 'Search', 
-                        icon: 'fa-search', 
+                        label: 'Search',
+                        icon: 'fa-search',
                         items: [
                             {
-                                label: 'Text', 
+                                label: 'Text',
                                 items: [
                                     {
                                         label: 'Workspace'


### PR DESCRIPTION
### Feature Requests

#### Current behavior
Currently the MenuModel includes a title property which sets the title element attribute on the various pMenu* templates, providing basic tooltip functionality via the browser's native support for displaying the title attribute of an HTML element.

#### Desired behavior
Display the pTooltip component on hover of a pMenu* menu item, via properties passed from a new tooltip property on the MenuItem API with properties corresponding to the pToolTip API:

pTooltip
tooltipPosition
tooltipEvent
positionStyle
tooltipDisabled
appendTo
hideDelay
showDelay
tooltipStyleClass
escape
tooltipZIndex

What is the motivation / use case for changing the behavior?
Consistent user (and developer) experience in displaying tooltips, regardless of the component in which the tooltip is embedded.