### PR TITLE
Spinner always at center of screen for long tree table

### DIFF
--- a/src/app/components/treetable/treetable.css
+++ b/src/app/components/treetable/treetable.css
@@ -214,7 +214,7 @@
 }
 
 .ui-treetable-loading-content {
-    position: absolute;
+    position: fixed;
     left: 50%;
     top: 50%;
     z-index: 2;


### PR DESCRIPTION
Spinner location fixed to be always at center of screen for scrollable tree table