### PR TITLE
Update steps to include tooltip and autowidth

### DIFF
--- a/src/app/components/steps/steps.ts
+++ b/src/app/components/steps/steps.ts
@@ -8,16 +8,16 @@ import {RouterModule} from '@angular/router';
     template: `
         <div [ngClass]="{'ui-steps ui-widget ui-helper-clearfix':true,'ui-steps-readonly':readonly}" [ngStyle]="style" [class]="styleClass">
             <ul role="tablist">
-                <li *ngFor="let item of model; let i = index" class="ui-steps-item" #menuitem
+                <li *ngFor="let item of model; let i = index" class="ui-steps-item" #menuitem [style.width]="autoWidth ? stepWidth+'%' : auto"
                     [ngClass]="{'ui-state-highlight ui-steps-current':(i === activeIndex),
                         'ui-state-default':(i !== activeIndex),
                         'ui-state-complete':(i < activeIndex),
                         'ui-state-disabled ui-steps-incomplete':item.disabled||(i !== activeIndex && readonly)}">
-                    <a *ngIf="!item.routerLink" [href]="item.url||'#'" class="ui-menuitem-link" (click)="itemClick($event, item, i)" [attr.target]="item.target" [attr.id]="item.id">
+                    <a *ngIf="!item.routerLink" [href]="item.url||'#'" class="ui-menuitem-link" (click)="itemClick($event, item, i)" [attr.target]="item.target" [attr.id]="item.id" [attr.title]="item.title">
                         <span class="ui-steps-number">{{i + 1}}</span>
                         <span class="ui-steps-title">{{item.label}}</span>
                     </a>
-                    <a *ngIf="item.routerLink" [routerLink]="item.routerLink" [queryParams]="item.queryParams" [routerLinkActive]="'ui-state-active'" [routerLinkActiveOptions]="item.routerLinkActiveOptions||{exact:false}" class="ui-menuitem-link" (click)="itemClick($event, item, i)" [attr.target]="item.target" [attr.id]="item.id">
+                    <a *ngIf="item.routerLink" [routerLink]="item.routerLink" [queryParams]="item.queryParams" [routerLinkActive]="'ui-state-active'" [routerLinkActiveOptions]="item.routerLinkActiveOptions||{exact:false}" class="ui-menuitem-link" (click)="itemClick($event, item, i)" [attr.target]="item.target" [attr.id]="item.id" [attr.title]="item.title">
                         <span class="ui-steps-number">{{i + 1}}</span>
                         <span class="ui-steps-title">{{item.label}}</span>
                     </a>
@@ -38,7 +38,13 @@ export class Steps {
         
     @Input() styleClass: string;
     
+    @Input() autoWidth: boolean;
+    
     @Output() activeIndexChange: EventEmitter<any> = new EventEmitter();
+    
+    get stepWidth() {
+      return 100 / this.model.length;
+    }
     
     itemClick(event: Event, item: MenuItem, i: number) {
         if(this.readonly || item.disabled) {


### PR DESCRIPTION
Hi,
For my project I wanted this component to take the full width of the container.
I suggest adding this autoWidth input property to automatically set the same width in % depending on the number of items.
To take the full width of the container, it also needs to be defined on the component, example with 100% : 
[autoWidth]="true" [style.width]="100 + '%'"
If set to false, it will set the li width as auto. If the width is set via css, then the value in css will be used, so your example with 25% will still work. Not sure if there are any side effects. Only tested with Chrome.
I also suggest adding the title element of "a" to use the menu item title property to display a tooltip on the step.
Thanks,
Aurore

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.