### PR TITLE
fixed #6671 - p-Dropdown : ExpressionChangedAfterItHasBeenCheckedErro…

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -255,6 +255,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             this.focused = false;
         
         this._disabled = _disabled;
+        this.cd.detectChanges();
     }
 
     overlay: HTMLDivElement;


### PR DESCRIPTION
…r: Expression has changed after it was checked. Previous value: 'ui-inputwrapper-focus: true'. Current value: 'ui-inputwrapper-focus: false'.
