### PR TITLE
Fix carousel when data is loaded async

### DIFF
--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -74,7 +74,7 @@ export class Carousel implements AfterViewChecked,AfterViewInit,OnDestroy{
         
     public items: any;
     
-    public columns: any;
+    public columns: number = 0;
         
     public page: number;
                     


### PR DESCRIPTION
We discovered that the carousel component is not working when you get the data asynchronously from a service (The previous and next buttons won't do anything).

This is caused by the property 'columns' which is set to NaN if you don't supply data at the components' creation time. Assigning a default value of 0 fixes this issue.
