### PR TITLE
Add Table ExportCSV option to ignore filters

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1339,6 +1339,10 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         let data = this.filteredValue || this.value;
         let csv = '';
 
+        if (options && options.ignoreFilters) {
+            data = this.value;
+        }
+
         if (options && options.selectionOnly) {
             data = this.selection || [];
         }


### PR DESCRIPTION
Add another option to Table.exportCSV, ignoreFilters. When set to true
exportCSV will include data hidden due to filters.