### PR TITLE
#7357 add onClickOutside output to calendar

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -330,6 +330,8 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     
     @Output() onYearChange: EventEmitter<any> = new EventEmitter();
     
+    @Output() onClickOutside: EventEmitter<any> = new EventEmitter();
+    
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
     
     _locale: LocaleSettings = {
@@ -2051,6 +2053,7 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
             this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
                 if (this.isOutsideClicked(event) && this.overlayVisible) {
                     this.hideOverlay();
+                    this.onClickOutside.emit(event);
                 }
 
                 this.cd.detectChanges();


### PR DESCRIPTION
Add new output to avoid onBlur being fired on datepicker click

###Defect Fixes
This PR should improve behavior described in #7357. 
`onClickOutside()` output is added to help understand whether user has finished working with calendar and clicked anywhere outside of calendar template, `onClickOutside()` can be used instead of `onBlur()` output in case calendar with `datepicker` (not inline) is used, 
