### PR TITLE
calendar multi date or range picked time changes not applying to the …

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1435,7 +1435,7 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     updateUI() {
         let val = this.value||this.defaultDate||new Date();
         if (Array.isArray(val)){
-            val = val[0];
+            val = val[val.length -1];
         }
 
         this.currentMonth = val.getMonth();


### PR DESCRIPTION
Defect Fixes
#6416

Description
When selectionMode is range and showTime enabled, changes to the time with mouse interaction will not be applied to the backing model which will lead inconsistent behaviour

To Reproduce:
 <p-calendar
   selectionMode="range" 
   [appendTo]="'body' 
   [showTime]="true"     
   [(ngModel)]="value"></p-calendar>
 