### PR TITLE
Move saveState() method from call stack

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1780,7 +1780,12 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
                 });
 
                 if (this.isStateful()) {
-                    this.saveState();
+                    /** Timeout need to move saveState() method from call stack
+                     * so saveColumnWidths() can use correct order of columns after reordering
+                     */
+                    setTimeout(() => {
+                        this.saveState();
+                    });
                 }
             }
 


### PR DESCRIPTION
so saveColumnWidths() can use correct order of columns after reordering

The problem was in incorrect order of column DOM elements after reordering
so wrapping saveState() in timeout fix this problem

Fix for - https://pro.primefaces.org/browse/BMC-2