### PR TITLE
Fixed #9123 #9121 - Unable to close p-messages on Firefox + Empty Template for FileUpload - v10.0.0-rc.3

### DIFF
--- a/src/app/components/fileupload/fileupload.css
+++ b/src/app/components/fileupload/fileupload.css
@@ -39,3 +39,7 @@
 .p-fluid .p-fileupload .p-button {
     width: auto;
 }
+
+.p-fileupload-empty p { 
+    margin-bottom: 0;
+}

--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -49,6 +49,9 @@ import {HttpClient, HttpEvent, HttpEventType, HttpHeaders} from "@angular/common
                         <ng-template ngFor [ngForOf]="files" [ngForTemplate]="fileTemplate"></ng-template>
                     </div>
                 </div>
+                <div class="p-fileupload-empty" *ngIf="!hasFiles()">
+                    <ng-container *ngTemplateOutlet="emptyTemplate"></ng-container>
+                </div>
                 <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
             </div>
         </div>
@@ -189,6 +192,8 @@ export class FileUpload implements AfterViewInit,AfterContentInit,OnDestroy,Bloc
 
     public toolbarTemplate: TemplateRef<any>;
 
+    public emptyTemplate: TemplateRef<any>;
+
     public uploadedFileCount: number = 0;
 
     focus: boolean;
@@ -212,6 +217,10 @@ export class FileUpload implements AfterViewInit,AfterContentInit,OnDestroy,Bloc
 
                 case 'toolbar':
                     this.toolbarTemplate = item.template;
+                break;
+
+                case 'empty':
+                    this.emptyTemplate = item.template;
                 break;
 
                 default:

--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -47,7 +47,8 @@ import {RippleModule} from 'primeng/ripple';
                 animate('{{showTransitionParams}}')
             ]),
             transition(':leave', [
-                animate('{{hideTransitionParams}}', style({ height:0, margin: 0, overflow: 'hidden', opacity: 0 }))
+                animate('{{hideTransitionParams}}'),
+                style({ height:0, opacity: 0 ,transform: 'translateY(-25%)'})
             ])
         ])
     ],

--- a/src/app/showcase/components/fileupload/fileuploaddemo.html
+++ b/src/app/showcase/components/fileupload/fileuploaddemo.html
@@ -18,6 +18,9 @@
                         <li *ngFor="let file of uploadedFiles">{{file.name}} - {{file.size}} bytes</li>
                     </ul>
                 </ng-template>
+                <ng-template pTemplate="empty">
+                    <p>Drag and drop files to here to upload.</p>
+                </ng-template>
         </p-fileUpload>
 
         <h5>Basic</h5>


### PR DESCRIPTION
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.