### PR TITLE
Fix 8591: resolve scrollFooter and scrollFooterBox @ViewChild after change detection

### DIFF
--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -1641,9 +1641,9 @@ export class TTScrollableView implements AfterViewInit, OnDestroy, AfterViewChec
 
     @ViewChild('loadingTable', { static: false }) scrollLoadingTableViewChild: ElementRef;
 
-    @ViewChild('scrollFooter', { static: true }) scrollFooterViewChild: ElementRef;
+    @ViewChild('scrollFooter', { static: false }) scrollFooterViewChild: ElementRef;
 
-    @ViewChild('scrollFooterBox', { static: true }) scrollFooterBoxViewChild: ElementRef;
+    @ViewChild('scrollFooterBox', { static: false}) scrollFooterBoxViewChild: ElementRef;
 
     @ViewChild('virtualScroller', { static: false }) virtualScrollerViewChild: ElementRef;
 


### PR DESCRIPTION
Set { static: false } to resolve scrollFooter and scrollFooterBox @ViewChild after change detection.
Otherwise, those fields are undefined. This makes alignScrollBar() does not work as expected and leads to the misalignment.
Fix #8591.