### PR TITLE
Multiselect - clear input on filter cross click

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -204,6 +204,8 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     
     @Input() resetFilterOnHide: boolean = false;
     
+    @Input() clearInputOnCross: boolean = false;
+    
     @Input() dropdownIcon: string = 'pi pi-caret-down';
     
     @Input() optionLabel: string;
@@ -540,7 +542,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     }
     
     close(event) {
-        this.hide();
+        this.clearInputOnCross ? this.filterInputChild.nativeElement.value = '' : this.hide();
         event.preventDefault();
         event.stopPropagation();
     }


### PR DESCRIPTION
We have a specific requirement in the multiselect component that when we click the cross at the left hand side, rather than closing the popup, it should just clear the filter input. 

I have added a flag 'clearInputOnCross' which when will be true, will only clear the filter text input and will not close the popup.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.