### PR TITLE
Fix import in the galleria component

### DIFF
--- a/src/app/components/galleria/galleria.ts
+++ b/src/app/components/galleria/galleria.ts
@@ -1,7 +1,7 @@
 import {NgModule,Component,ElementRef,OnDestroy,Input,Output,EventEmitter,ChangeDetectionStrategy, ViewChild, ContentChildren, QueryList, TemplateRef, OnInit, OnChanges, AfterContentChecked, SimpleChanges} from '@angular/core';
 import {CommonModule} from '@angular/common';
 import { SharedModule, PrimeTemplate } from 'primeng/api';
-import { UniqueComponentId } from '../utils/uniquecomponentid';
+import { UniqueComponentId } from 'primeng/utils';
 import { DomHandler } from 'primeng/dom';
 
 @Component({


### PR DESCRIPTION
This is just a small fix of the import statement for the `UniqueComponentId` in the `Galleria` component.

Without this change, I got errors about "imports from outside of the rootDir" when running `npm run build-lib`. This fix also makes the import consistent with how other components such as `Carousel` import `UniqueComponentId`.