### PR TITLE
Perform the export taking into consideration subfields of the objects in Turbotable

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1365,7 +1365,14 @@ export class Table implements OnInit, AfterContentInit, BlockableUI {
             for (let i = 0; i < this.columns.length; i++) {
                 let column = this.columns[i];
                 if (column.exportable !== false && column.field) {
-                    let cellData = this.objectUtils.resolveFieldData(record, column.field);
+                    let data = record;
+                    let field = column.field;
+                    if (typeof record[field] == 'object' ) {
+                        data = record[field];
+                        field = column.subfield;
+                    }
+
+                    let cellData = this.objectUtils.resolveFieldData(data, field);
                     
                     if (cellData != null) {
                         if (this.exportFunction) {


### PR DESCRIPTION
The method is modified so that at the time of exporting the objects shown in the table, subfields of the object are taken, since currently the table does show subfields of matched objects, but when exporting those subfields are not taken.

###Defect Fixes
Object properties are not exported when accessing a subfield of the object

###Feature Requests
The method is modified to validate if what is found to export is an object, if it is true, access the property of the subfield, exporting the information correctly.

> Structure of the columns for the table
![structure of information object](https://user-images.githubusercontent.com/42486911/44296404-f8991e80-a283-11e8-823e-28747247a49d.PNG)

> With the native method, if it shows the subfields in the table correctly, but when exporting it is displayed as in the attached image.
![view](https://user-images.githubusercontent.com/42486911/44296421-8543dc80-a284-11e8-8132-26df45f3d149.PNG)

> Subfields are displayed incorrectly, when exported with native method.
![native method](https://user-images.githubusercontent.com/42486911/44296469-6db92380-a285-11e8-80d0-ed69679d9457.PNG)

> With the proposed method, this error is solved.
![correctly form](https://user-images.githubusercontent.com/42486911/44296473-8c1f1f00-a285-11e8-8995-5425f5ae987d.PNG)

Thanks for your time! Greetings.




