### PR TITLE
SelectButton - reactive form and disabled control

### DIFF
--- a/src/app/components/selectbutton/selectbutton.ts
+++ b/src/app/components/selectbutton/selectbutton.ts
@@ -133,6 +133,10 @@ export class SelectButton implements ControlValueAccessor, OnChanges {
     }
     
     onBlur(event) {
+        if (this.disabled) {
+            return;
+        }
+        
         this.focusedItem = null;
         this.onModelTouched();
     }


### PR DESCRIPTION
When p-selectButton is used in reactive form mode and control is disabled, then clicking on button causes form is touched.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.