### PR TITLE
Autocomplete virtual scroll

### DIFF
--- a/src/app/components/autocomplete/autocomplete.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.spec.ts
@@ -1,11 +1,12 @@
 import { TestBed, ComponentFixture,fakeAsync,tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { AutoComplete } from './autocomplete';
+import { AutoComplete, AutoCompleteItem } from './autocomplete';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonModule } from '../button/button';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @Component({
   template: `<p-autoComplete [(ngModel)]="brand" [suggestions]="filteredBrands" (completeMethod)="filterBrands($event)"></p-autoComplete>
@@ -46,12 +47,12 @@ class TestAutocompleteComponent {
 }
 
 describe('AutoComplete', () => {
-  
+
     let autocomplete: AutoComplete;
     let autocomplete2: AutoComplete;
     let testComponent: TestAutocompleteComponent;
     let fixture: ComponentFixture<TestAutocompleteComponent>;
-  
+
     beforeEach(() => {
     TestBed.configureTestingModule({
 
@@ -60,13 +61,15 @@ describe('AutoComplete', () => {
         FormsModule,
         BrowserDynamicTestingModule,
         ButtonModule,
+        ScrollingModule,
       ],
       declarations: [
         AutoComplete,
+        AutoCompleteItem,
         TestAutocompleteComponent
       ]
     });
-    
+
     fixture = TestBed.createComponent(TestAutocompleteComponent);
     autocomplete = fixture.debugElement.children[0].componentInstance;
     autocomplete2 = fixture.debugElement.children[2].componentInstance;
@@ -159,7 +162,7 @@ describe('AutoComplete', () => {
       let focusValue;
       autocomplete.onFocus.subscribe(value => focusValue = value);
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -176,7 +179,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(2);
       expect(suggestionsEls.length).toEqual(2);
@@ -200,7 +203,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -212,7 +215,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       const panelEl = fixture.debugElement.query(By.css('div'));
       expect(panelEl.nativeElement.style.maxHeight).toEqual("450px")
@@ -227,7 +230,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -239,7 +242,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(2);
       expect(suggestionsEls.length).toEqual(2);
@@ -252,7 +255,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -264,7 +267,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(2);
       expect(suggestionsEls.length).toEqual(2);
@@ -276,7 +279,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -287,7 +290,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(0);
       expect(suggestionsEls.length).toEqual(0);
@@ -299,7 +302,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -318,7 +321,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const suggestionsEls = fixture.debugElement.queryAll(By.css('li'));
       expect(autocomplete.suggestions.length).toEqual(0);
       expect(suggestionsEls.length).toEqual(1);
@@ -332,18 +335,18 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
-      
+
       inputEl.nativeElement.value = "v";
       inputEl.nativeElement.dispatchEvent(new Event('keydown'));
       inputEl.nativeElement.dispatchEvent(new Event('input'));
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.query(By.css('li')).nativeElement;
       expect(firstItemEl.className).toContain('ui-state-highlight');
     }));
@@ -353,7 +356,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -367,7 +370,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('change'));
       tick(300);
       fixture.detectChanges();
-      
+
       expect(inputEl.nativeElement.value).toEqual('');
     }));
 
@@ -375,7 +378,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -387,7 +390,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.query(By.css('li')).nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -406,7 +409,7 @@ describe('AutoComplete', () => {
       const dropdownOpenEl = fixture.debugElement.query(By.css('.ui-autocomplete-dropdown'));
       dropdownOpenEl.nativeElement.click();
       fixture.detectChanges();
-      
+
       const panelEl = fixture.debugElement.query(By.css('div'));
       expect(panelEl).toBeTruthy();
       expect(autocomplete.overlayVisible).toEqual(true);
@@ -421,7 +424,7 @@ describe('AutoComplete', () => {
       const dropdownOpenEl = fixture.debugElement.query(By.css('.ui-autocomplete-dropdown'));
       dropdownOpenEl.nativeElement.click();
       fixture.detectChanges();
-      
+
       const panelEl = fixture.debugElement.query(By.css('div'));
       expect(panelEl).toBeTruthy();
       expect(autocomplete.overlayVisible).toEqual(true);
@@ -433,7 +436,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.queryAll(By.css('p-autoComplete'))[1].query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -445,7 +448,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('p-autoComplete'))[1].query(By.css('li')).nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -459,7 +462,7 @@ describe('AutoComplete', () => {
       autocomplete.minLength = 2;
       fixture.detectChanges();
       const inputEl = fixture.debugElement.query(By.css('.ui-inputtext.ui-widget'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.focus();
       inputEl.nativeElement.click();
       fixture.detectChanges();
@@ -472,7 +475,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const panelEl = fixture.debugElement.query(By.css('div'));
-      expect(panelEl).toBeFalsy();      
+      expect(panelEl).toBeFalsy();
     }));
 
     it('should multiple', () => {
@@ -491,7 +494,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -502,7 +505,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       inputEl.nativeElement.dispatchEvent(new Event('change'));
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
@@ -518,7 +521,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -529,7 +532,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -545,7 +548,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -556,7 +559,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -577,7 +580,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -588,7 +591,7 @@ describe('AutoComplete', () => {
       inputEl.nativeElement.dispatchEvent(new Event('keyup'));
       tick(300);
       fixture.detectChanges();
-      
+
       const firstItemEl = fixture.debugElement.queryAll(By.css('li'))[1].nativeElement;
       firstItemEl.click();
       fixture.detectChanges();
@@ -608,7 +611,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -634,7 +637,7 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
 
@@ -656,10 +659,10 @@ describe('AutoComplete', () => {
       fixture.detectChanges();
 
       const inputEl = fixture.debugElement.query(By.css('input'));
-      inputEl.nativeElement.dispatchEvent(new Event('focus'));  
+      inputEl.nativeElement.dispatchEvent(new Event('focus'));
       inputEl.nativeElement.click();
       fixture.detectChanges();
-     
+
       const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
       const hideSpy = spyOn(autocomplete, 'hide').and.callThrough();
       autocomplete.suggestions = ["Volvo","VW"]

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -19,10 +19,12 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
     template: `
         <span [ngClass]="{'ui-autocomplete ui-widget':true,'ui-autocomplete-dd':dropdown,'ui-autocomplete-multiple':multiple}" [ngStyle]="style" [class]="styleClass">
             <input *ngIf="!multiple" #in [attr.type]="type" [attr.id]="inputId" [ngStyle]="inputStyle" [class]="inputStyleClass" [autocomplete]="autocomplete" [attr.required]="required" [attr.name]="name"
-            [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all ui-autocomplete-input'" [value]="inputFieldValue" aria-autocomplete="list" role="combobox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'"
-            (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
-            [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required"
-            ><ul *ngIf="multiple" #multiContainer class="ui-autocomplete-multiple-container ui-widget ui-inputtext ui-state-default ui-corner-all" [ngClass]="{'ui-state-disabled':disabled,'ui-state-focus':focus}" (click)="multiIn.focus()">
+                [ngClass]="'ui-inputtext ui-widget ui-state-default ui-corner-all ui-autocomplete-input'" [value]="inputFieldValue" aria-autocomplete="list" role="combobox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'"
+                (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
+                [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required"
+            >
+
+            <ul *ngIf="multiple" #multiContainer class="ui-autocomplete-multiple-container ui-widget ui-inputtext ui-state-default ui-corner-all" [ngClass]="{'ui-state-disabled':disabled,'ui-state-focus':focus}" (click)="multiIn.focus()">
                 <li #token *ngFor="let val of value" class="ui-autocomplete-token ui-state-highlight ui-corner-all">
                     <span class="ui-autocomplete-token-icon pi pi-fw pi-times" (click)="removeItem(token)" *ngIf="!disabled"></span>
                     <span *ngIf="!selectedItemTemplate" class="ui-autocomplete-token-label">{{resolveFieldData(val)}}</span>
@@ -30,18 +32,25 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 </li>
                 <li class="ui-autocomplete-input-token">
                     <input #multiIn [attr.type]="type" [attr.id]="inputId" [disabled]="disabled" [attr.placeholder]="(value&&value.length ? null : placeholder)" [attr.tabindex]="tabindex" (input)="onInput($event)"  (click)="onInputClick($event)"
-                            (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" [autocomplete]="autocomplete"
-                            [ngStyle]="inputStyle" [class]="inputStyleClass" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required"
-                            aria-autocomplete="list" role="combobox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'">
+                        (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" [autocomplete]="autocomplete"
+                        [ngStyle]="inputStyle" [class]="inputStyleClass" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required"
+                        aria-autocomplete="list" role="combobox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'"
+                    >
                 </li>
-            </ul
-            ><i *ngIf="loading" class="ui-autocomplete-loader pi pi-spinner pi-spin"></i><button #ddBtn type="button" pButton [icon]="dropdownIcon" class="ui-autocomplete-dropdown" [disabled]="disabled"
-                (click)="handleDropdownClick($event)" *ngIf="dropdown" [attr.tabindex]="tabindex"></button>
+            </ul>
+
+            <i *ngIf="loading" class="ui-autocomplete-loader pi pi-spinner pi-spin"></i>
+            <button #ddBtn type="button" pButton [icon]="dropdownIcon" class="ui-autocomplete-dropdown" [disabled]="disabled"
+                (click)="handleDropdownClick($event)" *ngIf="dropdown" [attr.tabindex]="tabindex"
+            ></button>
+
             <div #panel *ngIf="overlayVisible" [ngClass]="['ui-autocomplete-panel ui-widget ui-widget-content ui-corner-all ui-shadow']" [style.max-height]="scrollHeight" [ngStyle]="panelStyle" [class]="panelStyleClass"
-                [@overlayAnimation]="{value: 'visible', params: {showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions}}" (@overlayAnimation.start)="onOverlayAnimationStart($event)" (@overlayAnimation.done)="onOverlayAnimationDone($event)" >
+                [@overlayAnimation]="{value: 'visible', params: {showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions}}" (@overlayAnimation.start)="onOverlayAnimationStart($event)" (@overlayAnimation.done)="onOverlayAnimationDone($event)"
+            >
                 <ul role="listbox" class="ui-autocomplete-items ui-autocomplete-list ui-widget-content ui-widget ui-corner-all ui-helper-reset">
                     <li role="option"  *ngFor="let option of suggestions; let idx = index" [ngClass]="{'ui-autocomplete-list-item ui-corner-all':true,'ui-state-highlight':(highlightOption==option)}"
-                        (mouseenter)="highlightOption=option" (mouseleave)="highlightOption=null" [id]="highlightOption == option ? 'p-highlighted-option':''" (click)="selectItem(option)">
+                        (mouseenter)="highlightOption=option" (mouseleave)="highlightOption=null" [id]="highlightOption == option ? 'p-highlighted-option':''" (click)="selectItem(option)"
+                    >
                         <span *ngIf="!itemTemplate">{{resolveFieldData(option)}}</span>
                         <ng-container *ngTemplateOutlet="itemTemplate; context: {$implicit: option, index: idx}"></ng-container>
                     </li>
@@ -81,7 +90,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,O
     @Input() panelStyle: any;
 
     @Input() styleClass: string;
-    
+
     @Input() panelStyleClass: string;
 
     @Input() inputStyle: any;
@@ -113,7 +122,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,O
     @Input() type: string = 'text';
 
     @Input() autoZIndex: boolean = true;
-    
+
     @Input() baseZIndex: number = 0;
 
     @Input() ariaLabel: string;
@@ -232,7 +241,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,O
 
     set suggestions(val:any[]) {
         this._suggestions = val;
-        
+
         if (this.immutable) {
             this.handleSuggestionsChange();
         }
@@ -295,7 +304,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,O
                     this.hide();
                 }
             }
-    
+
             this.loading = false;
         }
     }
@@ -421,7 +430,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,O
     show() {
         if (this.multiInputEL || this.inputEL) {
             let hasFocus = this.multiple ? document.activeElement == this.multiInputEL.nativeElement : document.activeElement == this.inputEL.nativeElement ;
-            
+
             if (!this.overlayVisible && hasFocus) {
                 this.overlayVisible = true;
             }
@@ -731,7 +740,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,DoCheck,O
         this.documentResizeListener = this.onWindowResize.bind(this);
         window.addEventListener('resize', this.documentResizeListener);
     }
-    
+
     unbindDocumentResizeListener() {
         if (this.documentResizeListener) {
             window.removeEventListener('resize', this.documentResizeListener);

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -7,7 +7,7 @@ import {SharedModule,PrimeTemplate} from '../common/shared';
 import {DomHandler} from '../dom/domhandler';
 import {ObjectUtils} from '../utils/objectutils';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
-import { ScrollingModule } from '@angular/cdk/scrolling';
+import {ScrollingModule} from '@angular/cdk/scrolling';
 
 export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -82,15 +82,32 @@ export class AutoCompleteItem {
                 (click)="handleDropdownClick($event)" *ngIf="dropdown" [attr.tabindex]="tabindex"
             ></button>
 
-            <div #panel *ngIf="overlayVisible" [ngClass]="['ui-autocomplete-panel ui-widget ui-widget-content ui-corner-all ui-shadow']" [style.max-height]="scrollHeight" [ngStyle]="panelStyle" [class]="panelStyleClass"
+            <div #panel *ngIf="overlayVisible" [ngClass]="['ui-autocomplete-panel ui-widget ui-widget-content ui-corner-all ui-shadow']"
+                [style.max-height]="virtualScroll ? 'auto' : (scrollHeight||'auto')" [ngStyle]="panelStyle" [class]="panelStyleClass"
                 [@overlayAnimation]="{value: 'visible', params: {showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions}}" (@overlayAnimation.start)="onOverlayAnimationStart($event)" (@overlayAnimation.done)="onOverlayAnimationDone($event)"
             >
                 <ul role="listbox" class="ui-autocomplete-items ui-autocomplete-list ui-widget-content ui-widget ui-corner-all ui-helper-reset">
-                    <p-autoCompleteItem *ngFor="let option of suggestions; let idx = index"
-                        [option]="option" [(highlightOption)]="highlightOption" [index]="idx"
-                        (onClick)="selectItem($event.option)" [itemSize]="itemSize"
-                        [template]="itemTemplate" [resolvedFieldData]="resolveFieldData(option)"
-                    ></p-autoCompleteItem>
+                    <ng-container *ngIf="!virtualScroll; else virtualScrollList">
+                        <p-autoCompleteItem *ngFor="let option of suggestions; let idx = index"
+                            [option]="option" [(highlightOption)]="highlightOption" [index]="idx"
+                            (onClick)="selectItem($event.option)" [itemSize]="itemSize"
+                            [template]="itemTemplate" [resolvedFieldData]="resolveFieldData(option)"
+                        ></p-autoCompleteItem>
+                    </ng-container>
+                    <ng-template #virtualScrollList>
+                        <cdk-virtual-scroll-viewport *ngIf="virtualScroll && suggestions && suggestions.length"
+                            [ngStyle]="{height: scrollHeight}" [itemSize]="itemSize"
+                        >
+                            <ng-container *cdkVirtualFor="let option of suggestions; let idx = index">
+                                <p-autoCompleteItem
+                                    [option]="option" [(highlightOption)]="highlightOption" [index]="idx"
+                                    (onClick)="selectItem($event.option)" [itemSize]="itemSize"
+                                    [template]="itemTemplate" [resolvedFieldData]="resolveFieldData(option)"
+                                ></p-autoCompleteItem>
+                            </ng-container>
+                        </cdk-virtual-scroll-viewport>
+                    </ng-template>
+
                     <li *ngIf="noResults && emptyMessage" class="ui-autocomplete-emptymessage ui-autocomplete-list-item ui-corner-all">{{emptyMessage}}</li>
                 </ul>
             </div>

--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -32,6 +32,31 @@
     <ul>
         <li *ngFor="let c of countries">{{c.name}}</li>
     </ul>
+
+    <h3 style="margin-bottom: 0">Virtual Scroll (5000 Items)</h3>
+    <div style="display: flex">
+        <div style="margin-right: 25px">
+            <h4 style="margin-bottom: 10px; margin-top: 10px">Single Selection</h4>
+            <p-autoComplete [suggestions]="virtualScrollItems" [(ngModel)]="virtualScrollItem" placeholder="Select one..." [size]="30"
+                [dropdown]="true" [minLength]="1" (completeMethod)="filterVirtualScroll($event)" [virtualScroll]="true"
+                [itemSize]="31"
+            ></p-autoComplete>
+            <br>
+            Selected: {{ virtualScrollItem }}
+        </div>
+        <div style="flex: 1">
+            <h4 style="margin-bottom: 10px; margin-top: 10px">Multiple Selection</h4>
+            <p-autoComplete [suggestions]="virtualScrollItems" [(ngModel)]="selectedVirtualScrollItems" placeholder="Select many..." [size]="30"
+                [dropdown]="true" [minLength]="1" (completeMethod)="filterVirtualScroll($event)" [virtualScroll]="true"
+                [itemSize]="31" [multiple]="true"
+            ></p-autoComplete>
+            <br>
+            Selected:
+            <ul>
+                <li *ngFor="let car of selectedVirtualScrollItems">{{car}}</li>
+            </ul>
+        </div>
+    </div>
 </div>
 
 <div class="content-section documentation">
@@ -213,7 +238,7 @@ export class AutoCompleteDemo &#123;
 </pre>
 
             <h3>Animation Configuration</h3>
-            <p>Transition of the open and hide animations can be customized using the showTransitionOptions and hideTransitionOptions properties, 
+            <p>Transition of the open and hide animations can be customized using the showTransitionOptions and hideTransitionOptions properties,
                 example below disables the animations altogether.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>

--- a/src/app/showcase/components/autocomplete/autocompletedemo.ts
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.ts
@@ -1,5 +1,7 @@
+import { SelectItem } from './../../../components/common/selectitem';
 import {Component} from '@angular/core';
 import {CountryService} from '../../service/countryservice';
+import { CarService } from '../../service/carservice';
 
 @Component({
     templateUrl: './autocompletedemo.html'
@@ -7,35 +9,50 @@ import {CountryService} from '../../service/countryservice';
 export class AutoCompleteDemo {
 
     country: any;
-    
+
     countries: any[];
-        
+
     filteredCountriesSingle: any[];
-    
+
     filteredCountriesMultiple: any[];
-    
+
     brands: string[] = ['Audi','BMW','Fiat','Ford','Honda','Jaguar','Mercedes','Renault','Volvo','VW'];
-    
+
     filteredBrands: any[];
-    
+
     brand: string;
-    
-    constructor(private countryService: CountryService) { }
-    
+
+    virtualScrollItems: string[];
+
+    virtualScrollItem: string;
+
+    selectedVirtualScrollItems: string[];
+
+    constructor(private countryService: CountryService, private carService: CarService) { }
+
     filterCountrySingle(event) {
-        let query = event.query;        
+        let query = event.query;
         this.countryService.getCountries().then(countries => {
             this.filteredCountriesSingle = this.filterCountry(query, countries);
         });
     }
-    
+
     filterCountryMultiple(event) {
         let query = event.query;
         this.countryService.getCountries().then(countries => {
             this.filteredCountriesMultiple = this.filterCountry(query, countries);
         });
     }
-    
+
+    filterVirtualScroll(event: {query: string}): void {
+        const query = event.query.toLowerCase();
+        this.carService.getCarsHuge()
+            .then(cars => cars.map(car => `${car.color} ${car.brand} (${car.year})`))
+            .then(cars => {
+                this.virtualScrollItems = cars.filter(car => car.toLowerCase().includes(query));
+            });
+    }
+
     filterCountry(query, countries: any[]):any[] {
         //in a real application, make a request to a remote url with the query and return filtered results, for demo we filter at client side
         let filtered : any[] = [];
@@ -47,7 +64,7 @@ export class AutoCompleteDemo {
         }
         return filtered;
     }
-        
+
     filterBrands(event) {
         this.filteredBrands = [];
         for(let i = 0; i < this.brands.length; i++) {


### PR DESCRIPTION
Implementation of VirtualScroll for the AutoComplete.

I followed the PR for the Dropdown VirtualScroll implementation:
https://github.com/primefaces/primeng/pull/7245

There was a ticket requesting this:
https://github.com/primefaces/primeng/issues/7442

There are many whitespace changes because of the .editorconfig.
If required, I can fix this so that there are no unrequired whitespace changes.


Any chance this can get merged?