### PR TITLE
Fixed #9123 - Unable to close p-messages on Firefox

### DIFF
--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -47,7 +47,8 @@ import {RippleModule} from 'primeng/ripple';
                 animate('{{showTransitionParams}}')
             ]),
             transition(':leave', [
-                animate('{{hideTransitionParams}}', style({ height:0, margin: 0, overflow: 'hidden', opacity: 0 }))
+                animate('{{hideTransitionParams}}'),
+                style({height:0, opacity: 0, transform: 'translateY(-5%)'})
             ])
         ])
     ],


### PR DESCRIPTION
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.