### PR TITLE
Fixed radiobutton with template-driven forms #9162

### DIFF
--- a/src/app/components/radiobutton/radiobutton.ts
+++ b/src/app/components/radiobutton/radiobutton.ts
@@ -1,12 +1,47 @@
-import {NgModule,Component,Input,Output,ElementRef,EventEmitter,forwardRef,ViewChild,ChangeDetectorRef,ChangeDetectionStrategy} from '@angular/core';
+import {NgModule, Component, Input, Output, ElementRef, EventEmitter, forwardRef, ViewChild, ChangeDetectorRef, ChangeDetectionStrategy, Injectable, OnInit, OnDestroy, Injector} from '@angular/core';
 import {CommonModule} from '@angular/common';
-import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
+import {NG_VALUE_ACCESSOR, ControlValueAccessor, NgControl} from '@angular/forms';
 
 export const RADIO_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
     useExisting: forwardRef(() => RadioButton),
     multi: true
 };
+
+/**
+ * Internal class used by RadioButton to uncheck radio buttons with the matching name.
+ */
+@Injectable({
+    providedIn: 'root',
+})
+export class RadioControlRegistry {
+    private accessors: any[] = [];
+
+    add(control: NgControl, accessor: RadioButton) {
+        this.accessors.push([control, accessor]);
+    }
+
+    remove(accessor: RadioButton) {
+        this.accessors = this.accessors.filter((c) => {
+            return c[1] !== accessor;
+        })
+    }
+
+    select(accessor: RadioButton) {
+        this.accessors.forEach((c) => {
+            if (this.isSameGroup(c, accessor) && c[1] !== accessor) {
+                c[1].writeValue(accessor.value);
+            }
+        });
+    }
+
+    private isSameGroup(controlPair: [NgControl, RadioButton], accessor: RadioButton): boolean {
+        if (!controlPair[0].control) {
+            return false;
+        }
+        return controlPair[0].control.root === accessor.control.control.root && controlPair[1].name === accessor.name;
+    }
+}
 
 @Component({
     selector: 'p-radioButton',
@@ -29,14 +64,16 @@ export const RADIO_VALUE_ACCESSOR: any = {
     providers: [RADIO_VALUE_ACCESSOR],
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class RadioButton implements ControlValueAccessor {
+export class RadioButton implements ControlValueAccessor, OnInit, OnDestroy {
 
     @Input() value: any;
+
+    @Input() formControlName: string;
 
     @Input() name: string;
 
     @Input() disabled: boolean;
-    
+
     @Input() label: string;
 
     @Input() tabindex: number;
@@ -44,7 +81,7 @@ export class RadioButton implements ControlValueAccessor {
     @Input() inputId: string;
 
     @Input() ariaLabelledBy: string;
-    
+
     @Input() style: any;
 
     @Input() styleClass: string;
@@ -56,19 +93,31 @@ export class RadioButton implements ControlValueAccessor {
     @Output() onFocus: EventEmitter<any> = new EventEmitter();
 
     @Output() onBlur: EventEmitter<any> = new EventEmitter();
-    
+
     @ViewChild('rb') inputViewChild: ElementRef;
-            
+
     public onModelChange: Function = () => {};
-    
+
     public onModelTouched: Function = () => {};
-    
+
     public checked: boolean;
-        
+
     public focused: boolean;
 
-    constructor(public cd: ChangeDetectorRef) {}
-    
+    control: NgControl;
+
+    constructor(public cd: ChangeDetectorRef, private injector: Injector, private registry: RadioControlRegistry) {}
+
+    ngOnInit() {
+        this.control = this.injector.get(NgControl);
+        this.checkName();
+        this.registry.add(this.control, this);
+    }
+
+    ngOnDestroy() {
+        this.registry.remove(this);
+    }
+
     handleClick(event, radioButton, focus) {
         event.preventDefault();
 
@@ -82,26 +131,27 @@ export class RadioButton implements ControlValueAccessor {
             radioButton.focus();
         }
     }
-    
+
     select(event) {
         if (!this.disabled) {
             this.inputViewChild.nativeElement.checked = true;
             this.checked = true;
             this.onModelChange(this.value);
             this.onClick.emit(event);
+            this.registry.select(this);
         }
     }
-            
+
     writeValue(value: any) : void {
         this.checked = (value == this.value);
 
         if (this.inputViewChild && this.inputViewChild.nativeElement) {
             this.inputViewChild.nativeElement.checked = this.checked;
         }
-        
+
         this.cd.markForCheck();
     }
-    
+
     registerOnChange(fn: Function): void {
         this.onModelChange = fn;
     }
@@ -109,12 +159,12 @@ export class RadioButton implements ControlValueAccessor {
     registerOnTouched(fn: Function): void {
         this.onModelTouched = fn;
     }
-    
+
     setDisabledState(val: boolean): void {
         this.disabled = val;
         this.cd.markForCheck();
     }
-    
+
     onInputFocus(event) {
         this.focused = true;
         this.onFocus.emit(event);
@@ -125,13 +175,29 @@ export class RadioButton implements ControlValueAccessor {
         this.onModelTouched();
         this.onBlur.emit(event);
     }
-    
+
     onChange(event) {
         this.select(event);
     }
 
     focus() {
         this.inputViewChild.nativeElement.focus();
+    }
+
+    private checkName() {
+        if (this.name && this.formControlName && this.name !== this.formControlName) {
+            this.throwNameError();
+        }
+        if (!this.name && this.formControlName) {
+            this.name = this.formControlName;
+        }
+    }
+
+    private throwNameError() {
+        throw new Error(`
+          If you define both a name and a formControlName attribute on your radio button, their values
+          must match. Ex: <p-radioButton formControlName="food" name="food"></p-radioButton>
+        `);
     }
 }
 


### PR DESCRIPTION
###Defect Fixes
#9162 

Fix radiobutton for template-driven forms. Cause of the problem: writeValue is not called on controls other than control that is changed by user. If there are 3 radio buttons and user clicks on the first one, 2nd and 3rd controls will not receive updated value through writeValue call. It'is not really a bug, but rather made on purpose by angular team. To work around the problem we need a singleton service that will keep registry of all buttons in all groups. When user changes value of one of the button, corresponding control propagates this changes to all sibling buttons in the same form through registry.

The solution and code is borrowed from angular's RadioControlValueAccessor (https://github.com/angular/angular/blob/c0523fc3b45cdb5ba52109f7ae0e4dab555b7d72/packages/forms/src/directives/radio_control_value_accessor.ts)