### PR TITLE
New filter constraint `containsIn`

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1205,24 +1205,23 @@ export class Table implements OnInit, AfterContentInit {
             return value > filter;
         },
 
-        containsIn: function (value, filter) {
+        containsIn(value, filter): boolean {
             if (filter === undefined || filter === null || filter.length === 0) {
                 return true;
             }
             if (value === undefined || value === null) {
                 return false;
             }
-            for (let _i = 0; _i < filter.length; _i++) {
-                if (filter[_i] === undefined || filter[_i] === null || (typeof filter[_i] === 'string' && filter[_i].trim() === '')) {
+            for (let i = 0; i < filter.length; i++) {
+                if (filter[i] === undefined || filter[i] === null || (typeof filter[i] === 'string' && filter[i].trim() === '')) {
                     return true;
                 }
                 if (value === undefined || value === null) {
                     return false;
                 }
-                const _regExp = new RegExp('\\b' + filter[_i].toLowerCase() + '\\b');
-                const _result = _regExp.test(value.toString().toLowerCase());
-                if (_result) {
-                    return _result;
+                const regExp = new RegExp('\\b' + filter[i].toLowerCase() + '\\b');
+                if (regExp.test(value.toString().toLowerCase())) {
+                    return true;
                 }
             }
             return false;

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1219,7 +1219,7 @@ export class Table implements OnInit, AfterContentInit {
                 if (value === undefined || value === null) {
                     return false;
                 }
-                const regExp = new RegExp('\\b' + filter[i].toLowerCase() + '\\b');
+                const regExp = new RegExp('\\b' + filter[i].toLowerCase().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\\b');
                 if (regExp.test(value.toString().toLowerCase())) {
                     return true;
                 }


### PR DESCRIPTION
#### Feature request

Added a new constraint to Table allowing user to multi-select over a list of elements containing several possibilities.

context ex: a list of cars with several colors options and users who want to select only cars having at least one of the selected colors.
(please look at commit message 01d4f9b which contains a deeper presentation and examples)

#### How this impact the current code ?

This pull request simply add a new attribute to `Table.filterConstraints` : `containsIn` that can be passed 
as an option to `dt.filter` and return a boolean such as the other filters currently in use.

#### How this work ?

The filter will take the value as a string and compare it to each filter as a regexp, if one element in the filters array is present in the value then it return true else if none has been found  it return false.