### PR TITLE
MegaMenu ignores visible property of MenuItem API

### DIFF
--- a/src/app/components/megamenu/megamenu.ts
+++ b/src/app/components/megamenu/megamenu.ts
@@ -12,8 +12,8 @@ import {RouterModule} from '@angular/router';
             [ngClass]="{'ui-megamenu ui-widget ui-widget-content ui-corner-all':true,'ui-megamenu-horizontal': orientation == 'horizontal','ui-megamenu-vertical': orientation == 'vertical'}">
             <ul class="ui-megamenu-root-list">
                 <ng-template ngFor let-category [ngForOf]="model">
-                    <li *ngIf="category.separator" class="ui-menu-separator ui-widget-content">
-                    <li *ngIf="!category.separator" #item [ngClass]="{'ui-menuitem ui-corner-all':true,'ui-menuitem-active':item==activeItem}"
+                    <li *ngIf="category.separator" class="ui-menu-separator ui-widget-content" [ngClass]="{'ui-helper-hidden': category.visible === false}">
+                    <li *ngIf="!category.separator" #item [ngClass]="{'ui-menuitem ui-corner-all':true,'ui-menuitem-active':item==activeItem, 'ui-helper-hidden': category.visible === false}"
                         (mouseenter)="onItemMouseEnter($event, item, category)" (mouseleave)="onItemMouseLeave($event, item)">
    
                         <a *ngIf="!category.routerLink" [href]="category.url||'#'" [attr.target]="category.target" [attr.title]="category.title" [attr.id]="category.id" (click)="itemClick($event, category)"
@@ -37,8 +37,8 @@ import {RouterModule} from '@angular/router';
                                             <ul class="ui-megamenu-submenu">
                                                 <li class="ui-widget-header ui-megamenu-submenu-header ui-corner-all">{{submenu.label}}</li>
                                                 <ng-template ngFor let-item [ngForOf]="submenu.items">
-                                                    <li *ngIf="item.separator" class="ui-menu-separator ui-widget-content">
-                                                    <li *ngIf="!item.separator" class="ui-menuitem ui-corner-all">
+                                                    <li *ngIf="item.separator" class="ui-menu-separator ui-widget-content" [ngClass]="{'ui-helper-hidden': item.visible === false}">
+                                                    <li *ngIf="!item.separator" class="ui-menuitem ui-corner-all" [ngClass]="{'ui-helper-hidden': item.visible === false}">
                                                         <a *ngIf="!item.routerLink" [href]="item.url||'#'" class="ui-menuitem-link ui-corner-all" [attr.target]="item.target" [attr.title]="item.title" [attr.id]="item.id"
                                                             [ngClass]="{'ui-state-disabled':item.disabled}" (click)="itemClick($event, item)">
                                                             <span class="ui-menuitem-icon fa fa-fw" *ngIf="item.icon" [ngClass]="item.icon"></span>


### PR DESCRIPTION
**Feature Requests**

**Current behavior**
Currently, the MegaMenu ignores the "_visible_" attribute of the MenuModel being passed. So the user is not able to hide the menu items based on the Model attribute values.

**Desired behavior**
A user should be able to hide menu elements by passing _"visible": false_ in the MegaMenu.