### PR TITLE
Fix #7389 calendar bindDocumentClickListener in order to avoid flickering.

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -2004,10 +2004,11 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
             this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
-                if (!this.datepickerClick && this.overlayVisible) {
+                if (!this.datepickerClick && !this.focus && this.overlayVisible) {
                     this.hideOverlay();
                 }
 
+                this.focus = false;
                 this.datepickerClick = false;
                 this.cd.detectChanges();
             });


### PR DESCRIPTION
###Defect Fixes
Fix #7389 Nevertheless, I'm not if It was the best solution to avoid flickering on calendar.