### PR TITLE
Fixed #7324 Text selectedItemsLabel Multiselect

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -676,6 +676,8 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                 let pattern = /{(.*?)}/;
                 if (pattern.test(this.selectedItemsLabel)) {
                     this.valuesAsString = this.selectedItemsLabel.replace(this.selectedItemsLabel.match(pattern)[0], this.value.length + '');
+                } else {
+                    this.valuesAsString = this.selectedItemsLabel;
                 }
             }
         }


### PR DESCRIPTION
Set the visible selected items label to `selectedItemsLabel` parameter in case no occurrences of pattern are found in the selectedItemsLabel string passed by user.

###Defect Fixes
#7324 