### PR TITLE
check-box: adds viewchild to allow focus on input

### DIFF
--- a/src/app/components/checkbox/checkbox.ts
+++ b/src/app/components/checkbox/checkbox.ts
@@ -53,6 +53,8 @@ export class Checkbox implements ControlValueAccessor {
     
     @Output() onChange: EventEmitter<any> = new EventEmitter();
     
+    @ViewChild('cb') inputViewChild: ElementRef;
+    
     model: any;
     
     onModelChange: Function = () => {};

--- a/src/app/components/checkbox/checkbox.ts
+++ b/src/app/components/checkbox/checkbox.ts
@@ -1,4 +1,4 @@
-import {NgModule,Component,Input,Output,EventEmitter,forwardRef,ChangeDetectorRef} from '@angular/core';
+import {NgModule,Component,Input,Output,ElementRef,EventEmitter,forwardRef,ViewChild,ChangeDetectorRef} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor, FormControl} from '@angular/forms';
 


### PR DESCRIPTION
###Defect Fixes
This PR addresses the accessibility improvements outlined in issue [#7411](https://github.com/primefaces/primeng/issues/7411)

###Feature Requests
This PR adds a viewchild to the checkbox component. This small change can be a benefit for visually impaired users with screen readers by improving how focus on a checkbox input can be programmatically added when a new element is created. This will improve PrimeNG's overall accessibility.