### PR TITLE
Accessibility: dropdown aria label category

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -75,7 +75,7 @@ export class DropdownItem {
                 <ng-container *ngTemplateOutlet="selectedItemTemplate; context: {$implicit: selectedOption}"></ng-container>
             </label>
             <label [ngClass]="{'ui-dropdown-label ui-inputtext ui-corner-all ui-placeholder':true,'ui-dropdown-label-empty': (placeholder == null || placeholder.length === 0)}" *ngIf="!editable && (label == null)">{{placeholder||'empty'}}</label>
-            <input #editableInput type="text" [attr.aria-label]="selectedOption ? ariaLabelCategory ? ariaLabelCategory + ': ' selectedOption.label : selectedOption.label : ' '" class="ui-dropdown-label ui-inputtext ui-corner-all" *ngIf="editable" [disabled]="disabled" [attr.placeholder]="placeholder"
+            <input #editableInput type="text" [attr.aria-label]="selectedOption ? ariaLabelCategory ? ariaLabelCategory + ': ' + selectedOption.label : selectedOption.label : ' '" class="ui-dropdown-label ui-inputtext ui-corner-all" *ngIf="editable" [disabled]="disabled" [attr.placeholder]="placeholder"
                         (click)="onEditableInputClick($event)" (input)="onEditableInputChange($event)" (focus)="onEditableInputFocus($event)" (blur)="onInputBlur($event)">
             <i class="ui-dropdown-clear-icon pi pi-times" (click)="clear($event)" *ngIf="value != null && showClear && !disabled"></i>
             <div class="ui-dropdown-trigger ui-state-default ui-corner-right">

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -19,7 +19,7 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
     selector: 'p-dropdownItem',
     template: `
         <li (click)="onOptionClick($event)" role="option"
-            [attr.aria-label]="option.label"
+            [attr.aria-label]="ariaLabelCategory ? ariaLabelCategory + ': ' + option.label : option.label"
             [ngStyle]="{'height': itemSize + 'px'}"
             [ngClass]="{'ui-dropdown-item ui-corner-all':true,
                                                 'ui-state-highlight': selected,
@@ -41,6 +41,8 @@ export class DropdownItem {
     @Input() visible: boolean;
 
     @Input() itemSize: number;
+    
+    @Input() ariaLabelCategory: string;
 
     @Input() template: TemplateRef<any>;
 
@@ -73,7 +75,7 @@ export class DropdownItem {
                 <ng-container *ngTemplateOutlet="selectedItemTemplate; context: {$implicit: selectedOption}"></ng-container>
             </label>
             <label [ngClass]="{'ui-dropdown-label ui-inputtext ui-corner-all ui-placeholder':true,'ui-dropdown-label-empty': (placeholder == null || placeholder.length === 0)}" *ngIf="!editable && (label == null)">{{placeholder||'empty'}}</label>
-            <input #editableInput type="text" [attr.aria-label]="selectedOption ? selectedOption.label : ' '" class="ui-dropdown-label ui-inputtext ui-corner-all" *ngIf="editable" [disabled]="disabled" [attr.placeholder]="placeholder"
+            <input #editableInput type="text" [attr.aria-label]="selectedOption ? ariaLabelCategory ? ariaLabelCategory + ': ' selectedOption.label : selectedOption.label : ' '" class="ui-dropdown-label ui-inputtext ui-corner-all" *ngIf="editable" [disabled]="disabled" [attr.placeholder]="placeholder"
                         (click)="onEditableInputClick($event)" (input)="onEditableInputChange($event)" (focus)="onEditableInputFocus($event)" (blur)="onInputBlur($event)">
             <i class="ui-dropdown-clear-icon pi pi-times" (click)="clear($event)" *ngIf="value != null && showClear && !disabled"></i>
             <div class="ui-dropdown-trigger ui-state-default ui-corner-right">
@@ -111,7 +113,7 @@ export class DropdownItem {
                             <ng-template #virtualScrollList>
                                 <cdk-virtual-scroll-viewport #viewport [ngStyle]="{'height': scrollHeight}" [itemSize]="itemSize" *ngIf="virtualScroll && optionsToDisplay && optionsToDisplay.length">
                                     <ng-container *cdkVirtualFor="let option of options; let i = index; let c = count; let f = first; let l = last; let e = even; let o = odd">         
-                                        <p-dropdownItem [option]="option" [selected]="selectedOption == option"
+                                        <p-dropdownItem [option]="option" [selected]="selectedOption == option" [ariaLabelCategory]="ariaLabelCategory"
                                                                    (onClick)="onItemClick($event)"
                                                                    [template]="itemTemplate"></p-dropdownItem>
                                     </ng-container>
@@ -213,6 +215,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     @Input() hideTransitionOptions: string = '195ms ease-in';
 
     @Input() ariaFilterLabel: string;
+    
+    @Input() ariaLabelCategory: string;
     
     @Output() onChange: EventEmitter<any> = new EventEmitter();
     

--- a/src/app/components/paginator/paginator.ts
+++ b/src/app/components/paginator/paginator.ts
@@ -34,7 +34,7 @@ import {SharedModule} from '../common/shared';
                 <span class="ui-paginator-icon pi pi-step-forward"></span>
             </a>
             <p-dropdown [options]="rowsPerPageItems" [(ngModel)]="rows" *ngIf="rowsPerPageOptions" 
-                (onChange)="onRppChange($event)" [appendTo]="dropdownAppendTo"></p-dropdown>
+                (onChange)="onRppChange($event)" [appendTo]="dropdownAppendTo" ariaLabelCategory="Rows per page"></p-dropdown>
             <div class="ui-paginator-right-content" *ngIf="templateRight">
                 <ng-container *ngTemplateOutlet="templateRight; context: {$implicit: paginatorState}"></ng-container>
             </div>


### PR DESCRIPTION
###Defect Fixes
This PR addresses accessibility improvements outlined in [issue #5835](https://github.com/primefaces/primeng/issues/5835), which refers to the drop down, and [issue #6812](https://github.com/primefaces/primeng/issues/6812), which refers to the paginator. This PR focuses on allowing the user to set the category for the aria labels of options in the drop down (as requested in #5835) and setting a default aria label category to clarify the purpose of the paginator dropdown (as requested in #6812)

A separate PR [(#7423)](https://github.com/primefaces/primeng/pull/7423) addresses adding additional accessibility support for the paginator nav buttons.

###Feature Requests
This small PR adds an aria label category to the drop down options, which allows users with screen readers to be better informed about each option's purpose (such as "Rows per page" in the paginator)

PS - If you prefer a function for adding the ': ' in the aria labels rather than nested ternaries, I am happy to make that change.