### PR TITLE
Fixed #6757 TurboTable responsive with colgroup breaks column width

### DIFF
--- a/src/app/components/table/table.css
+++ b/src/app/components/table/table.css
@@ -159,6 +159,10 @@
         display: none !important;
     }
 
+    .ui-table-responsive colgroup {
+        display: none !important;
+    }
+
     .ui-table-responsive .ui-table-tbody > tr > td {
         text-align: left;
         display: block;


### PR DESCRIPTION
Fixed #6757