### PR TITLE
country rename

### DIFF
--- a/src/assets/showcase/data/countries.json
+++ b/src/assets/showcase/data/countries.json
@@ -211,7 +211,7 @@
         {"name": "Sweden", "code": "SE"}, 
         {"name": "Switzerland", "code": "CH"}, 
         {"name": "Syrian Arab Republic", "code": "SY"}, 
-        {"name": "Taiwan, Province of China", "code": "TW"}, 
+        {"name": "Taiwan, Republic of China", "code": "TW"}, 
         {"name": "Tajikistan", "code": "TJ"}, 
         {"name": "Tanzania, United Republic of", "code": "TZ"}, 
         {"name": "Thailand", "code": "TH"}, 


### PR DESCRIPTION
Campaign for rectifying the name of Taiwan (R.O.C)