### PR TITLE
Fixes ChartJS generateLegend. Needs to return the HTML string.

### DIFF
--- a/src/app/components/chart/chart.ts
+++ b/src/app/components/chart/chart.ts
@@ -78,7 +78,7 @@ export class UIChart implements AfterViewInit, OnDestroy {
     
     generateLegend() {
         if(this.chart) {
-            this.chart.generateLegend();
+            return this.chart.generateLegend();
         }
     }
     


### PR DESCRIPTION
###Defect Fixes
ChartJS needs to return the generated legend HTML string.

Fixes https://github.com/primefaces/primeng/issues/5669.

Refers back to issue https://github.com/primefaces/primeng/issues/2035, the fix never seems to have been merged.