### PR TITLE
closeOnEscape property not working on p-confirmDialog

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -262,7 +262,7 @@ export class ConfirmDialog implements OnDestroy {
         if (this.closeOnEscape && this.closable && !this.documentEscapeListener) {
             this.documentEscapeListener = this.renderer.listen('document', 'keydown', (event) => {
                 if (event.which == 27) {
-                    if (parseInt(this.container.style.zIndex) === DomHandler.zindex && this.visible) {
+                    if (parseInt(this.container.style.zIndex) === (DomHandler.zindex + this.baseZIndex) && this.visible) {
                         this.close(event);
                     }
                 }


### PR DESCRIPTION
###Defect Fixes
This defect is similar to https://github.com/primefaces/primeng/issues/7123 but for confirmDialog.