### PR TITLE
Fixed #7209 - Prevent overlay panel from closing when clicked inside.

### DIFF
--- a/src/app/components/overlaypanel/overlaypanel.spec.ts
+++ b/src/app/components/overlaypanel/overlaypanel.spec.ts
@@ -19,10 +19,10 @@ class TestOverlayPanelComponent {
 }
 
 describe('OverlayPanel', () => {
-  
+
     let overlaypanel: OverlayPanel;
     let fixture: ComponentFixture<TestOverlayPanelComponent>;
-    
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         schemas: [NO_ERRORS_SCHEMA],
@@ -34,7 +34,7 @@ describe('OverlayPanel', () => {
         TestOverlayPanelComponent
       ],
       });
-      
+
       fixture = TestBed.createComponent(TestOverlayPanelComponent);
       overlaypanel = fixture.debugElement.query(By.css('p-overlayPanel')).componentInstance;
     });
@@ -103,6 +103,21 @@ describe('OverlayPanel', () => {
 
       expect(hide).toHaveBeenCalled();
       expect(overlaypanelEl).toBeFalsy();
+    });
+
+    it('should not close on container click', () => {
+      const buttonEl = fixture.debugElement.query(By.css('button')).nativeElement;
+      const hide = spyOn(overlaypanel, 'hide').and.callThrough();
+      const overlaypanelEl = fixture.debugElement.query(By.css('div'));
+      buttonEl.click();
+      fixture.detectChanges();
+
+      const containerChildEl = fixture.debugElement.query(By.css('img')).nativeElement;
+      containerChildEl.click();
+      fixture.detectChanges();
+
+      expect(hide).not.toHaveBeenCalled();
+      expect(overlaypanelEl).toBeTruthy();
     });
 
 });

--- a/src/app/components/overlaypanel/overlaypanel.spec.ts
+++ b/src/app/components/overlaypanel/overlaypanel.spec.ts
@@ -108,10 +108,10 @@ describe('OverlayPanel', () => {
     it('should not close on container click', () => {
       const buttonEl = fixture.debugElement.query(By.css('button')).nativeElement;
       const hide = spyOn(overlaypanel, 'hide').and.callThrough();
-      const overlaypanelEl = fixture.debugElement.query(By.css('div'));
       buttonEl.click();
       fixture.detectChanges();
 
+      const overlaypanelEl = fixture.debugElement.query(By.css('div'));
       const containerChildEl = fixture.debugElement.query(By.css('img')).nativeElement;
       containerChildEl.click();
       fixture.detectChanges();

--- a/src/app/components/overlaypanel/overlaypanel.ts
+++ b/src/app/components/overlaypanel/overlaypanel.ts
@@ -40,13 +40,13 @@ export class OverlayPanel implements OnDestroy {
     @Input() style: any;
 
     @Input() styleClass: string;
-    
+
     @Input() appendTo: any;
 
     @Input() autoZIndex: boolean = true;
-    
+
     @Input() baseZIndex: number = 0;
-    
+
     @Input() showTransitionOptions: string = '225ms ease-out';
 
     @Input() hideTransitionOptions: string = '195ms ease-in';
@@ -54,27 +54,32 @@ export class OverlayPanel implements OnDestroy {
     @Output() onShow: EventEmitter<any> = new EventEmitter();
 
     @Output() onHide: EventEmitter<any> = new EventEmitter();
-    
+
     container: HTMLDivElement;
 
     visible: boolean = false;
 
     documentClickListener: any;
-            
+
     target: any;
-    
+
     willHide: boolean;
-        
+
     documentResizeListener: any;
-    
+
     constructor(public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, private zone: NgZone) {}
-        
+
     bindDocumentClickListener() {
         if (!this.documentClickListener && this.dismissable) {
             this.zone.runOutsideAngular(() => {
                 let documentEvent = DomHandler.isIOS() ? 'touchstart' : 'click';
                 this.documentClickListener = this.renderer.listen('document', documentEvent, (event) => {
-                    if (!this.el.nativeElement.contains(event.target) && this.target !== event.target && !this.target.contains(event.target)) {
+                    if (
+                        !this.el.nativeElement.contains(event.target) &&
+                        !this.container.contains(event.target) &&
+                        this.target !== event.target &&
+                        !this.target.contains(event.target)
+                    ) {
                         this.zone.run(() => {
                             this.hide();
                         });
@@ -85,14 +90,14 @@ export class OverlayPanel implements OnDestroy {
             });
         }
     }
-    
+
     unbindDocumentClickListener() {
         if (this.documentClickListener) {
             this.documentClickListener();
             this.documentClickListener = null;
         }
     }
-    
+
     toggle(event, target?) {
         if (this.visible) {
             this.visible = false;
@@ -175,7 +180,7 @@ export class OverlayPanel implements OnDestroy {
         this.documentResizeListener = this.onWindowResize.bind(this);
         window.addEventListener('resize', this.documentResizeListener);
     }
-    
+
     unbindDocumentResizeListener() {
         if (this.documentResizeListener) {
             window.removeEventListener('resize', this.documentResizeListener);


### PR DESCRIPTION
###Defect Fixes
https://github.com/primefaces/primeng/issues/7209 - Clicks on overlay panel from overlayPanel component when appendTo is set to 'body' are closing the overlay