### PR TITLE
check if overlay still exists

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -250,9 +250,11 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,C
 
         if (this.highlightOptionChanged) {
             setTimeout(() => {
-                let listItem = DomHandler.findSingle(this.overlay, 'li.ui-state-highlight');
-                if (listItem) {
-                    DomHandler.scrollInView(this.overlay, listItem);
+                if (this.overlay) {
+                    let listItem = DomHandler.findSingle(this.overlay, 'li.ui-state-highlight');
+                    if (listItem) {
+                        DomHandler.scrollInView(this.overlay, listItem);
+                    }
                 }
             }, 1);
             this.highlightOptionChanged = false;


### PR DESCRIPTION
This issue similar to #6259 and fixes in #7182.

but i found that sometime overlay not exists in highlightOptionChanged too. it error like 
`Cannot read property 'querySelector' of null` 