### PR TITLE
TreeTable | Added text property to allow clickable text along with icon.

### DIFF
--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -2831,13 +2831,14 @@ export class TTRow {
     template: `
         <a class="ui-treetable-toggler ui-unselectable-text" *ngIf="rowNode.node.leaf === false || rowNode.level !== 0 || rowNode.node.children && rowNode.node.children.length" (click)="onClick($event)"
             [style.visibility]="rowNode.node.leaf === false || (rowNode.node.children && rowNode.node.children.length) ? 'visible' : 'hidden'" [style.marginLeft]="rowNode.level * 16 + 'px'">
-            <i [ngClass]="rowNode.node.expanded ? 'pi pi-fw pi-chevron-down' : 'pi pi-fw pi-chevron-right'"></i>
+            <i [ngClass]="rowNode.node.expanded ? 'pi pi-fw pi-chevron-down' : 'pi pi-fw pi-chevron-right'"></i> {{text}}
         </a>
     `
 })
 export class TreeTableToggler {
 
     @Input() rowNode: any;
+    @Input() text: string;
 
     constructor(public tt: TreeTable) {}
 


### PR DESCRIPTION
TreeTable | Use case - As of now, we could not click on the row text shown on the cell and expand its child nodes. We can expand child nodes only on the icon click. With this change, it would be an option to show cell text as a part of anchor (clickable).

###Defect Fixes
N/A

###Feature Requests
TreeTable | Use case - As of now, we could not click on the row text shown on the cell and expand its child nodes. We can expand child nodes only on the icon click. With this change, it would be an option to show cell text as a part of anchor (clickable).