### PR TITLE
[Fix #5598] authorize all used component selectors

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -123,7 +123,7 @@
     "component-selector": [
       true,
       "element",
-      "app",
+      ["app", "p", "datascroller", "datatable", "table"],
       "kebab-case"
     ],
     "use-input-property-decorator": true,


### PR DESCRIPTION
As "p", "datascroller", "datatable" and "table" are used as component selector prefixes,
We expect to see them authorized in the tslint.json

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

Partially fixes #5598 

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.