### PR TITLE
#7669: SortIcon calculates aria text, but does not bind the template to it

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2666,7 +2666,7 @@ export class SortableColumn implements OnInit, OnDestroy {
 @Component({
     selector: 'p-sortIcon',
     template: `
-        <i class="ui-sortable-column-icon pi pi-fw" [ngClass]="{'pi-sort-up': sortOrder === 1, 'pi-sort-down': sortOrder === -1, 'pi-sort': sortOrder === 0}"></i>
+        <i class="ui-sortable-column-icon pi pi-fw" [ngClass]="{'pi-sort-up': sortOrder === 1, 'pi-sort-down': sortOrder === -1, 'pi-sort': sortOrder === 0}" [attr.aria-label]="ariaText"></i>
     `
 })
 export class SortIcon implements OnInit, OnDestroy {


### PR DESCRIPTION
It was noted that sortable tables do not give useful info about the
sort state for blind users. We tried to use the ariaLabel, ariaLabelAsc
and ariaLabelDesc properties, but they did not improve the situation.

Analysis in the inspector showed, that the aria-label attribute is not
updated, as I would expect it to be.

This change binds the calculated SortIcon#ariaText to the templates
aria-label attribute.