### PR TITLE
Dialog Movement - Body offset is always 0 in PrimeNG

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -339,8 +339,8 @@ export class DomHandler {
         let rect = el.getBoundingClientRect();
         
         return {
-            top: rect.top + document.body.scrollTop,
-            left: rect.left + document.body.scrollLeft
+            top: rect.top,
+            left: rect.left
         };
     }
 


### PR DESCRIPTION
#5713 fixed moving a dialog out of the view port. This causes a bug with domhandler offset because the PrimeNG document body always returns 0 as the scrollTop and scrollLeft. If you have an app where the body scroll return values for scrollTop and scrollLeft it breaks dragging the dialog on the page once any scrolling has happened.

https://stackblitz.com/edit/github-hsl3wk?file=src/styles.css

Steps (note only shows drag up and down failing):
Open the dialog
Move it around
Scroll down and it will fail to move around
Scroll back up to top and it will move around