### PR TITLE
[Fix #5598] ignore no-inferrable-types rule on class properties.

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -58,7 +58,8 @@
     "no-eval": true,
     "no-inferrable-types": [
       true,
-      "ignore-params"
+      "ignore-params",
+      "ignore-properties",
     ],
     "no-misused-new": true,
     "no-non-null-assertion": true,

--- a/tslint.json
+++ b/tslint.json
@@ -59,7 +59,7 @@
     "no-inferrable-types": [
       true,
       "ignore-params",
-      "ignore-properties",
+      "ignore-properties"
     ],
     "no-misused-new": true,
     "no-non-null-assertion": true,


### PR DESCRIPTION
As Component suffix is never used in component classes in the whole project,
we expect this rule disabled in tslint.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

Partially Fixes #5598

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.