### PR TITLE
Removing href="#" attribute from accordion header <a> tag

### DIFF
--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -12,7 +12,7 @@ let idx: number = 0;
     selector: 'p-accordionTab',
     template: `
         <div class="ui-accordion-header ui-state-default ui-corner-all" [ngClass]="{'ui-state-active': selected,'ui-state-disabled':disabled}">
-            <a href="#" [attr.id]="id" [attr.aria-controls]="id + '-content'" role="tab" [attr.aria-expanded]="selected" (click)="toggle($event)" (keydown.space)="toggle($event)">
+            <a [attr.id]="id" [attr.aria-controls]="id + '-content'" role="tab" [attr.aria-expanded]="selected" (click)="toggle($event)" (keydown.space)="toggle($event)">
                 <span class="ui-accordion-toggle-icon" [ngClass]="selected ? accordion.collapseIcon : accordion.expandIcon"></span>
                 <span class="ui-accordion-header-text" *ngIf="!hasHeaderFacet">
                     {{header}}


### PR DESCRIPTION
Fixed [bug #5518 ](https://github.com/primefaces/primeng/issues/5518)

Since accordion header content is wrapped in <a href...> tag, hovering on the header displays the hyperlink on the page's left-bottom corner.
This is even visible in the demo pages as the hypelink https://www.primefaces.org/primeng/#.
This looks weird in an angular app which itself doesnt have hyperlinks.
Could disable this by styling 'pointer-events:none;', but that also disables any custom click events binding or anything on the header.
Also while trying to bind custom click events it triggered app reload due to href='#' (similar to https://github.com/angular/angular/issues/7294)
**All the functionalities are working without href tag and  it seems more apt not to have an href tag in an angular 2+ app.**
Kindly review the same.


Thanks