### PR TITLE
fixed #6809 - Documentation typo on MultiSelect

### DIFF
--- a/src/app/showcase/components/multiselect/multiselectdemo.html
+++ b/src/app/showcase/components/multiselect/multiselectdemo.html
@@ -134,8 +134,8 @@ export class MyModel &#123;
 </pre>
 
             <h3>Animation Configuration</h3>
-            <p>Transition of the open and hide animations can be customized using the showTransitionOptions and hideTransitionOptions properties, 
-                example below disables the animations altogether.</p> 
+            <p>Transition of the open and hide animations can be customized using the showTransitionOptions and hideTransitionOptions properties,
+                example below disables the animations altogether.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
 &lt;p-multiSelect [options]="cities" formControlName="selectedCities" [showTransitionOptions]="'0ms'" [hideTransitionOptions]="'0ms'"&gt;&lt;/p-multiSelect&gt;
@@ -221,7 +221,7 @@ export class MyModel &#123;
                             <td>Inline style of the overlay panel.</td>
                         </tr>
                         <tr>
-                            <td>styleClass</td>
+                            <td>panelStyleClass</td>
                             <td>string</td>
                             <td>null</td>
                             <td>Style class of the overlay panel.</td>


### PR DESCRIPTION
Fixed Issue [#6809 - Documentation typo on MultiSelect](https://github.com/primefaces/primeng/issues/6809)

Corrected property name from _styleClass_ to _panelStyleClass_.