### PR TITLE
Simple typo: added missing ,

### DIFF
--- a/src/app/showcase/components/multiselect/multiselectdemo.html
+++ b/src/app/showcase/components/multiselect/multiselectdemo.html
@@ -67,7 +67,7 @@ export class MyModel &#123;
             &#123;label:'New York', value:&#123;id:1, name: 'New York', code: 'NY'&#125;&#125;,
             &#123;label:'Rome', value:&#123;id:2, name: 'Rome', code: 'RM'&#125;&#125;,
             &#123;label:'London', value:&#123;id:3, name: 'London', code: 'LDN'&#125;&#125;,
-            &#123;label:'Istanbul', value:&#123;id:4, name: 'Istanbul', code: 'IST'&#125;&#125;
+            &#123;label:'Istanbul', value:&#123;id:4, name: 'Istanbul', code: 'IST'&#125;&#125;,
             &#123;label:'Paris', value:&#123;id:5, name: 'Paris', code: 'PRS'&#125;&#125;
         ];
 


### PR DESCRIPTION
This just adds a missing `,` in the example code for MutliSelect.