### PR TITLE
Fixed #7161. Autocomplete multiple input clearing entire model

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -331,7 +331,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
             this.onModelChange(value);
         }
 
-        if (value.length === 0) {
+        if (value.length === 0 && !this.multiple) {
            this.hide();
            this.onClear.emit(event);
 	   this.onModelChange(value);


### PR DESCRIPTION
Added a check to the onInput method of the autocomplete to ensure that multiple mode is not active before emitting the model change when the value is an empty string.