### PR TITLE
Add generic SelectItem and TreeNode (fix #2089 and #2876)

### DIFF
--- a/src/app/components/common/selectitem.ts
+++ b/src/app/components/common/selectitem.ts
@@ -1,6 +1,6 @@
-export interface SelectItem {
+export interface SelectItem<T = any> {
     label?: string;
-    value: any;
+    value: T;
     styleClass?: string;
     icon?: string;
     title?: string;

--- a/src/app/components/common/treenode.ts
+++ b/src/app/components/common/treenode.ts
@@ -1,14 +1,14 @@
-export interface TreeNode {
+export interface TreeNode<T = any> {
     label?: string;
-    data?: any;
+    data?: T;
     icon?: any;
     expandedIcon?: any;
     collapsedIcon?: any;
-    children?: TreeNode[];
+    children?: TreeNode<T>[];
     leaf?: boolean;
     expanded?: boolean;
     type?: string;
-    parent?: TreeNode;
+    parent?: TreeNode<T>;
     partialSelected?: boolean;
     styleClass?: string;
     draggable?: boolean;


### PR DESCRIPTION
Issue #2089 was closed with the promise of adding the generic signature when Typescript 2.3 has wider adoption. Given that we're on Angular 7, with Typescript 3.1.x, this should not be a problem any more, and the improvement should be implemented.
I have also incorporated the suggested TreeNode signature improvement proposed on issue #2876.

Also, I'd like to ask: why don't the files have a newline at the end? It dirties the diff with displays like this:
```
diff --git a/src/app/components/common/selectitem.ts b/src/app/components/common/selectitem.ts
index 71123ccd..ad615c36 100644
--- a/src/app/components/common/selectitem.ts
+++ b/src/app/components/common/selectitem.ts
@@ -5,4 +5,4 @@ export interface SelectItem<T = any> {
     icon?: string;
     title?: string;
     disabled?: boolean;
-}
\ No newline at end of file
+}
```
which are kind of pointless. I would incorporate that change in my branch but I want to make sure that there isn't some other technical reason I don't know about for having no newlines at the end of the files.