### PR TITLE
[FileUpload] accept input to array

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -69,7 +69,7 @@ export class FileUpload implements AfterViewInit,AfterContentInit,OnDestroy,Bloc
 
     @Input() multiple: boolean;
 
-    @Input() accept: string;
+    @Input() accept: string | string[];
 
     @Input() disabled: boolean;
 
@@ -296,7 +296,12 @@ export class FileUpload implements AfterViewInit,AfterContentInit,OnDestroy,Bloc
     }
 
     private isFileTypeValid(file: File): boolean {
-        let acceptableTypes = this.accept.split(',').map(type => type.trim());
+        let acceptableTypes: string | string[] = this.accept;
+        if(!Array.isArray(this.accept))
+        {
+            acceptableTypes = acceptableTypes.split(',').map(type => type.trim());
+        }
+
         for(let type of acceptableTypes) {
             let acceptable = this.isWildcard(type) ? this.getTypeClass(file.type) === this.getTypeClass(type)
                                                     : file.type == type || this.getFileExtension(file).toLowerCase() === type.toLowerCase();


### PR DESCRIPTION
**Issue:**
Input _accept_ from FileUpload component is a string type and it can be difficult to build a string like ".jpg,.png,.doc..."

**Fix:**
I propose to add a pipe to this input so that it will be possible to declare _accept_ input as an array.
Using a pipe string | string[] will not introduce a breaking change and let file upload component retro compatible.