### PR TITLE
Fixed #8972 incorrect property pEditableRowIndex

### DIFF
--- a/src/app/showcase/components/table/tabledemo.html
+++ b/src/app/showcase/components/table/tabledemo.html
@@ -1469,7 +1469,7 @@ export class TableDemo implements OnInit &#123;
             <p>If you require the edited row data, rowIndex and the selected field in the <i>onEditInit</i>, <i>onEditComplete</i>, and <i>onEditCancel</i> events, bind the row data to the <i>pEditableColumn</i> directive, the <i>rowIndex</i> <i>pEditableColumnRowIndex</i> property and field to the the field to the <i>pEditableColumnField</i> directive.</p>
 <pre>
 <code class="language-markup" pCode ngNonBindable>
-&lt;td [pEditableColumn]="rowData" [pEditableColumnField]="'year'" [pEditableRowIndex]="index"&gt;
+&lt;td [pEditableColumn]="rowData" [pEditableColumnField]="'year'" [pEditableColumnRowIndex]="index"&gt;
 </code>
 </pre>
 


### PR DESCRIPTION
In the table demo, updated `pEditableRowIndex` to the property `pEditableColumnRowIndex` as it is the input property on the EditableColumn directive.
https://github.com/primefaces/primeng/blob/6f1c6c30a67b78c2b5979a0656a917fb7be3a494/src/app/components/table/table.ts#L3110

###Defect Fixes
https://github.com/primefaces/primeng/issues/8972