### PR TITLE
Dropdown: allow for implicit form submission

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -478,7 +478,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     
     hide() {
         this.panelVisible = false;
-        
+        this.focusViewChild.nativeElement.focus();
+
         if(this.filter && this.resetFilterOnHide) {
             this.resetFilter();
         }
@@ -591,11 +592,13 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             
             //enter
             case 13:
+                if (this.panelVisible) {
+                    event.preventDefault();
+                }
+
                 if (!this.filter || (this.optionsToDisplay && this.optionsToDisplay.length > 0)) {
                     this.hide();
                 }
-                
-                event.preventDefault();
             break;
             
             //escape and tab


### PR DESCRIPTION
This PR enables implicit form submission using the enter key in the context of the dropdown component.

Implicit form submission is only possible when the native input element has focus and the dropdown is closed.