### PR TITLE
[feat] Add column index for table

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -48,7 +48,12 @@ export class TableService {
         this.totalRecordsSource.next(value);
     }
 
+
     onColumnsChange(columns: any[]) {
+        columns.sort((a, b) => {
+            return (a.index ? a.index : 0) <= (b.index ? b.index : 0) ? -1 : 1;
+        });
+
         this.columnsSource.next(columns);
     }
 }

--- a/src/app/showcase/components/table/tablecoltoggledemo.ts
+++ b/src/app/showcase/components/table/tablecoltoggledemo.ts
@@ -19,10 +19,10 @@ export class TableColToggleDemo implements OnInit {
         this.carService.getCarsSmall().then(cars => this.cars = cars);
 
         this.cols = [
-            { field: 'vin', header: 'Vin' },
-            { field: 'year', header: 'Year' },
-            { field: 'brand', header: 'Brand' },
-            { field: 'color', header: 'Color' }
+            { field: "vin", header: "Vin", index: 0 },
+            { field: "year", header: "Year", index: 1 },
+            { field: "brand", header: "Brand", index: 2 },
+            { field: "color", header: "Color", index: 3 }
         ];
 
         this.selectedColumns = this.cols;


### PR DESCRIPTION
feat added for issue #6675.
The `index` helps you order columns in table, even if you toggle it.