### PR TITLE
#6803

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -83,12 +83,10 @@ export class DomHandler {
     public relativePosition(element: any, target: any): void {
         let elementDimensions = element.offsetParent ? { width: element.offsetWidth, height: element.offsetHeight } : this.getHiddenElementDimensions(element);
         let targetHeight = target.offsetHeight;
-        let targetWidth = target.offsetWidth;
         let targetOffset = target.getBoundingClientRect();
-        let windowScrollTop = this.getWindowScrollTop();
         let viewport = this.getViewport();
         let top, left;
-        
+
         if ((targetOffset.top + targetHeight + elementDimensions.height) > viewport.height) {
             top = -1 * (elementDimensions.height);
             if(targetOffset.top + top < 0) {
@@ -98,12 +96,13 @@ export class DomHandler {
         else {
             top = targetHeight;
         }
-            
-            
-        if ((targetOffset.left + elementDimensions.width) > viewport.width)
-            left = targetWidth - elementDimensions.width;
-        else
+
+        if ((targetOffset.left + elementDimensions.width) > viewport.width) {
+            left = (targetOffset.left * -1) / 2;
+        }
+        else {
             left = 0;
+        }
 
         element.style.top = top + 'px';
         element.style.left = left + 'px';


### PR DESCRIPTION
Fixes DOM handler moving elements off screen when size is too small and screen has set size (see issue number of example).

![example-of-fix](https://user-images.githubusercontent.com/5766272/48665740-8948eb80-ea79-11e8-8188-0bfd901543cd.png)
