### PR TITLE
onItemClick event for Breadcrumb

### DIFF
--- a/src/app/components/breadcrumb/breadcrumb.ts
+++ b/src/app/components/breadcrumb/breadcrumb.ts
@@ -1,4 +1,4 @@
-import {NgModule,Component,Input} from '@angular/core';
+import {NgModule,Component,Input,Output,EventEmitter} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import {MenuItem} from '../common/menuitem';
 import {Location} from '@angular/common';
@@ -48,6 +48,8 @@ export class Breadcrumb {
     @Input() styleClass: string;
     
     @Input() home: MenuItem;
+
+    @Output() selectItem: EventEmitter<any> = new EventEmitter<any>();
         
     itemClick(event, item: MenuItem) {
         if (item.disabled) {
@@ -65,6 +67,8 @@ export class Breadcrumb {
                 item: item
             });
         }
+
+        this.selectItem.emit({item: item, originalEvent: event});
     }
     
     onHomeClick(event) {


### PR DESCRIPTION
`item.command` seems inappropriate to pass to the component and use. If a hook is provided, then the consumer can do whatever he wishes to do.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.