### PR TITLE
Added the prevent open duplicates and prevent duplicates in toast #7219

### DIFF
--- a/src/app/showcase/components/toast/toastdemo.html
+++ b/src/app/showcase/components/toast/toastdemo.html
@@ -8,6 +8,10 @@
 <div class="content-section implementation">
     <p-toast [style]="{marginTop: '80px'}"></p-toast>
 
+    <p-toast [preventOpenDuplicates]="true" key="pod" [style]="{marginTop: '80px'}"></p-toast>
+
+    <p-toast [preventDuplicates]="true" key="pd" [style]="{marginTop: '80px'}"></p-toast>
+
     <p-toast [style]="{marginTop: '80px'}" position="top-left" key="tl"></p-toast>
 
     <p-toast [style]="{marginTop: '80px'}" position="top-center" key="tc"></p-toast>
@@ -52,6 +56,12 @@
 
     <h3>Template</h3>
     <button type="button" pButton (click)="showConfirm()" label="Confirm" class="ui-button-warning"></button>
+
+    <h3>Prevent Open Duplicates</h3>
+    <button type="button" pButton (click)="showWarn('pod')" label="Show" class="ui-button-warning"></button>
+
+    <h3>Prevent Duplicates</h3>
+    <button type="button" pButton (click)="showWarn('pd')" label="Show" class="ui-button-warning"></button>
 </div>
 
 <div class="content-section documentation">
@@ -320,6 +330,18 @@ this.messageService.clear('myKey1');    //clears messages of the first toast onl
                             <td>string</td>
                             <td>250ms ease-in</td>
                             <td>Transition options of the hide animation.</td>
+                        </tr>
+                        <tr>
+                            <td>preventOpenDuplicates</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>It does not add the new message if there is already a toast displayed with the same detail.</td>
+                        </tr>
+                        <tr>
+                            <td>preventDuplicates</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>Displays only once a message with the same detail.</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/app/showcase/components/toast/toastdemo.ts
+++ b/src/app/showcase/components/toast/toastdemo.ts
@@ -33,8 +33,8 @@ export class ToastDemo {
         this.messageService.add({severity:'info', summary: 'Info Message', detail:'PrimeNG rocks'});
     }
 
-    showWarn() {
-        this.messageService.add({severity:'warn', summary: 'Warn Message', detail:'There are unsaved changes'});
+    showWarn(key?: string) {
+        this.messageService.add({key: key, severity:'warn', summary: 'Warn Message', detail:'There are unsaved changes'});
     }
 
     showError() {
@@ -56,6 +56,11 @@ export class ToastDemo {
     showConfirm() {
         this.messageService.clear();
         this.messageService.add({key: 'c', sticky: true, severity:'warn', summary:'Are you sure?', detail:'Confirm to proceed'});
+    }
+
+    showConfirmPreventOpenDuplicate() {
+        this.messageService.clear();
+        this.messageService.add({key: 'pod', sticky: true, severity:'warn', summary:'Are you sure?', detail:'Confirm to proceed'});
     }
 
     showMultiple() {


### PR DESCRIPTION
#7219 
Added the preventOpenDuplicates and preventDuplicates properties. If the first one is true when adding a new message it is not displayed if there is already a toast with the same detailt, when the second property is true all the messages already added are stored in a list and adding a new message is checked if a message with the same detailt already exists in that list, and the message is only displayed if no messages are found.