### PR TITLE
Update editordemo documention for custom header

### DIFF
--- a/src/app/showcase/components/editor/editordemo.html
+++ b/src/app/showcase/components/editor/editordemo.html
@@ -284,10 +284,10 @@ npm install quill --save
 &lt;h3&gt;Custom Toolbar&lt;/h3&gt;
 &lt;p-editor [(ngModel)]="text2" [style]="&#123;'height':'320px'&#125;"&gt;
     &lt;p-header&gt;
-        &lt;span class="ql-formats"&gt;
-            &lt;button class="ql-bold" aria-label="Bold"&gt;&lt;/button&gt;
-            &lt;button class="ql-italic" aria-label="Italic"&gt;&lt;/button&gt;
-            &lt;button class="ql-underline" aria-label="Underline"&gt;&lt;/button&gt;
+        &lt;span class=&quot;ql-formats&quot;&gt;
+            &lt;button class=&quot;ql-bold&quot; aria-label=&quot;Bold&quot;&gt;&lt;/button&gt;
+            &lt;button class=&quot;ql-italic&quot; aria-label=&quot;Italic&quot;&gt;&lt;/button&gt;
+            &lt;button class=&quot;ql-underline&quot; aria-label=&quot;Underline&quot;&gt;&lt;/button&gt;
         &lt;/span&gt;
     &lt;/p-header&gt;
 &lt;/p-editor&gt;


### PR DESCRIPTION
Example in documentation for custom header was using old Quill template (v0.2.0).
Copied the markup from Source tab.

###Defect Fixes
Incorrect documentation in Editor Demo #7503