### PR TITLE
Calendar - Specify otherMonth when clicking "Today"

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1909,9 +1909,8 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     
     onTodayButtonClick(event) {
         let date: Date = new Date();
-        let dateMeta = {day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), today: true, selectable: true};
+        let dateMeta = {day: date.getDate(), month: date.getMonth(), year: date.getFullYear(), otherMonth: date.getMonth() !== this.currentMonth || date.getFullYear() !== this.currentYear, today: true, selectable: true};
         
-        this.createMonths(dateMeta.month, dateMeta.year);
         this.onDateSelect(event, dateMeta);
         this.onTodayClick.emit(event);
     }


### PR DESCRIPTION
This resolves `currentMonth` and `currentYear` not being properly updated in `onDateSelect`.

###Defect Fixes
https://stackblitz.com/edit/github-uggfuf-fuzz2b?file=src/app/app.component.html

1) Go forward 2 months `October`
2) Press "Today", you'll be at `August`, control will close
3) Open control, press forward
4) You'll be at `November`. Expected result: `September`

This is because `otherMonth` is undefined when clicking "Today". Only if `otherMonth` is `true` will the model be set properly.

https://github.com/primefaces/primeng/blob/master/src/app/components/calendar/calendar.ts#L724-L732

Also removed createMonths line;
- Not required if `otherMonth` is `false`
- Called in `onDateSelect` when otherMonth is `true`