### PR TITLE
Possibility to insert SafeHtml in toast message

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -131,7 +131,7 @@ export class DomHandler {
             top = targetOuterHeight + targetOffset.top + windowScrollTop;
         }
 
-        if (targetOffset.left + targetOuterWidth + elementOuterWidth > viewport.width)
+        if (targetOffset.left + elementOuterWidth > viewport.width)
             left = targetOffset.left + windowScrollLeft + targetOuterWidth - elementOuterWidth;
         else
             left = targetOffset.left + windowScrollLeft;

--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -131,7 +131,7 @@ export class DomHandler {
             top = targetOuterHeight + targetOffset.top + windowScrollTop;
         }
 
-        if (targetOffset.left + elementOuterWidth > viewport.width)
+        if (targetOffset.left + targetOuterWidth + elementOuterWidth > viewport.width)
             left = targetOffset.left + windowScrollLeft + targetOuterWidth - elementOuterWidth;
         else
             left = targetOffset.left + windowScrollLeft;

--- a/src/app/components/toast/toast.ts
+++ b/src/app/components/toast/toast.ts
@@ -21,8 +21,8 @@ import {trigger,state,style,transition,animate,query,animateChild} from '@angula
                         [ngClass]="{'pi-info-circle': message.severity == 'info', 'pi-exclamation-triangle': message.severity == 'warn',
                             'pi-times': message.severity == 'error', 'pi-check' :message.severity == 'success'}"></span>
                     <div class="ui-toast-message-text-content">
-                        <div class="ui-toast-summary" [innerHTML]="message.summary"></div>
-                        <div class="ui-toast-detail" [innerHTML]="message.detail"></div>
+                        <div class="ui-toast-summary" [innerHTML]="message.summary||''"></div>
+                        <div class="ui-toast-detail" [innerHTML]="message.detail||''"></div>
                     </div>
                 </ng-container>
                 <ng-container *ngTemplateOutlet="template; context: {$implicit: message}"></ng-container>

--- a/src/app/components/toast/toast.ts
+++ b/src/app/components/toast/toast.ts
@@ -21,8 +21,8 @@ import {trigger,state,style,transition,animate,query,animateChild} from '@angula
                         [ngClass]="{'pi-info-circle': message.severity == 'info', 'pi-exclamation-triangle': message.severity == 'warn',
                             'pi-times': message.severity == 'error', 'pi-check' :message.severity == 'success'}"></span>
                     <div class="ui-toast-message-text-content">
-                        <div class="ui-toast-summary">{{message.summary}}</div>
-                        <div class="ui-toast-detail">{{message.detail}}</div>
+                        <div class="ui-toast-summary" [innerHTML]="message.summary"></div>
+                        <div class="ui-toast-detail" [innerHTML]="message.detail"></div>
                     </div>
                 </ng-container>
                 <ng-container *ngTemplateOutlet="template; context: {$implicit: message}"></ng-container>


### PR DESCRIPTION
With this change, we are able to put SafeHtml in the toast message, like it was possible in the growl message.
cf. `<p [innerHTML]="msg.detail||''"></p>`
