### PR TITLE
Calendar UTC Fix

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -20,8 +20,8 @@ export interface LocaleSettings {
     dayNamesMin: string[];
     monthNames: string[];
     monthNamesShort: string[];
-    today: string,
-    clear: string
+    today: string;
+    clear: string;
 }
 
 @Component({
@@ -357,7 +357,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     set minDate(date: Date) {
         this._minDate = date;
 
-        if(this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
+        if (this.currentMonth != null && this.currentYear) {
             this.createMonth(this.currentMonth, this.currentYear);
         }
     }
@@ -368,8 +368,8 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     set maxDate(date: Date) {
         this._maxDate = date;
-      
-        if(this.currentMonth != undefined && this.currentMonth != null  && this.currentYear) {
+
+        if (this.currentMonth != null && this.currentYear) {
             this.createMonth(this.currentMonth, this.currentYear);
         }
     }
@@ -380,7 +380,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     set disabledDates(disabledDates: Date[]) {
         this._disabledDates = disabledDates;
-        if(this.currentMonth != undefined && this.currentMonth != null  && this.currentYear) {
+        if (this.currentMonth != null && this.currentYear) {
 
             this.createMonth(this.currentMonth, this.currentYear);
         }
@@ -393,7 +393,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     set disabledDays(disabledDays: number[]) {
         this._disabledDays = disabledDays;
 
-        if(this.currentMonth != undefined && this.currentMonth != null  && this.currentYear) {
+        if (this.currentMonth != null && this.currentYear) {
             this.createMonth(this.currentMonth, this.currentYear);
         }
     }
@@ -427,9 +427,9 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     ngOnInit() {
         let date = this.defaultDate||new Date();
         this.createWeekDays();
-        
-        this.currentMonth = date.getMonth();
-        this.currentYear = date.getFullYear();
+
+        this.currentMonth = this.getMonth(date);
+        this.currentYear = this.getFullYear(date);
         this.initTime(date);
 
         this.createMonth(this.currentMonth, this.currentYear);
@@ -539,25 +539,15 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     }
     
     initTime(date: Date) {
-        this.pm = (!this.utc) ? (date.getHours() > 11) : (date.getUTCHours() > 11);
+        this.pm = this.getHours(date) > 11;
         if (this.showTime) {
-            if (this.utc) {
-                this.currentMinute = date.getUTCMinutes();
-                this.currentSecond = date.getUTCSeconds();
+            this.currentMinute = this.getMinutes(date);
+            this.currentSecond = this.getSeconds(date);
 
-                if(this.hourFormat == '12')
-                    this.currentHour = date.getUTCHours() == 0 ? 12 : date.getUTCHours() % 12;
-                else
-                    this.currentHour = date.getUTCHours();
-            }
-            else {
-                this.currentMinute = date.getMinutes();
-                this.currentSecond = date.getSeconds();
-                
-                if(this.hourFormat == '12')
-                    this.currentHour = date.getHours() == 0 ? 12 : date.getHours() % 12;
-                else
-                    this.currentHour = date.getHours();
+            if (this.hourFormat == '12') {
+                this.currentHour = this.getHours(date) == 0 ? 12 : this.getHours(date) % 12;
+            } else {
+                this.currentHour = this.getHours(date);
             }
         }
         else if(this.timeOnly) {
@@ -710,45 +700,32 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     }
     
     selectDate(dateMeta) {
-        let date;
-        if(this.utc)
-            date = new Date(Date.UTC(dateMeta.year, dateMeta.month, dateMeta.day));
-        else
-            date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
-        
-        if(this.showTime) {
-            if(this.utc) {
-                if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
-                    date.setUTCHours(this.currentHour + 12);
-                else
-                    date.setUTCHours(this.currentHour);
+        let date = this.newDate(dateMeta.year, dateMeta.month, dateMeta.day);
 
-                date.setUTCMinutes(this.currentMinute);
-                date.setUTCSeconds(this.currentSecond);
-            }
-            else {
-                if(this.hourFormat === '12' && this.pm && this.currentHour != 12)
-                    date.setHours(this.currentHour + 12);
-                else
-                    date.setHours(this.currentHour);
+        if (this.showTime) {
+            if (this.hourFormat === '12' && this.pm && this.currentHour != 12)
+                this.setHours(date, this.currentHour + 12);
+            else
+                this.setHours(date, this.currentHour);
 
-                date.setMinutes(this.currentMinute);
-                date.setSeconds(this.currentSecond);
-            }
+            this.setMinutes(date, this.currentMinute);
+            this.setSeconds(date, this.currentSecond);
         }
         
         if(this.minDate && this.minDate > date) {
             date = this.minDate;
-            this.currentHour = date.getHours();
-            this.currentMinute = date.getMinutes();
-            this.currentSecond = date.getSeconds();
+
+            this.currentHour = this.getHours(date);
+            this.currentMinute = this.getMinutes(date);
+            this.currentSecond = this.getSeconds(date);
         }
         
         if(this.maxDate && this.maxDate < date) {
             date = this.maxDate;
-            this.currentHour = date.getHours();
-            this.currentMinute = date.getMinutes();
-            this.currentSecond = date.getSeconds();
+
+            this.currentHour = this.getHours(date);
+            this.currentMinute = this.getMinutes(date);
+            this.currentSecond = this.getSeconds(date);
         }
         
         if(this.isSingleSelection()) {
@@ -802,16 +779,17 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     getFirstDayOfMonthIndex(month: number, year: number) {
         let day = new Date();
-        day.setDate(1);
-        day.setMonth(month);
-        day.setFullYear(year);
-        
-        let dayIndex = day.getDay() + this.getSundayIndex();
+
+        this.setDate(day, 1);
+        this.setMonth(day, month);
+        this.setFullYear(day, year);
+
+        let dayIndex = this.getDay(day) + this.getSundayIndex();
         return dayIndex >= 7 ? dayIndex - 7 : dayIndex;
     }
     
     getDaysCountInMonth(month: number, year: number) {
-        return 32 - this.daylightSavingAdjust(new Date(year, month, 32)).getDate();
+        return 32 - this.getDate(this.daylightSavingAdjust(this.newDate(year, month, 32)));
     }
     
     getDaysCountInPrevMonth(month: number, year: number) {
@@ -881,16 +859,16 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     }
     
     isDateEquals(value, dateMeta) {
-        if(value)
-            return value.getDate() === dateMeta.day && value.getMonth() === dateMeta.month && value.getFullYear() === dateMeta.year;
-        else
-            return false;
+        return value &&
+            this.getDate(value) === dateMeta.day &&
+            this.getMonth(value) === dateMeta.month &&
+            this.getFullYear(value) === dateMeta.year
     }
     
     isDateBetween(start, end, dateMeta) {
-        let between : boolean = false;
-        if(start && end) {
-            let date: Date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
+        let between: boolean = false;
+        if (start && end) {
+            let date: Date = this.newDate(dateMeta.year, dateMeta.month, dateMeta.day);
             return start.getTime() <= date.getTime() && end.getTime() >= date.getTime();
         }
         
@@ -910,7 +888,7 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     }
     
     isToday(today, day, month, year): boolean {
-        return today.getDate() === day && today.getMonth() === month && today.getFullYear() === year;
+        return this.getDate(today) === day && this.getMonth(today) === month && this.getFullYear(today) === year;
     }
     
     isSelectable(day, month, year): boolean {
@@ -918,37 +896,37 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         let validMax = true;
         let validDate = true;
         let validDay = true;
-        
-        if(this.minDate) {
-             if(this.minDate.getFullYear() > year) {
-                 validMin = false;
-             }
-             else if(this.minDate.getFullYear() === year) {
-                 if(this.minDate.getMonth() > month) {
-                     validMin = false;
-                 }
-                 else if(this.minDate.getMonth() === month) {
-                     if(this.minDate.getDate() > day) {
-                         validMin = false;
-                     }
-                 }
-             }
+
+        if (this.minDate) {
+            if (this.getFullYear(this.minDate) > year) {
+                validMin = false;
+            }
+            else if (this.getFullYear(this.minDate) === year) {
+                if (this.getMonth(this.minDate) > month) {
+                    validMin = false;
+                }
+                else if (this.getMonth(this.minDate) === month) {
+                    if (this.getDate(this.minDate) > day) {
+                        validMin = false;
+                    }
+                }
+            }
         }
-        
-        if(this.maxDate) {
-             if(this.maxDate.getFullYear() < year) {
-                 validMax = false;
-             }
-             else if(this.maxDate.getFullYear() === year) {
-                 if(this.maxDate.getMonth() < month) {
-                     validMax = false;
-                 }
-                 else if(this.maxDate.getMonth() === month) {
-                     if(this.maxDate.getDate() < day) {
-                         validMax = false;
-                     }
-                 }
-             }
+
+        if (this.maxDate) {
+            if (this.getFullYear(this.maxDate) < year) {
+                validMax = false;
+            }
+            else if (this.getFullYear(this.maxDate) === year) {
+                if (this.getMonth(this.maxDate) < month) {
+                    validMax = false;
+                }
+                else if (this.getMonth(this.maxDate) === month) {
+                    if (this.getDate(this.maxDate) < day) {
+                        validMax = false;
+                    }
+                }
+            }
         }
         
         if(this.disabledDates) {
@@ -961,11 +939,11 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         
         return validMin && validMax && validDate && validDay;
     }
-    
-    isDateDisabled(day:number, month:number, year:number):boolean {
-        if(this.disabledDates) {
-            for(let disabledDate of this.disabledDates) {
-                if(disabledDate.getFullYear() === year && disabledDate.getMonth() === month && disabledDate.getDate() === day) {
+
+    isDateDisabled(day: number, month: number, year: number): boolean {
+        if (this.disabledDates) {
+            for (let disabledDate of this.disabledDates) {
+                if (this.getFullYear(disabledDate) === year && this.getMonth(disabledDate) === month && this.getDate(disabledDate) === day) {
                     return true;
                 }
             }
@@ -973,11 +951,11 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         
         return false;
     }
-    
-    isDayDisabled(day:number, month:number, year:number):boolean {
-        if(this.disabledDays) {
-            let weekday = new Date(year, month, day);
-            let weekdayNumber = weekday.getDay();
+
+    isDayDisabled(day: number, month: number, year: number): boolean {
+        if (this.disabledDays) {
+            let weekday = this.newDate(year, month, day);
+            let weekdayNumber = this.getDay(weekday);
             return this.disabledDays.indexOf(weekdayNumber) !== -1;
         }
         return false;
@@ -1089,15 +1067,15 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             value = this.value[this.value.length - 1];
         }
         let valueDateString = value ? value.toDateString() : null;
-        
-        if(this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
-            if(this.minDate.getHours() > hour) {
+
+        if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
+            if (this.getHours(this.minDate) > hour) {
                 valid = false;
             }
         }
-        
-        if(this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
-            if(this.maxDate.getHours() < hour) {
+
+        if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
+            if (this.getHours(this.maxDate) < hour) {
                 valid = false;
             }
         }
@@ -1135,15 +1113,15 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             value = this.value[this.value.length - 1];
         }
         let valueDateString = value ? value.toDateString() : null;
-        
-        if(this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
-            if(this.minDate.getMinutes() > minute) {
+
+        if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
+            if (this.getMinutes(this.minDate) > minute) {
                 valid = false;
             }
         }
-        
-        if(this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
-            if(this.maxDate.getMinutes() < minute) {
+
+        if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
+            if (this.getMinutes(this.maxDate) < minute) {
                 valid = false;
             }
         }
@@ -1181,15 +1159,15 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             value = this.value[this.value.length - 1];
         }
         let valueDateString = value ? value.toDateString() : null;
-        
-        if(this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
-            if(this.minDate.getSeconds() > second) {
+
+        if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
+            if (this.getSeconds(this.minDate) > second) {
                 valid = false;
             }
         }
-        
-        if(this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
-            if(this.maxDate.getSeconds() < second) {
+
+        if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
+            if (this.getSeconds(this.maxDate) < second) {
                 valid = false;
             }
         }
@@ -1207,33 +1185,20 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         }
         value = value ? new Date(value.getTime()) : new Date();
 
-        if (this.utc) {
-            if (this.hourFormat == '12') {
-                if (this.currentHour === 12)
-                    value.setUTCHours(this.pm ? 12 : 0);
-                else
-                    value.setUTCHours(this.pm ? this.currentHour + 12 : this.currentHour);
-            }
-            else {
-                value.setUTCHours(this.currentHour);
-            }
+        if (this.hourFormat == '12') {
+            if (this.currentHour === 12)
+                this.setHours(value, this.pm ? 12 : 0);
+            else
+                this.setHours(value, this.pm ? this.currentHour + 12 : this.currentHour);
         }
         else {
-            if (this.hourFormat == '12') {
-                if (this.currentHour === 12)
-                    value.setHours(this.pm ? 12 : 0);
-                else
-                    value.setHours(this.pm ? this.currentHour + 12 : this.currentHour);
-            }
-            else {
-                value.setHours(this.currentHour);
-            }
+            this.setHours(value, this.currentHour);
         }
-        
-        value.setMinutes(this.currentMinute);
-        value.setSeconds(this.currentSecond);
-        if(this.isRangeSelection()) {
-            if(this.value[1]) {
+
+        this.setMinutes(value, this.currentMinute);
+        this.setSeconds(value, this.currentSecond);
+        if (this.isRangeSelection()) {
+            if (this.value[1]) {
                 value = [this.value[0], value];
             } else {
                 value = [value, null];
@@ -1326,18 +1291,15 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     populateTime(value, timeString, ampm) {
         if(this.hourFormat == '12' && !ampm) {
-            throw 'Invalid Time';
+            throw new Error('Invalid Time');
         }
         
         this.pm = (ampm === 'PM' || ampm === 'pm');
         let time = this.parseTime(timeString);
-        if (!this.utc)
-            value.setHours(time.hour);
-        else
-            value.setUTCHours(time.hour);
-    
-        value.setMinutes(time.minute);
-        value.setSeconds(time.second);
+
+        this.setHours(value, time.hour);
+        this.setMinutes(value, time.minute);
+        this.setSeconds(value, time.second);
     }
     
     updateUI() {
@@ -1347,12 +1309,12 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             val = val[0];
         }
 
-        this.createMonth(val.getMonth(), val.getFullYear());
-        
-        if(this.showTime||this.timeOnly) {
-            let hours = (this.utc) ? val.getUTCHours() : val.getHours();
-            
-            if(this.hourFormat == '12') {
+        this.createMonth(this.getMonth(val), this.getFullYear(val));
+
+        if (this.showTime || this.timeOnly) {
+            let hours = this.getHours(val);
+
+            if (this.hourFormat == '12') {
                 this.pm = hours > 11;
                 
                 if(hours >= 12) {
@@ -1363,11 +1325,11 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                 }
             }
             else {
-                this.currentHour = (this.utc) ? val.getUTCHours() : val.getHours();
+                this.currentHour = this.getHours(val);
             }
-            
-            this.currentMinute = val.getMinutes();
-            this.currentSecond = val.getSeconds();
+
+            this.currentMinute = this.getMinutes(val);
+            this.currentSecond = this.getSeconds(val);
         }
     }
     
@@ -1454,34 +1416,27 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                 } else {
                     switch (format.charAt(iFormat)) {
                         case 'd':
-                            output += formatNumber('d', this.utc ? date.getUTCDate() : date.getDate(), 2);
+                            output += formatNumber('d', this.getDate(date), 2);
                             break;
                         case 'D':
-                            output += formatName('D', this.utc ? date.getUTCDay() : date.getDay(), this.locale.dayNamesShort, this.locale.dayNames);
+                            output += formatName('D', this.getDay(date), this.locale.dayNamesShort, this.locale.dayNames);
                             break;
                         case 'o':
-                            if (this.utc) {
-                                output += formatNumber('o',
-                                    Math.round((
-                                        new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()).getTime() -
-                                        new Date(date.getUTCFullYear(), 0, 0).getTime()) / 86400000), 3);
-                            } else {
-                                output += formatNumber('o',
-                                    Math.round((
-                                        new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() -
-                                        new Date(date.getFullYear(), 0, 0).getTime()) / 86400000), 3);
-                            }
+                            output += formatNumber('o',
+                                Math.round((
+                                    new Date(this.getFullYear(date), this.getMonth(date), this.getDate(date)).getTime() -
+                                    new Date(this.getFullYear(date), 0, 0).getTime()) / 86400000), 3);
                             break;
                         case 'm':
-                            output += formatNumber('m', (this.utc ? date.getUTCMonth() : date.getMonth()) + 1, 2);
+                            output += formatNumber('m', (this.getMonth(date)) + 1, 2);
                             break;
                         case 'M':
-                            output += formatName('M', this.utc ? date.getUTCMonth() : date.getMonth(), this.locale.monthNamesShort, this.locale.monthNames);
+                            output += formatName('M', this.getMonth(date), this.locale.monthNamesShort, this.locale.monthNames);
                             break;
                         case 'y':
-                            output += (lookAhead('y') ? (this.utc ? date.getUTCFullYear() : date.getFullYear()) :
-                                ((this.utc ? date.getUTCFullYear() : date.getFullYear()) % 100 < 10 ? '0' : '') +
-                                (this.utc ? date.getUTCFullYear() : date.getFullYear()) % 100);
+                            output += (lookAhead('y') ? this.getFullYear(date) :
+                                (this.getFullYear(date) % 100 < 10 ? '0' : '') +
+                                this.getFullYear(date) % 100);
                             break;
                         case '@':
                             output += date.getTime();
@@ -1511,12 +1466,12 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
         }
         
         let output = '';
-        let hours = (this.utc) ? date.getUTCHours() : date.getHours();
-        let minutes = date.getMinutes();
-        let seconds = date.getSeconds();
-        
-        if(this.hourFormat == '12' && hours > 11 && hours != 12) {
-            hours-=12;
+        let hours = this.getHours(date);
+        let minutes = this.getMinutes(date);
+        let seconds = this.getSeconds(date);
+
+        if (this.hourFormat == '12' && hours > 11 && hours != 12) {
+            hours -= 12;
         }
         
         if(this.hourFormat == '12') {
@@ -1542,17 +1497,17 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     parseTime(value) {
         let tokens: string[] = value.split(':');
         let validTokenLength = this.showSeconds ? 3 : 2;
-        
-        if(tokens.length !== validTokenLength) {
-            throw "Invalid time";
+
+        if (tokens.length !== validTokenLength) {
+            throw new Error('Invalid time');
         }
         
         let h = parseInt(tokens[0]);
         let m = parseInt(tokens[1]);
         let s = this.showSeconds ? parseInt(tokens[2]) : null;
-        
-        if(isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
-            throw "Invalid time";
+
+        if (isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
+            throw new Error('Invalid time');
         }
         else {
             if(this.hourFormat == '12' && h !== 12 && this.pm) {
@@ -1565,18 +1520,18 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     // Ported from jquery-ui datepicker parseDate
     parseDate(value, format) {
-        if(format == null || value == null) {
-            throw "Invalid arguments";
+        if (format == null || value == null) {
+            throw new Error('Invalid arguments');
         }
 
-        value = (typeof value === "object" ? value.toString() : value + "");
-        if(value === "") {
+        value = (typeof value === 'object' ? value.toString() : value + '');
+        if (value === '') {
             return null;
         }
 
         let iFormat, dim, extra,
         iValue = 0,
-        shortYearCutoff = (typeof this.shortYearCutoff !== "string" ? this.shortYearCutoff : new Date().getFullYear() % 100 + parseInt(this.shortYearCutoff, 10)),
+        shortYearCutoff = (typeof this.shortYearCutoff !== 'string' ? this.shortYearCutoff : this.getFullYear(new Date()) % 100 + parseInt(this.shortYearCutoff, 10)),
         year = -1,
         month = -1,
         day = -1,
@@ -1591,14 +1546,14 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             return matches;
         },
         getNumber = (match) => {
-            let isDoubled = lookAhead(match),
-                size = (match === "@" ? 14 : (match === "!" ? 20 :
-                (match === "y" && isDoubled ? 4 : (match === "o" ? 3 : 2)))),
-                minSize = (match === "y" ? size : 1),
-                digits = new RegExp("^\\d{" + minSize + "," + size + "}"),
+        let isDoubled = lookAhead(match),
+                size = (match === '@' ? 14 : (match === '!' ? 20 :
+                    (match === 'y' && isDoubled ? 4 : (match === 'o' ? 3 : 2)))),
+                minSize = (match === 'y' ? size : 1),
+                digits = new RegExp('^\\d{' + minSize + ',' + size + '}'),
                 num = value.substring(iValue).match(digits);
-            if(!num) {
-                throw "Missing number at position " + iValue;
+            if (!num) {
+                throw new Error('Missing number at position ' + iValue);
             }
             iValue += num[ 0 ].length;
             return parseInt(num[ 0 ], 10);
@@ -1627,12 +1582,12 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             if(index !== -1) {
                 return index + 1;
             } else {
-                throw "Unknown name at position " + iValue;
+                throw new Error('Unknown name at position ' + iValue);
             }
         },
         checkLiteral = () => {
-            if(value.charAt(iValue) !== format.charAt(iFormat)) {
-                throw "Unexpected literal at position " + iValue;
+            if (value.charAt(iValue) !== format.charAt(iFormat)) {
+                throw new Error('Unexpected literal at position ' + iValue);
             }
             iValue++;
         };
@@ -1666,15 +1621,15 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
                         break;
                     case "@":
                         date = new Date(getNumber("@"));
-                        year = date.getFullYear();
-                        month = date.getMonth() + 1;
-                        day = date.getDate();
+                        year = this.getFullYear(date);
+                        month = this.getMonth(date) + 1;
+                        day = this.getDate(date);
                         break;
                     case "!":
                         date = new Date((getNumber("!") - this.ticksTo1970) / 10000);
-                        year = date.getFullYear();
-                        month = date.getMonth() + 1;
-                        day = date.getDate();
+                        year = this.getFullYear(date);
+                        month = this.getMonth(date) + 1;
+                        day = this.getDate(date);
                         break;
                     case "'":
                         if(lookAhead("'")) {
@@ -1689,17 +1644,17 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             }
         }
 
-        if(iValue < value.length) {
+        if (iValue < value.length) {
             extra = value.substr(iValue);
-            if(!/^\s+/.test(extra)) {
-                throw "Extra/unparsed characters found in date: " + extra;
+            if (!/^\s+/.test(extra)) {
+                throw new Error('Extra/unparsed characters found in date: ' + extra);
             }
         }
 
-        if(year === -1) {
-            year = new Date().getFullYear();
-        } else if(year < 100) {
-            year += new Date().getFullYear() - new Date().getFullYear() % 100 +
+        if (year === -1) {
+            year = this.getFullYear(new Date());
+        } else if (year < 100) {
+            year += this.getFullYear(new Date()) - this.getFullYear(new Date()) % 100 +
                 (year <= shortYearCutoff ? 0 : -100);
         }
 
@@ -1716,17 +1671,11 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             } while (true);
         }
 
-        if (this.utc) {
-            date = new Date(Date.UTC(year, month - 1, day));
-            if (date.getUTCFullYear() !== year || date.getUTCMonth() + 1 !== month || date.getUTCDate() !== day) {
-                throw "Invalid date"; // E.g. 31/02/00
-            }
-        } else {
-            date = this.daylightSavingAdjust(new Date(year, month - 1, day));
-            if (date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) {
-                throw "Invalid date"; // E.g. 31/02/00
-            }
+        date = this.daylightSavingAdjust(this.newDate(year, month - 1, day));
+        if (this.getFullYear(date) !== year || this.getMonth(date) + 1 !== month || this.getDate(date) !== day) {
+            throw new Error('Invalid date'); // E.g. 31/02/00
         }
+
         return date;
     }
     
@@ -1748,8 +1697,14 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
     
     onTodayButtonClick(event) {
         let date: Date = new Date();
-        let dateMeta = {day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), today: true, selectable: true};
-        
+        let dateMeta = {
+            day: this.getDate(date),
+            month: this.getMonth(date),
+            year: this.getFullYear(date),
+            today: true,
+            selectable: true
+        };
+
         this.createMonth(dateMeta.month, dateMeta.year);
         this.onDateSelect(event, dateMeta);
         this.onTodayClick.emit(event);
@@ -1790,11 +1745,125 @@ export class Calendar implements AfterViewInit,AfterViewChecked,OnInit,OnDestroy
             this.el.nativeElement.appendChild(this.overlayViewChild.nativeElement);
         }
     }
+
+    // region Date Accessors
+    newDate(year: number, month: number, day: number): Date {
+        if (this.utc) {
+            return new Date(Date.UTC(year, month, day));
+        }
+        return new Date(year, month, day);
+    }
+
+    getDate(date: Date): number {
+        if (this.utc) {
+            return date.getUTCDate();
+        }
+        return date.getDate();
+    }
+
+    setDate(date: Date, dateValue: number): Date {
+        if (this.utc) {
+            date.setUTCDate(dateValue);
+        }
+        date.setDate(dateValue);
+
+        return date;
+    }
+
+    getDay(date: Date): number {
+        if (this.utc) {
+            return date.getUTCDay();
+        }
+        return date.getDay();
+    }
+
+    getMonth(date: Date): number {
+        if (this.utc) {
+            return date.getUTCMonth();
+        }
+        return date.getMonth();
+    }
+
+    setMonth(date: Date, month: number): Date {
+        if (this.utc) {
+            date.setUTCMonth(month);
+        }
+        date.setMonth(month);
+
+        return date;
+    }
+
+    getFullYear(date: Date): number {
+        if (this.utc) {
+            return date.getUTCFullYear();
+        }
+        return date.getFullYear();
+    }
+
+    setFullYear(date: Date, fullYear: number): Date {
+        if (this.utc) {
+            date.setUTCFullYear(fullYear);
+        }
+        date.setFullYear(fullYear);
+
+        return date;
+    }
+
+    getHours(date: Date): number {
+        if (this.utc) {
+            return date.getUTCHours();
+        }
+        return date.getHours();
+    }
+
+    setHours(date: Date, hours: number): Date {
+        if (this.utc) {
+            date.setUTCHours(hours);
+        }
+        date.setHours(hours);
+
+        return date
+    }
+
+    getMinutes(date: Date): number {
+        if (this.utc) {
+            return date.getUTCMinutes();
+        }
+        return date.getMinutes();
+    }
+
+    setMinutes(date: Date, minutes: number): Date {
+        if (this.utc) {
+            date.setUTCMinutes(minutes);
+        }
+        date.setMinutes(minutes);
+
+        return date;
+    }
+
+    getSeconds(date: Date): number {
+        if (this.utc) {
+            return date.getUTCSeconds();
+        }
+        return date.getSeconds();
+    }
+
+    setSeconds(date: Date, seconds: number): Date {
+        if (this.utc) {
+            date.setUTCSeconds(seconds);
+        }
+        date.setSeconds(seconds);
+
+        return date;
+    }
+
+    // endregion
 }
 
 @NgModule({
-    imports: [CommonModule,ButtonModule,SharedModule],
-    exports: [Calendar,ButtonModule,SharedModule],
+    imports: [CommonModule, ButtonModule, SharedModule],
+    exports: [Calendar, ButtonModule, SharedModule],
     declarations: [Calendar]
 })
-export class CalendarModule { }
+export class CalendarModule {
+}

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -19,17 +19,17 @@
 
         <div class="ui-g-12 ui-md-4">
             <h3>Icon</h3>
-            <p-calendar [(ngModel)]="date3" [showIcon]="true"></p-calendar>{{date3|date}}
+            <p-calendar [(ngModel)]="date3" [showIcon]="true"></p-calendar> {{date3|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Min-Max</h3>
-            <p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" readonlyInput="true"></p-calendar> {{date4|date}}
+            <p-calendar [(ngModel)]="date4" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true"></p-calendar> {{date4|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Disable Days</h3>
-            <p-calendar [(ngModel)]="date5" tabindex="0" [disabledDates]="invalidDates" [disabledDays]="[0,6]" readonlyInput="true"></p-calendar> {{date5|date}}
+            <p-calendar [(ngModel)]="date5" tabindex="0" [disabledDates]="invalidDates" [disabledDays]="[0,6]" [readonlyInput]="true"></p-calendar> {{date5|date}}
         </div>
 
         <div class="ui-g-12 ui-md-4">
@@ -49,17 +49,17 @@
 
         <div class="ui-g-12 ui-md-4">
             <h3>Multiple</h3>
-            <p-calendar [(ngModel)]="dates" selectionMode="multiple" readonlyInput="true"></p-calendar>
+            <p-calendar [(ngModel)]="dates" selectionMode="multiple" [readonlyInput]="true"></p-calendar>
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Range</h3>
-            <p-calendar [(ngModel)]="rangeDates" selectionMode="range" readonlyInput="true"></p-calendar>
+            <p-calendar [(ngModel)]="rangeDates" selectionMode="range" [readonlyInput]="true"></p-calendar>
         </div>
 
         <div class="ui-g-12 ui-md-4">
             <h3>Button Bar</h3>
-            <p-calendar [(ngModel)]="date9" showButtonBar="true"></p-calendar>
+            <p-calendar [(ngModel)]="date9" [showButtonBar]="true"></p-calendar>
         </div>
 
         <div class="ui-g-12 ui-md-4">
@@ -69,6 +69,19 @@
                     <span [ngStyle]="{backgroundColor: (date.day < 21 && date.day > 10) ? '#7cc67c' : 'inherit'}" style="border-radius:50%">{{date.day}}</span>
                 </ng-template>
             </p-calendar>
+        </div>
+
+        <div class="ui-g-12 ui-md-4">
+            <h3>UTC</h3>
+            <p-calendar [(ngModel)]="date12" [utc]="true" [showTime]="true" [readonlyInput]="true"></p-calendar>
+            {{date12|date}}
+        </div>
+
+        <div class="ui-g-12 ui-md-4">
+            <h3>UTC Min-Max</h3>
+            <p-calendar [(ngModel)]="date13" [minDate]="minDate" [maxDate]="maxDate"
+                        [utc]="true" [showTime]="true" [readonlyInput]="true"></p-calendar>
+            {{date13|date}}
         </div>
     </div>
 

--- a/src/app/showcase/components/calendar/calendardemo.ts
+++ b/src/app/showcase/components/calendar/calendardemo.ts
@@ -26,7 +26,11 @@ export class CalendarDemo {
     date10: Date;
     
     date11: Date;
-    
+
+    date12: Date;
+
+    date13: Date;
+
     dates: Date[];
     
     rangeDates: Date[];


### PR DESCRIPTION
This code uses the correct getUTC(Property) or get(Property) in every date element depending on the flag utc.

Fixes #5334 and Min Max ranges that sets incorrect values for the time picker during validation when setting the utc flag to true.

Same as #5814 but this time is really without blank space removal.