### PR TITLE
#7149 Clicking icon in advanced fileupload button does not open filechooser

### DIFF
--- a/src/app/components/fileupload/fileupload.css
+++ b/src/app/components/fileupload/fileupload.css
@@ -77,6 +77,7 @@
     filter: alpha(opacity=0);
     direction: ltr;
     cursor: pointer;
+    z-index: 1;
 }
 
 .ui-fileupload-choose.ui-fileupload-choose-selected input[type=file] {


### PR DESCRIPTION
The icon in the "Choose" button of the advanced fileupload button is
positioned absolute and is defined after the <input type="file">
element, which is also position=absolute.

So when a click is done in the region of the icon, the event is not
recorded on the file upload element, but on the icon and thus swallowed.

The solution is to raise the file element over the other elements via
a z-index style. This is considered to be save, as the button creates
a new stacking context.

The referenced issue was created independend of my analysis, but we
reached the same conclusion.

A sample project demostrating the problem can be found here:

https://github.com/matthiasblaesing/primengupload-icon-insensitive