### PR TITLE
#8046 Table cell editor not switching correctly with OnPush

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1586,6 +1586,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
                     this.editingCellField = null;
                     this.editingCellData = null;
                     this.unbindDocumentEditListener();
+                    this.cd.markForCheck();
                 }
 
                 this.editingCellClick = false;


### PR DESCRIPTION
### Code fix
For #8046  - Table cell editor not switching correctly from input to output with OnPush