### PR TITLE
Adds 'Closable' Feature to TabMenu

### DIFF
--- a/src/app/components/common/menuitem.ts
+++ b/src/app/components/common/menuitem.ts
@@ -21,4 +21,5 @@ export interface MenuItem {
     title?: string;
     id?: string;
     automationId?: any;
+    closable?: boolean;
 }

--- a/src/app/components/tabmenu/tabmenu.css
+++ b/src/app/components/tabmenu/tabmenu.css
@@ -35,6 +35,13 @@
     vertical-align: middle;
 }
 
+.ui-tabmenu .ui-tabmenu-close {
+    color: #848484;
+    cursor: pointer;
+    margin: 0.5em 0.5em 0 0;
+    vertical-align: -webkit-baseline-middle;
+}
+
 .ui-tabmenu .ui-tabmenu-nav .ui-tabmenuitem.ui-state-disabled a {
      cursor: default;
-} 
+}

--- a/src/app/components/tabmenu/tabmenu.ts
+++ b/src/app/components/tabmenu/tabmenu.ts
@@ -1,4 +1,4 @@
-import {NgModule,Component,ElementRef,Input,Output} from '@angular/core';
+import {NgModule, Component, ElementRef, Input, Output, EventEmitter} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {DomHandler} from '../dom/domhandler';
 import {MenuItem} from '../common/menuitem';
@@ -24,6 +24,7 @@ import {RouterModule} from '@angular/router';
                         <span class="ui-menuitem-icon " [ngClass]="item.icon" *ngIf="item.icon"></span>
                         <span class="ui-menuitem-text">{{item.label}}</span>
                     </a>
+                    <span *ngIf="item.closable" class="ui-tabmenu-close pi pi-times" (click)="clickClose($event,item)"></span>
                 </li>
             </ul>
         </div>
@@ -41,6 +42,10 @@ export class TabMenu {
     @Input() style: any;
 
     @Input() styleClass: string;
+
+    @Input() closable: boolean;
+
+    @Output() onTabCloseClick: EventEmitter<any> = new EventEmitter();
 
     itemClick(event: Event, item: MenuItem) {
         if(item.disabled) {
@@ -60,6 +65,13 @@ export class TabMenu {
         }
 
         this.activeItem = item;
+    }
+
+    clickClose(event, tab: MenuItem) {
+        this.onTabCloseClick.emit({
+            originalEvent: event,
+            tab: tab
+        })
     }
 }
 

--- a/src/app/components/tabmenu/tabmenu.ts
+++ b/src/app/components/tabmenu/tabmenu.ts
@@ -1,4 +1,4 @@
-import {NgModule, Component, ElementRef, Input, Output, EventEmitter} from '@angular/core';
+import {NgModule,Component,ElementRef,Input,Output,EventEmitter} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {DomHandler} from '../dom/domhandler';
 import {MenuItem} from '../common/menuitem';

--- a/src/app/showcase/components/tabmenu/tabmenudemo.html
+++ b/src/app/showcase/components/tabmenu/tabmenudemo.html
@@ -81,6 +81,37 @@ export class TabMenuDemo &#123;
 </code>
 </pre>
 
+            <h3>Closeable Item</h3>
+            <p>TabMenu allows items to be closed, removing them from the menu. To allow specific MenuItems to be closable set the `closeable` property to true within the the menu item and then listen for the `onTabCloseClick` output on the TabMenu.</p>
+            <pre>
+<code class="language-markup" pCode ngNonBindable>
+&lt;p-tabMenu [model]="items" (onTabCloseClick)="tabClosed($event)"&gt;&lt;/p-tabMenu&gt;
+</code>
+</pre>
+
+            <pre>
+<code class="language-typescript" pCode ngNonBindable>
+export class TabMenuDemo &#123;
+
+    items: MenuItem[];
+
+    ngOnInit() &#123;
+        this.items = [
+            &#123;label: 'Stats', icon: 'fa fa-fw fa-bar-chart'&#125;,
+            &#123;label: 'Calendar', icon: 'fa fa-fw fa-calendar', closable="true"&#125;,
+            &#123;label: 'Documentation', icon: 'fa fa-fw fa-book', closable="true"&#125;,
+            &#123;label: 'Support', icon: 'fa fa-fw fa-support'&#125;,
+            &#123;label: 'Social', icon: 'fa fa-fw fa-twitter'&#125;
+        ];
+    &#125;
+
+    tabClosed(event) &#123;
+        // Tab Closed Logic
+    &#125;
+&#125;
+</code>
+</pre>
+
             <h3>Properties</h3>
             <div class="doc-tablewrapper">
                 <table class="doc-table">


### PR DESCRIPTION
Adds a 'closable' feature to the TabMenu API by exposing an input to display the 'close' icon, along with exposing an 'onTabCloseClick' output to allow developers to react to closures. Should fix #3018 if implemented.

Rather than mutating the list of MenuItems, I opted to simply expose an output that would allow developers to determine what kind of "closing" needs they may have. I'd be open to suggestions if this isn't too big of a feature for a non-employee to implement.