### PR TITLE
Fix #8573: dialog covered by mask

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -234,15 +234,15 @@ export class ConfirmDialog implements OnDestroy {
     appendContainer() {
         if (this.appendTo) {
             if (this.appendTo === 'body')
-                document.body.appendChild(this.container);
+                document.body.appendChild(this.wrapper);
             else
-                DomHandler.appendChild(this.container, this.appendTo);
+                DomHandler.appendChild(this.wrapper, this.appendTo);
         }
     }
 
     restoreAppend() {
-        if (this.container && this.appendTo) {
-            this.el.nativeElement.appendChild(this.container);
+        if (this.wrapper && this.appendTo) {
+            this.el.nativeElement.appendChild(this.wrapper);
         }
     }
         

--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -569,15 +569,15 @@ export class Dialog implements OnDestroy {
     appendContainer() {
         if (this.appendTo) {
             if (this.appendTo === 'body')
-                document.body.appendChild(this.container);
+                document.body.appendChild(this.wrapper);
             else
-                DomHandler.appendChild(this.container, this.appendTo);
+                DomHandler.appendChild(this.wrapper, this.appendTo);
         }
     }
 
     restoreAppend() {
         if (this.container && this.appendTo) {
-            this.el.nativeElement.appendChild(this.container);
+            this.el.nativeElement.appendChild(this.wrapper);
         }
     }
 


### PR DESCRIPTION
fix https://github.com/primefaces/primeng/issues/8573

as per intention of https://github.com/primefaces/primeng/issues/8475 

rewrite of dialogs in primeng should comply the way of primereact

and in primereact, Dialog append the wrapper to body, not the container:

https://github.com/primefaces/primereact/blob/95f5dc3dcc500080f05a4cc93ead44b0f4dfbff0/src/components/dialog/Dialog.js#L378