### PR TITLE
Add ui-multiselect-open class - Fix for #5680

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -16,7 +16,7 @@ export const MULTISELECT_VALUE_ACCESSOR: any = {
 @Component({
     selector: 'p-multiSelect',
     template: `
-        <div #container [ngClass]="{'ui-multiselect ui-widget ui-state-default ui-corner-all':true,'ui-state-focus':focus,'ui-state-disabled': disabled}" [ngStyle]="style" [class]="styleClass"
+        <div #container [ngClass]="{'ui-multiselect ui-widget ui-state-default ui-corner-all':true,'ui-multiselect-open':overlayVisible,'ui-state-focus':focus,'ui-state-disabled': disabled}" [ngStyle]="style" [class]="styleClass"
             (click)="onMouseclick($event,in)">
             <div class="ui-helper-hidden-accessible">
                 <input #in type="text" readonly="readonly" [attr.id]="inputId" [attr.name]="name" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" [disabled]="disabled" [attr.tabindex]="tabindex" (keydown)="onInputKeydown($event)">

--- a/src/app/showcase/components/multiselect/multiselectdemo.html
+++ b/src/app/showcase/components/multiselect/multiselectdemo.html
@@ -348,7 +348,7 @@ export class MyModel &#123;
                             <td>Container of the label to display selected items.</td>
                         </tr>
                         <tr>
-                            <td>ui-multiselect-label-container</td>
+                            <td>ui-multiselect-label</td>
                             <td>Label to display selected items.</td>
                         </tr>
                         <tr>
@@ -370,6 +370,10 @@ export class MyModel &#123;
                         <tr>
                             <td>ui-multiselect-item</td>
                             <td>An item in the list.</td>
+                        </tr>
+                        <tr>
+                            <td>ui-multiselect-open</td>
+                            <td>Container element when overlay is visible.</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
Add ui-multiselect-open class to ui-multiselect and typo fix for multiselect documentation.
Implements feature request in #5680 

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.