### PR TITLE
Fixes #7841: When forceSelection is true, change model to null instead of empty string

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -347,7 +347,10 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,O
         if (value.length === 0 && !this.multiple) {
            this.hide();
            this.onClear.emit(event);
-	   this.onModelChange(value);
+           if (this.forceSelection)
+               this.onModelChange(null);
+           else
+               this.onModelChange(value);
         }
 
         if (value.length >= this.minLength) {


### PR DESCRIPTION
Fixes #7841: When using autocomplete with forceSelection=true, sets the model to null instead of empty string when the user clears the input field. 
The old behaviour, setting to an empty string, can cause problems if the value of the field is to be submitted to a server.