### PR TITLE
dialog resize not scaling when centered

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -475,6 +475,12 @@ export class Dialog implements OnDestroy {
             let minHeight = this.container.style.minHeight;
             let offset = DomHandler.getOffset(this.container);
             let viewport = DomHandler.getViewport();
+            let hasBeenDragged = !parseInt(this.container.style.top) || !parseInt(this.container.style.left);
+
+            if (hasBeenDragged) {
+                newWidth += deltaX;
+                newHeight += deltaY;
+            }
 
             if ((!minWidth || newWidth > parseInt(minWidth)) && (offset.left + newWidth) < viewport.width) {
                 this._style.width = newWidth + 'px';
@@ -482,7 +488,7 @@ export class Dialog implements OnDestroy {
             }
 
             if ((!minHeight || newHeight > parseInt(minHeight)) && (offset.top + newHeight) < viewport.height) {
-                this.contentViewChild.nativeElement.style.height = contentHeight + deltaY + 'px';
+                this.contentViewChild.nativeElement.style.height = contentHeight + newHeight - containerHeight + 'px';
 
                 if (this._style.height) {
                     this._style.height = newHeight + 'px';


### PR DESCRIPTION
Until container position has been changed (by dragging), container maintains centering on resize due to flexbox parent, causing it to resize in each direction equally, thus doubling size increase (as the right side is being resized, the left side also expands, maintaining centering). Therefore we add a second deltaX and deltaY distance, accounting for the other side.

Once container position has been changed, resize behavior changes and resizing causes only one side to resize. 
Because dragging causes the container to add css style "top" and "left", we can assess whether centered resizing behavior is active, storing it in "hasBeenDragged".

Behavior can be demoed here
https://stackblitz.com/github/qgnirxral
or naturally, here
https://www.primefaces.org/primeng/showcase/