### PR TITLE
Calendar UTC issues fix

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1,16 +1,34 @@
-import {NgModule,Component,ElementRef,AfterViewInit,AfterViewChecked,OnDestroy,OnInit,Input,Output,SimpleChange,EventEmitter,forwardRef,Renderer2,
-        ViewChild,ChangeDetectorRef,TemplateRef,ContentChildren,QueryList} from '@angular/core';
-import {trigger,state,style,transition,animate} from '@angular/animations';
+import {animate, state, style, transition, trigger} from '@angular/animations';
 import {CommonModule} from '@angular/common';
+import {
+    AfterViewChecked,
+    AfterViewInit,
+    ChangeDetectorRef,
+    Component,
+    ContentChildren,
+    ElementRef,
+    EventEmitter,
+    forwardRef,
+    Input,
+    NgModule,
+    OnDestroy,
+    OnInit,
+    Output,
+    QueryList,
+    Renderer2,
+    TemplateRef,
+    ViewChild
+} from '@angular/core';
+import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
 import {ButtonModule} from '../button/button';
+import {PrimeTemplate, SharedModule} from '../common/shared';
 import {DomHandler} from '../dom/domhandler';
-import {SharedModule,PrimeTemplate} from '../common/shared';
-import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
+
 
 export const CALENDAR_VALUE_ACCESSOR: any = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => Calendar),
-  multi: true
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => Calendar),
+    multi: true
 };
 
 export interface LocaleSettings {
@@ -20,25 +38,34 @@ export interface LocaleSettings {
     dayNamesMin: string[];
     monthNames: string[];
     monthNamesShort: string[];
-    today: string,
-    clear: string
+    today: string;
+    clear: string;
 }
 
 @Component({
     selector: 'p-calendar',
-    template:  `
+    template: `
         <span [ngClass]="{'ui-calendar':true,'ui-calendar-w-btn':showIcon}" [ngStyle]="style" [class]="styleClass">
             <ng-template [ngIf]="!inline">
-                <input #inputfield type="text" [attr.id]="inputId" [attr.name]="name" [attr.required]="required" [value]="inputFieldValue" (focus)="onInputFocus($event)" (keydown)="onInputKeydown($event)" (click)="onInputClick($event)" (blur)="onInputBlur($event)"
-                    [readonly]="readonlyInput" (input)="onUserInput($event)" [ngStyle]="inputStyle" [class]="inputStyleClass" [placeholder]="placeholder||''" [disabled]="disabled" [attr.tabindex]="tabindex"
-                    [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all'" autocomplete="off"
-                    ><button type="button" [icon]="icon" pButton *ngIf="showIcon" (click)="onButtonClick($event,inputfield)" class="ui-datepicker-trigger ui-calendar-button"
-                    [ngClass]="{'ui-state-disabled':disabled}" [disabled]="disabled" tabindex="-1"></button>
+                <input #inputfield type="text" [attr.id]="inputId" [attr.name]="name" [attr.required]="required"
+                       [value]="inputFieldValue" (focus)="onInputFocus($event)" (keydown)="onInputKeydown($event)"
+                       (click)="onInputClick($event)" (blur)="onInputBlur($event)"
+                       [readonly]="readonlyInput" (input)="onUserInput($event)" [ngStyle]="inputStyle"
+                       [class]="inputStyleClass" [placeholder]="placeholder||''" [disabled]="disabled"
+                       [attr.tabindex]="tabindex"
+                       [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all'" autocomplete="off"
+                ><button type="button" [icon]="icon" pButton *ngIf="showIcon" (click)="onButtonClick($event,inputfield)"
+                         class="ui-datepicker-trigger ui-calendar-button"
+                         [ngClass]="{'ui-state-disabled':disabled}" [disabled]="disabled" tabindex="-1"></button>
             </ng-template>
-            <div #datepicker [class]="panelStyleClass" [ngClass]="{'ui-datepicker ui-widget ui-widget-content ui-helper-clearfix ui-corner-all': true, 'ui-datepicker-inline':inline,'ui-shadow':!inline,'ui-state-disabled':disabled,'ui-datepicker-timeonly':timeOnly}"
-                [ngStyle]="{'display': inline ? 'inline-block' : (overlayVisible ? 'block' : 'none')}" (click)="onDatePickerClick($event)" [@overlayState]="inline ? 'visible' : (overlayVisible ? 'visible' : 'hidden')">
+            <div #datepicker [class]="panelStyleClass"
+                 [ngClass]="{'ui-datepicker ui-widget ui-widget-content ui-helper-clearfix ui-corner-all': true, 'ui-datepicker-inline':inline,'ui-shadow':!inline,'ui-state-disabled':disabled,'ui-datepicker-timeonly':timeOnly}"
+                 [ngStyle]="{'display': inline ? 'inline-block' : (overlayVisible ? 'block' : 'none')}"
+                 (click)="onDatePickerClick($event)"
+                 [@overlayState]="inline ? 'visible' : (overlayVisible ? 'visible' : 'hidden')">
 
-                <div class="ui-datepicker-header ui-widget-header ui-helper-clearfix ui-corner-all" *ngIf="!timeOnly && (overlayVisible || inline)">
+                <div class="ui-datepicker-header ui-widget-header ui-helper-clearfix ui-corner-all"
+                     *ngIf="!timeOnly && (overlayVisible || inline)">
                     <ng-content select="p-header"></ng-content>
                     <a class="ui-datepicker-prev ui-corner-all" href="#" (click)="prevMonth($event)">
                         <span class="fa fa-angle-left"></span>
@@ -47,11 +74,15 @@ export interface LocaleSettings {
                         <span class="fa fa-angle-right"></span>
                     </a>
                     <div class="ui-datepicker-title">
-                        <span class="ui-datepicker-month" *ngIf="!monthNavigator">{{locale.monthNames[currentMonth]}}</span>
-                        <select class="ui-datepicker-month" *ngIf="monthNavigator" (change)="onMonthDropdownChange($event.target.value)">
-                            <option [value]="i" *ngFor="let month of locale.monthNames;let i = index" [selected]="i == currentMonth">{{month}}</option>
+                        <span class="ui-datepicker-month"
+                              *ngIf="!monthNavigator">{{locale.monthNames[currentMonth]}}</span>
+                        <select class="ui-datepicker-month" *ngIf="monthNavigator"
+                                (change)="onMonthDropdownChange($event.target.value)">
+                            <option [value]="i" *ngFor="let month of locale.monthNames;let i = index"
+                                    [selected]="i == currentMonth">{{month}}</option>
                         </select>
-                        <select class="ui-datepicker-year" *ngIf="yearNavigator" (change)="onYearDropdownChange($event.target.value)">
+                        <select class="ui-datepicker-year" *ngIf="yearNavigator"
+                                (change)="onYearDropdownChange($event.target.value)">
                             <option [value]="year" *ngFor="let year of yearOptions" [selected]="year == currentYear">{{year}}</option>
                         </select>
                         <span class="ui-datepicker-year" *ngIf="!yearNavigator">{{currentYear}}</span>
@@ -70,10 +101,11 @@ export interface LocaleSettings {
                             <td *ngFor="let date of week" [ngClass]="{'ui-datepicker-other-month ui-state-disabled':date.otherMonth,
                                 'ui-datepicker-current-day':isSelected(date),'ui-datepicker-today':date.today}">
                                 <a class="ui-state-default" href="#" *ngIf="date.otherMonth ? showOtherMonths : true"
-                                    [ngClass]="{'ui-state-active':isSelected(date), 'ui-state-highlight':date.today, 'ui-state-disabled':!date.selectable}"
-                                    (click)="onDateSelect($event,date)" draggable="false">
+                                   [ngClass]="{'ui-state-active':isSelected(date), 'ui-state-highlight':date.today, 'ui-state-disabled':!date.selectable}"
+                                   (click)="onDateSelect($event,date)" draggable="false">
                                     <ng-container *ngIf="!dateTemplate">{{date.day}}</ng-container>
-                                    <ng-container *ngTemplateOutlet="dateTemplate; context: {$implicit: date}"></ng-container>
+                                    <ng-container *ngTemplateOutlet="dateTemplate; context: {$implicit: date}">
+                                    </ng-container>
                                 </a>
                             </td>
                         </tr>
@@ -84,7 +116,8 @@ export interface LocaleSettings {
                         <a href="#" (click)="incrementHour($event)">
                             <span class="fa fa-angle-up"></span>
                         </a>
-                        <span [ngStyle]="{'display': currentHour < 10 ? 'inline': 'none'}">0</span><span>{{currentHour}}</span>
+                        <span [ngStyle]="{'display': currentHour < 10 ? 'inline': 'none'}">0</span>
+                        <span>{{currentHour}}</span>
                         <a href="#" (click)="decrementHour($event)">
                             <span class="fa fa-angle-down"></span>
                         </a>
@@ -138,10 +171,12 @@ export interface LocaleSettings {
                 <div class="ui-datepicker-buttonbar ui-widget-header" *ngIf="showButtonBar">
                     <div class="ui-g">
                         <div class="ui-g-6">
-                            <button type="button" [label]="_locale.today" (click)="onTodayButtonClick($event)" pButton [ngClass]="[todayButtonStyleClass]"></button>
+                            <button type="button" [label]="_locale.today" (click)="onTodayButtonClick($event)" pButton
+                                    [ngClass]="[todayButtonStyleClass]"></button>
                         </div>
                         <div class="ui-g-6">
-                            <button type="button" [label]="_locale.clear" (click)="onClearButtonClick($event)" pButton [ngClass]="[clearButtonStyleClass]"></button>
+                            <button type="button" [label]="_locale.clear" (click)="onClearButtonClick($event)" pButton
+                                    [ngClass]="[clearButtonStyleClass]"></button>
                         </div>
                     </div>
                 </div>
@@ -165,329 +200,332 @@ export interface LocaleSettings {
         '[class.ui-inputwrapper-filled]': 'filled',
         '[class.ui-inputwrapper-focus]': 'focus'
     },
-    providers: [DomHandler,CALENDAR_VALUE_ACCESSOR]
+    providers: [DomHandler, CALENDAR_VALUE_ACCESSOR]
 })
-export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy,ControlValueAccessor {
-    
+export class Calendar implements AfterViewInit, AfterViewChecked, OnInit, OnDestroy, ControlValueAccessor {
+
     @Input() defaultDate: Date;
-    
+
     @Input() style: string;
-    
+
     @Input() styleClass: string;
-    
+
     @Input() inputStyle: string;
 
     @Input() inputId: string;
-    
+
     @Input() name: string;
-    
+
     @Input() inputStyleClass: string;
-    
+
     @Input() placeholder: string;
-    
+
     @Input() disabled: any;
-    
+
     @Input() dateFormat: string = 'mm/dd/yy';
-    
+
     @Input() inline: boolean = false;
-    
+
     @Input() showOtherMonths: boolean = true;
 
     @Input() selectOtherMonths: boolean;
-    
+
     @Input() showIcon: boolean;
-    
+
     @Input() icon: string = 'fa-calendar';
-    
+
     @Input() appendTo: any;
-    
+
     @Input() readonlyInput: boolean;
-    
+
     @Input() shortYearCutoff: any = '+10';
-    
+
     @Input() monthNavigator: boolean;
 
     @Input() yearNavigator: boolean;
 
     @Input() yearRange: string;
-    
+
     @Input() hourFormat: string = '24';
-    
+
     @Input() timeOnly: boolean;
-    
+
     @Input() stepHour: number = 1;
-    
+
     @Input() stepMinute: number = 1;
-    
+
     @Input() stepSecond: number = 1;
-    
+
     @Input() showSeconds: boolean = false;
 
     @Input() required: boolean;
 
     @Input() showOnFocus: boolean = true;
-    
+
     @Input() dataType: string = 'date';
-    
+
     @Input() utc: boolean;
-    
+
     @Input() selectionMode: string = 'single';
-    
+
     @Input() maxDateCount: number;
-    
+
     @Input() showButtonBar: boolean;
-    
+
     @Input() todayButtonStyleClass: string = 'ui-button-secondary';
-    
+
     @Input() clearButtonStyleClass: string = 'ui-button-secondary';
-    
+
     @Input() autoZIndex: boolean = true;
-    
+
     @Input() baseZIndex: number = 0;
 
     @Input() panelStyleClass: string;
-  
+
     @Input() keepInvalid: boolean = false;
 
     @Input() hideOnDateTimeSelect: boolean = false;
-    
+
     @Output() onFocus: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onBlur: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onClose: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onSelect: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onInput: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onTodayClick: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onClearClick: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onMonthChange: EventEmitter<any> = new EventEmitter();
-    
+
     @Output() onYearChange: EventEmitter<any> = new EventEmitter();
-    
+
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
-    
+
     _locale: LocaleSettings = {
         firstDayOfWeek: 0,
-        dayNames: ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"],
-        dayNamesShort: ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
-        dayNamesMin: ["Su","Mo","Tu","We","Th","Fr","Sa"],
-        monthNames: [ "January","February","March","April","May","June","July","August","September","October","November","December" ],
-        monthNamesShort: [ "Jan", "Feb", "Mar", "Apr", "May", "Jun","Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ],
+        dayNames: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+        dayNamesShort: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+        dayNamesMin: ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'],
+        monthNames: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+        monthNamesShort: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
         today: 'Today',
         clear: 'Clear'
     };
-    
+
     @Input() tabindex: number;
-    
+
     @ViewChild('datepicker') overlayViewChild: ElementRef;
-    
+
     @ViewChild('inputfield') inputfieldViewChild: ElementRef;
-    
+
     value: any;
-    
+
     dates: any[];
-    
+
     weekDays: string[];
-    
+
     currentMonthText: string;
-    
+
     currentMonth: number;
-    
+
     currentYear: number;
-    
+
     currentHour: number;
-    
+
     currentMinute: number;
-    
+
     currentSecond: number;
-    
+
     pm: boolean;
-    
+
     overlay: HTMLDivElement;
-    
+
     overlayVisible: boolean;
-    
+
     overlayShown: boolean;
-    
+
     datepickerClick: boolean;
-    
-    onModelChange: Function = () => {};
-    
-    onModelTouched: Function = () => {};
-    
+
+    onModelChange: Function = () => {
+    };
+
+    onModelTouched: Function = () => {
+    };
+
     calendarElement: any;
-    
+
     documentClickListener: any;
-    
+
     ticksTo1970: number;
-    
+
     yearOptions: number[];
-    
+
     focus: boolean;
-    
+
     isKeydown: boolean;
-    
+
     filled: boolean;
 
     inputFieldValue: string = null;
-    
+
     _minDate: Date;
-    
+
     _maxDate: Date;
-    
+
     _showTime: boolean;
-    
+
     preventDocumentListener: boolean;
-    
+
     dateTemplate: TemplateRef<any>;
-    
+
     _disabledDates: Array<Date>;
-    
+
     _disabledDays: Array<number>;
 
     @Input() get minDate(): Date {
         return this._minDate;
     }
-    
+
     set minDate(date: Date) {
         this._minDate = date;
 
-        if(this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
+        if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
             this.createMonth(this.currentMonth, this.currentYear);
         }
     }
-    
+
     @Input() get maxDate(): Date {
         return this._maxDate;
     }
-    
+
     set maxDate(date: Date) {
         this._maxDate = date;
-      
-        if(this.currentMonth != undefined && this.currentMonth != null  && this.currentYear) {
+
+        if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
             this.createMonth(this.currentMonth, this.currentYear);
         }
     }
-    
+
     @Input() get disabledDates(): Date[] {
         return this._disabledDates;
     }
-    
+
     set disabledDates(disabledDates: Date[]) {
         this._disabledDates = disabledDates;
-        if(this.currentMonth != undefined && this.currentMonth != null  && this.currentYear) {
+        if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
 
             this.createMonth(this.currentMonth, this.currentYear);
         }
     }
-    
+
     @Input() get disabledDays(): number[] {
         return this._disabledDays;
     }
-    
+
     set disabledDays(disabledDays: number[]) {
         this._disabledDays = disabledDays;
 
-        if(this.currentMonth != undefined && this.currentMonth != null  && this.currentYear) {
+        if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
             this.createMonth(this.currentMonth, this.currentYear);
         }
     }
-    
+
     @Input() get showTime(): boolean {
         return this._showTime;
     }
-    
+
     set showTime(showTime: boolean) {
         this._showTime = showTime;
-        
-        if(this.currentHour === undefined) {
-            this.initTime(this.value||new Date());
+
+        if (this.currentHour === undefined) {
+            this.initTime(this.value || new Date());
         }
         this.updateInputfield();
     }
-    
+
     get locale() {
-       return this._locale;
+        return this._locale;
     }
 
     @Input()
     set locale(newLocale: LocaleSettings) {
-       this._locale = newLocale;
-       this.createWeekDays();
-       this.createMonth(this.currentMonth, this.currentYear);
+        this._locale = newLocale;
+        this.createWeekDays();
+        this.createMonth(this.currentMonth, this.currentYear);
     }
 
-    constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public cd: ChangeDetectorRef) {}
+    constructor(public el: ElementRef, public domHandler: DomHandler, public renderer: Renderer2, public cd: ChangeDetectorRef) {
+    }
 
     ngOnInit() {
-        let date = this.defaultDate||new Date();
+        let date = this.defaultDate || new Date();
         this.createWeekDays();
-        
+
         this.currentMonth = date.getMonth();
         this.currentYear = date.getFullYear();
         this.initTime(date);
 
         this.createMonth(this.currentMonth, this.currentYear);
-        
+
         this.ticksTo1970 = (((1970 - 1) * 365 + Math.floor(1970 / 4) - Math.floor(1970 / 100) +
             Math.floor(1970 / 400)) * 24 * 60 * 60 * 10000000);
-            
-        if(this.yearNavigator && this.yearRange) {
+
+        if (this.yearNavigator && this.yearRange) {
             this.yearOptions = [];
             let years = this.yearRange.split(':'),
-            yearStart = parseInt(years[0]),
-            yearEnd = parseInt(years[1]);
-            
-            for(let i = yearStart; i <= yearEnd; i++) {
+                yearStart = parseInt(years[0]),
+                yearEnd = parseInt(years[1]);
+
+            for (let i = yearStart; i <= yearEnd; i++) {
                 this.yearOptions.push(i);
             }
         }
     }
-    
+
     ngAfterViewInit() {
-        if(!this.inline && this.appendTo) {
-            if(this.appendTo === 'body')
+        if (!this.inline && this.appendTo) {
+            if (this.appendTo === 'body')
                 document.body.appendChild(this.overlayViewChild.nativeElement);
             else
                 this.domHandler.appendChild(this.overlayViewChild.nativeElement, this.appendTo);
         }
     }
-    
+
     ngAfterViewChecked() {
-        if(this.overlayShown) {
+        if (this.overlayShown) {
             this.alignOverlay();
             this.overlayShown = false;
         }
     }
-    
+
     ngAfterContentInit() {
         this.templates.forEach((item) => {
-            switch(item.getType()) {
+            switch (item.getType()) {
                 case 'date':
                     this.dateTemplate = item.template;
-                break;
-                
+                    break;
+
                 default:
                     this.dateTemplate = item.template;
-                break;
+                    break;
             }
         });
     }
-    
+
     createWeekDays() {
         this.weekDays = [];
         let dayIndex = this.locale.firstDayOfWeek;
-        for(let i = 0; i < 7; i++) {
+        for (let i = 0; i < 7; i++) {
             this.weekDays.push(this.locale.dayNamesMin[dayIndex]);
             dayIndex = (dayIndex == 6) ? 0 : ++dayIndex;
         }
     }
-    
+
     createMonth(month: number, year: number) {
         this.dates = [];
         this.currentMonth = month;
@@ -499,45 +537,57 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         let sundayIndex = this.getSundayIndex();
         let dayNo = 1;
         let today = new Date();
-        
-        for(let i = 0; i < 6; i++) {
+
+        for (let i = 0; i < 6; i++) {
             let week = [];
-            
-            if(i == 0) {
-                for(let j = (prevMonthDaysLength - firstDay + 1); j <= prevMonthDaysLength; j++) {
+
+            if (i == 0) {
+                for (let j = (prevMonthDaysLength - firstDay + 1); j <= prevMonthDaysLength; j++) {
                     let prev = this.getPreviousMonthAndYear(month, year);
-                    week.push({day: j, month: prev.month, year: prev.year, otherMonth: true,
-                            today: this.isToday(today, j, prev.month, prev.year), selectable: this.isSelectable(j, prev.month, prev.year)});
+                    week.push({
+                        day: j,
+                        month: prev.month,
+                        year: prev.year,
+                        otherMonth: true,
+                        today: this.isToday(today, j, prev.month, prev.year),
+                        selectable: this.isSelectable(j, prev.month, prev.year)
+                    });
                 }
-                
+
                 let remainingDaysLength = 7 - week.length;
-                for(let j = 0; j < remainingDaysLength; j++) {
-                    week.push({day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year),
-                            selectable: this.isSelectable(dayNo, month, year)});
+                for (let j = 0; j < remainingDaysLength; j++) {
+                    week.push({
+                        day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year),
+                        selectable: this.isSelectable(dayNo, month, year)
+                    });
                     dayNo++;
                 }
             }
             else {
                 for (let j = 0; j < 7; j++) {
-                    if(dayNo > daysLength) {
+                    if (dayNo > daysLength) {
                         let next = this.getNextMonthAndYear(month, year);
-                        week.push({day: dayNo - daysLength, month: next.month, year: next.year, otherMonth:true,
-                                    today: this.isToday(today, dayNo - daysLength, next.month, next.year),
-                                    selectable: this.isSelectable((dayNo - daysLength), next.month, next.year)});
+                        week.push({
+                            day: dayNo - daysLength, month: next.month, year: next.year, otherMonth: true,
+                            today: this.isToday(today, dayNo - daysLength, next.month, next.year),
+                            selectable: this.isSelectable((dayNo - daysLength), next.month, next.year)
+                        });
                     }
                     else {
-                        week.push({day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year),
-                            selectable: this.isSelectable(dayNo, month, year)});
+                        week.push({
+                            day: dayNo, month: month, year: year, today: this.isToday(today, dayNo, month, year),
+                            selectable: this.isSelectable(dayNo, month, year)
+                        });
                     }
-                    
+
                     dayNo++;
                 }
             }
-            
+
             this.dates.push(week);
         }
     }
-    
+
     initTime(date: Date) {
         this.pm = (!this.utc) ? (date.getHours() > 11) : (date.getUTCHours() > 11);
         if (this.showTime) {
@@ -545,7 +595,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                 this.currentMinute = date.getUTCMinutes();
                 this.currentSecond = date.getUTCSeconds();
 
-                if(this.hourFormat == '12')
+                if (this.hourFormat == '12')
                     this.currentHour = date.getUTCHours() == 0 ? 12 : date.getUTCHours() % 12;
                 else
                     this.currentHour = date.getUTCHours();
@@ -553,82 +603,82 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             else {
                 this.currentMinute = date.getMinutes();
                 this.currentSecond = date.getSeconds();
-                
-                if(this.hourFormat == '12')
+
+                if (this.hourFormat == '12')
                     this.currentHour = date.getHours() == 0 ? 12 : date.getHours() % 12;
                 else
                     this.currentHour = date.getHours();
             }
         }
-        else if(this.timeOnly) {
+        else if (this.timeOnly) {
             this.currentMinute = 0;
             this.currentHour = 0;
             this.currentSecond = 0;
         }
     }
-    
+
     prevMonth(event) {
-        if(this.disabled) {
+        if (this.disabled) {
             event.preventDefault();
             return;
         }
-        
-        if(this.currentMonth === 0) {
+
+        if (this.currentMonth === 0) {
             this.currentMonth = 11;
             this.currentYear--;
-            
-            if(this.yearNavigator && this.currentYear < this.yearOptions[0]) {
+
+            if (this.yearNavigator && this.currentYear < this.yearOptions[0]) {
                 this.currentYear = this.yearOptions[this.yearOptions.length - 1];
             }
         }
         else {
             this.currentMonth--;
         }
-        
-        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
+
+        this.onMonthChange.emit({month: this.currentMonth + 1, year: this.currentYear});
         this.createMonth(this.currentMonth, this.currentYear);
         event.preventDefault();
     }
-    
+
     nextMonth(event) {
-        if(this.disabled) {
+        if (this.disabled) {
             event.preventDefault();
             return;
         }
 
-        if(this.currentMonth === 11) {
+        if (this.currentMonth === 11) {
             this.currentMonth = 0;
             this.currentYear++;
-            
-            if(this.yearNavigator && this.currentYear > this.yearOptions[this.yearOptions.length - 1]) {
+
+            if (this.yearNavigator && this.currentYear > this.yearOptions[this.yearOptions.length - 1]) {
                 this.currentYear = this.yearOptions[0];
             }
         }
         else {
             this.currentMonth++;
         }
-        
-        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
+
+        this.onMonthChange.emit({month: this.currentMonth + 1, year: this.currentYear});
         this.createMonth(this.currentMonth, this.currentYear);
         event.preventDefault();
     }
-    
+
     onDateSelect(event, dateMeta) {
-        if(this.disabled || !dateMeta.selectable) {
+        if (this.disabled || !dateMeta.selectable) {
             event.preventDefault();
             return;
         }
-        
-        if(this.isMultipleSelection() && this.isSelected(dateMeta)) {
+
+        if (this.isMultipleSelection() && this.isSelected(dateMeta)) {
             this.value = this.value.filter((date, i) => {
                 return !this.isDateEquals(date, dateMeta);
             });
             this.updateModel(this.value);
         }
         else {
-            if(this.shouldSelectDate(dateMeta)) {
-                if(dateMeta.otherMonth) {
-                    if(this.selectOtherMonths) {
+            if (this.shouldSelectDate(dateMeta)) {
+                if (dateMeta.otherMonth) {
+                    if (this.selectOtherMonths) {
                         this.currentMonth = dateMeta.month;
                         this.currentYear = dateMeta.year;
                         this.createMonth(this.currentMonth, this.currentYear);
@@ -636,89 +686,89 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                     }
                 }
                 else {
-                     this.selectDate(dateMeta);
+                    this.selectDate(dateMeta);
                 }
             }
         }
-        
-        if(this.isSingleSelection() && (!this.showTime || this.hideOnDateTimeSelect)) {
+
+        if (this.isSingleSelection() && (!this.showTime || this.hideOnDateTimeSelect)) {
             this.overlayVisible = false;
         }
 
         this.updateInputfield();
         event.preventDefault();
     }
-    
+
     shouldSelectDate(dateMeta) {
-        if(this.isMultipleSelection())
-            return !this.maxDateCount || !this.value || this.maxDateCount > this.value.length;
+        if (this.isMultipleSelection())
+            return !this.maxDateCount || !this.value || this.maxDateCount > this.value.length;
         else
             return true;
     }
-    
+
     updateInputfield() {
         let formattedValue = '';
 
-        if(this.value) {
-            if(this.isSingleSelection()) {
+        if (this.value) {
+            if (this.isSingleSelection()) {
                 formattedValue = this.formatDateTime(this.value);
             }
-            else if(this.isMultipleSelection()) {
-                for(let i = 0; i < this.value.length; i++) {
+            else if (this.isMultipleSelection()) {
+                for (let i = 0; i < this.value.length; i++) {
                     let dateAsString = this.formatDateTime(this.value[i]);
                     formattedValue += dateAsString;
-                    if(i !== (this.value.length - 1)) {
+                    if (i !== (this.value.length - 1)) {
                         formattedValue += ', ';
                     }
                 }
             }
-            else if(this.isRangeSelection()) {
-                if(this.value && this.value.length) {
+            else if (this.isRangeSelection()) {
+                if (this.value && this.value.length) {
                     let startDate = this.value[0];
                     let endDate = this.value[1];
-                    
+
                     formattedValue = this.formatDateTime(startDate);
-                    if(endDate) {
+                    if (endDate) {
                         formattedValue += ' - ' + this.formatDateTime(endDate);
                     }
                 }
             }
         }
-        
+
         this.inputFieldValue = formattedValue;
         this.updateFilledState();
-        if(this.inputfieldViewChild && this.inputfieldViewChild.nativeElement) {
+        if (this.inputfieldViewChild && this.inputfieldViewChild.nativeElement) {
             this.inputfieldViewChild.nativeElement.value = this.inputFieldValue;
         }
     }
-    
+
     formatDateTime(date) {
         let formattedValue = null;
-        if(date) {
-            if(this.timeOnly) {
+        if (date) {
+            if (this.timeOnly) {
                 formattedValue = this.formatTime(date);
             }
             else {
                 formattedValue = this.formatDate(date, this.dateFormat);
-                if(this.showTime) {
+                if (this.showTime) {
                     formattedValue += ' ' + this.formatTime(date);
                 }
             }
         }
-        
+
         return formattedValue;
     }
-    
+
     selectDate(dateMeta) {
         let date;
-        if(this.utc)
+        if (this.utc)
             date = new Date(Date.UTC(dateMeta.year, dateMeta.month, dateMeta.day));
         else
             date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
-        
-        if(this.showTime) {
-            if(this.utc) {
-                if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
+
+        if (this.showTime) {
+            if (this.utc) {
+                if (this.hourFormat === '12' && this.pm && this.currentHour != 12)
                     date.setUTCHours(this.currentHour + 12);
                 else
                     date.setUTCHours(this.currentHour);
@@ -727,7 +777,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                 date.setUTCSeconds(this.currentSecond);
             }
             else {
-                if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
+                if (this.hourFormat === '12' && this.pm && this.currentHour != 12)
                     date.setHours(this.currentHour + 12);
                 else
                     date.setHours(this.currentHour);
@@ -736,93 +786,93 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                 date.setSeconds(this.currentSecond);
             }
         }
-        
-        if(this.minDate && this.minDate > date) {
+
+        if (this.minDate && this.minDate > date) {
             date = this.minDate;
             this.currentHour = date.getHours();
             this.currentMinute = date.getMinutes();
             this.currentSecond = date.getSeconds();
         }
-        
-        if(this.maxDate && this.maxDate < date) {
+
+        if (this.maxDate && this.maxDate < date) {
             date = this.maxDate;
             this.currentHour = date.getHours();
             this.currentMinute = date.getMinutes();
             this.currentSecond = date.getSeconds();
         }
-        
-        if(this.isSingleSelection()) {
+
+        if (this.isSingleSelection()) {
             this.updateModel(date);
         }
-        else if(this.isMultipleSelection()) {
+        else if (this.isMultipleSelection()) {
             this.updateModel(this.value ? [...this.value, date] : [date]);
         }
-        else if(this.isRangeSelection()) {
-            if(this.value && this.value.length) {
+        else if (this.isRangeSelection()) {
+            if (this.value && this.value.length) {
                 let startDate = this.value[0];
                 let endDate = this.value[1];
-                
-                if(!endDate && date.getTime() >= startDate.getTime()) {
+
+                if (!endDate && date.getTime() >= startDate.getTime()) {
                     endDate = date;
                 }
                 else {
                     startDate = date;
                     endDate = null;
                 }
-                
+
                 this.updateModel([startDate, endDate]);
             }
             else {
                 this.updateModel([date, null]);
             }
         }
-        
+
         this.onSelect.emit(date);
     }
-    
+
     updateModel(value) {
         this.value = value;
-        
-        if(this.dataType == 'date') {
+
+        if (this.dataType == 'date') {
             this.onModelChange(this.value);
         }
-        else if(this.dataType == 'string') {
-            if(this.isSingleSelection()) {
+        else if (this.dataType == 'string') {
+            if (this.isSingleSelection()) {
                 this.onModelChange(this.formatDateTime(this.value));
             }
             else {
                 let stringArrValue = null;
-                if(this.value) {
+                if (this.value) {
                     stringArrValue = this.value.map(date => this.formatDateTime(date));
                 }
                 this.onModelChange(stringArrValue);
             }
         }
     }
-    
+
     getFirstDayOfMonthIndex(month: number, year: number) {
         let day = new Date();
         day.setDate(1);
         day.setMonth(month);
         day.setFullYear(year);
-        
+
         let dayIndex = day.getDay() + this.getSundayIndex();
         return dayIndex >= 7 ? dayIndex - 7 : dayIndex;
     }
-    
+
     getDaysCountInMonth(month: number, year: number) {
         return 32 - this.daylightSavingAdjust(new Date(year, month, 32)).getDate();
     }
-    
+
     getDaysCountInPrevMonth(month: number, year: number) {
         let prev = this.getPreviousMonthAndYear(month, year);
         return this.getDaysCountInMonth(prev.month, prev.year);
     }
-    
+
     getPreviousMonthAndYear(month: number, year: number) {
         let m, y;
-        
-        if(month === 0) {
+
+        if (month === 0) {
             m = 11;
             y = year - 1;
         }
@@ -830,14 +880,14 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             m = month - 1;
             y = year;
         }
-        
-        return {'month':m,'year':y};
+
+        return {'month': m, 'year': y};
     }
-    
+
     getNextMonthAndYear(month: number, year: number) {
         let m, y;
-        
-        if(month === 11) {
+
+        if (month === 11) {
             m = 0;
             y = year + 1;
         }
@@ -845,32 +895,32 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             m = month + 1;
             y = year;
         }
-        
-        return {'month':m,'year':y};
+
+        return {'month': m, 'year': y};
     }
-    
+
     getSundayIndex() {
         return this.locale.firstDayOfWeek > 0 ? 7 - this.locale.firstDayOfWeek : 0;
     }
-    
+
     isSelected(dateMeta): boolean {
-        if(this.value) {
-            if(this.isSingleSelection()) {
+        if (this.value) {
+            if (this.isSingleSelection()) {
                 return this.isDateEquals(this.value, dateMeta);
             }
-            else if(this.isMultipleSelection()) {
+            else if (this.isMultipleSelection()) {
                 let selected = false;
-                for(let date of this.value) {
+                for (let date of this.value) {
                     selected = this.isDateEquals(date, dateMeta);
-                    if(selected) {
+                    if (selected) {
                         break;
                     }
                 }
-                
+
                 return selected;
             }
-            else if(this.isRangeSelection()) {
-                if(this.value[1])
+            else if (this.isRangeSelection()) {
+                if (this.value[1])
                     return this.isDateEquals(this.value[0], dateMeta) || this.isDateEquals(this.value[1], dateMeta) || this.isDateBetween(this.value[0], this.value[1], dateMeta);
                 else
                     return this.isDateEquals(this.value[0], dateMeta)
@@ -879,172 +929,172 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         else
             return false;
     }
-    
+
     isDateEquals(value, dateMeta) {
-        if(value)
+        if (value)
             return value.getDate() === dateMeta.day && value.getMonth() === dateMeta.month && value.getFullYear() === dateMeta.year;
         else
             return false;
     }
-    
+
     isDateBetween(start, end, dateMeta) {
-        let between : boolean = false;
-        if(start && end) {
+        let between: boolean = false;
+        if (start && end) {
             let date: Date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
             return start.getTime() <= date.getTime() && end.getTime() >= date.getTime();
         }
-        
+
         return between;
     }
-    
+
     isSingleSelection(): boolean {
         return this.selectionMode === 'single';
     }
-    
+
     isRangeSelection(): boolean {
         return this.selectionMode === 'range';
     }
-    
+
     isMultipleSelection(): boolean {
         return this.selectionMode === 'multiple';
     }
-    
+
     isToday(today, day, month, year): boolean {
         return today.getDate() === day && today.getMonth() === month && today.getFullYear() === year;
     }
-    
+
     isSelectable(day, month, year): boolean {
         let validMin = true;
         let validMax = true;
         let validDate = true;
         let validDay = true;
-        
-        if(this.minDate) {
-             if(this.minDate.getFullYear() > year) {
-                 validMin = false;
-             }
-             else if(this.minDate.getFullYear() === year) {
-                 if(this.minDate.getMonth() > month) {
-                     validMin = false;
-                 }
-                 else if(this.minDate.getMonth() === month) {
-                     if(this.minDate.getDate() > day) {
-                         validMin = false;
-                     }
-                 }
-             }
+
+        if (this.minDate) {
+            if (this.minDate.getFullYear() > year) {
+                validMin = false;
+            }
+            else if (this.minDate.getFullYear() === year) {
+                if (this.minDate.getMonth() > month) {
+                    validMin = false;
+                }
+                else if (this.minDate.getMonth() === month) {
+                    if (this.minDate.getDate() > day) {
+                        validMin = false;
+                    }
+                }
+            }
         }
-        
-        if(this.maxDate) {
-             if(this.maxDate.getFullYear() < year) {
-                 validMax = false;
-             }
-             else if(this.maxDate.getFullYear() === year) {
-                 if(this.maxDate.getMonth() < month) {
-                     validMax = false;
-                 }
-                 else if(this.maxDate.getMonth() === month) {
-                     if(this.maxDate.getDate() < day) {
-                         validMax = false;
-                     }
-                 }
-             }
+
+        if (this.maxDate) {
+            if (this.maxDate.getFullYear() < year) {
+                validMax = false;
+            }
+            else if (this.maxDate.getFullYear() === year) {
+                if (this.maxDate.getMonth() < month) {
+                    validMax = false;
+                }
+                else if (this.maxDate.getMonth() === month) {
+                    if (this.maxDate.getDate() < day) {
+                        validMax = false;
+                    }
+                }
+            }
         }
-        
-        if(this.disabledDates) {
-           validDate = !this.isDateDisabled(day,month,year);
+
+        if (this.disabledDates) {
+            validDate = !this.isDateDisabled(day, month, year);
         }
-       
-        if(this.disabledDays) {
-           validDay = !this.isDayDisabled(day,month,year)
+
+        if (this.disabledDays) {
+            validDay = !this.isDayDisabled(day, month, year)
         }
-        
+
         return validMin && validMax && validDate && validDay;
     }
-    
-    isDateDisabled(day:number, month:number, year:number):boolean {
-        if(this.disabledDates) {
-            for(let disabledDate of this.disabledDates) {
-                if(disabledDate.getFullYear() === year && disabledDate.getMonth() === month && disabledDate.getDate() === day) {
+
+    isDateDisabled(day: number, month: number, year: number): boolean {
+        if (this.disabledDates) {
+            for (let disabledDate of this.disabledDates) {
+                if (disabledDate.getFullYear() === year && disabledDate.getMonth() === month && disabledDate.getDate() === day) {
                     return true;
                 }
             }
         }
-        
+
         return false;
     }
-    
-    isDayDisabled(day:number, month:number, year:number):boolean {
-        if(this.disabledDays) {
+
+    isDayDisabled(day: number, month: number, year: number): boolean {
+        if (this.disabledDays) {
             let weekday = new Date(year, month, day);
             let weekdayNumber = weekday.getDay();
             return this.disabledDays.indexOf(weekdayNumber) !== -1;
         }
         return false;
     }
-    
+
     onInputFocus(event: Event) {
         this.focus = true;
-        if(this.showOnFocus) {
-          this.showOverlay();
+        if (this.showOnFocus) {
+            this.showOverlay();
         }
         this.onFocus.emit(event);
     }
-    
+
     onInputClick(event: Event) {
-      this.datepickerClick=true;
-      if(this.autoZIndex) {
-        this.overlayViewChild.nativeElement.style.zIndex = String(this.baseZIndex + (++DomHandler.zindex));
-      }
+        this.datepickerClick = true;
+        if (this.autoZIndex) {
+            this.overlayViewChild.nativeElement.style.zIndex = String(this.baseZIndex + (++DomHandler.zindex));
+        }
     }
-    
+
     onInputBlur(event: Event) {
         this.focus = false;
         this.onBlur.emit(event);
-        if(!this.keepInvalid) {
+        if (!this.keepInvalid) {
             this.updateInputfield();
         }
         this.onModelTouched();
     }
-    
-    onButtonClick(event,inputfield) {
-        if(!this.overlayViewChild.nativeElement.offsetParent || this.overlayViewChild.nativeElement.style.display === 'none') {
+
+    onButtonClick(event, inputfield) {
+        if (!this.overlayViewChild.nativeElement.offsetParent || this.overlayViewChild.nativeElement.style.display === 'none') {
             inputfield.focus();
             this.showOverlay();
         }
         else
             this.overlayVisible = false;
-            
+
         this.datepickerClick = true;
     }
-    
+
     onInputKeydown(event) {
         this.isKeydown = true;
-        if(event.keyCode === 9) {
+        if (event.keyCode === 9) {
             this.overlayVisible = false;
         }
     }
-    
+
     onMonthDropdownChange(m: string) {
         this.currentMonth = parseInt(m);
-        this.onMonthChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
+        this.onMonthChange.emit({month: this.currentMonth + 1, year: this.currentYear});
         this.createMonth(this.currentMonth, this.currentYear);
     }
-    
+
     onYearDropdownChange(y: string) {
         this.currentYear = parseInt(y);
-        this.onYearChange.emit({ month: this.currentMonth + 1, year: this.currentYear });
+        this.onYearChange.emit({month: this.currentMonth + 1, year: this.currentYear});
         this.createMonth(this.currentMonth, this.currentYear);
     }
-    
+
     incrementHour(event) {
         const prevHour = this.currentHour;
         const newHour = this.currentHour + this.stepHour;
 
-        if(this.validateHour(newHour)) {
-            if(this.hourFormat == '24')
+        if (this.validateHour(newHour)) {
+            if (this.hourFormat == '24')
                 this.currentHour = (newHour >= 24) ? (newHour - 24) : newHour;
-            else if(this.hourFormat == '12') {
+            else if (this.hourFormat == '12') {
                 // Before the AM/PM break, now after
                 if (prevHour < 12 && newHour > 11) {
                     this.pm = !this.pm;
@@ -1052,157 +1102,157 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
 
                 this.currentHour = (newHour >= 13) ? (newHour - 12) : newHour;
             }
-            
+
             this.updateTime();
         }
-    
+
         event.preventDefault();
     }
-    
+
     decrementHour(event) {
         const newHour = this.currentHour - this.stepHour;
-        
-        if(this.validateHour(newHour)) {
-            if(this.hourFormat == '24')
+
+        if (this.validateHour(newHour)) {
+            if (this.hourFormat == '24')
                 this.currentHour = (newHour < 0) ? (24 + newHour) : newHour;
-            else if(this.hourFormat == '12') {
+            else if (this.hourFormat == '12') {
                 // If we were at noon/midnight, then switch
                 if (this.currentHour === 12) {
                     this.pm = !this.pm;
                 }
                 this.currentHour = (newHour <= 0) ? (12 + newHour) : newHour;
             }
-            
+
             this.updateTime();
         }
 
         event.preventDefault();
     }
-    
+
     validateHour(hour): boolean {
         let valid: boolean = true;
         let value = this.value;
-        if(this.isRangeSelection()) {
+        if (this.isRangeSelection()) {
             value = this.value[1] || this.value[0];
         }
-        if(this.isMultipleSelection()) {
+        if (this.isMultipleSelection()) {
             value = this.value[this.value.length - 1];
         }
         let valueDateString = value ? value.toDateString() : null;
-        
-        if(this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
-            if(this.minDate.getHours() > hour) {
+
+        if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
+            if (this.minDate.getHours() > hour) {
                 valid = false;
             }
         }
-        
-        if(this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
-            if(this.maxDate.getHours() < hour) {
+
+        if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
+            if (this.maxDate.getHours() < hour) {
                 valid = false;
             }
         }
-        
+
         return valid;
     }
-    
+
     incrementMinute(event) {
         let newMinute = this.currentMinute + this.stepMinute;
-        if(this.validateMinute(newMinute)) {
+        if (this.validateMinute(newMinute)) {
             this.currentMinute = (newMinute > 59) ? newMinute - 60 : newMinute;
             this.updateTime();
         }
-        
+
         event.preventDefault();
     }
-    
+
     decrementMinute(event) {
         let newMinute = this.currentMinute - this.stepMinute;
-        if(this.validateMinute(newMinute)) {
+        if (this.validateMinute(newMinute)) {
             this.currentMinute = (newMinute < 0) ? 60 + newMinute : newMinute;
             this.updateTime();
         }
-        
+
         event.preventDefault();
     }
-    
+
     validateMinute(minute): boolean {
         let valid: boolean = true;
         let value = this.value;
-        if(this.isRangeSelection()) {
+        if (this.isRangeSelection()) {
             value = this.value[1] || this.value[0];
         }
-        if(this.isMultipleSelection()) {
+        if (this.isMultipleSelection()) {
             value = this.value[this.value.length - 1];
         }
         let valueDateString = value ? value.toDateString() : null;
-        
-        if(this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
-            if(this.minDate.getMinutes() > minute) {
+
+        if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
+            if (this.minDate.getMinutes() > minute) {
                 valid = false;
             }
         }
-        
-        if(this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
-            if(this.maxDate.getMinutes() < minute) {
+
+        if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
+            if (this.maxDate.getMinutes() < minute) {
                 valid = false;
             }
         }
-        
+
         return valid;
     }
-    
+
     incrementSecond(event) {
         let newSecond = this.currentSecond + this.stepSecond;
-        if(this.validateSecond(newSecond)) {
+        if (this.validateSecond(newSecond)) {
             this.currentSecond = (newSecond > 59) ? newSecond - 60 : newSecond;
             this.updateTime();
         }
-    
+
         event.preventDefault();
     }
-    
+
     decrementSecond(event) {
         let newSecond = this.currentSecond - this.stepSecond;
-        if(this.validateSecond(newSecond)) {
+        if (this.validateSecond(newSecond)) {
             this.currentSecond = (newSecond < 0) ? 60 + newSecond : newSecond;
             this.updateTime();
         }
-        
+
         event.preventDefault();
     }
-    
+
     validateSecond(second): boolean {
         let valid: boolean = true;
         let value = this.value;
-        if(this.isRangeSelection()) {
+        if (this.isRangeSelection()) {
             value = this.value[1] || this.value[0];
         }
-        if(this.isMultipleSelection()) {
+        if (this.isMultipleSelection()) {
             value = this.value[this.value.length - 1];
         }
         let valueDateString = value ? value.toDateString() : null;
-        
-        if(this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
-            if(this.minDate.getSeconds() > second) {
+
+        if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
+            if (this.minDate.getSeconds() > second) {
                 valid = false;
             }
         }
-        
-        if(this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
-            if(this.maxDate.getSeconds() < second) {
+
+        if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
+            if (this.maxDate.getSeconds() < second) {
                 valid = false;
             }
         }
-        
+
         return valid;
     }
-    
+
     updateTime() {
         let value = this.value;
-        if(this.isRangeSelection()) {
+        if (this.isRangeSelection()) {
             value = this.value[1] || this.value[0];
         }
-        if(this.isMultipleSelection()) {
+        if (this.isMultipleSelection()) {
             value = this.value[this.value.length - 1];
         }
         value = value ? new Date(value.getTime()) : new Date();
@@ -1229,133 +1279,133 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                 value.setHours(this.currentHour);
             }
         }
-        
+
         value.setMinutes(this.currentMinute);
         value.setSeconds(this.currentSecond);
-        if(this.isRangeSelection()) {
-            if(this.value[1]) {
+        if (this.isRangeSelection()) {
+            if (this.value[1]) {
                 value = [this.value[0], value];
             } else {
                 value = [value, null];
             }
         }
-        if(this.isMultipleSelection()){
+        if (this.isMultipleSelection()) {
             value = [...this.value.slice(0, -1), value];
         }
         this.updateModel(value);
         this.onSelect.emit(value);
         this.updateInputfield();
     }
-    
+
     toggleAMPM(event) {
         this.pm = !this.pm;
         this.updateTime();
         event.preventDefault();
     }
-    
+
     onUserInput(event) {
         // IE 11 Workaround for input placeholder : https://github.com/primefaces/primeng/issues/2026
-        if(!this.isKeydown) {
+        if (!this.isKeydown) {
             return;
         }
         this.isKeydown = false;
-        
+
         let val = event.target.value;
         try {
             let value = this.parseValueFromString(val);
             this.updateModel(value);
             this.updateUI();
         }
-        catch(err) {
+        catch (err) {
             //invalid date
             this.updateModel(null);
         }
-        
+
         this.filled = val != null && val.length;
         this.onInput.emit(event);
     }
-    
+
     parseValueFromString(text: string): Date {
-        if(!text || text.trim().length === 0) {
+        if (!text || text.trim().length === 0) {
             return null;
         }
-        
+
         let value: any;
-        
-        if(this.isSingleSelection()) {
+
+        if (this.isSingleSelection()) {
             value = this.parseDateTime(text);
         }
-        else if(this.isMultipleSelection()) {
+        else if (this.isMultipleSelection()) {
             let tokens = text.split(',');
             value = [];
-            for(let token of tokens) {
+            for (let token of tokens) {
                 value.push(this.parseDateTime(token.trim()));
             }
         }
-        else if(this.isRangeSelection()) {
+        else if (this.isRangeSelection()) {
             let tokens = text.split(' - ');
             value = [];
-            for(let i = 0; i < tokens.length; i++) {
+            for (let i = 0; i < tokens.length; i++) {
                 value[i] = this.parseDateTime(tokens[i].trim());
             }
         }
-        
+
         return value;
     }
-    
+
     parseDateTime(text): Date {
         let date: Date;
         let parts: string[] = text.split(' ');
-        
-        if(this.timeOnly) {
+
+        if (this.timeOnly) {
             date = new Date();
             this.populateTime(date, parts[0], parts[1]);
         }
         else {
-            if(this.showTime) {
+            if (this.showTime) {
                 date = this.parseDate(parts[0], this.dateFormat);
                 this.populateTime(date, parts[1], parts[2]);
             }
             else {
-                 date = this.parseDate(text, this.dateFormat);
+                date = this.parseDate(text, this.dateFormat);
             }
         }
-        
+
         return date;
     }
-    
+
     populateTime(value, timeString, ampm) {
-        if(this.hourFormat == '12' && !ampm) {
+        if (this.hourFormat == '12' && !ampm) {
             throw 'Invalid Time';
         }
-        
+
         this.pm = (ampm === 'PM' || ampm === 'pm');
         let time = this.parseTime(timeString);
         if (!this.utc)
             value.setHours(time.hour);
         else
             value.setUTCHours(time.hour);
-    
+
         value.setMinutes(time.minute);
         value.setSeconds(time.second);
     }
-    
-    updateUI() {
-        let val = this.value||this.defaultDate||new Date();
 
-        if (Array.isArray(val)){
+    updateUI() {
+        let val = this.value || this.defaultDate || new Date();
+
+        if (Array.isArray(val)) {
             val = val[0];
         }
 
         this.createMonth(val.getMonth(), val.getFullYear());
-        
-        if(this.showTime||this.timeOnly) {
+
+        if (this.showTime || this.timeOnly) {
             let hours = (this.utc) ? val.getUTCHours() : val.getHours();
-            
-            if(this.hourFormat == '12') {
+
+            if (this.hourFormat == '12') {
                 this.pm = hours > 11;
-                
-                if(hours >= 12) {
+
+                if (hours >= 12) {
                     this.currentHour = (hours == 12) ? 12 : hours - 12;
                 }
                 else {
@@ -1365,43 +1415,43 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             else {
                 this.currentHour = (this.utc) ? val.getUTCHours() : val.getHours();
             }
-            
+
             this.currentMinute = val.getMinutes();
             this.currentSecond = val.getSeconds();
         }
     }
-    
+
     onDatePickerClick(event) {
         this.datepickerClick = true;
     }
-    
+
     showOverlay() {
         this.overlayVisible = true;
         this.overlayShown = true;
-        if(this.autoZIndex) {
+        if (this.autoZIndex) {
             this.overlayViewChild.nativeElement.style.zIndex = String(this.baseZIndex + (++DomHandler.zindex));
         }
-        
+
         this.bindDocumentClickListener();
     }
-    
+
     alignOverlay() {
-        if(this.appendTo)
+        if (this.appendTo)
             this.domHandler.absolutePosition(this.overlayViewChild.nativeElement, this.inputfieldViewChild.nativeElement);
         else
             this.domHandler.relativePosition(this.overlayViewChild.nativeElement, this.inputfieldViewChild.nativeElement);
     }
 
-    writeValue(value: any) : void {
+    writeValue(value: any): void {
         this.value = value;
-        if(this.value && typeof this.value === 'string') {
+        if (this.value && typeof this.value === 'string') {
             this.value = this.parseValueFromString(this.value);
         }
 
         this.updateInputfield();
         this.updateUI();
     }
-    
+
     registerOnChange(fn: Function): void {
         this.onModelChange = fn;
     }
@@ -1409,11 +1459,11 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     registerOnTouched(fn: Function): void {
         this.onModelTouched = fn;
     }
-    
+
     setDisabledState(val: boolean): void {
         this.disabled = val;
     }
-    
+
     // Ported from jquery-ui datepicker formatDate
     formatDate(date, format) {
         if (!date) {
@@ -1422,12 +1472,12 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
 
         let iFormat;
         const lookAhead = (match) => {
-            const matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
-            if (matches) {
-                iFormat++;
-            }
-            return matches;
-        },
+                const matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
+                if (matches) {
+                    iFormat++;
+                }
+                return matches;
+            },
             formatNumber = (match, value, len) => {
                 let num = '' + value;
                 if (lookAhead(match)) {
@@ -1504,180 +1554,180 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         }
         return output;
     }
-    
+
     formatTime(date) {
-        if(!date) {
+        if (!date) {
             return '';
         }
-        
+
         let output = '';
         let hours = (this.utc) ? date.getUTCHours() : date.getHours();
         let minutes = date.getMinutes();
         let seconds = date.getSeconds();
-        
-        if(this.hourFormat == '12' && hours > 11 && hours != 12) {
-            hours-=12;
+
+        if (this.hourFormat == '12' && hours > 11 && hours != 12) {
+            hours -= 12;
         }
-        
-        if(this.hourFormat == '12') {
+
+        if (this.hourFormat == '12') {
             output += hours === 0 ? 12 : (hours < 10) ? '0' + hours : hours;
         } else {
             output += (hours < 10) ? '0' + hours : hours;
         }
         output += ':';
         output += (minutes < 10) ? '0' + minutes : minutes;
-        
-        if(this.showSeconds) {
+
+        if (this.showSeconds) {
             output += ':';
             output += (seconds < 10) ? '0' + seconds : seconds;
         }
-        
-        if(this.hourFormat == '12') {
+
+        if (this.hourFormat == '12') {
             output += this.pm ? ' PM' : ' AM';
         }
-        
+
         return output;
     }
-    
+
     parseTime(value) {
         let tokens: string[] = value.split(':');
         let validTokenLength = this.showSeconds ? 3 : 2;
-        
-        if(tokens.length !== validTokenLength) {
-            throw "Invalid time";
+
+        if (tokens.length !== validTokenLength) {
+            throw 'Invalid time';
         }
-        
+
         let h = parseInt(tokens[0]);
         let m = parseInt(tokens[1]);
         let s = this.showSeconds ? parseInt(tokens[2]) : null;
-        
-        if(isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
-            throw "Invalid time";
+
+        if (isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
+            throw 'Invalid time';
         }
         else {
-            if(this.hourFormat == '12' && h !== 12 && this.pm) {
-                h+= 12;
+            if (this.hourFormat == '12' && h !== 12 && this.pm) {
+                h += 12;
             }
-            
+
             return {hour: h, minute: m, second: s};
         }
     }
-    
+
     // Ported from jquery-ui datepicker parseDate
     parseDate(value, format) {
-        if(format == null || value == null) {
-            throw "Invalid arguments";
+        if (format == null || value == null) {
+            throw 'Invalid arguments';
         }
 
-        value = (typeof value === "object" ? value.toString() : value + "");
-        if(value === "") {
+        value = (typeof value === 'object' ? value.toString() : value + '');
+        if (value === '') {
             return null;
         }
 
         let iFormat, dim, extra,
-        iValue = 0,
-        shortYearCutoff = (typeof this.shortYearCutoff !== "string" ? this.shortYearCutoff : new Date().getFullYear() % 100 + parseInt(this.shortYearCutoff, 10)),
-        year = -1,
-        month = -1,
-        day = -1,
-        doy = -1,
-        literal = false,
-        date,
-        lookAhead = (match) => {
-            let matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
-            if(matches) {
-                iFormat++;
-            }
-            return matches;
-        },
-        getNumber = (match) => {
-            let isDoubled = lookAhead(match),
-                size = (match === "@" ? 14 : (match === "!" ? 20 :
-                (match === "y" && isDoubled ? 4 : (match === "o" ? 3 : 2)))),
-                minSize = (match === "y" ? size : 1),
-                digits = new RegExp("^\\d{" + minSize + "," + size + "}"),
-                num = value.substring(iValue).match(digits);
-            if(!num) {
-                throw "Missing number at position " + iValue;
-            }
-            iValue += num[ 0 ].length;
-            return parseInt(num[ 0 ], 10);
-        },
-        getName = (match, shortNames, longNames) => {
-            let index = -1;
-            let arr = lookAhead(match) ? longNames : shortNames;
-            let names = [];
-            
-            for(let i = 0; i < arr.length; i++) {
-                names.push([i,arr[i]]);
-            }
-            names.sort((a,b) => {
-                return -(a[ 1 ].length - b[ 1 ].length);
-            });
-            
-            for(let i = 0; i < names.length; i++) {
-                let name = names[i][1];
-                if(value.substr(iValue, name.length).toLowerCase() === name.toLowerCase()) {
-                    index = names[i][0];
-                    iValue += name.length;
-                    break;
+            iValue = 0,
+            shortYearCutoff = (typeof this.shortYearCutoff !== 'string' ? this.shortYearCutoff : new Date().getFullYear() % 100 + parseInt(this.shortYearCutoff, 10)),
+            year = -1,
+            month = -1,
+            day = -1,
+            doy = -1,
+            literal = false,
+            date,
+            lookAhead = (match) => {
+                let matches = (iFormat + 1 < format.length && format.charAt(iFormat + 1) === match);
+                if (matches) {
+                    iFormat++;
                 }
-            }
+                return matches;
+            },
+            getNumber = (match) => {
+                let isDoubled = lookAhead(match),
+                    size = (match === '@' ? 14 : (match === '!' ? 20 :
+                        (match === 'y' && isDoubled ? 4 : (match === 'o' ? 3 : 2)))),
+                    minSize = (match === 'y' ? size : 1),
+                    digits = new RegExp('^\\d{' + minSize + ',' + size + '}'),
+                    num = value.substring(iValue).match(digits);
+                if (!num) {
+                    throw 'Missing number at position ' + iValue;
+                }
+                iValue += num[0].length;
+                return parseInt(num[0], 10);
+            },
+            getName = (match, shortNames, longNames) => {
+                let index = -1;
+                let arr = lookAhead(match) ? longNames : shortNames;
+                let names = [];
 
-            if(index !== -1) {
-                return index + 1;
-            } else {
-                throw "Unknown name at position " + iValue;
-            }
-        },
-        checkLiteral = () => {
-            if(value.charAt(iValue) !== format.charAt(iFormat)) {
-                throw "Unexpected literal at position " + iValue;
-            }
-            iValue++;
-        };
+                for (let i = 0; i < arr.length; i++) {
+                    names.push([i, arr[i]]);
+                }
+                names.sort((a, b) => {
+                    return -(a[1].length - b[1].length);
+                });
+
+                for (let i = 0; i < names.length; i++) {
+                    let name = names[i][1];
+                    if (value.substr(iValue, name.length).toLowerCase() === name.toLowerCase()) {
+                        index = names[i][0];
+                        iValue += name.length;
+                        break;
+                    }
+                }
+
+                if (index !== -1) {
+                    return index + 1;
+                } else {
+                    throw 'Unknown name at position ' + iValue;
+                }
+            },
+            checkLiteral = () => {
+                if (value.charAt(iValue) !== format.charAt(iFormat)) {
+                    throw 'Unexpected literal at position ' + iValue;
+                }
+                iValue++;
+            };
 
         for (iFormat = 0; iFormat < format.length; iFormat++) {
-            if(literal) {
-                if(format.charAt(iFormat) === "'" && !lookAhead("'")) {
+            if (literal) {
+                if (format.charAt(iFormat) === '\'' && !lookAhead('\'')) {
                     literal = false;
                 } else {
                     checkLiteral();
                 }
             } else {
                 switch (format.charAt(iFormat)) {
-                    case "d":
-                        day = getNumber("d");
+                    case 'd':
+                        day = getNumber('d');
                         break;
-                    case "D":
-                        getName("D", this.locale.dayNamesShort, this.locale.dayNames);
+                    case 'D':
+                        getName('D', this.locale.dayNamesShort, this.locale.dayNames);
                         break;
-                    case "o":
-                        doy = getNumber("o");
+                    case 'o':
+                        doy = getNumber('o');
                         break;
-                    case "m":
-                        month = getNumber("m");
+                    case 'm':
+                        month = getNumber('m');
                         break;
-                    case "M":
-                        month = getName("M", this.locale.monthNamesShort, this.locale.monthNames);
+                    case 'M':
+                        month = getName('M', this.locale.monthNamesShort, this.locale.monthNames);
                         break;
-                    case "y":
-                        year = getNumber("y");
+                    case 'y':
+                        year = getNumber('y');
                         break;
-                    case "@":
-                        date = new Date(getNumber("@"));
+                    case '@':
+                        date = new Date(getNumber('@'));
                         year = date.getFullYear();
                         month = date.getMonth() + 1;
                         day = date.getDate();
                         break;
-                    case "!":
-                        date = new Date((getNumber("!") - this.ticksTo1970) / 10000);
+                    case '!':
+                        date = new Date((getNumber('!') - this.ticksTo1970) / 10000);
                         year = date.getFullYear();
                         month = date.getMonth() + 1;
                         day = date.getDate();
                         break;
-                    case "'":
-                        if(lookAhead("'")) {
+                    case '\'':
+                        if (lookAhead('\'')) {
                             checkLiteral();
                         } else {
                             literal = true;
@@ -1689,26 +1739,26 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             }
         }
 
-        if(iValue < value.length) {
+        if (iValue < value.length) {
             extra = value.substr(iValue);
-            if(!/^\s+/.test(extra)) {
-                throw "Extra/unparsed characters found in date: " + extra;
+            if (!/^\s+/.test(extra)) {
+                throw 'Extra/unparsed characters found in date: ' + extra;
             }
         }
 
-        if(year === -1) {
+        if (year === -1) {
             year = new Date().getFullYear();
-        } else if(year < 100) {
+        } else if (year < 100) {
             year += new Date().getFullYear() - new Date().getFullYear() % 100 +
                 (year <= shortYearCutoff ? 0 : -100);
         }
 
-        if(doy > -1) {
+        if (doy > -1) {
             month = 1;
             day = doy;
             do {
                 dim = this.getDaysCountInMonth(year, month - 1);
-                if(day <= dim) {
+                if (day <= dim) {
                     break;
                 }
                 month++;
@@ -1719,82 +1769,89 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         if (this.utc) {
             date = new Date(Date.UTC(year, month - 1, day));
             if (date.getUTCFullYear() !== year || date.getUTCMonth() + 1 !== month || date.getUTCDate() !== day) {
-                throw "Invalid date"; // E.g. 31/02/00
+                throw 'Invalid date'; // E.g. 31/02/00
             }
         } else {
             date = this.daylightSavingAdjust(new Date(year, month - 1, day));
             if (date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) {
-                throw "Invalid date"; // E.g. 31/02/00
+                throw 'Invalid date'; // E.g. 31/02/00
             }
         }
         return date;
     }
-    
+
     daylightSavingAdjust(date) {
-        if(!date) {
+        if (!date) {
             return null;
         }
 
-        if(!this.utc) {
+        if (!this.utc) {
             date.setHours(date.getHours() > 12 ? date.getHours() + 2 : 0);
         }
-        
+
         return date;
     }
-    
+
     updateFilledState() {
         this.filled = this.inputFieldValue && this.inputFieldValue != '';
     }
-    
+
     onTodayButtonClick(event) {
         let date: Date = new Date();
-        let dateMeta = {day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), today: true, selectable: true};
-        
+        let dateMeta = {
+            day: date.getDate(),
+            month: date.getMonth(),
+            year: date.getFullYear(),
+            today: true,
+            selectable: true
+        };
+
         this.createMonth(dateMeta.month, dateMeta.year);
         this.onDateSelect(event, dateMeta);
         this.onTodayClick.emit(event);
     }
-    
+
     onClearButtonClick(event) {
         this.updateModel(null);
         this.updateInputfield();
         this.overlayVisible = false;
         this.onClearClick.emit(event);
     }
-    
+
     bindDocumentClickListener() {
-        if(!this.documentClickListener) {
+        if (!this.documentClickListener) {
             this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
-                if(!this.datepickerClick&&this.overlayVisible) {
+                if (!this.datepickerClick && this.overlayVisible) {
                     this.overlayVisible = false;
                     this.onClose.emit(event);
                 }
-                
+
                 this.datepickerClick = false;
                 this.cd.detectChanges();
             });
         }
     }
-    
+
     unbindDocumentClickListener() {
-        if(this.documentClickListener) {
+        if (this.documentClickListener) {
             this.documentClickListener();
             this.documentClickListener = null;
         }
     }
-    
+
     ngOnDestroy() {
         this.unbindDocumentClickListener();
-        
-        if(!this.inline && this.appendTo) {
+
+        if (!this.inline && this.appendTo) {
             this.el.nativeElement.appendChild(this.overlayViewChild.nativeElement);
         }
     }
 }
 
 @NgModule({
-    imports: [CommonModule,ButtonModule,SharedModule],
-    exports: [Calendar,ButtonModule,SharedModule],
+    imports: [CommonModule, ButtonModule, SharedModule],
+    exports: [Calendar, ButtonModule, SharedModule],
     declarations: [Calendar]
 })
-export class CalendarModule { }
+export class CalendarModule {
+}

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -9,37 +9,46 @@
     <div class="ui-g ui-fluid">
         <div class="ui-g-12 ui-md-4">
             <h3>Basic</h3>
-            <p-calendar [(ngModel)]="date1"></p-calendar> {{date1|date}}
+            <p-calendar [(ngModel)]="date1"></p-calendar>
+            {{date1|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Spanish</h3>
-            <p-calendar [(ngModel)]="date2" [locale]="es" dateFormat="dd/mm/yy"></p-calendar> {{date2|date}}
+            <p-calendar [(ngModel)]="date2" [locale]="es" dateFormat="dd/mm/yy"></p-calendar>
+            {{date2|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Icon</h3>
-            <p-calendar [(ngModel)]="date3" [showIcon]="true"></p-calendar>{{date3|date}}
+            <p-calendar [(ngModel)]="date3" [showIcon]="true"></p-calendar>
+            {{date3|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Min-Max</h3>
-            <p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" readonlyInput="true"></p-calendar> {{date4|date}}
+            <p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true"></p-calendar>
+            {{date4|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Disable Days</h3>
-            <p-calendar [(ngModel)]="date5" tabindex="0" [disabledDates]="invalidDates" [disabledDays]="[0,6]" readonlyInput="true"></p-calendar> {{date5|date}}
+            <p-calendar [(ngModel)]="date5" tabindex="0" [disabledDates]="invalidDates" [disabledDays]="[0,6]"
+                        [readonlyInput]="true"></p-calendar>
+            {{date5|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Navigators</h3>
-            <p-calendar [(ngModel)]="date6" [monthNavigator]="true" [yearNavigator]="true" yearRange="2000:2030"></p-calendar> {{date6|date}}
+            <p-calendar [(ngModel)]="date6" [monthNavigator]="true" [yearNavigator]="true"
+                        yearRange="2000:2030"></p-calendar>
+            {{date6|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Time</h3>
-            <p-calendar [(ngModel)]="date7" [showTime]="true"></p-calendar> {{date7}}
+            <p-calendar [(ngModel)]="date7" [showTime]="true"></p-calendar>
+            {{date7}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
@@ -49,26 +58,40 @@
 
         <div class="ui-g-12 ui-md-4">
             <h3>Multiple</h3>
-            <p-calendar [(ngModel)]="dates" selectionMode="multiple" readonlyInput="true"></p-calendar>
+            <p-calendar [(ngModel)]="dates" selectionMode="multiple" [readonlyInput]="true"></p-calendar>
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Range</h3>
-            <p-calendar [(ngModel)]="rangeDates" selectionMode="range" readonlyInput="true"></p-calendar>
+            <p-calendar [(ngModel)]="rangeDates" selectionMode="range" [readonlyInput]="true"></p-calendar>
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Button Bar</h3>
-            <p-calendar [(ngModel)]="date9" showButtonBar="true"></p-calendar>
+            <p-calendar [(ngModel)]="date9" [showButtonBar]="true"></p-calendar>
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Date Template</h3>
             <p-calendar [(ngModel)]="date10">
                 <ng-template pTemplate="date" let-date>
-                    <span [ngStyle]="{backgroundColor: (date.day < 21 && date.day > 10) ? '#7cc67c' : 'inherit'}" style="border-radius:50%">{{date.day}}</span>
+                    <span [ngStyle]="{backgroundColor: (date.day < 21 && date.day > 10) ? '#7cc67c' : 'inherit'}"
+                          style="border-radius:50%">{{date.day}}</span>
                 </ng-template>
             </p-calendar>
+        </div>
+
+        <div class="ui-g-12 ui-md-4">
+            <h3>UTC</h3>
+            <p-calendar [(ngModel)]="date12" [utc]="true" [showTime]="true" [readonlyInput]="true"></p-calendar>
+            {{date12|date}}
+        </div>
+
+        <div class="ui-g-12 ui-md-4">
+            <h3>UTC Min-Max</h3>
+            <p-calendar [(ngModel)]="date13" [minDate]="minDate" [maxDate]="maxDate"
+                        [utc]="true" [showTime]="true" [readonlyInput]="true"></p-calendar>
+            {{date13|date}}
         </div>
     </div>
 
@@ -80,7 +103,7 @@
     <p-tabView effect="fade">
         <p-tabPanel header="Documentation">
             <h3>Import</h3>
-<pre>
+            <pre>
 <code class="language-typescript" pCode ngNonBindable>
 import &#123;CalendarModule&#125; from 'primeng/calendar';
 </code>
@@ -89,13 +112,13 @@ import &#123;CalendarModule&#125; from 'primeng/calendar';
             <h3>Getting Started</h3>
             <p>Two-way value binding is defined using the standard ngModel directive referencing to a Date property.</p>
 
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="value"&gt;&lt;/p-calendar&gt;
 </code>
 </pre>
 
-<pre>
+            <pre>
 <code class="language-typescript" pCode ngNonBindable>
 export class MyModel &#123;
 
@@ -107,7 +130,7 @@ export class MyModel &#123;
 
             <h3>Model Driven Forms</h3>
             <p>Calendar can be used in a model driven form as well.</p>
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar formControlName="date"&gt;&lt;/p-calendar&gt;
 </code>
@@ -115,21 +138,24 @@ export class MyModel &#123;
 
             <h3>Popup and Inline</h3>
             <p>Calendar is displayed in a popup by default and inline property needs to be enabled for inline mode.</p>
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="value" [inline]="true"&gt;&lt;/p-calendar&gt;
 </code>
 </pre>
 
             <h3>Selection Mode</h3>
-            <p>By default calendar allows selecting one date and multiple dates can be selected by setting selectionMode to multiple. In this
-            case calendar updates the value with an array of dates where optionally number of selectable dates can be restricted with maxDateCount property.
-            Third alternative is the range mode that allows selecting a range based on an array of two values where first value is the start date and second value
-            is the end date.</p>
+            <p>By default calendar allows selecting one date and multiple dates can be selected by setting selectionMode
+                to multiple. In this
+                case calendar updates the value with an array of dates where optionally number of selectable dates can
+                be restricted with maxDateCount property.
+                Third alternative is the range mode that allows selecting a range based on an array of two values where
+                first value is the start date and second value
+                is the end date.</p>
 
             <h3>DateFormat</h3>
             <p>Default date format is mm/dd/yy, to customize this use dateFormat property.</p>
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="dateValue" dateFormat="dd.mm.yy"&gt;&lt;/p-calendar&gt;
 </code>
@@ -137,28 +163,29 @@ export class MyModel &#123;
 
             <p>Following options can be a part of the format.</p>
             <ul>
-    			<li>d - day of month (no leading zero)</li>
-    			<li>dd - day of month (two digit)</li>
-    			<li>o - day of the year (no leading zeros)</li>
-    			<li>oo - day of the year (three digit)</li>
-    			<li>D - day name short</li>
-    			<li>DD - day name long</li>
-    			<li>m - month of year (no leading zero)</li>
-    			<li>mm - month of year (two digit)</li>
-    			<li>M - month name short</li>
-    			<li>MM - month name long</li>
-    			<li>y - year (two digit)</li>
-    			<li>yy - year (four digit)</li>
-    			<li>@ - Unix timestamp (ms since 01/01/1970)</li>
-    			<li> ! - Windows ticks (100ns since 01/01/0001)</li>
-    			<li>'...' - literal text</li>
-    			<li>'' - single quote</li>
-    			<li>anything else - literal text</li>
-		    </ul>
+                <li>d - day of month (no leading zero)</li>
+                <li>dd - day of month (two digit)</li>
+                <li>o - day of the year (no leading zeros)</li>
+                <li>oo - day of the year (three digit)</li>
+                <li>D - day name short</li>
+                <li>DD - day name long</li>
+                <li>m - month of year (no leading zero)</li>
+                <li>mm - month of year (two digit)</li>
+                <li>M - month name short</li>
+                <li>MM - month name long</li>
+                <li>y - year (two digit)</li>
+                <li>yy - year (four digit)</li>
+                <li>@ - Unix timestamp (ms since 01/01/1970)</li>
+                <li> ! - Windows ticks (100ns since 01/01/0001)</li>
+                <li>'...' - literal text</li>
+                <li>'' - single quote</li>
+                <li>anything else - literal text</li>
+            </ul>
 
             <h3>Time</h3>
-            <p>TimePicker is enabled with showTime property and 24 (default) or 12 hour mode is configured using hourFormat option.</p>
-<pre>
+            <p>TimePicker is enabled with showTime property and 24 (default) or 12 hour mode is configured using
+                hourFormat option.</p>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="value" showTime="true" hourFormat="12"&gt;&lt;/p-calendar&gt;
 &lt;p-calendar [(ngModel)]="value" showTime="true" hourFormat="24"&gt;&lt;/p-calendar&gt;
@@ -166,17 +193,19 @@ export class MyModel &#123;
 </pre>
 
             <h3>Date Restriction</h3>
-            <p>To disable entering dates manually, set readonlyInput to true and to restrict selectable dates use minDate
+            <p>To disable entering dates manually, set readonlyInput to true and to restrict selectable dates use
+                minDate
                 and maxDate options.</p>
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="dateValue" [minDate]="minDateValue" [maxDate]="maxDateValue" readonlyInput="true"&gt;&lt;/p-calendar&gt;
 </code>
 </pre>
 
             <h3>Disable specific dates and/or days</h3>
-            <p>To disable specific dates or days, set readonlyInput to true and to restrict selectable dates use disabledDates and/or disabledDays options.</p>
-<pre>
+            <p>To disable specific dates or days, set readonlyInput to true and to restrict selectable dates use
+                disabledDates and/or disabledDays options.</p>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="dateValue" [disabledDates]="invalidDates" [disabledDays]="[0,6]" readonlyInput="true"&gt;&lt;/p-calendar&gt;
 </code>
@@ -184,21 +213,22 @@ export class MyModel &#123;
 
             <h3>Button Bar</h3>
             <p>Button bar displays today and clear buttons and enabled using showButtonBar property.</p>
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="dateValue" showButtonBar="true"&gt;&lt;/p-calendar&gt;
 </code>
 </pre>
 
             <h3>Localization</h3>
-            <p>Localization for different languages and formats is defined by binding the locale settings object to the locale property. Following is the default values for English.</p>
-<pre>
+            <p>Localization for different languages and formats is defined by binding the locale settings object to the
+                locale property. Following is the default values for English.</p>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="dateValue" [locale]="en"&gt;&lt;/p-calendar&gt;
 </code>
 </pre>
 
-<pre>
+            <pre>
 <code class="language-typescript" pCode ngNonBindable>
 export class MyModel &#123;
 
@@ -222,7 +252,7 @@ export class MyModel &#123;
 
             <h3>Custom Content</h3>
             <p>Calendar UI accepts custom content using p-header and p-footer components.</p>
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="dateValue"&gt;
     &lt;p-header&gt;Header&lt;/p-header&gt;
@@ -231,11 +261,13 @@ export class MyModel &#123;
 </code>
 </pre>
 
-            <p>In addition, cell contents can be templated using an ng-template with a pTemplate directive whose value is "date". This is a handy feature to highlight specific dates. Note that the implicit
-            variable passed to the template is not a date instance but a metadata object to represent a Date with "day", "month" and "year" properties. Example below
-            changes the background color of dates between 10th and 21st of each month.</p>
+            <p>In addition, cell contents can be templated using an ng-template with a pTemplate directive whose value
+                is "date". This is a handy feature to highlight specific dates. Note that the implicit
+                variable passed to the template is not a date instance but a metadata object to represent a Date with
+                "day", "month" and "year" properties. Example below
+                changes the background color of dates between 10th and 21st of each month.</p>
 
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-calendar [(ngModel)]="date10"&gt;
     &lt;ng-template pTemplate="date" let-date&gt;
@@ -250,302 +282,313 @@ export class MyModel &#123;
             <div class="doc-tablewrapper">
                 <table class="doc-table">
                     <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Type</th>
-                            <th>Default</th>
-                            <th>Description</th>
-                        </tr>
+                    <tr>
+                        <th>Name</th>
+                        <th>Type</th>
+                        <th>Default</th>
+                        <th>Description</th>
+                    </tr>
                     </thead>
                     <tbody>
-                        <tr>
-                            <td>defaultDate</td>
-                            <td>Date</td>
-                            <td>null</td>
-                            <td>Set the date to highlight on first opening if the field is blank.</td>
-                        </tr>
-                        <tr>
-                            <td>selectionMode</td>
-                            <td>string</td>
-                            <td>single</td>
-                            <td>Defines the quantity of the selection, valid values are "single", "multiple" and "range".</td>
-                        </tr>
-                        <tr>
-                            <td>style</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Inline style of the component.</td>
-                        </tr>
-                        <tr>
-                            <td>styleClass</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Style class of the component.</td>
-                        </tr>
-                        <tr>
-                            <td>inputStyle</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Inline style of the input field.</td>
-                        </tr>
-                        <tr>
-                            <td>inputStyleClass</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Style class of the input field.</td>
-                        </tr>
-                        <tr>
-                            <td>inputId</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Identifier of the focus input to match a label defined for the component.</td>
-                        </tr>
-                        <tr>
-                            <td>name</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Name of the input element.</td>
-                        </tr>
-                        <tr>
-                            <td>placeholder</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Placeholder text for the input.</td>
-                        </tr>
-                        <tr>
-                            <td>disabled</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>When specified, disables the component.</td>
-                        </tr>
-                        <tr>
-                            <td>dateFormat</td>
-                            <td>string</td>
-                            <td>mm/dd/yy</td>
-                            <td>Format of the date.</td>
-                        </tr>
-                        <tr>
-                            <td>inline</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>When enabled, displays the calendar as inline. Default is false for popup mode.</td>
-                        </tr>
-                        <tr>
-                            <td>showOtherMonths</td>
-                            <td>boolean</td>
-                            <td>true</td>
-                            <td>Whether to display dates in other months (non-selectable) at the start or end of the current month. To make these days selectable use the selectOtherMonths option.</td>
-                        </tr>
-                        <tr>
-                            <td>selectOtherMonths</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether days in other months shown before or after the current month are selectable. This only applies if the showOtherMonths option is set to true.</td>
-                        </tr>
-                        <tr>
-                            <td>showIcon</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>When enabled, displays a button with icon next to input.</td>
-                        </tr>
-                         <tr>
-                            <td>showOnFocus</td>
-                            <td>boolean</td>
-                            <td>true</td>
-                            <td>When disabled, datepicker will not be visible with input focus.</td>
-                        </tr>
-                        <tr>
-                            <td>icon</td>
-                            <td>string</td>
-                            <td>fa-calendar</td>
-                            <td>Icon of the calendar button.</td>
-                        </tr>
-                        <tr>
-                            <td>appendTo</td>
-                            <td>any</td>
-                            <td>null</td>
-                            <td>Target element to attach the overlay, valid values are "body" or a local ng-template variable of another element.</td>
-                        </tr>
-                        <tr>
-                            <td>readonlyInput</td>
-                            <td>boolean</td>
-                            <td>null</td>
-                            <td>When specified, prevents entering the date manually with keyboard.</td>
-                        </tr>
-                        <tr>
-                            <td>shortYearCutoff</td>
-                            <td>string</td>
-                            <td>+10</td>
-                            <td>The cutoff year for determining the century for a date.</td>
-                        </tr>
-                        <tr>
-                            <td>minDate</td>
-                            <td>Date</td>
-                            <td>null</td>
-                            <td>The minimum selectable date.</td>
-                        </tr>
-                        <tr>
-                            <td>maxDate</td>
-                            <td>Date</td>
-                            <td>null</td>
-                            <td>The maximum selectable date.</td>
-                        </tr>
-                        <tr>
-                            <td>disabledDates</td>
-                            <td>Array&lt;Date&gt;</td>
-                            <td>null</td>
-                            <td>Array with dates that should be disabled (not selectable).</td>
-                        </tr>
-                        <tr>
-                            <td>disabledDays</td>
-                            <td>Array&lt;number&gt;</td>
-                            <td>null</td>
-                            <td>Array with weekday numbers that should be disabled (not selectable).</td>
-                        </tr>
-                        <tr>
-                            <td>monthNavigator</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether the month should be rendered as a dropdown instead of text.</td>
-                        </tr>
-                        <tr>
-                            <td>yearNavigator</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether the year should be rendered as a dropdown instead of text.</td>
-                        </tr>
-                        <tr>
-                            <td>yearRange</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>The range of years displayed in the year drop-down in (nnnn:nnnn) format such as (2000:2020).</td>
-                        </tr>
-                        <tr>
-                            <td>showTime</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether to display timepicker.</td>
-                        </tr>
-                        <tr>
-                            <td>hourFormat</td>
-                            <td>string</td>
-                            <td>24</td>
-                            <td>Specifies 12 or 24 hour format.</td>
-                        </tr>
-                        <tr>
-                            <td>locale</td>
-                            <td>object</td>
-                            <td>null</td>
-                            <td>An object having regional configuration properties for the calendar.</td>
-                        </tr>
-                        <tr>
-                            <td>timeOnly</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether to display timepicker only.</td>
-                        </tr>
-                        <tr>
-                            <td>dataType</td>
-                            <td>string</td>
-                            <td>date</td>
-                            <td>Type of the value to write back to ngModel, default is date and alternative is string.</td>
-                        </tr>
-                        <tr>
-                            <td>required</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>When present, it specifies that an input field must be filled out before submitting the form.</td>
-                        </tr>
-                        <tr>
-                            <td>tabindex</td>
-                            <td>number</td>
-                            <td>null</td>
-                            <td>Index of the element in tabbing order.</td>
-                        </tr>
-                        <tr>
-                            <td>showSeconds</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether to show the seconds in time picker.</td>
-                        </tr>
-                        <tr>
-                            <td>stepHour</td>
-                            <td>number</td>
-                            <td>1</td>
-                            <td>Hours to change per step.</td>
-                        </tr>
-                        <tr>
-                            <td>stepMinute</td>
-                            <td>number</td>
-                            <td>1</td>
-                            <td>Minutes to change per step.</td>
-                        </tr>
-                        <tr>
-                            <td>stepSecond</td>
-                            <td>number</td>
-                            <td>1</td>
-                            <td>Seconds to change per step.</td>
-                        </tr>
-                        <tr>
-                            <td>utc</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether to convert date to UTC on selection.</td>
-                        </tr>
-                        <tr>
-                            <td>maxDateCount</td>
-                            <td>number</td>
-                            <td>null</td>
-                            <td>Maximum number of selectable dates in multiple mode.</td>
-                        </tr>
-                        <tr>
-                            <td>showButtonBar</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether to display today and clear buttons at the footer</td>
-                        </tr>
-                        <tr>
-                            <td>todayButtonStyleClass</td>
-                            <td>string</td>
-                            <td>ui-secondary-button</td>
-                            <td>Style class of the today button.</td>
-                        </tr>
-                        <tr>
-                            <td>clearButtonStyleClass</td>
-                            <td>string</td>
-                            <td>ui-secondary-button</td>
-                            <td>Style class of the clear button.</td>
-                        </tr>
-                        <tr>
-                            <td>baseZIndex</td>
-                            <td>number</td>
-                            <td>0</td>
-                            <td>Base zIndex value to use in layering.</td>
-                        </tr>
-                        <tr>
-                            <td>autoZIndex</td>
-                            <td>boolean</td>
-                            <td>true</td>
-                            <td>Whether to automatically manage layering.</td>
-                        </tr>
-                        <tr>
-                            <td>panelStyleClass</td>
-                            <td>string</td>
-                            <td>null</td>
-                            <td>Style class of the datetimepicker container element.</td>
-                        </tr>
-                        <tr>
-                          <td>keepInvalid</td>
-                          <td>boolean</td>
-                          <td>false</td>
-                          <td>Keep invalid value when input blur.</td>
-                        </tr>
-                        <tr>
-                            <td>hideOnDateTimeSelect</td>
-                            <td>boolean</td>
-                            <td>false</td>
-                            <td>Whether to hide the overlay on date selection when showTime is enabled.</td>
-                        </tr>
+                    <tr>
+                        <td>defaultDate</td>
+                        <td>Date</td>
+                        <td>null</td>
+                        <td>Set the date to highlight on first opening if the field is blank.</td>
+                    </tr>
+                    <tr>
+                        <td>selectionMode</td>
+                        <td>string</td>
+                        <td>single</td>
+                        <td>Defines the quantity of the selection, valid values are "single", "multiple" and "range".
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>style</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Inline style of the component.</td>
+                    </tr>
+                    <tr>
+                        <td>styleClass</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Style class of the component.</td>
+                    </tr>
+                    <tr>
+                        <td>inputStyle</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Inline style of the input field.</td>
+                    </tr>
+                    <tr>
+                        <td>inputStyleClass</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Style class of the input field.</td>
+                    </tr>
+                    <tr>
+                        <td>inputId</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Identifier of the focus input to match a label defined for the component.</td>
+                    </tr>
+                    <tr>
+                        <td>name</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Name of the input element.</td>
+                    </tr>
+                    <tr>
+                        <td>placeholder</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Placeholder text for the input.</td>
+                    </tr>
+                    <tr>
+                        <td>disabled</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>When specified, disables the component.</td>
+                    </tr>
+                    <tr>
+                        <td>dateFormat</td>
+                        <td>string</td>
+                        <td>mm/dd/yy</td>
+                        <td>Format of the date.</td>
+                    </tr>
+                    <tr>
+                        <td>inline</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>When enabled, displays the calendar as inline. Default is false for popup mode.</td>
+                    </tr>
+                    <tr>
+                        <td>showOtherMonths</td>
+                        <td>boolean</td>
+                        <td>true</td>
+                        <td>Whether to display dates in other months (non-selectable) at the start or end of the current
+                            month. To make these days selectable use the selectOtherMonths option.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>selectOtherMonths</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether days in other months shown before or after the current month are selectable. This
+                            only applies if the showOtherMonths option is set to true.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>showIcon</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>When enabled, displays a button with icon next to input.</td>
+                    </tr>
+                    <tr>
+                        <td>showOnFocus</td>
+                        <td>boolean</td>
+                        <td>true</td>
+                        <td>When disabled, datepicker will not be visible with input focus.</td>
+                    </tr>
+                    <tr>
+                        <td>icon</td>
+                        <td>string</td>
+                        <td>fa-calendar</td>
+                        <td>Icon of the calendar button.</td>
+                    </tr>
+                    <tr>
+                        <td>appendTo</td>
+                        <td>any</td>
+                        <td>null</td>
+                        <td>Target element to attach the overlay, valid values are "body" or a local ng-template
+                            variable of another element.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>readonlyInput</td>
+                        <td>boolean</td>
+                        <td>null</td>
+                        <td>When specified, prevents entering the date manually with keyboard.</td>
+                    </tr>
+                    <tr>
+                        <td>shortYearCutoff</td>
+                        <td>string</td>
+                        <td>+10</td>
+                        <td>The cutoff year for determining the century for a date.</td>
+                    </tr>
+                    <tr>
+                        <td>minDate</td>
+                        <td>Date</td>
+                        <td>null</td>
+                        <td>The minimum selectable date.</td>
+                    </tr>
+                    <tr>
+                        <td>maxDate</td>
+                        <td>Date</td>
+                        <td>null</td>
+                        <td>The maximum selectable date.</td>
+                    </tr>
+                    <tr>
+                        <td>disabledDates</td>
+                        <td>Array&lt;Date&gt;</td>
+                        <td>null</td>
+                        <td>Array with dates that should be disabled (not selectable).</td>
+                    </tr>
+                    <tr>
+                        <td>disabledDays</td>
+                        <td>Array&lt;number&gt;</td>
+                        <td>null</td>
+                        <td>Array with weekday numbers that should be disabled (not selectable).</td>
+                    </tr>
+                    <tr>
+                        <td>monthNavigator</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether the month should be rendered as a dropdown instead of text.</td>
+                    </tr>
+                    <tr>
+                        <td>yearNavigator</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether the year should be rendered as a dropdown instead of text.</td>
+                    </tr>
+                    <tr>
+                        <td>yearRange</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>The range of years displayed in the year drop-down in (nnnn:nnnn) format such as
+                            (2000:2020).
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>showTime</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether to display timepicker.</td>
+                    </tr>
+                    <tr>
+                        <td>hourFormat</td>
+                        <td>string</td>
+                        <td>24</td>
+                        <td>Specifies 12 or 24 hour format.</td>
+                    </tr>
+                    <tr>
+                        <td>locale</td>
+                        <td>object</td>
+                        <td>null</td>
+                        <td>An object having regional configuration properties for the calendar.</td>
+                    </tr>
+                    <tr>
+                        <td>timeOnly</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether to display timepicker only.</td>
+                    </tr>
+                    <tr>
+                        <td>dataType</td>
+                        <td>string</td>
+                        <td>date</td>
+                        <td>Type of the value to write back to ngModel, default is date and alternative is string.</td>
+                    </tr>
+                    <tr>
+                        <td>required</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>When present, it specifies that an input field must be filled out before submitting the
+                            form.
+                        </td>
+                    </tr>
+                    <tr>
+                        <td>tabindex</td>
+                        <td>number</td>
+                        <td>null</td>
+                        <td>Index of the element in tabbing order.</td>
+                    </tr>
+                    <tr>
+                        <td>showSeconds</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether to show the seconds in time picker.</td>
+                    </tr>
+                    <tr>
+                        <td>stepHour</td>
+                        <td>number</td>
+                        <td>1</td>
+                        <td>Hours to change per step.</td>
+                    </tr>
+                    <tr>
+                        <td>stepMinute</td>
+                        <td>number</td>
+                        <td>1</td>
+                        <td>Minutes to change per step.</td>
+                    </tr>
+                    <tr>
+                        <td>stepSecond</td>
+                        <td>number</td>
+                        <td>1</td>
+                        <td>Seconds to change per step.</td>
+                    </tr>
+                    <tr>
+                        <td>utc</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether to convert date to UTC on selection.</td>
+                    </tr>
+                    <tr>
+                        <td>maxDateCount</td>
+                        <td>number</td>
+                        <td>null</td>
+                        <td>Maximum number of selectable dates in multiple mode.</td>
+                    </tr>
+                    <tr>
+                        <td>showButtonBar</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether to display today and clear buttons at the footer</td>
+                    </tr>
+                    <tr>
+                        <td>todayButtonStyleClass</td>
+                        <td>string</td>
+                        <td>ui-secondary-button</td>
+                        <td>Style class of the today button.</td>
+                    </tr>
+                    <tr>
+                        <td>clearButtonStyleClass</td>
+                        <td>string</td>
+                        <td>ui-secondary-button</td>
+                        <td>Style class of the clear button.</td>
+                    </tr>
+                    <tr>
+                        <td>baseZIndex</td>
+                        <td>number</td>
+                        <td>0</td>
+                        <td>Base zIndex value to use in layering.</td>
+                    </tr>
+                    <tr>
+                        <td>autoZIndex</td>
+                        <td>boolean</td>
+                        <td>true</td>
+                        <td>Whether to automatically manage layering.</td>
+                    </tr>
+                    <tr>
+                        <td>panelStyleClass</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>Style class of the datetimepicker container element.</td>
+                    </tr>
+                    <tr>
+                        <td>keepInvalid</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Keep invalid value when input blur.</td>
+                    </tr>
+                    <tr>
+                        <td>hideOnDateTimeSelect</td>
+                        <td>boolean</td>
+                        <td>false</td>
+                        <td>Whether to hide the overlay on date selection when showTime is enabled.</td>
+                    </tr>
                     </tbody>
                 </table>
             </div>
@@ -554,92 +597,94 @@ export class MyModel &#123;
             <div class="doc-tablewrapper">
                 <table class="doc-table">
                     <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Parameters</th>
-                            <th>Description</th>
-                        </tr>
+                    <tr>
+                        <th>Name</th>
+                        <th>Parameters</th>
+                        <th>Description</th>
+                    </tr>
                     </thead>
                     <tbody>
-                        <tr>
-                            <td>onSelect</td>
-                            <td>value: Selected value
-                            </td>
-                            <td>Callback to invoke when a date is selected.</td>
-                        </tr>
-                        <tr>
-                            <td>onBlur</td>
-                            <td>event: Blur event
-                            </td>
-                            <td>Callback to invoke on blur of input field.</td>
-                        </tr>
-                        <tr>
-                            <td>onFocus</td>
-                            <td>event: Focus event
-                            </td>
-                            <td>Callback to invoke on focus of input field.</td>
-                        </tr>
-                        <tr>
-                            <td>onClose</td>
-                            <td>event: Close event
-                            </td>
-                            <td>Callback to invoke when datepicker panel is closed.</td>
-                        </tr>
-                        <tr>
-                            <td>onInput</td>
-                            <td>event: Input event
-                            </td>
-                            <td>Callback to invoke when input field is being typed.</td>
-                        </tr>
-                        <tr>
-                            <td>onTodayClick</td>
-                            <td>event: Click event
-                            </td>
-                            <td>Callback to invoke when today button is clicked.</td>
-                        </tr>
-                        <tr>
-                            <td>onClearClick</td>
-                            <td>event: Click event
-                            </td>
-                            <td>Callback to invoke when clear button is clicked.</td>
-                        </tr>
-                        <tr>
-                            <td>onMonthChange</td>
-                            <td>event.month: New month <br />
-                                event.year: New year
-                            </td>
-                            <td>Callback to invoke when a month is changed using the navigators.</td>
-                        </tr>
-                        <tr>
-                            <td>onYearChange</td>
-                            <td>event.month: New month <br />
-                                event.year: New year
-                            </td>
-                            <td>Callback to invoke when a year is changed using the navigators.</td>
-                        </tr>
+                    <tr>
+                        <td>onSelect</td>
+                        <td>value: Selected value
+                        </td>
+                        <td>Callback to invoke when a date is selected.</td>
+                    </tr>
+                    <tr>
+                        <td>onBlur</td>
+                        <td>event: Blur event
+                        </td>
+                        <td>Callback to invoke on blur of input field.</td>
+                    </tr>
+                    <tr>
+                        <td>onFocus</td>
+                        <td>event: Focus event
+                        </td>
+                        <td>Callback to invoke on focus of input field.</td>
+                    </tr>
+                    <tr>
+                        <td>onClose</td>
+                        <td>event: Close event
+                        </td>
+                        <td>Callback to invoke when datepicker panel is closed.</td>
+                    </tr>
+                    <tr>
+                        <td>onInput</td>
+                        <td>event: Input event
+                        </td>
+                        <td>Callback to invoke when input field is being typed.</td>
+                    </tr>
+                    <tr>
+                        <td>onTodayClick</td>
+                        <td>event: Click event
+                        </td>
+                        <td>Callback to invoke when today button is clicked.</td>
+                    </tr>
+                    <tr>
+                        <td>onClearClick</td>
+                        <td>event: Click event
+                        </td>
+                        <td>Callback to invoke when clear button is clicked.</td>
+                    </tr>
+                    <tr>
+                        <td>onMonthChange</td>
+                        <td>event.month: New month <br/>
+                            event.year: New year
+                        </td>
+                        <td>Callback to invoke when a month is changed using the navigators.</td>
+                    </tr>
+                    <tr>
+                        <td>onYearChange</td>
+                        <td>event.month: New month <br/>
+                            event.year: New year
+                        </td>
+                        <td>Callback to invoke when a year is changed using the navigators.</td>
+                    </tr>
                     </tbody>
                 </table>
             </div>
 
             <h3>Styling</h3>
-            <p>Following is the list of structural style classes, for theming classes visit <a href="#" [routerLink]="['/theming']">theming page</a>.</p>
+            <p>Following is the list of structural style classes, for theming classes visit <a href="#"
+                                                                                               [routerLink]="['/theming']">theming
+                page</a>.</p>
             <div class="doc-tablewrapper">
                 <table class="doc-table">
                     <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th>Element</th>
-                        </tr>
+                    <tr>
+                        <th>Name</th>
+                        <th>Element</th>
+                    </tr>
                     </thead>
                     <tbody>
-                        <tr>
-                            <td>ui-calendar</td>
-                            <td>Wrapper of input element</td>
-                        </tr>
-                        <tr>
-                            <td>ui-inputtext</td>
-                            <td>Input element</td>
-                        </tr>
+                    <tr>
+                        <td>ui-calendar</td>
+                        <td>Wrapper of input element</td>
+                    </tr>
+                    <tr>
+                        <td>ui-inputtext</td>
+                        <td>Input element</td>
+                    </tr>
                     </tbody>
                 </table>
             </div>
@@ -649,11 +694,12 @@ export class MyModel &#123;
         </p-tabPanel>
 
         <p-tabPanel header="Source">
-            <a href="https://github.com/primefaces/primeng/tree/master/src/app/showcase/components/calendar" class="btn-viewsource" target="_blank">
+            <a href="https://github.com/primefaces/primeng/tree/master/src/app/showcase/components/calendar"
+               class="btn-viewsource" target="_blank">
                 <i class="fa fa-github"></i>
                 <span>View on GitHub</span>
             </a>
-<pre>
+            <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;div class="ui-g ui-fluid"&gt;
     &lt;div class="ui-g-12 ui-md-4"&gt;
@@ -726,7 +772,7 @@ export class MyModel &#123;
 </code>
 </pre>
 
-<pre>
+            <pre>
 <code class="language-typescript" pCode ngNonBindable>
 export class CalendarDemo &#123;
 

--- a/src/app/showcase/components/calendar/calendardemo.ts
+++ b/src/app/showcase/components/calendar/calendardemo.ts
@@ -16,27 +16,31 @@ export class CalendarDemo {
     date5: Date;
 
     date6: Date;
-    
+
     date7: Date;
-    
+
     date8: Date;
-    
+
     date9: Date;
-    
+
     date10: Date;
-    
+
     date11: Date;
-    
+
+    date12: Date;
+
+    date13: Date;
+
     dates: Date[];
-    
+
     rangeDates: Date[];
-    
+
     minDate: Date;
-    
+
     maxDate: Date;
-    
+
     invalidDates: Array<Date>;
-    
+
     es: any;
 
     ngOnInit() {
@@ -50,7 +54,7 @@ export class CalendarDemo {
             today: 'Hoy',
             clear: 'Borrar'
         };
-        
+
         let today = new Date();
         let month = today.getMonth();
         let year = today.getFullYear();
@@ -64,7 +68,7 @@ export class CalendarDemo {
         this.maxDate = new Date();
         this.maxDate.setMonth(nextMonth);
         this.maxDate.setFullYear(nextYear);
-        
+
         let invalidDate = new Date();
         invalidDate.setDate(today.getDate() - 1);
         this.invalidDates = [today,invalidDate];


### PR DESCRIPTION
This code uses the correct `getUTC(Property)` or `get(Property)` in every date element depending on the flag `utc`.

Fixes #5334 and Min Max ranges that sets incorrect values for the time picker during validation when setting the utc flag to `true`.
