### PR TITLE
Inputmask - returning error 'begin' of undefined when mask is populated from chrome address

### DIFF
--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -344,6 +344,7 @@ export class InputMask implements OnInit,OnDestroy,ControlValueAccessor {
     handleAndroidInput(e) {
         var curVal = this.inputViewChild.nativeElement.value;
         var pos = this.caret();
+        if(!pos) return;
         if (this.oldVal && this.oldVal.length && this.oldVal.length > curVal.length ) {
             // a deletion or backspace happened
             this.checkVal(true);


### PR DESCRIPTION
If the mask was populated from an address saved in chrome, this.caret() will return null and error will occur. 
Happens only on android devices.