### PR TITLE
Prevent table from sorting when no initial sort defined.

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -409,9 +409,9 @@ export class Table implements OnInit, AfterContentInit {
         if (!this.lazy) {
             this.totalRecords = (this._value ? this._value.length : 0);
 
-            if (this.sortMode == 'single')
+            if (this.sortMode == 'single' && this._sortField)
                 this.sortSingle();
-            else if (this.sortMode == 'multiple')
+            else if (this.sortMode == 'multiple' && this._multiSortMeta)
                 this.sortMultiple();
         }
 


### PR DESCRIPTION
Initial load of data is sometimes sorted server side, so no need
to specifiy an initial.  Before change, it would still try to sort
in a undefined manner.