### PR TITLE
Fix issue #8455 with clicking on dropdowns inside labels

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -513,6 +513,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     }
     
     onMouseclick(event) {
+        event.preventDefault();
+
         if (this.disabled||this.readonly) {
             return;
         }


### PR DESCRIPTION
When the dropdown is wrapped inside a label, clicking on the dropdown (right next to the text) can open the dropdown twice, thereby effectively closing it again because the click event works as a toggle.