### PR TITLE
fixed #6863 - Calendar touchui doesn't close correctly with tab key

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1127,7 +1127,12 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     onInputKeydown(event) {
         this.isKeydown = true;
         if (event.keyCode === 9) {
-            this.overlayVisible = false;
+            if (this.touchUI) {
+                this.disableModality();
+            }
+            else {
+                this.overlayVisible = false;
+            }
         }
     }
     


### PR DESCRIPTION
touchui control added in onInputKeydown.