### PR TITLE
Allow disabling dialog button focus

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -102,6 +102,8 @@ export class Dialog implements AfterViewInit,AfterViewChecked,OnDestroy {
     @Input() minY: number = 0;
 
     @Input() autoAlign: boolean = true;
+
+    @Input() focusOnDisplay: boolean = true;
         
     @ContentChildren(Header, {descendants: false}) headerFacet: QueryList<Header>;
     
@@ -184,7 +186,9 @@ export class Dialog implements AfterViewInit,AfterViewChecked,OnDestroy {
         if(this.executePostDisplayActions) {
             this.onShow.emit({});
             this.positionOverlay();
-            this.focus();
+            if(this.focusOnDisplay) {
+                this.focus();
+            }
             this.currentHeight = this.domHandler.getOuterHeight(this.containerViewChild.nativeElement);
             this.executePostDisplayActions = false;
         }


### PR DESCRIPTION
The dialog focus functionality forces focus on the first button in the dialog. That functionality often isn't desired.

In our use case, we use a variety of text inputs in our dialogs which need focus instead of the cancel and confirmation buttons at the bottom of the dialog. This PR allows a consumer to disable the focus functionality and to handle it in the parent component.