### PR TITLE
Fix for InputTextArea auto-resize moves scroll position #8826

### DIFF
--- a/src/app/components/inputtextarea/inputtextarea.ts
+++ b/src/app/components/inputtextarea/inputtextarea.ts
@@ -61,7 +61,6 @@ export class InputTextarea implements DoCheck {
     }
     
     resize(event?: Event) {
-        this.el.nativeElement.style.height = 'auto';
         this.el.nativeElement.style.height = this.el.nativeElement.scrollHeight + 'px';
 
         if (parseFloat(this.el.nativeElement.style.height) >= parseFloat(this.el.nativeElement.style.maxHeight)) {


### PR DESCRIPTION
Remove the auto style for height as it was causing the scrollbar to jump for long text

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.