### PR TITLE
IMP - global filter - now filters with objects inside objects in all the tables

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1171,8 +1171,12 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
                     if (this.filters['global'] && !globalMatch && globalFilterFieldsArray) {
                         for(let j = 0; j < globalFilterFieldsArray.length; j++) {
                             let globalFilterField = globalFilterFieldsArray[j].field||globalFilterFieldsArray[j];
-                            globalMatch = this.filterConstraints[this.filters['global'].matchMode](ObjectUtils.resolveFieldData(this.value[i], globalFilterField), this.filters['global'].value);
-                            
+                            let fieldData = ObjectUtils.resolveFieldData(this.value[i], globalFilterField);
+                            if (globalFilterFieldsArray[j].subfield ) {
+                                fieldData = ObjectUtils.resolveFieldData(fieldData, globalFilterFieldsArray[j].subfield);
+                            }
+                            globalMatch = this.filterConstraints[this.filters['global'].matchMode](
+                                fieldData, this.filters['global'].value);
                             if(globalMatch) {
                                 break;
                             }


### PR DESCRIPTION
###Defect Fixes
When you use the global filter in a table with objects inside an object, the filter doesn't work with the subfields
###Feature Requests
The method is modified to validate if the element of each column is an object that include more objects inside, if the field has subfields, the filter search inside the property of the object aggregated in the general object. Method resolveFieldData with the fix, return the correct property of the subfield.