### PR TITLE
Fix #8498 Carousel - Invalid Array Length error

### DIFF
--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -394,9 +394,10 @@ export class Carousel implements AfterContentInit {
 	totalDots() {
 		return this.value ? Math.ceil((this.value.length - this._numVisible) / this._numScroll) + 1 : 0;
 	}
+
 	totalDotsArray() {
-		let totalDots = this.totalDots();
-		return totalDots === 0 ? [] : Array(totalDots).fill(0);
+		const totalDots = this.totalDots();
+		return totalDots <= 0 ? [] : Array(totalDots).fill(0);
 	}
 
 	containerClass() {


### PR DESCRIPTION
### Defect Fixes

Fix #8498 Carousel - Invalid Array Length error
Fix 6909edbb1f0d663f23d053e3ed1af7650ae49502

Current:
Just a case match if array length is 0 but not on negative numbers.

Fixed:
Now matches if array length is 0 or lower.


Edit:
This pr does not fix all problems of carousel if provided data contains less items 
than carousel should show.