### PR TITLE
add missing events on confirmdialog

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -87,7 +87,11 @@ export class ConfirmDialog implements AfterViewInit,AfterViewChecked,OnDestroy {
     @Input() key: string;
         
     @ContentChild(Footer) footer;
-    
+
+    @Output() onBeforeHide: EventEmitter<any> = new EventEmitter();
+
+    @Output() onAfterHide: EventEmitter<any> = new EventEmitter();
+
     confirmation: Confirmation;
         
     _visible: boolean;
@@ -219,7 +223,9 @@ export class ConfirmDialog implements AfterViewInit,AfterViewChecked,OnDestroy {
             this.confirmation.rejectEvent.emit();
         }
         
+        this.onBeforeHide.emit(event);
         this.hide();
+        this.onAfterHide.emit(event);
         event.preventDefault();
     }
     

--- a/src/app/showcase/components/confirmdialog/confirmdialogdemo.html
+++ b/src/app/showcase/components/confirmdialog/confirmdialogdemo.html
@@ -282,6 +282,31 @@ export class ConfirmDialogDemo &#123;
                 </table>
             </div>
 
+            <h3>Events</h3>
+            <div class="doc-tablewrapper">
+                <table class="doc-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Parameters</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>onBeforeHide</td>
+                            <td>-</td>
+                            <td>Callback to invoke before confirmation dialog is hidden.</td>
+                        </tr>
+                        <tr>
+                            <td>onAfterHide</td>
+                            <td>-</td>
+                            <td>Callback to invoke after confirmation dialog is hidden.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        
             <h3>Styling</h3>
             <p>Following is the list of structural style classes, for theming classes visit <a href="#" [routerLink]="['/theming']">theming page</a>.</p>
             <div class="doc-tablewrapper">


### PR DESCRIPTION
We needed to know when the confirmdialog is closed by using the cross in the upper right corner without accepting nor rejecting.
Our use case is as follows: when a user tries to navigate to another page, but has made some changes, we wanted to ask the user whether or not those changes should be saved. When the confirmation is simply closed, we need to prevent the navigation and stay on the current page. Without these events, it's impossible to know when that happens.