### PR TITLE
Use HTTPClient in FileUpload #4945

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -153,7 +153,7 @@ export class FileUpload implements OnInit,AfterViewInit,AfterContentInit,OnDestr
 
     duplicateIEEvent: boolean;  // flag to recognize duplicate onchange event for file input
 
-    constructor(private el: ElementRef, public domHandler: DomHandler, public sanitizer: DomSanitizer, public zone: NgZone, private http: HttpClient){}
+    constructor(private el: ElementRef, public sanitizer: DomSanitizer, public zone: NgZone, private http: HttpClient){}
 
     ngOnInit() {
         this.files = [];

--- a/src/app/showcase/components/fileupload/fileuploaddemo.html
+++ b/src/app/showcase/components/fileupload/fileuploaddemo.html
@@ -311,28 +311,25 @@ myUploader(event) &#123;
                     <tbody>
                         <tr>
                             <td>onBeforeUpload</td>
-                            <td>event.xhr: XmlHttpRequest instance. <br/>
-                                event.formData: FormData object.</td>
+                            <td>event.formData: FormData object.</td>
                             <td>Callback to invoke before file upload begins to customize the request
                                 such as post parameters before the files.</td>
                         </tr>
 						<tr>
                             <td>onBeforeSend</td>
-                            <td>event.xhr: XmlHttpRequest instance. <br/>
-                                event.formData: FormData object.</td>
+                            <td>event.formData: FormData object.</td>
                             <td>Callback to invoke before file send begins to customize the request
                                 such as adding headers.</td>
                         </tr>
                         <tr>
                             <td>onUpload</td>
-                            <td>event.xhr: XmlHttpRequest instance.<br />
-                                event.files: Uploaded files.</td>
+                            <td>event.files: Uploaded files.</td>
                             <td>Callback to invoke when file upload is complete.</td>
                         </tr>
                         <tr>
                             <td>onError</td>
-                            <td>event.xhr: XmlHttpRequest instance.<br />
-                                event.files: Files that are not uploaded.</td>
+                            <td>event.files: Files that are not uploaded.<br />
+                                event.error: Request Error.</td>
                             <td>Callback to invoke if file upload fails.</td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Changed the XHR request to now use the HookpClient of the Angular, so that it is possible to use the interceptors. The onBeforeUpload, onBeforeSend, onUpload and onError events were also changed, in the first 3 events the XHR object was removed, and in the 4 event the request error was added.