### PR TITLE
Add position check in carousel mobile onTouchEnd event comparing onTouchStart event

### DIFF
--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -165,6 +165,8 @@ export class Carousel implements AfterContentInit {
 
 	startPos: any;
 
+	endPos: any;
+
 	documentResizeListener: any;
 
 	clonedItemsForStarting: any[];
@@ -439,6 +441,10 @@ export class Carousel implements AfterContentInit {
 		return !this.value || this.value.length === 0;
 	}
 
+	isSamePosition() {
+		return this.startPos.x === this.endPos.x && this.startPos.y === this.endPos.y;
+	}
+
 	navForward(e,index?) {
 		if (this.circular || this._page < (this.totalDots() - 1)) {
 			this.step(-1, index);
@@ -578,6 +584,15 @@ export class Carousel implements AfterContentInit {
 	}
 	onTouchEnd(e) {
 		let touchobj = e.changedTouches[0];
+
+		this.endPos = {
+			x: touchobj.pageX,
+			y: touchobj.pageY
+		};
+
+		if(this.isSamePosition()) {
+			return;
+		}
 
 		if (this.isVertical()) {
 			this.changePageOnTouch(e, (touchobj.pageY - this.startPos.y));

--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -441,10 +441,6 @@ export class Carousel implements AfterContentInit {
 		return !this.value || this.value.length === 0;
 	}
 
-	isSamePosition() {
-		return this.startPos.x === this.endPos.x && this.startPos.y === this.endPos.y;
-	}
-
 	navForward(e,index?) {
 		if (this.circular || this._page < (this.totalDots() - 1)) {
 			this.step(-1, index);
@@ -573,7 +569,8 @@ export class Carousel implements AfterContentInit {
 
 		this.startPos = {
 			x: touchobj.pageX,
-			y: touchobj.pageY
+			y: touchobj.pageY,
+			r: touchobj.radiusX
 		};
 	}
 
@@ -587,10 +584,11 @@ export class Carousel implements AfterContentInit {
 
 		this.endPos = {
 			x: touchobj.pageX,
-			y: touchobj.pageY
+			y: touchobj.pageY,
+			r: touchobj.radiusX
 		};
 
-		if(this.isSamePosition()) {
+		if(this.isTouchedCircleIntersect()) {
 			return;
 		}
 
@@ -601,6 +599,13 @@ export class Carousel implements AfterContentInit {
 			this.changePageOnTouch(e, (touchobj.pageX - this.startPos.x));
 		}
 	}
+
+	isTouchedCircleIntersect(){
+		let d: number = Math.sqrt((this.startPos.x - this.endPos.x)* (this.startPos.x - this.endPos.x) 
+		+ (this.startPos.y - this.endPos.y)* (this.startPos.y - this.endPos.y));
+
+		return !(d > this.startPos.r + this.endPos.r)
+	} 
 
 	changePageOnTouch(e, diff) {
 		if (diff < 0) {


### PR DESCRIPTION
The main problem with OnTouchEnd event which prevent emit any nested event in ngTemplateContext. This pr add check on touchEnd event that the position click didn`t changed compare onTouchStarted event (see #8377)