### PR TITLE
Fix chart.js and quill library imports

### DIFF
--- a/src/app/components/chart/chart.ts
+++ b/src/app/components/chart/chart.ts
@@ -1,6 +1,6 @@
 import {NgModule,Component,ElementRef,AfterViewInit,OnDestroy,Input,Output,EventEmitter} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import Chart from 'chart.js';
+import * as Chart from 'chart.js';
 
 @Component({
     selector: 'p-chart',

--- a/src/app/components/editor/editor.ts
+++ b/src/app/components/editor/editor.ts
@@ -3,7 +3,7 @@ import {CommonModule} from '@angular/common';
 import {SharedModule,Header} from '../common/shared'
 import {DomHandler} from '../dom/domhandler';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
-import Quill from "quill";
+import * as Quill from "quill";
 
 export const EDITOR_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,


### PR DESCRIPTION
###Defect Fixes
When importing primeng/chart, the chart component fails with error: `chart_js_1.default is not a constructor`
This was caused by commit 8fddfcba75702adf60c23342448fb80961ab1a78

