### PR TITLE
Fixes ChartJS responsive mode sizing

### DIFF
--- a/src/app/components/chart/chart.ts
+++ b/src/app/components/chart/chart.ts
@@ -6,8 +6,8 @@ declare var Chart: any;
 @Component({
     selector: 'p-chart',
     template: `
-        <div style="position:relative" [style.width]="responsive ? null : width" [style.height]="responsive ? null : height">
-            <canvas [attr.width]="responsive ? null : width" [attr.height]="responsive ? null : height" (click)="onCanvasClick($event)"></canvas>
+        <div style="position:relative" [style.width]="responsive && !width ? null : width" [style.height]="responsive && !height ? null : height">
+            <canvas [attr.width]="responsive && !width ? null : width" [attr.height]="responsive && !height ? null : height" (click)="onCanvasClick($event)"></canvas>
         </div>
     `
 })
@@ -60,7 +60,12 @@ export class UIChart implements AfterViewInit, OnDestroy {
     initChart() {
         let opts = this.options||{};
         opts.responsive = this.responsive;
-        
+
+        // allows chart to resize in responsive mode
+        if (opts.responsive&&(this.height||this.width)) {
+            opts.maintainAspectRatio = false;
+        }
+
         this.chart = new Chart(this.el.nativeElement.children[0].children[0], {
             type: this.type,
             data: this.data,

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -86,18 +86,18 @@ update(event: Event) &#123;
                     <td>width</td>
                     <td>string</td>
                     <td>null</td>
-                    <td>Width of the chart in non-responsive mode.</td>
+                    <td>Width of the chart, is only applied in non-responsive mode.</td>
                 </tr>
                 <tr>
                     <td>height</td>
                     <td>string</td>
                     <td>null</td>
-                    <td>Height of the chart in non-responsive mode.</td>
+                    <td>Height of the chart.</td>
                 </tr>
                 <tr>
                     <td>responsive</td>
                     <td>boolean</td>
-                    <td>false</td>
+                    <td>true</td>
                     <td>Whether the chart is redrawn on screen size change.</td>
                 </tr>
                 <tr>
@@ -249,7 +249,7 @@ selectData(event) &#123;
     <p>Charts are responsive by default and vw-vh units should be used when customizing the width and height of the chart.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
-&lt;p-chart type="line" [data]="data" width="40w" height="80w"&gt;&lt;/p-chart&gt;
+&lt;p-chart type="line" [data]="data" width="40vw" height="80vh"&gt;&lt;/p-chart&gt;
 </code>
 </pre>
 

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -86,7 +86,7 @@ update(event: Event) &#123;
                     <td>width</td>
                     <td>string</td>
                     <td>null</td>
-                    <td>Width of the chart, is only applied in non-responsive mode.</td>
+                    <td>Width of the chart.</td>
                 </tr>
                 <tr>
                     <td>height</td>


### PR DESCRIPTION
###Defect Fixes
See issue https://github.com/primefaces/primeng/issues/5126.
Also https://github.com/primefaces/primeng/issues/5748.

1) Fixes typo in doc that responsive mode is set to false by default.
2) Fixes typo in doc about using width="40w" height="80w" in responsive mode.
3) Fixes that width and height have no effect on the charts sizing in responsive mode.