### PR TITLE
Add ES2016 as lib file to allow includes() on arrays

### DIFF
--- a/src/app/components/tsconfig.lib.json
+++ b/src/app/components/tsconfig.lib.json
@@ -12,6 +12,7 @@
       "rootDir": ".",
       "lib": [
         "es2015",
+        "es2016",
         "dom"
       ],
       "skipLibCheck": true,


### PR DESCRIPTION
This small change was necessary for me in order to succesfully execute `npm run build-lib`.

The problem is that `VirtualScroller.loadPage()` uses the `includes()` method on the `loadPage` array of numbers. That method only exists in ES2016, but the tsconfig had only ES2015 specified.