### PR TITLE
Frozen Table scrollbar overlaps paginator

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1802,7 +1802,7 @@ export class ScrollableView implements AfterViewInit,OnDestroy,AfterViewChecked 
             }
         }
         else {
-            this.scrollBodyViewChild.nativeElement.style.paddingBottom = this.domHandler.calculateScrollbarWidth() + 'px';
+            this.scrollBodyViewChild.nativeElement.style.marginBottom = this.domHandler.calculateScrollbarWidth() + 'px';
         }
 
         if(this.dt.virtualScroll) {


### PR DESCRIPTION
###Defect Fixes
Very simple PR to fix the turbo table scrollbar appearing on top of the paginator due to it using padding instead of margin.

The documenting issue is https://github.com/primefaces/primeng/issues/5566.