### PR TITLE
Fix for #8727

### DIFF
--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -94,7 +94,7 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
 
     @Input() autocomplete: string;
 
-    @ViewChild('input') inputViewChild: ElementRef;
+    @ViewChild('input', { static: true }) inputViewChild: ElementRef;
 
     @Output() onComplete: EventEmitter<any> = new EventEmitter();
 
@@ -360,7 +360,7 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
                     this.onComplete.emit();
                 }
             }, 0);
-        } 
+        }
         else {
             this.checkVal(true);
             while (pos.begin < this.len && !this.tests[pos.begin])
@@ -420,11 +420,11 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
             this.onInput.emit(e);
 
             e.preventDefault();
-        } 
+        }
         else if ( k === 13 ) { // enter
             this.onInputBlur(e);
             this.updateModel(e);
-        } 
+        }
         else if (k === 27) { // escape
             this.inputViewChild.nativeElement.value = this.focusText;
             this.caret(0, this.checkVal());


### PR DESCRIPTION
By default @ViewChild is set to static: false, which means that corresponding value is set only after ngAfterViewInit. Setting @ViewChild('input') to static: false in inputMask makes it miss writeValue call from FormGroup, because it happens before ngAfterViewInit and this.inputViewChild is still undefined at the time of call.

You might want to review the rest of the [9908406e1e8078ccc433d152c0dae25c627be43e](https://github.com/primefaces/primeng/commit/9908406e1e8078ccc433d152c0dae25c627be43e) commit (specifically removing static: true option) to make sure that nothing else is broken.

###Defect Fixes
#8727