### PR TITLE
Added the ability to configure icon classes for a nodes when the component is called.

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -24,7 +24,7 @@ import {BlockableUI} from '../common/blockableui';
                     ><div class="ui-chkbox" *ngIf="tree.selectionMode == 'checkbox' && node.selectable !== false"><div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default">
                         <span class="ui-chkbox-icon ui-clickable pi"
                             [ngClass]="{'pi-check':isSelected(),'pi-minus':node.partialSelected}"></span></div></div
-                    ><span [class]="getIcon()" *ngIf="node.icon||node.expandedIcon||node.collapsedIcon"></span
+                    ><span [class]="getIcon()" *ngIf="isIconShow(node)"></span
                     ><span class="ui-treenode-label ui-corner-all"
                         [ngClass]="{'ui-state-highlight':isSelected()}">
                             <span *ngIf="!tree.getTemplateForNode(node)">{{node.label}}</span>
@@ -61,7 +61,7 @@ import {BlockableUI} from '../common/blockableui';
                                 (touchend)="onNodeTouchEnd()">
                                 <span class="ui-tree-toggler pi pi-fw" [ngClass]="{'pi-plus':!node.expanded,'pi-minus':node.expanded}" *ngIf="!isLeaf()"
                                         (click)="toggle($event)"></span
-                                ><span [class]="getIcon()" *ngIf="node.icon||node.expandedIcon||node.collapsedIcon"></span
+                                ><span [class]="getIcon()" *ngIf="isIconShow(node)"></span
                                 ><span class="ui-treenode-label ui-corner-all">
                                         <span *ngIf="!tree.getTemplateForNode(node)">{{node.label}}</span>
                                         <span *ngIf="tree.getTemplateForNode(node)">
@@ -113,12 +113,27 @@ export class UITreeNode implements OnInit {
     getIcon() {
         let icon: string;
 
-        if(this.node.icon)
-            icon = this.node.icon;
-        else
-            icon = this.node.expanded && this.node.children && this.node.children.length ? this.node.expandedIcon : this.node.collapsedIcon;
+        if(!this.node.children)
+            icon = this.tree.classEndNodeIcon || this.node.icon;
+        else {
+            icon = this.node.expanded 
+                    && this.node.children 
+                    && this.node.children.length 
+                    ? (this.tree.classExpandedIcon || this.node.expandedIcon) 
+                    : (this.tree.classCollapsedIcon || this.node.collapsedIcon);
+        }
 
         return UITreeNode.ICON_CLASS + ' ' + icon;
+    }
+
+    /**
+     * Returns true if you want to display the icon for the node
+     * @param node tree node
+     */
+    isIconShow(node: any): boolean {
+        return (this.tree.classEndNodeIcon || this.node.icon) 
+            || (this.tree.classExpandedIcon || this.node.expandedIcon) 
+            || (this.tree.classCollapsedIcon || this.node.collapsedIcon);
     }
 
     isLeaf() {
@@ -367,6 +382,21 @@ export class Tree implements OnInit,AfterContentInit,OnDestroy,BlockableUI {
     @Input() emptyMessage: string = 'No records found';
 
     @Input() nodeTrackBy: Function = (index: number, item: any) => item;
+
+    /**
+     * Class 0f node expanded 
+     */
+    @Input() classExpandedIcon: string;
+
+    /**
+     * Class of node collapsed  
+     */
+    @Input() classCollapsedIcon: string;
+
+    /**
+     * Class of end node
+     */
+    @Input() classEndNodeIcon: string;
 
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
 

--- a/src/app/showcase/components/tree/treedemo.html
+++ b/src/app/showcase/components/tree/treedemo.html
@@ -82,6 +82,14 @@
     <h3>Horizontal Tree</h3>
     <p-tree [value]="filesTree11" layout="horizontal" selectionMode="single" [(selection)]="selectedFile3" ></p-tree>
     <div style="margin-top:8px">Selected Node: {{selectedFile3 ? selectedFile3.label : 'none'&#125;&#125;</div>
+
+    <h3>Custom classes for icons</h3>
+    <p-tree 
+    [value]="filesTree12"
+    [classEndNodeIcon]="'pi pi-file'"  
+    [classExpandedIcon]="'pi pi-chevron-circle-down'" 
+    [classCollapsedIcon]="'pi pi-chevron-circle-right'" 
+    ></p-tree>
 </div>
 
 <div class="content-section documentation">
@@ -403,7 +411,7 @@ export class TreeDemoComponent implements OnInit &#123;
 
             <h3>Icons</h3>
             <p>Icon of a treenode is defined using the icon property, if you need an icon depending on the expand or collapse state, use
-                expandedIcon and collapsedIcon instead.</p>
+                expandedIcon and collapsedIcon instead. In addition, you can use the classEndNodeIcon classExpandedIcon and classCollapsedIcon properties to customize the classes of icons.</p>
 
             <h3>Templating</h3>
             <p>By default label of a treenode is displayed inside a tree node, in case you need to place custom content define a pTemplate that gets
@@ -597,6 +605,24 @@ import &#123;TreeDragDropService&#125; from 'primeng/api';
                             <td>string</td>
                             <td>null</td>
                             <td>Style class of the component.</td>
+                        </tr>
+                        <tr>
+                            <td>classEndNodeIcon</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Style class of end node.</td>
+                        </tr>
+                        <tr>
+                            <td>classExpandedIcon</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Style class of node expanded.</td>
+                        </tr>
+                        <tr>
+                            <td>classCollapsedIcon</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Style class of node collapsed.</td>
                         </tr>
                         <tr>
                             <td>contextMenu</td>
@@ -840,9 +866,12 @@ import &#123;TreeDragDropService&#125; from 'primeng/api';
 &lt;h3&gt;Horizontal Tree&lt;/h3&gt;
 &lt;p-tree [value]="filesTree11" layout="horizontal" selectionMode="single" [(selection)]="selectedFile3" &gt;&lt;/p-tree&gt;
 &lt;div style="margin-top:8px"&gt;Selected Node: &#123;selectedFile3 ? selectedFile3.label : 'none'&#125;&lt;/div&gt;
+
+
+&lt;h3&gt;Custom classes for icons&lt;/h3&gt;
+&lt;p-tree [value]="filesTree12" [classEndNodeIcon]="&#39;pi pi-file&#39;" [classExpandedIcon]="&#39;pi pi-chevron-circle-down&#39;" [classCollapsedIcon]="&#39;pi pi-chevron-circle-right&#39;" &gt;&lt;/p-tree&gt;
 </code>
 </pre>
-
 <pre>
 <code class="language-typescript" pCode ngNonBindable>
 export class TreeDemo implements OnInit &#123;

--- a/src/app/showcase/components/tree/treedemo.ts
+++ b/src/app/showcase/components/tree/treedemo.ts
@@ -32,6 +32,7 @@ export class TreeDemo implements OnInit {
     filesTree9: TreeNode[];
     filesTree10: TreeNode[];
     filesTree11: TreeNode[];
+    filesTree12: TreeNode[];
     
     lazyFiles: TreeNode[];
     
@@ -89,6 +90,8 @@ export class TreeDemo implements OnInit {
         });
 
         this.nodeService.getLazyFiles().then(files => this.lazyFiles = files);
+
+        this.nodeService.getFiles().then(files => this.filesTree12 = files);
         
         this.items = [
             {label: 'View', icon: 'fa fa-search', command: (event) => this.viewFile(this.selectedFile2)},


### PR DESCRIPTION
When I was creating a Tree on the server with a large number of nodes a problem appeared. To avoid the problem, I had to add the ability to configure icon classes for a node directly into the template when the component is calledIn my opinion, it will separate the logic of the client from the logic of the server, and also it will help to get rid of duplicated properties of classes for a node in the tree data, during nodes creation.
At the same time I could preserve the ability to generate data on the server, including classes for a node. It means that you can keep transmitting data as you used to do before...
But now you can send data like this:
```
{
    "data":
    [
        {
            "label": "Documents",
            "data": "Documents Folder",
            "children": [{
                    "label": "Work",
                    "data": "Work Folder",
                    "children": [{"label": "Expenses.doc", "data": "Expenses Document"}, {"label": "Resume.doc", "data": "Resume Document"}]
                },
                {
                    "label": "Home",
                    "data": "Home Folder",
                    "children": [{"label": "Invoices.txt", "data": "Invoices for this month"}]
                }]
        }
    ]
}
// call
<p-tree 
    [value]="filesTree12"
    [classEndNodeIcon]="'pi pi-file'"  
    [classExpandedIcon]="'pi pi-chevron-circle-down'" 
    [classCollapsedIcon]="'pi pi-chevron-circle-right'" 
    ></p-tree>
```

