### PR TITLE
p-calendar with touchUI needed to disableModality

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1992,7 +1992,11 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     onClearButtonClick(event) {
         this.updateModel(null);
         this.updateInputfield();
-        this.hideOverlay();
+        if (this.touchUI) {
+            this.disableModality();
+        } else {
+            this.hideOverlay();
+        }
         this.onClearClick.emit(event);
     }
     
@@ -2000,7 +2004,11 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
         if (!this.documentClickListener) {
             this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
                 if (!this.datepickerClick && this.overlayVisible) {
-                    this.hideOverlay();
+                    if (this.touchUI) {
+                        this.disableModality();
+                    } else {
+                        this.hideOverlay();
+                    }
                 }
 
                 this.datepickerClick = false;

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1129,7 +1129,11 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
             this.showOverlay();
         }
         else {
-            this.hideOverlay();
+            if (this.touchUI) {
+                this.disableModality();
+            } else {
+                this.hideOverlay();
+            }
         }
         
         this.datepickerClick = true;


### PR DESCRIPTION
In the current release the display stays blocked if the Clear-Button is clicked or the user clicks anywhere but the modal window.

This changes should fix the two mentioned problems.