### PR TITLE
Add contains any filter

### DIFF
--- a/src/app/components/utils/filterutils.spec.ts
+++ b/src/app/components/utils/filterutils.spec.ts
@@ -70,6 +70,29 @@ describe('FilterUtils Suite', () => {
         expect(FilterUtils.notEquals(null,"brand")).toBeTruthy();
     });
 
+    it('Should filter by in', () => {
+        let filteredValue = FilterUtils.filter(data, ['brand'], ['BMW', 'Jaguar', 'Subaru'], 'in');
+        expect(filteredValue.length).toEqual(2);
+        filteredValue = FilterUtils.filter(data, ['brand'], undefined, 'in');
+        expect(filteredValue.length).toEqual(10);
+        filteredValue = FilterUtils.filter(data, ['brand'], null, 'in');
+        expect(filteredValue.length).toEqual(10);
+        filteredValue = FilterUtils.filter(data, ['brand'], [], 'in');
+        expect(filteredValue.length).toEqual(10);
+        filteredValue = FilterUtils.filter(data, ['brand'], ['Kia'], 'in');
+        expect(filteredValue.length).toEqual(0);
+        expect(FilterUtils.in('Test', ['Some', 'Allowed', 'Test', 'Values'])).toBe(true);
+        expect(FilterUtils.in(undefined, [new Date('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(false);
+        expect(FilterUtils.in(null, [new Date('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(false);
+        expect(FilterUtils.in('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)', undefined)).toBe(true);
+        expect(FilterUtils.in('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)', null)).toBe(true);
+        expect(FilterUtils.in('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)', [])).toBe(true);
+        expect(FilterUtils.in('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)', [])).toBe(true);
+        expect(FilterUtils.in(new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)'), [new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(true);
+        expect(FilterUtils.in(new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)'), [new Date('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(false);
+        expect(FilterUtils.in(new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)'), [new Date('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)'), new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(true);
+    });
+
     it('Should filter by lt', () => {
         let filteredValue = FilterUtils.filter(timeData,['date'],'Tue Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)','lt');
         expect(filteredValue.length).toEqual(1);

--- a/src/app/components/utils/filterutils.spec.ts
+++ b/src/app/components/utils/filterutils.spec.ts
@@ -3,16 +3,16 @@ import { FilterUtils } from './filterutils';
 describe('FilterUtils Suite', () => {
 
     let data: any = [
-        {brand: "VW", year: 2012, color: {name:"Orange"}, vin: "dsad231ff"},
-        {brand: "Audi", year: 2011, color: {name:"Black"}, vin: "gwregre345"},
-        {brand: "Renault", year: 2005, color: {name:"Black"}, vin: "h354htr"},
-        {brand: "BMW", year: 2003, color: {name:"Blue"}, vin: "j6w54qgh"},
-        {brand: "Mercedes", year: 1995, color: {name:"Red"}, vin: "hrtwy34"},
-        {brand: "Volvo", year: 2005, color: {name:"Orange"}, vin: "jejtyj"},
-        {brand: "Honda", year: 2012, color: {name:"Blue"}, vin: "g43gr"},
-        {brand: "Jaguar", year: 2013,color: {name:"Black"}, vin: "greg34"},
-        {brand: "Ford", year: 2000, color: {name:"White"}, vin: "h54hw5"},
-        {brand: "Fiat", year: 2013, color: {name:"Yellow"}, vin: "245t2s"}
+        {brand: "VW", year: 2012, color: {name:"Orange"}, vin: "dsad231ff", dealers: ['Philadelphia', 'Boston']},
+        {brand: "Audi", year: 2011, color: {name:"Black"}, vin: "gwregre345", dealers: ['Philadelphia']},
+        {brand: "Renault", year: 2005, color: {name:"Black"}, vin: "h354htr", dealers: ['New York', 'Chicago']},
+        {brand: "BMW", year: 2003, color: {name:"Blue"}, vin: "j6w54qgh", dealers: ['Dallas']},
+        {brand: "Mercedes", year: 1995, color: {name:"Red"}, vin: "hrtwy34", dealers: []},
+        {brand: "Volvo", year: 2005, color: {name:"Orange"}, vin: "jejtyj", dealers: []},
+        {brand: "Honda", year: 2012, color: {name:"Blue"}, vin: "g43gr" , dealers: ['Baltimore', 'Denver']},
+        {brand: "Jaguar", year: 2013,color: {name:"Black"}, vin: "greg34", dealers: ['Denver', 'Washington']},
+        {brand: "Ford", year: 2000, color: {name:"White"}, vin: "h54hw5", dealers: []},
+        {brand: "Fiat", year: 2013, color: {name:"Yellow"}, vin: "245t2s", dealers: ['Portland']}
     ];
     let timeData  = [
         {date:'Tue Aug 04 2019 00:00:00 GMT+0300 (GMT+03:00)'},
@@ -91,6 +91,25 @@ describe('FilterUtils Suite', () => {
         expect(FilterUtils.in(new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)'), [new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(true);
         expect(FilterUtils.in(new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)'), [new Date('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(false);
         expect(FilterUtils.in(new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)'), [new Date('Mon Aug 05 2019 00:00:00 GMT+0300 (GMT+03:00)'), new Date('Tue Aug 06 2019 00:00:00 GMT+0300 (GMT+03:00)')])).toBe(true);
+    });
+
+    it('Should filter by containsAny', () => {
+        let filteredValue = FilterUtils.filter(data, ['dealers'], ['Denver', 'Philadelphia'], 'containsAny');
+        expect(filteredValue.length).toEqual(4);
+        filteredValue = FilterUtils.filter(data, ['dealers'], ['Lima', 'Santiago'], 'containsAny');
+        expect(filteredValue.length).toEqual(0);
+        filteredValue = FilterUtils.filter(data, ['dealers'], [], 'containsAny');
+        expect(filteredValue.length).toEqual(10);
+        filteredValue = FilterUtils.filter(data, [], ['Dallas'], 'containsAny');
+        expect(filteredValue.length).toEqual(0);
+        expect(FilterUtils.containsAny(['A', 'Test'], undefined)).toBe(true);
+        expect(FilterUtils.containsAny(['A', 'Test'], null)).toBe(true);
+        expect(FilterUtils.containsAny(['A', 'Test'], [])).toBe(true);
+        expect(FilterUtils.containsAny(undefined, ['Value'])).toBe(false);
+        expect(FilterUtils.containsAny(null, ['Value'])).toBe(false);
+        expect(FilterUtils.containsAny([], ['Value'])).toBe(false);
+        expect(FilterUtils.containsAny(['A', 'Test'], ['Some', 'Allowed', 'Test', 'Values'])).toBe(true);
+        expect(FilterUtils.containsAny(['One', 'Two'], ['Three', 'Four'])).toBe(false);
     });
 
     it('Should filter by lt', () => {

--- a/src/app/components/utils/filterutils.ts
+++ b/src/app/components/utils/filterutils.ts
@@ -17,9 +17,16 @@ export class FilterUtils {
         if (value) {
             for (let item of value) {
                 for (let field of fields) {
-                    let fieldValue = ObjectUtils.removeAccents(String(ObjectUtils.resolveFieldData(item, field))).toLowerCase();
+                    const fieldValue = ObjectUtils.resolveFieldData(item, field);
+                    let sanitizedFieldValue = fieldValue;
 
-                    if (FilterUtils[filterMatchMode](fieldValue,sanitizedFilterText)) {
+                    if (Object.prototype.toString.call(fieldValue) === '[object Array]') {
+                        sanitizedFieldValue = (fieldValue as any[]).map(x => this.sanitizeForFiltering(String(x)));
+                    } else {
+                        sanitizedFieldValue = this.sanitizeForFiltering(String(fieldValue));
+                    }
+
+                    if (FilterUtils[filterMatchMode](sanitizedFieldValue, sanitizedFilterText)) {
                         filteredItems.push(item);
                         break;
                     }
@@ -126,6 +133,24 @@ export class FilterUtils {
 
         for (let i = 0; i < filter.length; i++) {
             if (filter[i] === value || (value.getTime && filter[i].getTime && value.getTime() === filter[i].getTime())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static containsAny(values: any[], filters: any[]): boolean {
+        if (filters === undefined || filters === null || filters.length === 0) {
+            return true;
+        }
+
+        if (values === undefined || values === null || values.length === 0) {
+            return false;
+        }
+
+        for (const value of values) {
+            if (this.in(value, filters)) {
                 return true;
             }
         }

--- a/src/app/showcase/components/table/tabledemo.html
+++ b/src/app/showcase/components/table/tabledemo.html
@@ -835,7 +835,7 @@ export class CustomTableSortDemo implements OnInit &#123;
 
             <h3>Filtering</h3>
             <p>Filtering is enabled by defining the filter and calling filter method on the local template variable of the table with value, column field and match mode parameters. Available match modes are
-            "startsWith", "contains", "endsWith", "equals", "notEquals", "in", "lt", "lte", "gt" and "gte". Following is an example that utilizes various PrimeNG form components as filters.</p>
+            "startsWith", "contains", "endsWith", "equals", "notEquals", "in", "containsAny", "lt", "lte", "gt" and "gte". Following is an example that utilizes various PrimeNG form components as filters.</p>
 
             <p>An optional global filter feature is available to search all fields with the same query, to enable this place an input component and call the filterGlobal function with value and match mode properties on your event of choice.</p>
 <pre>

--- a/src/app/showcase/components/treetable/treetabledemo.html
+++ b/src/app/showcase/components/treetable/treetabledemo.html
@@ -908,7 +908,7 @@ export class TreeTableSortDemo implements OnInit &#123;
 
             <h3>Filtering</h3>
             <p>Filtering is enabled by defining the filter elements and calling filter method on the local template variable of the table with value, column field and match mode parameters. Available match modes are
-            "startsWith", "contains", "endsWith", "equals", "notEquals", "in", "lt", "lte", "gt" and "gte".</p>
+            "startsWith", "contains", "endsWith", "equals", "notEquals", "in", "containsAny", "lt", "lte", "gt" and "gte".</p>
 
             <p>An optional global filter feature is available to search all fields with the same query, to enable this place an input component and call the filterGlobal function with value and match mode properties on your event of choice.</p>
 


### PR DESCRIPTION
### Feature Requests
We're using a PrimeNG Table to display data with a column type that is an array. We display the values as a pipe-delimited string inside each cell. We would like to filter the grid using a multi-select and show only rows that contain any of the selected filters inside the array column. Right now, the `in` filter type only works for a single cell value. This pull request adds a new `containsAny` filter type that searches an array for any matching filter value.