### PR TITLE
Fix HSBtoRGB from ColorPicker component

### DIFF
--- a/src/app/components/colorpicker/colorpicker.ts
+++ b/src/app/components/colorpicker/colorpicker.ts
@@ -496,9 +496,9 @@ export class ColorPicker implements ControlValueAccessor, OnDestroy {
         var rgb = {
             r: null, g: null, b: null
         };
-        var h = Math.round(hsb.h);
-        var s = Math.round(hsb.s*255/100);
-        var v = Math.round(hsb.b*255/100);
+        let h: number = hsb.h;
+        let s: number = hsb.s*255/100;
+        let v: number = hsb.b*255/100;
         if(s == 0) {
             rgb = {
                 r: v,
@@ -507,9 +507,9 @@ export class ColorPicker implements ControlValueAccessor, OnDestroy {
             }
         } 
         else {
-            var t1 = v;
-            var t2 = (255-s)*v/255;
-            var t3 = (t1-t2)*(h%60)/60;
+            let t1: number = v;
+            let t2: number = (255-s)*v/255;
+            let t3: number = (t1-t2)*(h%60)/60;
             if(h==360) h = 0;
             if(h<60) {rgb.r=t1;	rgb.b=t2; rgb.g=t2+t3}
             else if(h<120) {rgb.g=t1; rgb.b=t2;	rgb.r=t1-t3}


### PR DESCRIPTION
#8334 colorPicker - wrong color rendered

**Issue**

Due to irrationnal numbers manipulation, method HSBtoRGB in ColorPicker component is not accurate as expected.

**Fix**
- Avoid Math.round in h,s,v values initialization.
- Use type number instead of var to have an accurate value needed in the process.