### PR TITLE
Button Visuals Fix

### DIFF
--- a/src/assets/components/themes/ludvig/theme.scss
+++ b/src/assets/components/themes/ludvig/theme.scss
@@ -55,3 +55,22 @@ $invalidInputBorderColor: #ec4e4e;
 $inputGroupTextColor: #333333;
 
 @import '../_theme';
+
+
+.ui-button:focus,
+.ui-button:enabled:not(.ui-dataview-layout-option .ui-button):hover,
+.ui-fileupload-choose:not(.ui-state-disabled):hover {
+    outline: 0 none;
+    @include hover-element();
+}
+
+.ui-togglebutton.ui-button.ui-state-focus,
+.ui-selectbutton .ui-button.ui-state-focus.ui-state-active,
+.ui-selectbutton .ui-button.ui-state-active:focus  {
+    -moz-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    -webkit-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    border-color: $stateActiveBorderColor;
+    background-color: $stateActiveBgColor;
+    color: $stateActiveTextColor;
+}

--- a/src/assets/components/themes/redmond/theme.scss
+++ b/src/assets/components/themes/redmond/theme.scss
@@ -55,3 +55,22 @@ $invalidInputBorderColor: #cd0a0a;
 $inputGroupTextColor: #2e6e9e;
 
 @import '../_theme';
+
+
+.ui-button:focus,
+.ui-button:enabled:not(.ui-dataview-layout-option .ui-button):hover,
+.ui-fileupload-choose:not(.ui-state-disabled):hover {
+    outline: 0 none;
+    @include hover-element();
+}
+
+.ui-togglebutton.ui-button.ui-state-focus,
+.ui-selectbutton .ui-button.ui-state-focus.ui-state-active,
+.ui-selectbutton .ui-button.ui-state-active:focus  {
+    -moz-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    -webkit-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    border-color: $stateActiveBorderColor;
+    background-color: $stateActiveBgColor;
+    color: $stateActiveTextColor;
+}

--- a/src/assets/components/themes/rocket/theme.scss
+++ b/src/assets/components/themes/rocket/theme.scss
@@ -55,3 +55,22 @@ $invalidInputBorderColor: #ca3838;
 $inputGroupTextColor: #ffffff;
 
 @import '../_theme';
+
+
+.ui-button:focus,
+.ui-button:enabled:not(.ui-dataview-layout-option .ui-button):hover,
+.ui-fileupload-choose:not(.ui-state-disabled):hover {
+    outline: 0 none;
+    @include hover-element();
+}
+
+.ui-togglebutton.ui-button.ui-state-focus,
+.ui-selectbutton .ui-button.ui-state-focus.ui-state-active,
+.ui-selectbutton .ui-button.ui-state-active:focus  {
+    -moz-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    -webkit-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    border-color: $stateActiveBorderColor;
+    background-color: $stateActiveBgColor;
+    color: $stateActiveTextColor;
+}

--- a/src/assets/components/themes/south-street/theme.scss
+++ b/src/assets/components/themes/south-street/theme.scss
@@ -61,3 +61,22 @@ $inputGroupTextColor: #ffffff;
     color: #459e00;
     border-color: #d4ccb0;
 }
+
+
+.ui-button:focus,
+.ui-button:enabled:not(.ui-dataview-layout-option .ui-button):hover,
+.ui-fileupload-choose:not(.ui-state-disabled):hover {
+    outline: 0 none;
+    @include hover-element();
+}
+
+.ui-togglebutton.ui-button.ui-state-focus,
+.ui-selectbutton .ui-button.ui-state-focus.ui-state-active,
+.ui-selectbutton .ui-button.ui-state-active:focus  {
+    -moz-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    -webkit-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    border-color: $stateActiveBorderColor;
+    background-color: $stateActiveBgColor;
+    color: $stateActiveTextColor;
+}

--- a/src/assets/components/themes/start/theme.scss
+++ b/src/assets/components/themes/start/theme.scss
@@ -55,3 +55,22 @@ $invalidInputBorderColor: #cd0a0a;
 $inputGroupTextColor: #026890;
 
 @import '../_theme';
+
+
+.ui-button:focus,
+.ui-button:enabled:not(.ui-dataview-layout-option .ui-button):hover,
+.ui-fileupload-choose:not(.ui-state-disabled):hover {
+    outline: 0 none;
+    @include hover-element();
+}
+
+.ui-togglebutton.ui-button.ui-state-focus,
+.ui-selectbutton .ui-button.ui-state-focus.ui-state-active,
+.ui-selectbutton .ui-button.ui-state-active:focus  {
+    -moz-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    -webkit-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    border-color: $stateActiveBorderColor;
+    background-color: $stateActiveBgColor;
+    color: $stateActiveTextColor;
+}

--- a/src/assets/components/themes/voclain/theme.scss
+++ b/src/assets/components/themes/voclain/theme.scss
@@ -55,3 +55,21 @@ $invalidInputBorderColor: #ec4e4e;
 $inputGroupTextColor: #ffffff;
 
 @import '../_theme';
+
+.ui-button:focus,
+.ui-button:enabled:not(.ui-dataview-layout-option .ui-button):hover,
+.ui-fileupload-choose:not(.ui-state-disabled):hover {
+    outline: 0 none;
+    @include hover-element();
+}
+
+.ui-togglebutton.ui-button.ui-state-focus,
+.ui-selectbutton .ui-button.ui-state-focus.ui-state-active,
+.ui-selectbutton .ui-button.ui-state-active:focus  {
+    -moz-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    -webkit-box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    box-shadow: 0px 0px 5px $stateActiveBgColor;;
+    border-color: $stateActiveBorderColor;
+    background-color: $stateActiveBgColor;
+    color: $stateActiveTextColor;
+}


### PR DESCRIPTION
In the past, a clicked button's visual "active" was overridden by "focus", resulting in a bad css. Also, on dataview's layout options, buttons became nearly invisible due to a similar problem. Now, if a button is active, it is not blocked by focus. Moreover, focused buttons are highlighted with the hue of the background colour.
This fix is focused on some free themes. Omega is not touched.
