### PR TITLE
Updated "View on Github" link in carousel doc

### DIFF
--- a/src/app/showcase/components/carousel/carouseldemo.html
+++ b/src/app/showcase/components/carousel/carouseldemo.html
@@ -352,7 +352,7 @@ export class CarouselDemo &#123;
             <p>None.</p>
         </p-tabPanel>
         <p-tabPanel header="Source">
-            <a href="https://github.com/primefaces/primeng/tree/master/src/app/showcase/components/button" class="btn-viewsource" target="_blank">
+            <a href="https://github.com/primefaces/primeng/tree/master/src/app/showcase/components/carousel" class="btn-viewsource" target="_blank">
                 <i class="fa fa-github"></i>
                 <span>View on GitHub</span>
             </a>


### PR DESCRIPTION
Defect fix - "View on Github" link in carousel document is pointed to buttons module
https://github.com/primefaces/primeng/issues/8254
