### PR TITLE
Fix style of floating label and (Chromes) autofill

### DIFF
--- a/src/app/components/inputtext/inputtext.css
+++ b/src/app/components/inputtext/inputtext.css
@@ -95,14 +95,10 @@
 }
     
 .ui-float-label > input:focus ~ label,
+.ui-float-label > input:-webkit-autofill ~ label,
 .ui-float-label > input.ui-state-filled ~ label,
 .ui-float-label > .ui-inputwrapper-focus ~ label,
 .ui-float-label > .ui-inputwrapper-filled ~ label {
   top:-.75em;
-  font-size:12px;
-}
-
-.ui-float-label > .input:-webkit-autofill ~ label {
-  top:-20px;
   font-size:12px;
 }


### PR DESCRIPTION
Selector was using .input, which imho doesn't make any sense here. 

When (chromes) autofill feature happened, the label should have the same style as when the input if filled.

###Defect Fixes
Fixes [#5472](https://github.com/primefaces/primeng/issues/5472)
