### PR TITLE
InputMask - updated host binding for ui-inputwrapper-focus

### DIFF
--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -45,7 +45,7 @@ export const INPUTMASK_VALUE_ACCESSOR: any = {
         (input)="onInputChange($event)" (paste)="handleInputChange($event)">`,
     host: {
         '[class.ui-inputwrapper-filled]': 'filled',
-        '[class.ui-inputwrapper-focus]': 'focus'
+        '[class.ui-inputwrapper-focus]': 'focused'
     },
     providers: [INPUTMASK_VALUE_ACCESSOR]
 })


### PR DESCRIPTION
###Defect Fixes
[#8032 InputMask always setting class ui-inputwrapper-focus](https://github.com/primefaces/primeng/issues/8032) 
