### PR TITLE
Fix closing tag for input switch

### DIFF
--- a/src/app/showcase/components/inputswitch/inputswitchdemo.html
+++ b/src/app/showcase/components/inputswitch/inputswitchdemo.html
@@ -142,7 +142,7 @@ export class ModelComponent &#123;
 
 <pre>
 <code class="language-markup" pCode ngNonBindable>
-&lt;p-inputSwitch (onChange)="handleChange($event)" [(ngModel)]="val"&gt;
+&lt;p-inputSwitch (onChange)="handleChange($event)" [(ngModel)]="val"&gt;&lt;/p-inputSwitch&gt;
 </code>
 </pre>
  <pre>


### PR DESCRIPTION
Missing closing tag in documentation  for input switch

![image](https://user-images.githubusercontent.com/9201481/61362924-cc768b00-a8a2-11e9-990e-251e714f7990.png)
