### PR TITLE
ConfirmDialog close via service feature

### DIFF
--- a/src/app/components/api/confirmationservice.ts
+++ b/src/app/components/api/confirmationservice.ts
@@ -16,6 +16,11 @@ export class ConfirmationService {
         return this;
     }
 
+    close() {
+        this.requireConfirmationSource.next(null);
+        return this;
+    }
+
     onAccept() {
         this.acceptConfirmationSource.next();
     }

--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -133,6 +133,11 @@ export class ConfirmDialog implements OnDestroy {
                 
     constructor(public el: ElementRef, public renderer: Renderer2, private confirmationService: ConfirmationService, public zone: NgZone) {
         this.subscription = this.confirmationService.requireConfirmation$.subscribe(confirmation => {
+            if (!confirmation) {
+                this.visible = false;
+                return;
+            }
+
             if (confirmation.key === this.key) {
                 this.confirmation = confirmation;
                 this.message = this.confirmation.message||this.message;


### PR DESCRIPTION
Implementation to close ConfirmDialog via ConfirmationService.
Needed for closing the confirmationbox while browser-based navigation events.
Otherwise popup stays opened.