### PR TITLE
Fix #8516 Tooltip - on create ensure that old tooltip is removed

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -149,6 +149,10 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     }
 
     create() {
+        if (this.container) {
+            this.remove();
+        }
+
         this.container = document.createElement('div');
 
         let tooltipArrow = document.createElement('div');


### PR DESCRIPTION
In very rare cases it is possible that a new tooltip is created without destroying the old one.
This PR ensures that the old is destroyed before creating a new one.

### Defect Fixes

fixes #8516
