### PR TITLE
Doc. fix for the expected theme

### DIFF
--- a/src/app/showcase/components/setup/setup.component.html
+++ b/src/app/showcase/components/setup/setup.component.html
@@ -165,7 +165,7 @@ export class YourAppModule &#123; &#125;
 </app-code>
 
     <h6>Styles Configuration</h6>
-    <p>Configure required styles at the styles section, example below uses the Nova Light theme.</p>
+    <p>Configure required styles at the styles section, example below uses the Saga Blue theme.</p>
     
 <app-code lang="typescript" ngNonBindable>
 "styles": [


### PR DESCRIPTION
Documentation Fix

Code example shows `.../themes/saga-blue/theme.css` in use, but the documentation has "Nova Light" instead.

This update fixes the text to also be: Saga Blue.