### PR TITLE
Fix issue 7253 - Autodisplayfirst and Value

### DIFF
--- a/src/app/components/dropdown/dropdown.spec.ts
+++ b/src/app/components/dropdown/dropdown.spec.ts
@@ -229,4 +229,12 @@ describe('Dropdown', () => {
       expect(emptyMesage.nativeElement.textContent).toEqual("No results found");
     }));
 
+    it('should change the value to the first option by default if autoDisplayFirst = true', () => {
+      dropdown.autoDisplayFirst = true;
+      dropdown.options = ['1', '2'];
+      fixture.detectChanges();
+      expect(dropdown.selectedOption).toEqual('1');
+      expect(dropdown.value).toEqual('1');
+    });
+
 });

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -293,6 +293,11 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         let opts = this.optionLabel ? ObjectUtils.generateSelectItems(val, this.optionLabel) : val;
         this._options = opts;
         this.optionsToDisplay = this._options;
+
+        if (this.autoDisplayFirst && this.optionsToDisplay && this.optionsToDisplay.length) {
+            this.value = this.optionsToDisplay[0];
+        }
+
         this.updateSelectedOption(this.value);
         this.optionsChanged = true;
         


### PR DESCRIPTION
###Defect Fixes
Fixes issue 7253 for the Autodisplayfirst setting. 

Issue: When options are set, the `this.value` is passed in, but is empty since it was never selected manually.
https://github.com/primefaces/primeng/issues/7253