### PR TITLE
Issue #8947: Accessibility: Dialog close button needs aria- label

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -40,8 +40,8 @@ const hideAnimation = animation([
                     <ng-container *ngTemplateOutlet="footerTemplate"></ng-container>
                 </div>
                 <div class="p-dialog-footer" *ngIf="!footer">
-                    <button type="button" pButton [icon]="option('acceptIcon')" [label]="option('acceptLabel')" (click)="accept()" [ngClass]="'p-confirm-dialog-accept'" [class]="option('acceptButtonStyleClass')" *ngIf="option('acceptVisible')"></button>
-                    <button type="button" pButton [icon]="option('rejectIcon')" [label]="option('rejectLabel')" (click)="reject()" [ngClass]="'p-confirm-dialog-reject'" [class]="option('rejectButtonStyleClass')" *ngIf="option('rejectVisible')"></button>
+                    <button type="button" pButton [icon]="option('acceptIcon')" [label]="option('acceptLabel')" (click)="accept()" [ngClass]="'p-confirm-dialog-accept'" [class]="option('acceptButtonStyleClass')" *ngIf="option('acceptVisible')" [attr.aria-label]="acceptAriaLabel"></button>
+                    <button type="button" pButton [icon]="option('rejectIcon')" [label]="option('rejectLabel')" (click)="reject()" [ngClass]="'p-confirm-dialog-reject'" [class]="option('rejectButtonStyleClass')" *ngIf="option('rejectVisible')" [attr.aria-label]="rejectAriaLabel"></button>
                 </div>
             </div>
         </div>
@@ -78,11 +78,15 @@ export class ConfirmDialog implements AfterContentInit,OnDestroy {
 
     @Input() acceptLabel: string = 'Yes';
 
+    @Input() acceptAriaLabel: string;
+
     @Input() acceptVisible: boolean = true;
 
     @Input() rejectIcon: string = 'pi pi-times';
 
     @Input() rejectLabel: string = 'No';
+
+    @Input() rejectAriaLabel: string;
 
     @Input() rejectVisible: boolean = true;
 

--- a/src/app/showcase/components/confirmdialog/confirmdialogdemo.html
+++ b/src/app/showcase/components/confirmdialog/confirmdialogdemo.html
@@ -293,6 +293,12 @@ export class ConfirmDialogDemo &#123;
                           <td>Label of the accept button.</td>
                         </tr>
                         <tr>
+                            <td>acceptAriaLabel</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Defines a string that labels the accept button for accessibility.</td>
+                        </tr>
+                        <tr>
                           <td>acceptIcon</td>
                           <td>string</td>
                           <td>pi pi-check</td>
@@ -309,6 +315,12 @@ export class ConfirmDialogDemo &#123;
                           <td>string</td>
                           <td>No</td>
                           <td>Label of the reject button.</td>
+                        </tr>
+                        <tr>
+                            <td>rejectAriaLabel</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Defines a string that labels the reject button for accessibility.</td>
                         </tr>
                         <tr>
                           <td>rejectIcon</td>


### PR DESCRIPTION
Added accessibility label support for accept and reject button on the confirmation dialog. The element documentation has also been updated.