### PR TITLE
Issue #9441: Re-add CSS for p-overlaypanel-shifted

### DIFF
--- a/src/app/components/overlaypanel/overlaypanel.css
+++ b/src/app/components/overlaypanel/overlaypanel.css
@@ -36,6 +36,12 @@
 	margin-left: -10px;
 }
 
+.p-overlaypanel-shifted:after, .p-overlaypanel-shifted:before {
+    left: auto;
+    right: 1.25em;
+    margin-left: auto;
+}
+
 .p-overlaypanel-flipped:after, .p-overlaypanel-flipped:before {
     bottom: auto;
     top: 100%;


### PR DESCRIPTION
Re-added CSS for p-overlaypanel-shifted class so that the arrow points to the correct location when the panel is up against the right edge of the screen. This CSS was (unintentionally?) removed in commit: https://github.com/primefaces/primeng/commit/c7dd064da6e05d549a1a91f33ac3a9b5aa5dd267#diff-4166dfa8da6660ec4e195e891b761a9ce8f5e49db19ace3613ac9d66ad8e4f94L56 

Note this CSS was also removed (ui should be renamed to p):
```
.ui-overlaypanel-shifted:after {
    margin-right: -8px;
}

.ui-overlaypanel:before {
    margin-right: -10px;
}
```
But I chose not to add it back, because with it, the arrow overlaps the close button slightly. Without it though, the arrow is offset from the edge on the right side of the panel slightly more than it is when it appears on the left. Perhaps this could be made dynamic in the future to adjust when the close button is/isn't showing?

See issue for more information/context.

### Defect Fixes
https://github.com/primefaces/primeng/issues/9441

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.