### PR TITLE
Fix for #8964, more events when dialog is dragged, fix position of resized dialog, event on dialog hide

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "primeng",
-  "version": "9.1.1-SNAPSHOT",
+  "version": "9.1.1",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/primefaces/primeng.git"
+    "url": "https://github.com/PetrJajtner/primeng.git"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "~0.901.0",
@@ -42,7 +42,7 @@
     "codelyzer": "^5.1.2",
     "del": "^2.2.0",
     "file-saver": "^2.0.2",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-concat": "^2.6.0",
     "gulp-flatten": "^0.2.0",
     "gulp-rename": "^1.2.2",
@@ -52,7 +52,7 @@
     "jasmine-spec-reporter": "~4.2.1",
     "jspdf": "^1.5.3",
     "jspdf-autotable": "^3.2.5",
-    "karma": "~4.1.0",
+    "karma": "^5.1.0",
     "karma-chrome-launcher": "~2.2.0",
     "karma-coverage-istanbul-reporter": "~2.0.1",
     "karma-jasmine": "~2.0.1",
@@ -61,7 +61,7 @@
     "primeflex": "1.1.0",
     "primeicons": "2.0.0",
     "prismjs": "1.15.0",
-    "protractor": "~5.4.0",
+    "protractor": "^7.0.0",
     "quill": "^1.3.7",
     "rxjs": "~6.5.3",
     "ts-node": "~7.0.0",

--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -20,7 +20,7 @@ const hideAnimation = animation([
 @Component({
     selector: 'p-dialog',
     template: `
-        <div *ngIf="maskVisible" [class]="maskStyleClass" 
+        <div *ngIf="maskVisible" [class]="maskStyleClass"
             [ngClass]="{'ui-dialog-mask': true, 'ui-widget-overlay': this.modal, 'ui-dialog-visible': this.maskVisible, 'ui-dialog-mask-scrollblocker': this.modal || this.blockScroll,
                 'ui-dialog-left': position === 'left',
                 'ui-dialog-right': position === 'right',
@@ -177,6 +177,10 @@ export class Dialog implements OnDestroy {
     @Output() onResizeInit: EventEmitter<any> = new EventEmitter();
 
     @Output() onResizeEnd: EventEmitter<any> = new EventEmitter();
+
+    @Output() onDragInit: EventEmitter<any> = new EventEmitter();
+
+    @Output() onDragEnd: EventEmitter<any> = new EventEmitter();
 
     _visible: boolean;
 
@@ -364,6 +368,7 @@ export class Dialog implements OnDestroy {
 
             this.container.style.margin = '0';
             DomHandler.addClass(document.body, 'ui-unselectable-text');
+            this.onDragInit.emit(event);
         }
     }
 
@@ -435,9 +440,10 @@ export class Dialog implements OnDestroy {
     }
 
     endDrag(event: MouseEvent) {
-        if (this.draggable) {
+        if (this.dragging) {
             this.dragging = false;
             DomHandler.removeClass(document.body, 'ui-unselectable-text');
+            this.onDragEnd.emit(event);
             this.cd.detectChanges();
         }
     }
@@ -457,6 +463,15 @@ export class Dialog implements OnDestroy {
     initResize(event: MouseEvent) {
         if (this.resizable) {
             this.resizing = true;
+
+            this.container.style.position = 'fixed';
+
+            let offset = DomHandler.getOffset(this.container);
+            this._style.top = offset.top + 'px';
+            this.container.style.top = offset.top + 'px';
+            this._style.left = offset.left + 'px';
+            this.container.style.left = offset.left + 'px';
+
             this.lastPageX = event.pageX;
             this.lastPageY = event.pageY;
             DomHandler.addClass(document.body, 'ui-unselectable-text');
@@ -640,7 +655,7 @@ export class Dialog implements OnDestroy {
         switch(event.toState) {
             case 'void':
                 this.onContainerDestroy();
-                this.onHide.emit({});
+                this.onHide.emit(event);
             break;
         }
     }


### PR DESCRIPTION
###Defect Fixes
There was a typo in `endDrag()` method: `this.draggable` has been replaced by `this.dragging`. And additionaly there were added new EventEmitter on `initDrag ` and `endDrag`. 
Also fixed initial position when starting resizing dialog.
OnHide emits event instead of empty object.
