### PR TITLE
Removed unclosed span in source tab inputswitch

### DIFF
--- a/src/app/showcase/components/inputswitch/inputswitchdemo.html
+++ b/src/app/showcase/components/inputswitch/inputswitchdemo.html
@@ -202,7 +202,7 @@ export class ModelComponent &#123;
 &lt;h3 class="first"&gt;Basic - {{checked1}}&lt;/h3&gt;
 &lt;p-inputSwitch [(ngModel)]="checked1"&gt;&lt;/p-inputSwitch&gt;
 
-&lt;h3&gt;Labels - &lt;span&gt; {{checked2}}&lt;/h3&gt;
+&lt;h3&gt;Labels - {{checked2}}&lt;/h3&gt;
 &lt;p-inputSwitch [(ngModel)]="checked2"&gt;&lt;/p-inputSwitch&gt;
 </code>
 </pre>


### PR DESCRIPTION
An unclosed span was part of source example for inputSwitch. Hence not creating and issue for this

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.