### PR TITLE
FileUpload size formatting is incorrect

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -499,7 +499,7 @@ export class FileUpload implements AfterViewInit,AfterContentInit,OnDestroy,Bloc
         if (bytes == 0) {
             return '0 B';
         }
-        let k = 1000,
+        let k = 1024,
         dm = 3,
         sizes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'],
         i = Math.floor(Math.log(bytes) / Math.log(k));


### PR DESCRIPTION
It's displayed wrong.
For example 5MB are 5242880 and not 5000000

Setting it as [maxFileSize]="5242880" the validation is correct but the message says that the limit is:
5.242880 MB

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.