### PR TITLE
Add empty filter message property support for multiselect

### DIFF
--- a/src/app/components/multiselect/multiselect.css
+++ b/src/app/components/multiselect/multiselect.css
@@ -77,6 +77,10 @@
     position: relative;
 }
 
+.ui-multiselect-panel .ui-multiselect-empty-message {
+    padding: .5em;
+} 
+
 .ui-multiselect-panel .ui-multiselect-item .ui-chkbox {
     display: inline-block;
     vertical-align: middle;

--- a/src/app/components/multiselect/multiselect.spec.ts
+++ b/src/app/components/multiselect/multiselect.spec.ts
@@ -449,4 +449,35 @@ describe('MultiSelect', () => {
 
 		expect(fixture.debugElement.query(By.css("div")).nativeElement.className).not.toContain("ui-multiselect-open");
 	});
+
+	it('should display not found message when filter returns 0 results', () => {
+		multiselect.options = [
+			{label: 'Audi', value: 'Audi'},
+			{label: 'BMW', value: 'BMW'},
+			{label: 'Fiat', value: 'Fiat'},
+			{label: 'Ford', value: 'Ford'},
+			{label: 'Honda', value: 'Honda'},
+			{label: 'Jaguar', value: 'Jaguar'},
+			{label: 'Mercedes', value: 'Mercedes'},
+			{label: 'Renault', value: 'Renault'},
+			{label: 'VW', value: 'VW'},
+			{label: 'Volvo', value: 'Volvo'}
+			];
+			const multiselectEl = fixture.debugElement.children[0].nativeElement;
+			multiselectEl.click();
+			fixture.detectChanges();
+	
+			const filterInputEl = fixture.debugElement.query(By.css('.ui-inputtext')).nativeElement;
+			filterInputEl.value = "1";
+			filterInputEl.dispatchEvent(new Event('input'));
+			fixture.detectChanges();
+	
+			const visibleItems = fixture.debugElement.queryAll(By.css('.ui-multiselect-items li'))
+				.filter(el => el.styles.display !== 'none');
+			const emptyMesage = visibleItems[0]; 
+			expect(multiselect.visibleOptions.length).toEqual(0);
+			expect(visibleItems.length).toEqual(1);
+			expect(emptyMesage).toBeTruthy();
+			expect(emptyMesage.nativeElement.textContent).toEqual("No results found");
+	});
 });

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -114,13 +114,14 @@ export class MultiSelectItem {
                             </ng-template>
                         </ng-container>
                         <ng-template #virtualScrollList>
-                            <cdk-virtual-scroll-viewport #viewport [ngStyle]="{'height': scrollHeight}" [itemSize]="itemSize" *ngIf="virtualScroll">
+                            <cdk-virtual-scroll-viewport #viewport [ngStyle]="{'height': scrollHeight}" [itemSize]="itemSize" *ngIf="virtualScroll && visibleOptions && visibleOptions.length">
                                 <ng-container *cdkVirtualFor="let option of visibleOptions; let i = index; let c = count; let f = first; let l = last; let e = even; let o = odd">
                                     <p-multiSelectItem [option]="option" [selected]="isSelected(option.value)" (onClick)="onOptionClick($event)" (onKeydown)="onOptionKeydown($event)" 
                                         [maxSelectionLimitReached]="maxSelectionLimitReached" [visible]="isItemVisible(option)" [template]="itemTemplate" [itemSize]="itemSize"></p-multiSelectItem>
                                 </ng-container>
                             </cdk-virtual-scroll-viewport>
                         </ng-template>
+                        <li *ngIf="filter && visibleOptions && visibleOptions.length === 0" class="ui-multiselect-empty-message">{{emptyFilterMessage}}</li>
                     </ul>
                 </div>
                 <div class="ui-multiselect-footer ui-widget-content" *ngIf="footerFacet">
@@ -201,6 +202,8 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     @Input() selectedItemsLabel: string = '{0} items selected';
     
     @Input() showToggleAll: boolean = true;
+    
+    @Input() emptyFilterMessage: string = 'No results found';
     
     @Input() resetFilterOnHide: boolean = false;
     

--- a/src/app/showcase/components/multiselect/multiselectdemo.html
+++ b/src/app/showcase/components/multiselect/multiselectdemo.html
@@ -345,6 +345,12 @@ export class MyModel &#123;
                             <td>Icon class of the dropdown icon.</td>
                         </tr>
                         <tr>
+                            <td>emptyFilterMessage</td>
+                            <td>string</td>
+                            <td>No results found</td>
+                            <td>Text to display when filtering does not return any results.</td>
+                        </tr>
+                        <tr>
                             <td>showHeader</td>
                             <td>boolean</td>
                             <td>true</td>


### PR DESCRIPTION
When filter in p-multiselect returns 0 results there are no empty filter message, on the other hand p-dropdown has this functionality. So in this PR I've added filter no results message support similar to what p-dropdown has.