### PR TITLE
Don't decrease page when totalRecords is not (yet) set (fix #8358)

### DIFF
--- a/src/app/components/paginator/paginator.ts
+++ b/src/app/components/paginator/paginator.ts
@@ -189,7 +189,7 @@ export class Paginator implements OnInit, OnChanges {
 
     updateFirst() {
         const page = this.getPage();
-        if (page > 0 && (this.first >= this.totalRecords)) {
+        if (page > 0 && this.totalRecords && this.first >= this.totalRecords) {
             Promise.resolve(null).then(() => this.changePage(page - 1));
         }
     }


### PR DESCRIPTION
When totalRecords is 0 not yet set, then don't try to correct the page. This is a solution for issue #8358.