### PR TITLE
#6445- Allow half star ratings

### DIFF
--- a/src/app/components/rating/rating.css
+++ b/src/app/components/rating/rating.css
@@ -1,3 +1,14 @@
 .ui-rating {
     font-size: 1.25em;
 }
+
+.empty-icon {
+    position: relative;
+    display: inline-block;
+}
+
+.filled-icon {
+    position: absolute;
+    display: inline-block;
+    overflow: hidden;
+}

--- a/src/app/components/rating/rating.spec.ts
+++ b/src/app/components/rating/rating.spec.ts
@@ -63,13 +63,13 @@ describe('Rating', () => {
       rating.iconCancelStyle = {'primeng':'rocks!'};
       fixture.detectChanges();
 
-      const starElements = fixture.debugElement.queryAll(By.css('span'));
+      const starElements = fixture.debugElement.queryAll(By.css('.ui-rating-icon'));
       expect(starElements[0].nativeElement.className).toContain('Primeng Rocks!');
-      expect(starElements[1].nativeElement.className).toContain('icon on');
-      expect(starElements[3].nativeElement.className).toContain('icon off');
+      expect(starElements[1].nativeElement.children[0].children[0].className).toContain('icon on');
+      expect(starElements[3].nativeElement.children[1].className).toContain('icon off');
       expect(starElements[0].nativeElement.style.primeng).toContain('rocks');
-      expect(starElements[1].nativeElement.style.icon).toContain('on');
-      expect(starElements[3].nativeElement.style.icon).toContain('off');
+      expect(starElements[1].nativeElement.children[0].children[0].style.icon).toContain('on');
+      expect(starElements[3].nativeElement.children[1].style.icon).toContain('off');
     });
 
     it('should value 3', () => {

--- a/src/app/showcase/components/rating/ratingdemo.html
+++ b/src/app/showcase/components/rating/ratingdemo.html
@@ -23,6 +23,9 @@
     
     <h3>Custom Icons</h3> 
     <p-rating [ngModel]="val5" iconOnClass="pi pi-circle-on" iconOffClass="pi pi-circle-off" iconCancelClass="pi pi-times"></p-rating>
+
+    <h3>Half Rating {{val6}} (Click icon left side)</h3>
+    <p-rating [(ngModel)]="val6" [halfRating]="true"></p-rating>
 </div>
 
 <div class="content-section documentation">
@@ -90,6 +93,12 @@ export class ModelComponent &#123;
                                     <td>number</td>
                                     <td>5</td>
                                     <td>Number of stars.</td>
+                                </tr>
+                                <tr>
+                                    <td>halfRating</td>
+                                    <td>boolean</td>
+                                    <td>false</td>
+                                    <td>Allows half ratings by clicking on the left side of the icon.</td>
                                 </tr>
                                 <tr>
                                     <td>cancel</td>

--- a/src/app/showcase/components/rating/ratingdemo.ts
+++ b/src/app/showcase/components/rating/ratingdemo.ts
@@ -15,6 +15,8 @@ export class RatingDemo {
     
     val5: number;
 
+    val6: number = 0.5;
+
     msg: string;
 
     handleRate(event) {


### PR DESCRIPTION
#6445 - Allows rating component to do half star ratings. 

I use this for my own personal use for a dashboard, just wanted to share incase anyone else might need it. This has some accessibility issues since you cannot tab on to a half star rating or anything like that. It calcs the half star rating by detecting if you clicked on the first or second half of the icon. I implemented it this way since it seemed like the easiest way for no breaking changes in case someone else wanted to pull it in.