### PR TITLE
duplicate autoAlign attribute

### DIFF
--- a/src/app/showcase/components/dialog/dialogdemo.html
+++ b/src/app/showcase/components/dialog/dialogdemo.html
@@ -115,7 +115,7 @@ export class ModelComponent &#123;
 
 <pre>
 <code class="language-markup" pCode ngNonBindable>
-&lt;p-dialog [autoAlign]="false" [contentStyle]="&#123;'max-height':'200px' [autoAlign]="true"&#125;"&gt;
+&lt;p-dialog [contentStyle]="&#123;'max-height':'200px' [autoAlign]="true"&#125;"&gt;
     &lt;ul&gt;
         &lt;li *ngFor="let item of items"&gt;&#123;&#123;item&#125;&#125;&lt;li&gt;
     &lt;/ul&gt;


### PR DESCRIPTION
###Defect Fixes
documentation update

###Feature Requests
remove duplicate autoAlign attribute in the doc.