### PR TITLE
removed ngIf condition for selectable === false on ui-chkbox in order…

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -23,7 +23,7 @@ import {BlockableUI} from '../common/blockableui';
                     (keydown)="onKeyDown($event)" [attr.aria-posinset]="this.index + 1" [attr.aria-expanded]="this.node.expanded" [attr.aria-selected]="isSelected()">
                     <span class="ui-tree-toggler pi pi-fw ui-unselectable-text" [ngClass]="{'pi-caret-right':!node.expanded,'pi-caret-down':node.expanded}"
                             (click)="toggle($event)"></span
-                    ><div class="ui-chkbox" *ngIf="tree.selectionMode == 'checkbox' && node.selectable !== false"><div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default">
+                    ><div class="ui-chkbox" *ngIf="tree.selectionMode == 'checkbox'"><div class="ui-chkbox-box ui-widget ui-corner-all ui-state-default">
                         <span class="ui-chkbox-icon ui-clickable pi"
                             [ngClass]="{'pi-check':isSelected(),'pi-minus':node.partialSelected}"></span></div></div
                     ><span [class]="getIcon()" *ngIf="node.icon||node.expandedIcon||node.collapsedIcon"></span


### PR DESCRIPTION
This code seems to have been removed with the 6.0.0 release. Someone already created an issue, but this seems intentional. 

Previously, if a node has the selectable option set to false, an opaque, "disabled" checkbox is displayed. Currently, there is simply an absence of a checkbox.

What is the reasoning behind the change? If the team is not interested in replacing the old functionality, would it be open to adding an option to turn on or off the disabled checkboxes under the "!selectable" condition?

###Defect Fixes
https://github.com/primefaces/primeng/issues/6144
