### PR TITLE
fix(multiselect): initialize property value, enabling selectionLimit.

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -246,7 +246,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     
     @Output() onPanelHide: EventEmitter<any> = new EventEmitter();
     
-    public value: any[];
+    public value: any[] = [];
     
     public onModelChange: Function = () => {};
     


### PR DESCRIPTION
Add initialization for the property value in multi-select-component, making if-cases to pass/fail as intended in function `onOptionClick`.

###Defect Fixes
#7221 