### PR TITLE
Fix: TreeTable multi-sort functionality

### DIFF
--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -702,7 +702,7 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
             });
         }
         else {
-            this.value.sort((node1, node2) => {
+            nodes.sort((node1, node2) => {
                 return this.multisortField(node1, node2, this.multiSortMeta, 0);
             });
         }


### PR DESCRIPTION
TreeTables were only sorting the root level of children, and not all levels in the data.

Can be reproduced in example (https://www.primefaces.org/primeng/#/treetable/sort) by sorting first by 'Name', and then ctrl+clicking on 'Size'. If you continue to ctrl+click on 'Size', you can see only the ordering of Documents/Documents(folder) changes, when you'd expect the note-meetings.txt and note-todo.txt records to change order as well.

###Defect Fixes
Resolves opened opened issue [#8530 ](https://github.com/primefaces/primeng/issues/8530)