### PR TITLE
Fixed #8587 DynamicDialog close button alignment is broken

### DIFF
--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -16,9 +16,11 @@ import { DynamicDialogRef } from './dynamicdialog-ref';
 			[style.width]="config.width" [style.height]="config.height">
             <div class="ui-dialog-titlebar ui-widget-header ui-helper-clearfix ui-corner-top" *ngIf="config.showHeader === false ? false: true">
                 <span class="ui-dialog-title">{{config.header}}</span>
-                <a [ngClass]="'ui-dialog-titlebar-icon ui-dialog-titlebar-close ui-corner-all'" tabindex="0" role="button" (click)="close()" (keydown.enter)="close()" *ngIf="config.closable === false ? false : true">
-                    <span class="pi pi-times"></span>
-                </a>
+                <div class="ui-dialog-titlebar-icons">
+                    <a [ngClass]="'ui-dialog-titlebar-icon ui-dialog-titlebar-close ui-corner-all'" tabindex="0" role="button" (click)="close()" (keydown.enter)="close()" *ngIf="config.closable !== false">
+                        <span class="pi pi-times"></span>
+                    </a>
+                </div>
             </div>
             <div class="ui-dialog-content ui-widget-content" [ngStyle]="config.contentStyle">
 				<ng-template pDynamicDialogContent></ng-template>


### PR DESCRIPTION
- Wrap close button with div with ui-dialog-titlebar-icons class
to have the same layout as the normal dialog
- Simplify ngIf expression for close button

### Defect Fixes
Fixes #8587 