### PR TITLE
Listbox with checkboxes click behaviour

### DIFF
--- a/src/app/components/listbox/listbox.ts
+++ b/src/app/components/listbox/listbox.ts
@@ -226,7 +226,7 @@ export class Listbox implements AfterContentInit, ControlValueAccessor {
         let metaSelection = this.optionTouched ? false : this.metaKeySelection;
 
         if (metaSelection) {
-            let metaKey = (event.metaKey || event.ctrlKey);
+            let metaKey = (event.metaKey || event.ctrlKey || this.checkbox);
 
             if (selected) {
                 if (metaKey) {


### PR DESCRIPTION
If checkboxes are enabled the Listbox behaves as if the ctrl-key is pressed so the list wont be cleared if the checkbox is missed.
Issue #5638 on primefaces/primeng describes that problem.
A demonstration of the problem and it's fix here:
https://stackblitz.com/github/primefaces/primeng-issue-template?file=src%2Fapp%2Fapp.component.html

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.