### PR TITLE
Fix type error Cannot read property parentElement of null

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3168,7 +3168,11 @@ export class EditableColumn implements AfterViewInit {
 
     moveToPreviousCell(event: KeyboardEvent) {
         let currentCell = this.findCell(event.target);
-        let row = currentCell.parentElement;
+
+        if (!currentCell) {
+            return;
+        }
+
         let targetCell = this.findPreviousEditableColumn(currentCell);
 
         if (targetCell) {
@@ -3180,7 +3184,11 @@ export class EditableColumn implements AfterViewInit {
 
     moveToNextCell(event: KeyboardEvent) {
         let currentCell = this.findCell(event.target);
-        let row = currentCell.parentElement;
+
+        if (!currentCell) {
+            return;
+        }
+
         let targetCell = this.findNextEditableColumn(currentCell);
 
         if (targetCell) {


### PR DESCRIPTION
Fixed #8470 
Filter `null` values from `findCell` in Table/EditableColumn
