### PR TITLE
Corrected the GitHub link

### DIFF
--- a/src/app/showcase/components/toast/toastdemo.html
+++ b/src/app/showcase/components/toast/toastdemo.html
@@ -409,7 +409,7 @@ this.messageService.clear('myKey1');    //clears messages of the first toast onl
         </p-tabPanel>
 
         <p-tabPanel header="Source">
-            <a href="https://github.com/primefaces/primeng/tree/master/src/app/showcase/components/growl" class="btn-viewsource" target="_blank">
+            <a href="https://github.com/primefaces/primeng/tree/master/src/app/showcase/components/toast" class="btn-viewsource" target="_blank">
                 <i class="fa fa-github"></i>
                 <span>View on GitHub</span>
             </a>


### PR DESCRIPTION
The GitHub link was directing to the growl page, which was probably a copy-paste mistake.