### PR TITLE
Spinner: fix readonly binding & tests

### DIFF
--- a/src/app/components/spinner/spinner.spec.ts
+++ b/src/app/components/spinner/spinner.spec.ts
@@ -192,10 +192,9 @@ describe('Spinner', () => {
         expect(inputEl.nativeElement.style.primeng).toEqual("rocks!");
     });
 
-    it('should change inputId placeholder readonly tabindex and required', () => {
+    it('should change inputId placeholder tabindex and required', () => {
         spinner.inputId = "primeng";
         spinner.placeholder = "Primeng ROCKS!";
-        spinner.readonly = true;
         spinner.tabindex = 13;
         spinner.required = true;
         fixture.detectChanges();
@@ -205,7 +204,25 @@ describe('Spinner', () => {
         expect(inputEl.nativeElement.placeholder).toEqual("Primeng ROCKS!");
         expect(inputEl.nativeElement.tabIndex).toEqual(13);
         expect(inputEl.nativeElement.required).toEqual(true);
+    });
+
+    it('should change readonly and disable buttons', () => {
+        spinner.readonly = true;
+        fixture.detectChanges();
+
+        const inputEl = fixture.debugElement.query(By.css('input'));
+        const upButtonEl = fixture.debugElement.query(By.css('.ui-spinner-up'));
+        const downButtonEl = fixture.debugElement.query(By.css('.ui-spinner-down'));
         expect(inputEl.nativeElement.readOnly).toEqual(true);
+        expect(upButtonEl.nativeElement.disabled).toEqual(true);
+        expect(downButtonEl.nativeElement.disabled).toEqual(true);
+
+        spinner.readonly = false;
+        fixture.detectChanges();
+
+        expect(inputEl.nativeElement.readOnly).toEqual(false);
+        expect(upButtonEl.nativeElement.disabled).toEqual(false);
+        expect(downButtonEl.nativeElement.disabled).toEqual(false);
     });
 
     it('should listen onChange onFocus and onBlur', () => {

--- a/src/app/components/spinner/spinner.ts
+++ b/src/app/components/spinner/spinner.ts
@@ -14,14 +14,14 @@ export const SPINNER_VALUE_ACCESSOR: any = {
     template: `
         <span class="ui-spinner ui-widget ui-corner-all">
             <input #inputfield [attr.type]="type" [attr.id]="inputId" [value]="value === 0 ? '0' : value||null" [attr.name]="name"
-            [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [attr.placeholder]="placeholder" [disabled]="disabled" [attr.readonly]="readonly" [attr.required]="required"
+            [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [attr.placeholder]="placeholder" [disabled]="disabled" [readonly]="readonly" [attr.required]="required"
             (keydown)="onInputKeydown($event)" (blur)="onInputBlur($event)" (input)="onInput($event)" (change)="onInputChange($event)" (focus)="onInputFocus($event)"
             [ngStyle]="inputStyle" [class]="inputStyleClass" [ngClass]="'ui-spinner-input ui-inputtext ui-widget ui-state-default ui-corner-all'">
-            <button type="button" [ngClass]="{'ui-spinner-button ui-spinner-up ui-corner-tr ui-button ui-widget ui-state-default':true,'ui-state-disabled':disabled}" [disabled]="disabled" [attr.readonly]="readonly"
+            <button type="button" [ngClass]="{'ui-spinner-button ui-spinner-up ui-corner-tr ui-button ui-widget ui-state-default':true,'ui-state-disabled':disabled}" [disabled]="disabled || readonly"
                 (mouseleave)="onUpButtonMouseleave($event)" (mousedown)="onUpButtonMousedown($event)" (mouseup)="onUpButtonMouseup($event)">
                 <span class="ui-spinner-button-icon pi pi-caret-up ui-clickable"></span>
             </button>
-            <button type="button" [ngClass]="{'ui-spinner-button ui-spinner-down ui-corner-br ui-button ui-widget ui-state-default':true,'ui-state-disabled':disabled}" [disabled]="disabled" [attr.readonly]="readonly"
+            <button type="button" [ngClass]="{'ui-spinner-button ui-spinner-down ui-corner-br ui-button ui-widget ui-state-default':true,'ui-state-disabled':disabled}" [disabled]="disabled || readonly"
                 (mouseleave)="onDownButtonMouseleave($event)" (mousedown)="onDownButtonMousedown($event)" (mouseup)="onDownButtonMouseup($event)">
                 <span class="ui-spinner-button-icon pi pi-caret-down ui-clickable"></span>
             </button>


### PR DESCRIPTION
Use `[readOnly]` rather than `[attr.readonly]` to bind the readonly value, as only the former one results in HtmlInputElement.readOnly to be false when the bound value is false.

Disable the buttons when readonly.

Fix #7262 and #7261