### PR TITLE
Fixed #6901 Turbotable export creates file with UTF-8-BOM instead of …

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1337,7 +1337,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
     public exportCSV(options?: any) {
         let data = this.filteredValue || this.value;
-        let csv = '\ufeff';
+        let csv = '';
 
         if (options && options.selectionOnly) {
             data = this.selection || [];


### PR DESCRIPTION
…UTF-8
Fixed #6901 