### PR TITLE
Make frozen width work dynamically

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -86,7 +86,7 @@ export class TableService {
 
             <div class="ui-table-scrollable-wrapper" *ngIf="scrollable">
                <div class="ui-table-scrollable-view ui-table-frozen-view" *ngIf="frozenColumns||frozenBodyTemplate" [pScrollableView]="frozenColumns" [frozen]="true" [ngStyle]="{width: frozenWidth}" [scrollHeight]="scrollHeight"></div>
-               <div class="ui-table-scrollable-view" [pScrollableView]="columns" [frozen]="false" [scrollHeight]="scrollHeight"></div>
+	       <div class="ui-table-scrollable-view" [pScrollableView]="columns" [frozen]="false" [scrollHeight]="scrollHeight" [ngStyle]="{left: frozenWidth, width: 'calc(100% - '+frozenWidth+')'}"></div>
             </div>
             
             <p-paginator [rows]="rows" [first]="first" [totalRecords]="totalRecords" [pageLinkSize]="pageLinks" styleClass="ui-paginator-bottom" [alwaysShow]="alwaysShowPaginator"
@@ -1920,11 +1920,6 @@ export class ScrollableView implements AfterViewInit,OnDestroy,AfterViewChecked 
         if(!this.frozen) {
             if (this.dt.frozenColumns || this.dt.frozenBodyTemplate) {
                 this.domHandler.addClass(this.el.nativeElement, 'ui-table-unfrozen-view');
-            }
-
-            if(this.dt.frozenWidth) {
-                this.el.nativeElement.style.left = this.dt.frozenWidth;
-                this.el.nativeElement.style.width = 'calc(100% - ' + this.dt.frozenWidth + ')';
             }
 
             let frozenView = this.el.nativeElement.previousElementSibling;

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -86,7 +86,7 @@ export class TableService {
 
             <div class="ui-table-scrollable-wrapper" *ngIf="scrollable">
                <div class="ui-table-scrollable-view ui-table-frozen-view" *ngIf="frozenColumns||frozenBodyTemplate" [pScrollableView]="frozenColumns" [frozen]="true" [ngStyle]="{width: frozenWidth}" [scrollHeight]="scrollHeight"></div>
-	       <div class="ui-table-scrollable-view" [pScrollableView]="columns" [frozen]="false" [scrollHeight]="scrollHeight" [ngStyle]="{left: frozenWidth, width: 'calc(100% - '+frozenWidth+')'}"></div>
+               <div class="ui-table-scrollable-view" [pScrollableView]="columns" [frozen]="false" [scrollHeight]="scrollHeight" [ngStyle]="{left: frozenWidth, width: 'calc(100% - '+frozenWidth+')'}"></div>
             </div>
             
             <p-paginator [rows]="rows" [first]="first" [totalRecords]="totalRecords" [pageLinkSize]="pageLinks" styleClass="ui-paginator-bottom" [alwaysShow]="alwaysShowPaginator"


### PR DESCRIPTION
The currently rejected PR had a very large and complex fix. I have created a much simpler one that also works, by removing it from the ngAfterViewInit() and moving it straight to the attributes, which makes changes in the width trigger a re-render.