### PR TITLE
Allow passing of per-chart plugins

### DIFF
--- a/src/app/components/chart/chart.ts
+++ b/src/app/components/chart/chart.ts
@@ -16,6 +16,8 @@ export class UIChart implements AfterViewInit, OnDestroy {
     @Input() type: string;
 
     @Input() options: any = {};
+
+    @Input() plugins: any[] = [];
     
     @Input() width: string;
     
@@ -69,7 +71,8 @@ export class UIChart implements AfterViewInit, OnDestroy {
         this.chart = new Chart(this.el.nativeElement.children[0].children[0], {
             type: this.type,
             data: this.data,
-            options: this.options
+            options: this.options,
+            plugins: this.plugins
         });
     }
     

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -83,6 +83,12 @@ update(event: Event) &#123;
                     <td>Options to customize the chart.</td>
                 </tr>
                 <tr>
+                    <td>plugins</td>
+                    <td>any[]</td>
+                    <td>null</td>
+                    <td>Array of per-chart plugins to customize the chart behaviour.</td>
+                </tr>
+                <tr>
                     <td>width</td>
                     <td>string</td>
                     <td>null</td>


### PR DESCRIPTION
Chart.js allows (since version 2.5) per chart plugins but Primeng does no allow passign of this parameter. This PR adds input to chart component to allow passing of this parameter to underlying Chart.js object.