### PR TITLE
fix #8077: sub menu of p-contextMenu in p-table go off screen

### DIFF
--- a/src/app/components/contextmenu/contextmenu.ts
+++ b/src/app/components/contextmenu/contextmenu.ts
@@ -108,9 +108,11 @@ export class ContextMenuSub {
 
         if ((parseInt(this.containerOffset.top) + itemOuterHeight + sublistHeight) > (viewport.height - DomHandler.calculateScrollbarHeight())) {
             sublist.style.bottom = '0px';
+            sublist.style.top = '';
         }
         else {
             sublist.style.top = '0px';
+            sublist.style.bottom = '';
         }
 
         if ((parseInt(this.containerOffset.left) + itemOuterWidth + sublistWidth) > (viewport.width - DomHandler.calculateScrollbarWidth())) {


### PR DESCRIPTION
for p-table with p-contextMenu that contains a sub menu attached to it, right click on center of table and then on bottom of screen, sub menu style is broken and position is wrong. see https://github.com/primefaces/primeng/issues/8077 for detail.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.