### PR TITLE
Support icon field of MenuItem

### DIFF
--- a/src/app/components/breadcrumb/breadcrumb.ts
+++ b/src/app/components/breadcrumb/breadcrumb.ts
@@ -16,7 +16,7 @@ import {RouterModule} from '@angular/router';
                     </a>
                     <a *ngIf="home.routerLink" [routerLink]="home.routerLink" [queryParams]="home.queryParams" [routerLinkActive]="'ui-state-active'" [routerLinkActiveOptions]="home.routerLinkActiveOptions||{exact:false}" class="ui-menuitem-link" (click)="itemClick($event, home)" 
                         [ngClass]="{'ui-state-disabled':home.disabled}" [attr.target]="home.target" [attr.title]="home.title" [attr.id]="home.id">
-                        <span class="pi pi-home"></span>
+                        <span [ngClass]="home.icon||'pi pi-home'"></span>
                     </a>
                 </li>
                 <li class="ui-breadcrumb-chevron pi pi-chevron-right" *ngIf="model&&home"></li>
@@ -24,10 +24,12 @@ import {RouterModule} from '@angular/router';
                     <li role="menuitem">
                         <a *ngIf="!item.routerLink" [href]="item.url||'#'" class="ui-menuitem-link" (click)="itemClick($event, item)" 
                             [ngClass]="{'ui-state-disabled':item.disabled}" [attr.target]="item.target" [attr.title]="item.title" [attr.id]="item.id">
+                            <span *ngIf="item.icon" class=\"ui-menuitem-icon\" [ngClass]="item.icon"></span>
                             <span class="ui-menuitem-text">{{item.label}}</span>
                         </a>
                         <a *ngIf="item.routerLink" [routerLink]="item.routerLink" [queryParams]="item.queryParams" [routerLinkActive]="'ui-state-active'" [routerLinkActiveOptions]="item.routerLinkActiveOptions||{exact:false}" class="ui-menuitem-link" (click)="itemClick($event, item)" 
                             [ngClass]="{'ui-state-disabled':item.disabled}" [attr.target]="item.target" [attr.title]="item.title" [attr.id]="item.id">
+                            <span *ngIf="item.icon" class=\"ui-menuitem-icon\" [ngClass]="item.icon"></span>
                             <span class="ui-menuitem-text">{{item.label}}</span>
                         </a>
                     </li>


### PR DESCRIPTION
If `MenuItem` structure specifies an icon, let's draw that on the Breadcrumbs.  Applying a class of `ui-menuitem-icon` would allow user to customize display, if desired.
Additional fix is provided for customizing `home.icon` in the case where `home.routerLink` is defined.
It can solve #4891