### PR TITLE
Carousel documentation typo

### DIFF
--- a/src/app/showcase/components/carousel/carouseldemo.html
+++ b/src/app/showcase/components/carousel/carouseldemo.html
@@ -188,7 +188,7 @@ export class CarouselDemo &#123;
             <p>When <i>autoplayInterval</i> is defined in milliseconds, items are scrolled automatically. In addition, for infinite scrolling <i>circular</i> property needs to be enabled. Note that in autoplay mode, circular is enabled by default.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
-&lt;carousel [value]="cars" [autoplayIntervla]="3000" [circular]="true"&gt;
+&lt;carousel [value]="cars" [autoplayInterval]="3000" [circular]="true"&gt;
     &lt;p-header&gt;
         &lt;h3&gt;Vertical&lt;/h3&gt;
     &lt;/p-header&gt;


### PR DESCRIPTION
The documentation has a typo so I changed the property `autoplayIntervla` to `autoplayInterval`

```
<carousel [value]="cars" [autoplayIntervla]="3000" [circular]="true">
    <p-header>
        <h3>Vertical</h3>
    </p-header>
    <ng-template let-car pTemplate="item">
        Content to display
    </ng-template>
</carousel>
```

