### PR TITLE
Fix issue #7128 regarding shifted overlays

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -136,7 +136,7 @@ export class DomHandler {
         }
 
         if (targetOffset.left + targetOuterWidth + elementOuterWidth > viewport.width)
-            left = targetOffset.left + windowScrollLeft + targetOuterWidth - elementOuterWidth;
+            left = Math.max(0, targetOffset.left + windowScrollLeft + targetOuterWidth - elementOuterWidth);
         else
             left = targetOffset.left + windowScrollLeft;
 

--- a/src/app/components/overlaypanel/overlaypanel.css
+++ b/src/app/components/overlaypanel/overlaypanel.css
@@ -53,6 +53,20 @@
 	margin-left: -10px;
 }
 
+.ui-overlaypanel-shifted:after, .ui-overlaypanel-shifted:before {
+    left: auto;
+    right: 1.25em;
+    margin-left: auto;
+}
+
+.ui-overlaypanel-shifted:after {
+    margin-right: -8px;
+}
+
+.ui-overlaypanel:before {
+    margin-right: -10px;
+}
+
 .ui-overlaypanel-flipped:after, .ui-overlaypanel-flipped:before {
     bottom: auto;
     top: 100%;

--- a/src/app/components/overlaypanel/overlaypanel.ts
+++ b/src/app/components/overlaypanel/overlaypanel.ts
@@ -147,6 +147,9 @@ export class OverlayPanel implements OnDestroy {
                 if (DomHandler.getOffset(this.container).top < DomHandler.getOffset(this.target).top) {
                     DomHandler.addClass(this.container, 'ui-overlaypanel-flipped');
                 }
+                if (DomHandler.getOffset(this.container).left < DomHandler.getOffset(this.target).left) {
+                    DomHandler.addClass(this.container, 'ui-overlaypanel-shifted');
+                }
                 this.bindDocumentClickListener();
                 this.bindDocumentResizeListener();
             break;

--- a/src/app/components/overlaypanel/overlaypanel.ts
+++ b/src/app/components/overlaypanel/overlaypanel.ts
@@ -147,7 +147,8 @@ export class OverlayPanel implements OnDestroy {
                 if (DomHandler.getOffset(this.container).top < DomHandler.getOffset(this.target).top) {
                     DomHandler.addClass(this.container, 'ui-overlaypanel-flipped');
                 }
-                if (DomHandler.getOffset(this.container).left < DomHandler.getOffset(this.target).left) {
+                if (DomHandler.getOffset(this.container).left < DomHandler.getOffset(this.target).left &&
+                    DomHandler.getOffset(this.container).left > 0) {
                     DomHandler.addClass(this.container, 'ui-overlaypanel-shifted');
                 }
                 this.bindDocumentClickListener();

--- a/src/app/showcase/components/overlaypanel/overlaypaneldemo.html
+++ b/src/app/showcase/components/overlaypanel/overlaypaneldemo.html
@@ -43,28 +43,28 @@
     <p-table [value]="cars2">
         <ng-template pTemplate="header">
             <tr>
-                <th style="width: 4em"></th>
                 <th>Vin</th>
                 <th>Year</th>
                 <th>Brand</th>
                 <th>Color</th>
+                <th style="width: 4em"></th>
             </tr>
         </ng-template>
         <ng-template pTemplate="body" let-car>
             <tr>
-                <td>
-                    <button type="button" pButton (click)="selectCar($event,car,op3)" icon="pi pi-search"></button>
-                </td>
                 <td>{{car.vin}}</td>
                 <td>{{car.year}}</td>
                 <td>{{car.brand}}</td>
                 <td>{{car.color}}</td>
+                <td>
+                    <button type="button" pButton (click)="selectCar($event,car,op3)" icon="pi pi-search"></button>
+                </td>
             </tr>
         </ng-template>
     </p-table>
     
     <p-overlayPanel #op3>
-        <img src="assets/showcase/images/demo/car/{{selectedCar.brand}}.png" *ngIf="selectedCar"/>
+        <img src="assets/showcase/images/demo/car/{{selectedCar.brand}}.png" width="120" height="120" *ngIf="selectedCar"/>
     </p-overlayPanel>
 </div>
 


### PR DESCRIPTION
This PR fixes #7218 and #7220.

The problem was that OverlayPanels on the right side of the screen are automatically shifted to the left side by the DomHandler so that they are not cut off on their right side. This however causes the little triangle on the left side of the panel to point to an empty space or a different element, instead of pointing to the target element. This can be pretty confusing for the user. So in this case, the little triangle should be shifted to the right side. This PR contains three very simple commits:

1. Fix the actual issue by shifting the little triangle to the right if the element is shifted left.
2. Make the demo page show the effect and fix a small issue with the demo.
3. Fix the additional problem that in the case that the panel is wider than the viewport, it will be shifted too much to the left by the DomHandler. It should no go beyond the left side of the viewport. Note that this issue is already covered by the DomHandler for relatively positioned elements. This commit also handles the case of absolutely positioned elements.

You can see the third issue when you make the window with the [OverlayPanel demo](https://www.primefaces.org/primeng/#/overlaypanel) very narrow and then click on the "Basic" button. You only see a small portion of the right side of the image in the panel in this case.