### PR TITLE
FileUpload accept should be case insensitive

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -264,7 +264,7 @@ export class FileUpload implements OnInit,AfterViewInit,AfterContentInit,OnDestr
         let acceptableTypes = this.accept.split(',');
         for(let type of acceptableTypes) {
             let acceptable = this.isWildcard(type) ? this.getTypeClass(file.type) === this.getTypeClass(type)
-                                                    : file.type == type || this.getFileExtension(file) === type;
+                                                    : file.type == type || this.getFileExtension(file).toLowerCase() === type.toLowerCase();
 
             if(acceptable) {
                 return true;


### PR DESCRIPTION
If the `accept` property is set for example to '.txt,.pdf', then file upload won't accept files like `test.PDF` or `logs.Txt`, that is not expected behavior.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.