### PR TITLE
[Fix #5598] Disable component-class-suffix rule.

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -133,7 +133,7 @@
     "no-output-rename": true,
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
-    "component-class-suffix": true,
+    "component-class-suffix": false,
     "directive-class-suffix": true,
     "no-access-missing-member": true,
     "templates-use-public": true,


### PR DESCRIPTION
As Component suffix is never used in component classes in the whole project,
we expect this rule disabled in tslint.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

Partially Fixes #5598

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.