### PR TITLE
Add onFilter events for picklist

### DIFF
--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -20,7 +20,7 @@ import {ObjectUtils} from '../utils/objectutils';
             <div class="ui-picklist-listwrapper ui-picklist-source-wrapper" [ngClass]="{'ui-picklist-listwrapper-nocontrols':!showSourceControls}">
                 <div class="ui-picklist-caption ui-widget-header ui-corner-tl ui-corner-tr" *ngIf="sourceHeader">{{sourceHeader}}</div>
                 <div class="ui-picklist-filter-container ui-widget-content" *ngIf="filterBy && showSourceFilter !== false">
-                    <input #sourceFilter type="text" role="textbox" (keyup)="onFilter($event,source,SOURCE_LIST)" class="ui-picklist-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [disabled]="disabled" [attr.placeholder]="sourceFilterPlaceholder">
+                    <input #sourceFilter type="text" role="textbox" (keyup)="onFilter($event,source,SOURCE_LIST,onSourceFilter)" class="ui-picklist-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [disabled]="disabled" [attr.placeholder]="sourceFilterPlaceholder">
                     <span class="ui-picklist-filter-icon pi pi-search"></span>
                 </div>
                 <ul #sourcelist class="ui-widget-content ui-picklist-list ui-picklist-source ui-corner-bottom" [ngClass]="{'ui-picklist-highlight': listHighlightSource}" [ngStyle]="sourceStyle" (dragover)="onListMouseMove($event,SOURCE_LIST)" (dragleave)="onListDragLeave()" (drop)="onListDrop($event, SOURCE_LIST)">
@@ -49,7 +49,7 @@ import {ObjectUtils} from '../utils/objectutils';
             <div class="ui-picklist-listwrapper ui-picklist-target-wrapper" [ngClass]="{'ui-picklist-listwrapper-nocontrols':!showTargetControls}">
                 <div class="ui-picklist-caption ui-widget-header ui-corner-tl ui-corner-tr" *ngIf="targetHeader">{{targetHeader}}</div>
                 <div class="ui-picklist-filter-container ui-widget-content" *ngIf="filterBy && showTargetFilter !== false">
-                    <input #targetFilter type="text" role="textbox" (keyup)="onFilter($event,target,TARGET_LIST)" class="ui-picklist-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [disabled]="disabled" [attr.placeholder]="targetFilterPlaceholder">
+                    <input #targetFilter type="text" role="textbox" (keyup)="onFilter($event,target,TARGET_LIST,onTargetFilter)" class="ui-picklist-filter ui-inputtext ui-widget ui-state-default ui-corner-all" [disabled]="disabled" [attr.placeholder]="targetFilterPlaceholder">
                     <span class="ui-picklist-filter-icon pi pi-search"></span>
                 </div>
                 <ul #targetlist class="ui-widget-content ui-picklist-list ui-picklist-target ui-corner-bottom" [ngClass]="{'ui-picklist-highlight': listHighlightTarget}" [ngStyle]="targetStyle" (dragover)="onListMouseMove($event,TARGET_LIST)" (dragleave)="onListDragLeave()" (drop)="onListDrop($event,TARGET_LIST)">
@@ -142,6 +142,10 @@ export class PickList implements AfterViewChecked,AfterContentInit {
     @Output() onSourceSelect: EventEmitter<any> = new EventEmitter();
 
     @Output() onTargetSelect: EventEmitter<any> = new EventEmitter();
+
+    @Output() onSourceFilter: EventEmitter<any> = new EventEmitter();
+
+    @Output() onTargetFilter: EventEmitter<any> = new EventEmitter();
 
     @ViewChild('sourcelist') listViewSourceChild: ElementRef;
     
@@ -286,15 +290,17 @@ export class PickList implements AfterViewChecked,AfterContentInit {
         this.moveLeft();
     }
     
-    onFilter(event: KeyboardEvent, data: any[], listType: number) {
+    onFilter(event: KeyboardEvent, data: any[], listType: number, callback: EventEmitter<any>) {
         let query = (<HTMLInputElement> event.target).value.trim().toLowerCase();
-        
+
         if(listType === this.SOURCE_LIST)
             this.filterValueSource = query;
         else
             this.filterValueTarget = query;
-                
+
         this.activateFilter(data, listType);
+        
+        callback.emit(query);
     }
     
     activateFilter(data: any[], listType: number) {


### PR DESCRIPTION
###Feature Requests
This is a small feature request, which is hereby also immediately implemented. Due to a need for server-side filtering when using the Prime picklist, I have added event emitters when the text in the text boxes has changed. There are many use cases for these emitters, of which the server-side filtering is only one. Another use case would be to observe the values in the filters to bind another element in the view to it, e.g. to show a message when no items are found, etc. 

Having these event emitters available, I was able to perform server-side filtering in a list of thousands of users, and then select relevant users quickly. Sending all users to the client and using the prime pick list as it was caused huge problems with performance. 