### PR TITLE
Update multiselect.ts to avoid nullCheck errors

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -168,7 +168,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
             
     public itemTemplate: TemplateRef<any>;
     
-    public focusedItemCheckbox: HTMLInputElement;
+    public focusedItemCheckbox: HTMLInputElement | null;
     
     _options: any[];
     


### PR DESCRIPTION
When strickNullChecks is true in tsconfig.json, webpack returns an error in production environment if the MultiSelectModule is imported: "Type 'null' is not assignable to type 'HTMLInputElement'".