### PR TITLE
Update overlayPanel and dialog. Emit onHide only if panel/dialog is visible.

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -598,7 +598,9 @@ export class Dialog implements OnDestroy {
     }
 
     onOverlayHide() {
-        this.onHide.emit({});
+        if (this.visible) {
+            this.onHide.emit({});
+        }
         this.unbindGlobalListeners();
         this.dragging = false;
 

--- a/src/app/components/overlaypanel/overlaypanel.ts
+++ b/src/app/components/overlaypanel/overlaypanel.ts
@@ -194,7 +194,9 @@ export class OverlayPanel implements OnDestroy {
     }
 
     onOverlayHide() {
-        this.onHide.emit(null);
+        if (this.visible) {
+            this.onHide.emit(null);
+        }
         this.unbindDocumentClickListener();
         this.unbindDocumentResizeListener();
         this.selfClick = false;


### PR DESCRIPTION
###Defect Fixes
We have a panel on layout, subscription to onHide. Once we navigate to another form, onDestroy is triggered and then onHide is emmited, but it was not supposed to as dialog was not even shown.

###Feature Requests
N/A