### PR TITLE
autocomplete accessibility improvement

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -21,7 +21,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             <input *ngIf="!multiple" #in [attr.type]="type" [attr.id]="inputId" [ngStyle]="inputStyle" [class]="inputStyleClass" autocomplete="off" [attr.required]="required"
             [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all ui-autocomplete-input'" [value]="inputFieldValue"
             (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
-            [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled"
+            [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [attr.aria-label]="ariaLabel" [attr.aria-required]="ariaRequired" [readonly]="readonly" [disabled]="disabled"
             ><ul *ngIf="multiple" #multiContainer class="ui-autocomplete-multiple-container ui-widget ui-inputtext ui-state-default ui-corner-all" [ngClass]="{'ui-state-disabled':disabled,'ui-state-focus':focus}" (click)="multiIn.focus()">
                 <li #token *ngFor="let val of value" class="ui-autocomplete-token ui-state-highlight ui-corner-all">
                     <span class="ui-autocomplete-token-icon pi pi-fw pi-times" (click)="removeItem(token)" *ngIf="!disabled"></span>
@@ -135,6 +135,10 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
     @Input() multiple: boolean;
 
     @Input() tabindex: number;
+    
+    @Input() ariaLabel: string;
+     
+    @Input() ariaRequired: boolean;
 
     @Input() dataKey: string;
 


### PR DESCRIPTION
### Defect Fixes
This PR addresses the accessibility improvements outlined in [issue #6565 ](https://github.com/primefaces/primeng/issues/6565).

### Feature Requests
This PR adds "aria-label" and "aria-required" attributes to the autocomplete component. The changes are small, but impactful for visually impaired users with screen readers. This will improve PrimeNG's overall accessibility.

The biggest change made to any of the input components was the addition of the following code to the typescript:

The addition of [attr.aria-label]="ariaLabel" [attr.aria-required]="ariaRequired" to the input element in the template and the addition of @Input() ariaLabel: string; and @Input() ariaRequired: boolean; to the list of inputs.

NOTE - The "required" attribute does a lot of what the "aria-required" attribute does, but the latter is still useful for user agents that do not yet support HTML5.