### PR TITLE
Add fine-grained controls over what move buttons to disable/hide

### DIFF
--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -11,10 +11,10 @@ import {ObjectUtils} from '../utils/objectutils';
         <div [class]="styleClass" [ngStyle]="style" [ngClass]="{'ui-picklist ui-widget ui-helper-clearfix': true,'ui-picklist-responsive': responsive}">
             <div class="ui-picklist-source-controls ui-picklist-buttons" *ngIf="showSourceControls">
                 <div class="ui-picklist-buttons-cell">
-                    <button type="button" pButton icon="pi pi-angle-up" [disabled]="disabled" (click)="moveUp(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
-                    <button type="button" pButton icon="pi pi-angle-double-up" [disabled]="disabled" (click)="moveTop(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
-                    <button type="button" pButton icon="pi pi-angle-down" [disabled]="disabled" (click)="moveDown(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
-                    <button type="button" pButton icon="pi pi-angle-double-down" [disabled]="disabled" (click)="moveBottom(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-up" [disabled]="disabled || reorderDisabled || reorderSourceDisabled" (click)="moveUp(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-double-up" [disabled]="disabled || reorderDisabled || reorderSourceDisabled" (click)="moveTop(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-down" [disabled]="disabled || reorderDisabled || reorderSourceDisabled" (click)="moveDown(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-double-down" [disabled]="disabled || reorderDisabled || reorderSourceDisabled" (click)="moveBottom(sourcelist,source,selectedItemsSource,onSourceReorder)"></button>
                 </div>
             </div>
             <div class="ui-picklist-listwrapper ui-picklist-source-wrapper" [ngClass]="{'ui-picklist-listwrapper-nocontrols':!showSourceControls}">
@@ -69,10 +69,10 @@ import {ObjectUtils} from '../utils/objectutils';
             </div>
             <div class="ui-picklist-target-controls ui-picklist-buttons" *ngIf="showTargetControls">
                 <div class="ui-picklist-buttons-cell">
-                    <button type="button" pButton icon="pi pi-angle-up" [disabled]="disabled" (click)="moveUp(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
-                    <button type="button" pButton icon="pi pi-angle-double-up" [disabled]="disabled" (click)="moveTop(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
-                    <button type="button" pButton icon="pi pi-angle-down" [disabled]="disabled" (click)="moveDown(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
-                    <button type="button" pButton icon="pi pi-angle-double-down" [disabled]="disabled" (click)="moveBottom(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-up" [disabled]="disabled || reorderDisabled || reorderTargetDisabled" (click)="moveUp(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-double-up" [disabled]="disabled || reorderDisabled || reorderTargetDisabled" (click)="moveTop(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-down" [disabled]="disabled || reorderDisabled || reorderTargetDisabled" (click)="moveDown(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
+                    <button type="button" pButton icon="pi pi-angle-double-down" [disabled]="disabled || reorderDisabled || reorderTargetDisabled" (click)="moveBottom(targetlist,target,selectedItemsTarget,onTargetReorder)"></button>
                 </div>
             </div>
         </div>
@@ -124,6 +124,12 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     @Input() disabled: boolean = false;
 
     @Input() moveDisabled: boolean = false;
+
+    @Input() reorderDisabled: boolean = false;
+
+    @Input() reorderSourceDisabled: boolean = false;
+
+    @Input() reorderTargetDisabled: boolean = false;
 
     @Input() moveOneLeftDisabled: boolean = false;
 
@@ -585,6 +591,10 @@ export class PickList implements AfterViewChecked,AfterContentInit {
                     this.insert(this.draggedItemIndexTarget, this.target, index, this.source, this.onMoveToSource);
                 }
                 else {
+                    if (this.disabled || this.reorderDisabled || this.reorderSourceDisabled) {
+                        event.preventDefault();
+                        return;
+                    }
                     this.objectUtils.reorderArray(this.source, this.draggedItemIndexSource, (this.draggedItemIndexSource > index) ? index : (index === 0) ? 0 : index - 1);
                 }
 
@@ -599,6 +609,10 @@ export class PickList implements AfterViewChecked,AfterContentInit {
                     this.insert(this.draggedItemIndexSource, this.source, index, this.target, this.onMoveToTarget);
                 }
                 else {
+                    if (this.disabled || this.reorderDisabled || this.reorderTargetDisabled) {
+                        event.preventDefault();
+                        return;
+                    }
                     this.objectUtils.reorderArray(this.target, this.draggedItemIndexTarget, (this.draggedItemIndexTarget > index) ? index : (index === 0) ? 0 : index - 1);
                 }
                     

--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -40,10 +40,10 @@ import {ObjectUtils} from '../utils/objectutils';
             </div>
             <div class="ui-picklist-buttons">
                 <div class="ui-picklist-buttons-cell">
-                    <button type="button" pButton icon="pi pi-angle-right" [disabled]="disabled" (click)="moveRight()"></button>
-                    <button type="button" pButton icon="pi pi-angle-double-right" [disabled]="disabled" (click)="moveAllRight()"></button>
-                    <button type="button" pButton icon="pi pi-angle-left" [disabled]="disabled" (click)="moveLeft()"></button>
-                    <button type="button" pButton icon="pi pi-angle-double-left" [disabled]="disabled" (click)="moveAllLeft()"></button>
+                    <button type="button" pButton icon="pi pi-angle-right" *ngIf="!hideMoveOneRight" [disabled]="disabled || moveDisabled || moveOneRightDisabled" (click)="moveRight()"></button>
+                    <button type="button" pButton icon="pi pi-angle-double-right" *ngIf="!hideMoveAllRight" [disabled]="disabled || moveDisabled || moveAllRightDisabled" (click)="moveAllRight()"></button>
+                    <button type="button" pButton icon="pi pi-angle-left" *ngIf="!hideMoveOneLeft" [disabled]="disabled || moveDisabled || moveOneLeftDisabled" (click)="moveLeft()"></button>
+                    <button type="button" pButton icon="pi pi-angle-double-left" *ngIf="!hideMoveAllLeft" [disabled]="disabled || moveDisabled || moveAllLeftDisabled" (click)="moveAllLeft()"></button>
                 </div>
             </div>
             <div class="ui-picklist-listwrapper ui-picklist-target-wrapper" [ngClass]="{'ui-picklist-listwrapper-nocontrols':!showTargetControls}">
@@ -122,6 +122,24 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     @Input() targetFilterPlaceholder: string;
 
     @Input() disabled: boolean = false;
+
+    @Input() moveDisabled: boolean = false;
+
+    @Input() moveOneLeftDisabled: boolean = false;
+
+    @Input() moveOneRightDisabled: boolean = false;
+
+    @Input() moveAllLeftDisabled: boolean = false;
+
+    @Input() moveAllRightDisabled: boolean = false;
+
+    @Input() hideMoveOneLeft: boolean = false;
+
+    @Input() hideMoveOneRight: boolean = false;
+
+    @Input() hideMoveAllLeft: boolean = false;
+
+    @Input() hideMoveAllRight: boolean = false;
     
     @Output() onMoveToSource: EventEmitter<any> = new EventEmitter();
     
@@ -259,7 +277,7 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     }
     
     onSourceItemDblClick() {
-        if(this.disabled) {
+        if(this.disabled || this.moveDisabled || this.moveOneRightDisabled) {
             return;
         }
         
@@ -267,7 +285,7 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     }
     
     onTargetItemDblClick() {
-        if(this.disabled) {
+        if(this.disabled || this.moveDisabled || this.moveOneLeftDisabled) {
             return;
         }
         
@@ -559,18 +577,30 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     onDrop(event: DragEvent, index: number, listType: number) {
         if(this.onListItemDroppoint) {
             if(listType === -1) {
-                if(this.fromListType === 1)
+                if(this.fromListType === 1) {
+                    if(this.disabled || this.moveDisabled || this.moveOneLeftDisabled) {
+                        event.preventDefault();
+                        return;
+                    }
                     this.insert(this.draggedItemIndexTarget, this.target, index, this.source, this.onMoveToSource);
-                else
+                }
+                else {
                     this.objectUtils.reorderArray(this.source, this.draggedItemIndexSource, (this.draggedItemIndexSource > index) ? index : (index === 0) ? 0 : index - 1);
+                }
 
                 this.dragOverItemIndexSource = null;
             }
             else {
-                if(this.fromListType === -1)
+                if(this.fromListType === -1) {
+                    if(this.disabled || this.moveDisabled || this.moveOneRightDisabled) {
+                        event.preventDefault();
+                        return;
+                    }
                     this.insert(this.draggedItemIndexSource, this.source, index, this.target, this.onMoveToTarget);
-                else
+                }
+                else {
                     this.objectUtils.reorderArray(this.target, this.draggedItemIndexTarget, (this.draggedItemIndexTarget > index) ? index : (index === 0) ? 0 : index - 1);
+                }
                     
                 this.dragOverItemIndexTarget = null;
             }
@@ -588,12 +618,22 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     onListDrop(event: DragEvent, listType:  number) {
         if(!this.onListItemDroppoint) {
             if(listType === -1) {
-                if(this.fromListType === 1)
+                if(this.fromListType === 1) {
+                    if(this.disabled || this.moveDisabled || this.moveOneLeftDisabled) {
+                        event.preventDefault();
+                        return;
+                    }
                     this.insert(this.draggedItemIndexTarget, this.target, null, this.source, this.onMoveToSource);
+                }
             }
             else {
-                if(this.fromListType === -1)
+                if(this.fromListType === -1) {
+                    if(this.disabled || this.moveDisabled || this.moveOneRightDisabled) {
+                        event.preventDefault();
+                        return;
+                    }
                     this.insert(this.draggedItemIndexSource, this.source, null, this.target, this.onMoveToTarget);
+                }
             }
             
             this.listHighlightTarget = false;


### PR DESCRIPTION
###Defect Fixes
This PR adds more fine-grained controls over disabling individual buttons (move one or all in either direction) allowing the programmer to individually disable any of the buttons, as requested in issue #4380. I also added a `moveDisabled` attribute that will only disable movement from one list to another but still allow other operations (like reordering) on the list.

I have also added an input to hide any of the item moving buttons individually.

If you approve the PR, I'm also happy to add documentation to the showcase section on the new attributes!