### PR TITLE
Possibility to use default message

### DIFF
--- a/src/app/components/common/confirmation.ts
+++ b/src/app/components/common/confirmation.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from '@angular/core';
 
 export interface Confirmation {
-    message: string;
+    message?: string;
     key?: string;
     icon?: string;
     header?: string;


### PR DESCRIPTION
I have included this line of code in my app.component.ts (root). So, i can use confirm dialog in all child components:

`<p-confirmDialog message="Are you sure you want to perform this operation?" header="Confirm"></p-confirmDialog>`

As you can see, i have specified message and header inputs because i want to use them as default values.
But i can not create confirm dialog without specifying 'message' property, because it is required.

So i have to create dialog like this way every time when i want to use default message:

```
this.confirmationService.confirm({
  message: null,
  accept: onAcceptCallback
});
```

Doing it every time i use confirm dialog is annoying.
This looks much better:

```
this.confirmationService.confirm({
  accept: onAcceptCallback
});
```