### PR TITLE
Fix table component only applying the last filter before timeout (#5660)

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -975,13 +975,14 @@ export class Table implements OnInit, AfterContentInit {
         if(this.filterTimeout) {
             clearTimeout(this.filterTimeout);
         }
-
+        
+        if (!this.isFilterBlank(value)) {
+            this.filters[field] = { value: value, matchMode: matchMode };
+        } else if (this.filters[field]) {
+            delete this.filters[field];
+        }
+        
         this.filterTimeout = setTimeout(() => {
-            if (!this.isFilterBlank(value))
-                this.filters[field] = { value: value, matchMode: matchMode };
-            else if (this.filters[field])
-                delete this.filters[field];
-
             this._filter();
             this.filterTimeout = null;
         }, this.filterDelay);


### PR DESCRIPTION
Fixes issue #5660 

Filter function modified to store the filter value immediately, instead of on timeout.  
This ensures that ALL calls to filter within the same timeout are applied, not just the last one.  
The filter is still not executed until the timeout.