### PR TITLE
Fix #7965 BlockUI won't call block() in the blocked setter

### DIFF
--- a/src/app/components/blockui/blockui.ts
+++ b/src/app/components/blockui/blockui.ts
@@ -18,7 +18,7 @@ export class BlockUI implements AfterViewInit,OnDestroy {
     
     @Input() baseZIndex: number = 0;
     
-    @ViewChild('mask', { static: false }) mask: ElementRef;
+    @ViewChild('mask', { static: true }) mask: ElementRef;
     
     _blocked: boolean;
         


### PR DESCRIPTION
Mark the `static` value as true to resolve query before change detection runs, then the `block()` will be called in `blocked` setter correctly.