### PR TITLE
Add stopPropagation to pRowToggler

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2403,6 +2403,8 @@ export class RowToggler {
 
     @Input() pRowTogglerDisabled: boolean;
 
+    @Input('pStopPropagation') stopPropagation: boolean = false;
+
     constructor(public dt: Table) { }
 
     @HostListener('click', ['$event'])
@@ -2410,6 +2412,10 @@ export class RowToggler {
         if (this.isEnabled()) {
             this.dt.toggleRow(this.data, event);
             event.preventDefault();
+
+            if(this.stopPropagation) {
+                event.stopPropagation();
+            }
         }
     }
 


### PR DESCRIPTION
This pull requests adds stopPropagation to pRowToggler. We have expandable row and use this directive, while we have custom events for table row. We could manually add stop propagation

```
(click)="$event.stopPropagation()"
```
but I find this solution more DRY. Also this is backward compatible.