### PR TITLE
Fix for suggestions on second time load.

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -202,6 +202,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
         this._suggestions = val;
         
         if(this.immutable) {
+            this.loading = true;
             this.handleSuggestionsChange();
         }
     }

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -202,7 +202,9 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
         this._suggestions = val;
         
         if(this.immutable) {
-            this.loading = true;
+            if (this._suggestions && this._suggestions.length) {
+                this.loading = true;
+            }
             this.handleSuggestionsChange();
         }
     }


### PR DESCRIPTION
I'm using p-autocomplete for postcode lookup. it is work like below.
search with HU1 1UU post code it will give me 1 suggestion with placeholder 13 addresses.
When i'm selecting that I'm changing the suggetions with that 13 addresses from api result.
at that time below line is stopping me to show 13 addresses in suggestion dropdown. Specially this.loading is false so it is not entering inside of condition in handleSuggestionsChange function.

Code Line :  if (this.panelEL && this.panelEL.nativeElement && this.loading) {

###Defect Fixes
[https://github.com/primefaces/primeng/issues/6142](https://github.com/primefaces/primeng/issues/6142)

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.