### PR TITLE
Ensures pTooltip is removed from DOM if the element ref is removed.

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -1,4 +1,4 @@
-import { NgModule, Directive, ElementRef, AfterViewInit, OnDestroy, HostBinding, HostListener, Input, NgZone } from '@angular/core';
+import { NgModule, Directive, ElementRef, AfterViewInit, OnDestroy, Input, NgZone } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DomHandler } from '../dom/domhandler';
 
@@ -53,6 +53,8 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     focusListener: Function;
 
     blurListener: Function;
+
+    intervalFn: NodeJS.Timeout;
 
     resizeListener: any;
 
@@ -172,6 +174,17 @@ export class Tooltip implements AfterViewInit, OnDestroy {
             this.domHandler.appendChild(this.container, this.appendTo);
 
         this.container.style.display = 'inline-block';
+
+        this.zone.runOutsideAngular(() => {
+            if (this.intervalFn) {
+                clearInterval(this.intervalFn);
+            }
+            this.intervalFn = setInterval(() => {
+                if (!document.body.contains(this.el.nativeElement)) {
+                    this.remove();
+                }
+            }, 50);
+        });
     }
 
     show() {
@@ -365,6 +378,10 @@ export class Tooltip implements AfterViewInit, OnDestroy {
                 this.domHandler.removeChild(this.container, this.appendTo);
         }
 
+        if (this.intervalFn) {
+            clearInterval(this.intervalFn);
+        }
+        
         this.unbindDocumentResizeListener();
         this.clearTimeouts();
         this.container = null;

--- a/src/app/showcase/components/tooltip/tooltipdemo.html
+++ b/src/app/showcase/components/tooltip/tooltipdemo.html
@@ -9,21 +9,13 @@
     <h3 class="first">Positions</h3>
     <div class="ui-g ui-fluid">
         <div class="ui-g-12 ui-md-3">
-            <input type="text" pInputText pTooltip="Enter your username" placeholder="Right">                
-        </div>
-        <div class="ui-g-12 ui-md-3">
-            <input type="text" pInputText pTooltip="Enter your username" tooltipPosition="top" placeholder="Top">
-        </div>
-        <div class="ui-g-12 ui-md-3">
-            <input type="text" pInputText pTooltip="Enter your username" tooltipPosition="bottom" placeholder="Bottom">
-        </div>
-        <div class="ui-g-12 ui-md-3">
-            <input type="text" pInputText pTooltip="Enter your username" tooltipPosition="left" placeholder="Left">
+            <p-overlayPanel #op1 [appendTo]="'body'" [dismissable]="true">
+                <button type="text" pButton label="Button" pTooltip="Tooltip in overlay on a button"
+                        tooltipPosition="top" (click)="op1.hide($event)"></button>
+            </p-overlayPanel>
+            <button type="text" pButton label="Basic" (click)="op1.show($event)"></button>
         </div>
     </div>
-    
-    <h3>Focus and Blur</h3>
-    <input type="text" pInputText pTooltip="Enter your username" placeholder="Right" tooltipEvent="focus" style="margin-left:.5em">
 </div>
 
 <div class="content-section documentation">

--- a/src/app/showcase/components/tooltip/tooltipdemo.module.ts
+++ b/src/app/showcase/components/tooltip/tooltipdemo.module.ts
@@ -6,6 +6,8 @@ import {TooltipModule} from '../../../components/tooltip/tooltip';
 import {InputTextModule} from '../../../components/inputtext/inputtext';
 import {TabViewModule} from '../../../components/tabview/tabview';
 import {CodeHighlighterModule} from '../../../components/codehighlighter/codehighlighter';
+import { OverlayPanelModule } from 'src/app/components/overlaypanel/overlaypanel';
+import { ButtonModule } from 'src/app/components/button/button';
 
 @NgModule({
 	imports: [
@@ -14,7 +16,9 @@ import {CodeHighlighterModule} from '../../../components/codehighlighter/codehig
         TooltipModule,
         InputTextModule,
         TabViewModule,
-        CodeHighlighterModule
+		CodeHighlighterModule,
+		OverlayPanelModule,
+		ButtonModule
 	],
 	declarations: [
 		TooltipDemo


### PR DESCRIPTION
###Defect Fixes
#6921 - Race condition where the tooltip can persist in the DOM even when the element it's attached to is destroyed.

tooltipdemo.html and tooltipdemo.module.ts should not be merged. I left them in to make it easier for you to test the scenario described in the issue number.

Maybe there's some way to detect changes on 'el' injected in the constructor which would remove the need for the set interval but I haven't found an effective way of doing that.
