### PR TITLE
Fix bug where spinner with min value on blur automatically set the value to min

### DIFF
--- a/src/app/components/spinner/spinner.ts
+++ b/src/app/components/spinner/spinner.ts
@@ -237,7 +237,7 @@ export class Spinner implements OnInit,ControlValueAccessor {
         let value: number;
                 
         if (val.trim() === '') {
-            value = this.min != null ? this.min : null;
+            value = null;
         }
         else {
             if (this.precision)


### PR DESCRIPTION
Fix bug ticket https://github.com/primefaces/primeng/issues/6798 where spinner with min value on blur automatically set the value to min.