### PR TITLE
calendar should be able to read date from array of strings fixes #7758

### DIFF
--- a/src/app/components/calendar/calendar.spec.ts
+++ b/src/app/components/calendar/calendar.spec.ts
@@ -1962,4 +1962,15 @@ describe('Calendar', () => {
       expect(calendar.currentMinute).toEqual(10);
       expect(calendar.pm).toEqual(false);
     });
+
+    it('should read dates correctly when provided in array', () => {
+        calendar.dataType = 'string';
+        calendar.selectionMode = 'range';
+        fixture.detectChanges();
+        calendar.writeValue(['08/08/2008', '08/09/2008']);
+        fixture.detectChanges();
+
+        expect(calendar.value[0]).toEqual(new Date('08/08/2008'));
+        expect(calendar.value[1]).toEqual(new Date('08/09/2008'));
+    });
 });

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1688,8 +1688,18 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
 
     writeValue(value: any) : void {
         this.value = value;
-        if (this.value && typeof this.value === 'string') {
-            this.value = this.parseValueFromString(this.value);
+        if (this.value) {
+            if(typeof this.value === 'string') {
+                this.value = this.parseValueFromString(this.value);
+            } else if(Array.isArray(this.value)) {
+                this.value = this.value.map(v => {
+                    if(typeof v === 'string') {
+                        return v && v.trim().length!==0 && this.parseDateTime(v);
+                    } else {
+                        return v;
+                    }
+                });
+            }
         }
 
         this.updateInputfield();


### PR DESCRIPTION
calendar should be able to read date from array of strings, specially since dataType='string' returns and array of string so that [(ngModel)] input and output are consistent with each other. fixes #7758

This fix doesn't break backward compatibility and still allows to provide input as string when dataType = date. for cleaner code and consitency between ngModel and onNgModelChange, we suggest some small refactoring that takes dataType intoAccount to check whether to parse or not instead of checking the value type equal to string.
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.