### PR TITLE
Add textarea to the exception list on draggin

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2570,7 +2570,11 @@ export class ReorderableColumn implements AfterViewInit, OnDestroy {
     }
 
     onMouseDown(event) {
-        if (event.target.nodeName === 'INPUT' || this.domHandler.hasClass(event.target, 'ui-column-resizer'))
+        if (
+            event.target.nodeName === 'TEXTAREA' ||
+            event.target.nodeName === 'INPUT' || 
+            this.domHandler.hasClass(event.target, 'ui-column-resizer')
+        )
             this.el.nativeElement.draggable = false;
         else
             this.el.nativeElement.draggable = true;


### PR DESCRIPTION
Add possibility to use TEXTAREA instead INPUT when we use drag&drop for column transfer. Now, when we try to highlighted text in the TEXTAREA, the column moves.

There are cases where we can not use INPUT.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.