### PR TITLE
inputmode="none", so no keyboard pops up on mobile devices

### DIFF
--- a/src/app/components/tristatecheckbox/tristatecheckbox.ts
+++ b/src/app/components/tristatecheckbox/tristatecheckbox.ts
@@ -13,7 +13,7 @@ export const TRISTATECHECKBOX_VALUE_ACCESSOR: any = {
     template: `
         <div [ngStyle]="style" [ngClass]="{'p-checkbox p-component': true,'p-checkbox-disabled': disabled, 'p-checkbox-focused': focused}" [class]="styleClass">
             <div class="p-hidden-accessible">
-                <input #input type="text" [attr.id]="inputId" [name]="name" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled" (keyup)="onKeyup($event)" (keydown)="onKeydown($event)" (focus)="onFocus()" (blur)="onBlur()" [attr.aria-labelledby]="ariaLabelledBy">
+                <input #input type="text" [attr.id]="inputId" [name]="name" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled" (keyup)="onKeyup($event)" (keydown)="onKeydown($event)" (focus)="onFocus()" (blur)="onBlur()" [attr.aria-labelledby]="ariaLabelledBy" inputmode="none">
             </div>
             <div class="p-checkbox-box" (click)="onClick($event,input)"  role="checkbox" [attr.aria-checked]="value === true"
                 [ngClass]="{'p-highlight':value!=null,'p-disabled':disabled,'p-focus':focused}">


### PR DESCRIPTION
###Defect Fixes
Fixes the behavior described in #9085 - now no keyboard pops up on mobile devices, when clicking on a TriStateCheckbox.
The used tag is well defined: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode