### PR TITLE
Remove deprecated method from table docs

### DIFF
--- a/src/app/showcase/components/table/tabledemo.html
+++ b/src/app/showcase/components/table/tabledemo.html
@@ -3163,11 +3163,6 @@ export class TableDemo implements OnInit &#123;
                             <td>Exports the data in csv format.</td>
                         </tr>
                         <tr>
-                            <td>closeCellEdit</td>
-                            <td>-</td>
-                            <td>Closes the editing cell.</td>
-                        </tr>
-                        <tr>
                             <td>resetScrollTop</td>
                             <td>-</td>
                             <td>Resets the scrollable table scroll position to the beginning.</td>


### PR DESCRIPTION
`closeCellEdit` is no longer a public method on the table component.

###Defect Fixes
Possible solution to https://github.com/primefaces/primeng/issues/8974 .  If there is no immediate intent to restore the `closeCellEdit` method to the table component, this fix would remove the confusion in the documentation.