### PR TITLE
Use el.ownerDocument.activeElement to check for focus where possible.

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -709,7 +709,9 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
                 if (event.which === 3) {
                     return;
                 }

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -3,7 +3,7 @@ import {CommonModule} from '@angular/common';
 import {trigger,style,transition,animate,AnimationEvent} from '@angular/animations';
 import {InputTextModule} from 'primeng/inputtext';
 import {ButtonModule} from 'primeng/button';
-import {RippleModule} from 'primeng/ripple';  
+import {RippleModule} from 'primeng/ripple';
 import {SharedModule,PrimeTemplate} from 'primeng/api';
 import {DomHandler} from 'primeng/dom';
 import {ObjectUtils, UniqueComponentId} from 'primeng/utils';
@@ -81,7 +81,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
     @Input() panelStyle: any;
 
     @Input() styleClass: string;
-    
+
     @Input() panelStyleClass: string;
 
     @Input() inputStyle: any;
@@ -113,7 +113,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
     @Input() type: string = 'text';
 
     @Input() autoZIndex: boolean = true;
-    
+
     @Input() baseZIndex: number = 0;
 
     @Input() ariaLabel: string;
@@ -227,7 +227,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
     forceSelectionUpdateModelTimeout: any;
 
     listId: string;
-    
+
     itemClicked: boolean;
 
     constructor(public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public differs: IterableDiffers) {
@@ -291,7 +291,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                     this.hide();
                 }
             }
-    
+
             this.loading = false;
         }
     }
@@ -417,8 +417,10 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     show() {
         if (this.multiInputEL || this.inputEL) {
-            let hasFocus = this.multiple ? document.activeElement == this.multiInputEL.nativeElement : document.activeElement == this.inputEL.nativeElement ;
-            
+            let hasFocus = this.multiple ?
+                this.multiInputEL.nativeElement.ownerDocument.activeElement == this.multiInputEL.nativeElement :
+                this.inputEL.nativeElement.ownerDocument.activeElement == this.inputEL.nativeElement ;
+
             if (!this.overlayVisible && hasFocus) {
                 this.overlayVisible = true;
             }
@@ -743,7 +745,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
         this.documentResizeListener = this.onWindowResize.bind(this);
         window.addEventListener('resize', this.documentResizeListener);
     }
-    
+
     unbindDocumentResizeListener() {
         if (this.documentResizeListener) {
             window.removeEventListener('resize', this.documentResizeListener);

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1536,11 +1536,11 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
         let focusableElements = DomHandler.getFocusableElements(this.contentViewChild.nativeElement);
 
         if (focusableElements && focusableElements.length > 0) {
-            if (!document.activeElement) {
+            if (!focusableElements[0].ownerDocument.activeElement) {
                 focusableElements[0].focus();
             }
             else {
-                let focusedIndex = focusableElements.indexOf(document.activeElement);
+                let focusedIndex = focusableElements.indexOf(focusableElements[0].ownerDocument.activeElement);
 
                 if (event.shiftKey) {
                     if (focusedIndex == -1 || focusedIndex === 0) {

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -2461,7 +2461,9 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
             this.zone.runOutsideAngular(() => {
-                this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
+                const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+                this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
                     if (this.isOutsideClicked(event) && this.overlayVisible) {
                         this.zone.run(() => {
                             this.hideOverlay();

--- a/src/app/components/colorpicker/colorpicker.ts
+++ b/src/app/components/colorpicker/colorpicker.ts
@@ -362,7 +362,9 @@ export class ColorPicker implements ControlValueAccessor, OnDestroy {
     
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', () => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', () => {
                 if (!this.selfClick) {
                     this.overlayVisible = false;
                     this.unbindDocumentClickListener();
@@ -383,7 +385,9 @@ export class ColorPicker implements ControlValueAccessor, OnDestroy {
     
     bindDocumentMousemoveListener() {
         if (!this.documentMousemoveListener) {
-            this.documentMousemoveListener = this.renderer.listen('document', 'mousemove', (event: MouseEvent) => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentMousemoveListener = this.renderer.listen(documentTarget, 'mousemove', (event: MouseEvent) => {
                 if (this.colorDragging) {
                     this.pickColor(event);
                 }
@@ -404,7 +408,9 @@ export class ColorPicker implements ControlValueAccessor, OnDestroy {
     
     bindDocumentMouseupListener() {
         if (!this.documentMouseupListener) {
-            this.documentMouseupListener = this.renderer.listen('document', 'mouseup', () => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentMouseupListener = this.renderer.listen(documentTarget, 'mouseup', () => {
                 this.colorDragging = false;
                 this.hueDragging = false;
                 this.unbindDocumentMousemoveListener();

--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -363,7 +363,9 @@ export class ConfirmDialog implements AfterContentInit,OnDestroy {
 
     bindGlobalListeners() {
         if ((this.closeOnEscape && this.closable) || this.focusTrap && !this.documentEscapeListener) {
-            this.documentEscapeListener = this.renderer.listen('document', 'keydown', (event) => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentEscapeListener = this.renderer.listen(documentTarget, 'keydown', (event) => {
                 if (event.which == 27 && (this.closeOnEscape && this.closable)) {
                     if (parseInt(this.container.style.zIndex) === (DomHandler.zindex + this.baseZIndex) && this.visible) {
                         this.close(event);

--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -121,7 +121,7 @@ export class ConfirmDialog implements AfterContentInit,OnDestroy {
         if (this._visible && !this.maskVisible) {
             this.maskVisible = true;
         }
-        
+
         this.cd.markForCheck();
     }
 
@@ -376,11 +376,11 @@ export class ConfirmDialog implements AfterContentInit,OnDestroy {
                     let focusableElements = DomHandler.getFocusableElements(this.container);
 
                     if (focusableElements && focusableElements.length > 0) {
-                        if (!document.activeElement) {
+                        if (!focusableElements[0].ownerDocument.activeElement) {
                             focusableElements[0].focus();
                         }
                         else {
-                            let focusedIndex = focusableElements.indexOf(document.activeElement);
+                            let focusedIndex = focusableElements.indexOf(focusableElements[0].ownerDocument.activeElement);
 
                             if (event.shiftKey) {
                                 if (focusedIndex == -1 || focusedIndex === 0)

--- a/src/app/components/contextmenu/contextmenu.ts
+++ b/src/app/components/contextmenu/contextmenu.ts
@@ -185,7 +185,9 @@ export class ContextMenu implements AfterViewInit, OnDestroy {
 
     ngAfterViewInit() {
         if (this.global) {
-            this.triggerEventListener = this.renderer.listen('document', this.triggerEvent, (event) => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.triggerEventListener = this.renderer.listen(documentTarget, this.triggerEvent, (event) => {
                 this.show(event);
                 event.preventDefault();
             });
@@ -276,7 +278,9 @@ export class ContextMenu implements AfterViewInit, OnDestroy {
 
     bindGlobalListeners() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
                 if (this.containerViewChild.nativeElement.offsetParent && this.isOutsideClicked(event) && event.button !== 2) {
                     this.hide();
                 }

--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -618,7 +618,9 @@ export class Dialog implements AfterContentInit,OnDestroy {
     }
 
     bindDocumentEscapeListener() {
-        this.documentEscapeListener = this.renderer.listen('document', 'keydown', (event) => {
+        const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+        this.documentEscapeListener = this.renderer.listen(documentTarget, 'keydown', (event) => {
             if (event.which == 27) {
                 if (parseInt(this.container.style.zIndex) === (DomHandler.zindex + this.baseZIndex)) {
                     this.close(event);

--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -5,7 +5,7 @@ import {CommonModule} from '@angular/common';
 import {DomHandler} from 'primeng/dom';
 import {Header,Footer,SharedModule, PrimeTemplate} from 'primeng/api';
 import {FocusTrapModule} from 'primeng/focustrap';
-import {RippleModule} from 'primeng/ripple';  
+import {RippleModule} from 'primeng/ripple';
 
 let idx: number = 0;
 
@@ -21,7 +21,7 @@ const hideAnimation = animation([
 @Component({
     selector: 'p-dialog',
     template: `
-        <div *ngIf="maskVisible" [class]="maskStyleClass" 
+        <div *ngIf="maskVisible" [class]="maskStyleClass"
             [ngClass]="{'p-dialog-mask': true, 'p-component-overlay': this.modal, 'p-dialog-mask-scrollblocker': this.modal || this.blockScroll,
                 'p-dialog-left': position === 'left',
                 'p-dialog-right': position === 'right',
@@ -412,11 +412,11 @@ export class Dialog implements AfterContentInit,OnDestroy {
                 let focusableElements = DomHandler.getFocusableElements(this.container);
 
                 if (focusableElements && focusableElements.length > 0) {
-                    if (!document.activeElement) {
+                    if (!focusableElements[0].ownerDocument.activeElement) {
                         focusableElements[0].focus();
                     }
                     else {
-                        let focusedIndex = focusableElements.indexOf(document.activeElement);
+                        let focusedIndex = focusableElements.indexOf(focusableElements[0].ownerDocument.activeElement);
 
                         if (event.shiftKey) {
                             if (focusedIndex == -1 || focusedIndex === 0)

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -10,7 +10,7 @@ import {ObjectUtils} from 'primeng/utils';
 import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {FilterUtils} from 'primeng/utils';
 import {TooltipModule} from 'primeng/tooltip';
-import {RippleModule} from 'primeng/ripple';  
+import {RippleModule} from 'primeng/ripple';
 
 export const DROPDOWN_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -520,8 +520,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     }
 
     isInputClick(event): boolean {
-        return DomHandler.hasClass(event.target, 'p-dropdown-clear-icon') || 
-            event.target.isSameNode(this.accessibleViewChild.nativeElement) || 
+        return DomHandler.hasClass(event.target, 'p-dropdown-clear-icon') ||
+            event.target.isSameNode(this.accessibleViewChild.nativeElement) ||
             (this.editableInputViewChild && event.target.isSameNode(this.editableInputViewChild.nativeElement));
     }
 
@@ -1042,7 +1042,9 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
 
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
                 if (this.isOutsideClicked(event)) {
                     this.hide(event);
                     this.unbindDocumentClickListener();

--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -133,7 +133,7 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
 
 	onContainerDestroy() {
 		this.unbindGlobalListeners();
-        
+
         if (this.config.modal !== false) {
             this.disableModality();
         }
@@ -182,11 +182,11 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
             let focusableElements = DomHandler.getFocusableElements(this.container);
 
             if (focusableElements && focusableElements.length > 0) {
-                if (!document.activeElement) {
+                if (!focusableElements[0].ownerDocument.activeElement) {
                     focusableElements[0].focus();
                 }
                 else {
-                    let focusedIndex = focusableElements.indexOf(document.activeElement);
+                    let focusedIndex = focusableElements.indexOf(focusableElements[0].ownerDocument.activeElement);
 
                     if (event.shiftKey) {
                         if (focusedIndex == -1 || focusedIndex === 0)

--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -242,7 +242,9 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
     }
 
 	bindDocumentEscapeListener() {
-        this.documentEscapeListener = this.renderer.listen('document', 'keydown', (event) => {
+        const documentTarget: any = this.maskViewChild ? this.maskViewChild.nativeElement.ownerDocument : 'document';
+
+        this.documentEscapeListener = this.renderer.listen(documentTarget, 'keydown', (event) => {
             if (event.which == 27) {
                 if (parseInt(this.container.style.zIndex) == (DomHandler.zindex + (this.config.baseZIndex ? this.config.baseZIndex : 0))) {
 					this.close();

--- a/src/app/components/focustrap/focustrap.ts
+++ b/src/app/components/focustrap/focustrap.ts
@@ -18,11 +18,11 @@ export class FocusTrap {
             e.preventDefault();
             let focusableElements = DomHandler.getFocusableElements(this.el.nativeElement);
             if (focusableElements && focusableElements.length > 0) {
-                if (!document.activeElement) {
+                if (!focusableElements[0].ownerDocument.activeElement) {
                     focusableElements[0].focus();
                 }
                 else {
-                    let focusedIndex = focusableElements.indexOf(document.activeElement);
+                    let focusedIndex = focusableElements.indexOf(focusableElements[0].ownerDocument.activeElement);
 
                     if (e.shiftKey) {
                         if (focusedIndex == -1 || focusedIndex === 0)

--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -239,7 +239,7 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
     caret(first?: number, last?: number) {
         let range, begin, end;
 
-        if (!this.inputViewChild.nativeElement.offsetParent||this.inputViewChild.nativeElement !== document.activeElement) {
+        if (!this.inputViewChild.nativeElement.offsetParent||this.inputViewChild.nativeElement !== this.inputViewChild.nativeElement.ownerDocument.activeElement) {
             return;
         }
 
@@ -576,7 +576,7 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
         pos = this.checkVal();
 
         this.caretTimeoutId = setTimeout(() => {
-            if (this.inputViewChild.nativeElement !== document.activeElement){
+            if (this.inputViewChild.nativeElement !== this.inputViewChild.nativeElement.ownerDocument.activeElement){
                 return;
             }
             this.writeBuffer();

--- a/src/app/components/lightbox/lightbox.ts
+++ b/src/app/components/lightbox/lightbox.ts
@@ -207,15 +207,17 @@ export class Lightbox implements AfterViewInit,OnDestroy {
     }
 
     bindGlobalListeners() {
-        this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
-            if (!this.preventDocumentClickListener&&this.visible) {
+        const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+        this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
+            if (!this.preventDocumentClickListener && this.visible) {
                 this.hide(event);
             }
             this.preventDocumentClickListener = false;
             this.cd.markForCheck();
         });
         if (this.closeOnEscape && !this.documentEscapeListener) {
-            this.documentEscapeListener = this.renderer.listen('document', 'keydown', (event) => {
+            this.documentEscapeListener = this.renderer.listen(documentTarget, 'keydown', (event) => {
                     if (event.which == 27) {
                     if (parseInt(this.panel.style.zIndex) === (DomHandler.zindex + this.baseZIndex)) {
                         this.hide(event);

--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -214,7 +214,9 @@ export class Menu implements OnDestroy {
 
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', () => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', () => {
                 if (!this.preventDocumentDefault) {
                     this.hide();
                 }

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -359,7 +359,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                 case 'selectedItems':
                     this.selectedItemsTemplate = item.template;
                 break;
-                
+
                 case 'header':
                     this.headerTemplate = item.template;
                 break;
@@ -851,7 +851,9 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
 
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', (event) => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
                 if (this.isOutsideClicked(event)) {
                     this.hide();
                 }

--- a/src/app/components/overlaypanel/overlaypanel.ts
+++ b/src/app/components/overlaypanel/overlaypanel.ts
@@ -118,8 +118,10 @@ export class OverlayPanel implements AfterContentInit, OnDestroy {
         if (!this.documentClickListener && this.dismissable) {
             this.zone.runOutsideAngular(() => {
                 let documentEvent = DomHandler.isIOS() ? 'touchstart' : 'click';
-                this.documentClickListener = this.renderer.listen('document', documentEvent, (event) => {
-                    if (!this.container.contains(event.target) && this.target !== event.target && !this.target.contains(event.target) && !this.isContainerClicked) {
+                const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+                this.documentClickListener = this.renderer.listen(documentTarget, documentEvent, (event) => {
+                    if (!this.container.contains(event.target) && this.target !== event.target && !this.target.contains(event.target) && !this.isContainerClicked) {
                         this.zone.run(() => {
                             this.hide();
                         });

--- a/src/app/components/sidebar/sidebar.ts
+++ b/src/app/components/sidebar/sidebar.ts
@@ -8,9 +8,9 @@ import {PrimeTemplate} from 'primeng/api';
 @Component({
     selector: 'p-sidebar',
     template: `
-        <div #container [ngClass]="{'p-sidebar':true, 'p-sidebar-active': visible, 
+        <div #container [ngClass]="{'p-sidebar':true, 'p-sidebar-active': visible,
             'p-sidebar-left': (position === 'left'), 'p-sidebar-right': (position === 'right'),
-            'p-sidebar-top': (position === 'top'), 'p-sidebar-bottom': (position === 'bottom'), 
+            'p-sidebar-top': (position === 'top'), 'p-sidebar-bottom': (position === 'bottom'),
             'p-sidebar-full': fullScreen}"
             [@panelState]="visible ? 'visible' : 'hidden'" (@panelState.start)="onAnimationStart($event)" [ngStyle]="style" [class]="styleClass"  role="complementary" [attr.aria-modal]="modal">
             <div class="p-sidebar-content">
@@ -180,7 +180,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, AfterViewChecke
             this.mask = document.createElement('div');
             this.mask.style.zIndex = String(parseInt(this.containerViewChild.nativeElement.style.zIndex) - 1);
             DomHandler.addMultipleClasses(this.mask, 'p-component-overlay p-sidebar-mask');
-            
+
             if (this.dismissible){
                 this.maskClickListener = this.renderer.listen(this.mask, 'click', (event: any) => {
                     if (this.dismissible) {
@@ -214,7 +214,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, AfterViewChecke
                     this.bindDocumentEscapeListener();
                 }
             break;
-            
+
             case 'hidden':
                 this.unbindGlobalListeners();
             break;
@@ -222,7 +222,9 @@ export class Sidebar implements AfterViewInit, AfterContentInit, AfterViewChecke
     }
 
     bindDocumentEscapeListener() {
-        this.documentEscapeListener = this.renderer.listen('document', 'keydown', (event) => {
+        const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+        this.documentEscapeListener = this.renderer.listen(documentTarget, 'keydown', (event) => {
             if (event.which == 27) {
                 if (parseInt(this.containerViewChild.nativeElement.style.zIndex) === (DomHandler.zindex + this.baseZIndex)) {
                     this.close(event);

--- a/src/app/components/slidemenu/slidemenu.ts
+++ b/src/app/components/slidemenu/slidemenu.ts
@@ -287,7 +287,9 @@ export class SlideMenu implements AfterViewChecked, OnDestroy {
 
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', () => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', () => {
                 if (!this.preventDocumentDefault) {
                     this.hide();
                     this.cd.detectChanges();

--- a/src/app/components/slider/slider.ts
+++ b/src/app/components/slider/slider.ts
@@ -235,8 +235,10 @@ export class Slider implements OnDestroy,ControlValueAccessor {
     
     bindDragListeners() {
         this.ngZone.runOutsideAngular(() => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
             if (!this.dragListener) {
-                this.dragListener = this.renderer.listen('document', 'mousemove', (event) => {
+                this.dragListener = this.renderer.listen(documentTarget, 'mousemove', (event) => {
                     if (this.dragging) {
                         this.ngZone.run(() => {
                             this.handleChange(event);
@@ -246,7 +248,7 @@ export class Slider implements OnDestroy,ControlValueAccessor {
             }
 
             if (!this.mouseupListener) {
-                this.mouseupListener = this.renderer.listen('document', 'mouseup', (event) => {
+                this.mouseupListener = this.renderer.listen(documentTarget, 'mouseup', (event) => {
                     if (this.dragging) {
                         this.dragging = false;
                         this.ngZone.run(() => {

--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -147,7 +147,9 @@ export class TieredMenuSub implements AfterViewInit, OnDestroy {
 
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', () => {
+            const documentTarget: any = this.tieredMenu && this.tieredMenu.el ? this.tieredMenu.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', () => {
                 if (!this.rootItemClick) {
                     this.parentActive = false;
                     this.activeItem = null;
@@ -301,7 +303,9 @@ export class TieredMenu implements OnDestroy {
     
     bindDocumentClickListener() {
         if (!this.documentClickListener) {
-            this.documentClickListener = this.renderer.listen('document', 'click', () => {
+            const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
+
+            this.documentClickListener = this.renderer.listen(documentTarget, 'click', () => {
                 if (!this.preventDocumentDefault && this.popup) {
                     this.hide();
                 }


### PR DESCRIPTION
###Defect Fixes
Fixes #9181 

Allows focus checks to work correctly regardless of which document object is hosting the element.