### PR TITLE
[issues/5977]: Add specific class for first and last day in calendar

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -85,7 +85,7 @@ export interface LocaleSettings {
                                                     {{month.weekNumbers[j]}}
                                                 </span>
                                             </td>
-                                            <td *ngFor="let date of week" [ngClass]="{'p-datepicker-other-month': date.otherMonth,'p-datepicker-today':date.today}">
+                                            <td *ngFor="let date of week" [ngClass]="{'p-datepicker-other-month': date.otherMonth,'p-datepicker-today':date.today, 'p-datepicker-start-date':isStartDate(date), 'p-datepicker-end-date':isEndDate(date)}">
                                                 <ng-container *ngIf="date.otherMonth ? showOtherMonths : true">
                                                     <span [ngClass]="{'p-highlight':isSelected(date), 'p-disabled': !date.selectable}"
                                                         (click)="onDateSelect($event,date)" draggable="false" (keydown)="onDateCellKeydown($event,date,i)" pRipple>
@@ -1062,6 +1062,25 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
             return false;
         }
     }
+
+    isStartDate(dateMeta): boolean {
+        if (this.value) {
+            if (this.isRangeSelection()) {
+                return this.isDateEquals(this.value[0], dateMeta);
+            }
+        }
+        return false;
+    }
+
+    isEndDate(dateMeta): boolean {
+        if (this.value) {
+            if (this.isRangeSelection()) {
+                return this.isDateEquals(this.value[1], dateMeta);
+            }
+        }
+        return false;
+    }
+
 
     isMonthSelected(month: number): boolean {
         let day = this.value ? (Array.isArray(this.value) ? this.value[0].getDate() : this.value.getDate()) : 1;

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -794,6 +794,14 @@ export class MyModel &#123;
                             <td>Cell of selected date.</td>
                         </tr>
                         <tr>
+                            <td>p-datepicker-start-date</td>
+                            <td>Cell of the first day in the selected range.</td>
+                        </tr>
+                        <tr>
+                            <td>p-datepicker-end-date</td>
+                            <td>Cell of the last day in the selected range.</td>
+                        </tr>
+                        <tr>
                             <td>p-datepicker-today</td>
                             <td>Cell of today's date.</td>
                         </tr>


### PR DESCRIPTION
Add a specific class for first and last day in calendar.

###Feature Requests
#5977

Consider adjusting the themes to highlight first and last days.