### PR TITLE
Fix textarea floating label in Firefox

### DIFF
--- a/src/app/components/inputtext/inputtext.css
+++ b/src/app/components/inputtext/inputtext.css
@@ -103,7 +103,9 @@
 .ui-float-label > input:focus ~ label,
 .ui-float-label > input.ui-state-filled ~ label,
 .ui-float-label > .ui-inputwrapper-focus ~ label,
-.ui-float-label > .ui-inputwrapper-filled ~ label {
+.ui-float-label > .ui-inputwrapper-filled ~ label,
+.ui-float-label>textarea:focus~label,
+.ui-float-label>textarea.ui-state-filled~label {
   top:-.75em;
   font-size:12px;
 }


### PR DESCRIPTION
Closes #6957

###Defect Fixes
See #6957 - the floating label does not work in Firefox.  This applies the same style that is applied to input to textarea.