### PR TITLE
fixed #3684 - Calendars inline with icons overlapping

### DIFF
--- a/src/app/components/calendar/calendar.css
+++ b/src/app/components/calendar/calendar.css
@@ -4,7 +4,7 @@
 }
 
 .ui-calendar .ui-calendar-button {
-    position: absolute;
+    position: relative;
     height: 100%;
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;


### PR DESCRIPTION
ui-calendar-button position changed to relative
