### PR TITLE
Add filter autoapply for multiselect on options update

### DIFF
--- a/src/app/components/multiselect/multiselect.spec.ts
+++ b/src/app/components/multiselect/multiselect.spec.ts
@@ -419,6 +419,41 @@ describe('MultiSelect', () => {
 		expect(multiselect.visibleOptions.length).toEqual(2);
 	});
 
+	it('should reapply filter on options change', () => {
+		multiselect.options = [
+		{label: 'Audi', value: 'Audi'},
+		{label: 'BMW', value: 'BMW'},
+		{label: 'Fiat', value: 'Fiat'},
+		{label: 'Ford', value: 'Ford'},
+		{label: 'Honda', value: 'Honda'},
+		{label: 'Jaguar', value: 'Jaguar'},
+		{label: 'Mercedes', value: 'Mercedes'},
+		{label: 'Renault', value: 'Renault'},
+		{label: 'VW', value: 'VW'},
+		{label: 'Volvo', value: 'Volvo'}
+		];
+
+		const multiselectEl = fixture.debugElement.children[0].nativeElement;
+		multiselectEl.click();
+		fixture.detectChanges();
+
+		const filterInputEl = fixture.debugElement.query(By.css('.ui-inputtext')).nativeElement;
+		filterInputEl.value = "f";
+		filterInputEl.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+
+		multiselect.options = [
+			{label: 'Toyota', value: 'Toyota'},
+			{label: 'Hyundai', value: 'Hyundai'},
+			{label: 'Nissan', value: 'Nissan'},
+			{label: 'Suzuki', value: 'Suzuki'},
+			{label: 'Ford', value: 'Ford'},
+		];
+		fixture.detectChanges();
+
+		expect(multiselect.visibleOptions.length).toEqual(1);
+	});
+
 	it('should close with close icon and reset filter input', () => {
 		multiselect.options = [
 		{label: 'Audi', value: 'Audi'},

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -297,6 +297,10 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
         this.visibleOptions = opts;
         this._options = opts;
         this.updateLabel();
+
+        if (this.filterValue && this.filterValue.length) {
+            this.activateFilter();
+        }
     }
     
     ngOnInit() {


### PR DESCRIPTION
Filter in p-multiselect is not applied automatically when you update options input property, firstly this brings some inconsistency with p-dropdown where it's applied in that way, secondly filter in p-multiselect persists by default which is why most probably consumer will update an options input array during that time especially if getter is used to map an array.

Please take a look on this example on stackblitz:
https://stackblitz.com/edit/angular-7-master-qg8xbb?file=src%2Fapp%2Fexample.component.ts

The solution is to apply filter, if it is set, on every options property update (as it's done in p-dropdown).