### PR TITLE
fix: corrected docs for p-table checkbox selection

### DIFF
--- a/src/app/showcase/components/table/tableselectiondemo.html
+++ b/src/app/showcase/components/table/tableselectiondemo.html
@@ -405,7 +405,7 @@ export class TableSelectionDemo implements OnInit &#123;
         &lt;/tr&gt;
     &lt;/ng-template&gt;
     &lt;ng-template pTemplate="body" let-rowData let-columns="columns"&gt;
-        &lt;tr [pSelectableRow]="rowData"&gt;
+        &lt;tr&gt;
             &lt;td&gt;
                 &lt;p-tableCheckbox [value]="rowData"&gt;&lt;/p-tableCheckbox&gt;
             &lt;/td&gt;


### PR DESCRIPTION
###Documentation Fix
Here I have removed a piece of code,
As [pSelectableRow]="rowData" and p-tableCheckBox together conflict each other and both row and checkbox gets selected when clicked on a checkbox!

Note: It is not a defect nor a feature request.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.