### PR TITLE
Fix multiselect filled state

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -376,7 +376,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
     }
 
     updateFilledState() {
-        this.filled = (this.valuesAsString != null && this.valuesAsString.length > 0);
+        this.filled = (this.value && this.value.length > 0);
     }
     
     registerOnChange(fn: Function): void {


### PR DESCRIPTION
Updated updateFilledState method to check for a non-empty value, instead of checking the label.
Since there is always a label (unless you add defaultLabel="") this was always returning true.

###Defect Fixes
#8279 

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.