### PR TITLE
docs(showcase): fix formatting typo in showcase for InputText

### DIFF
--- a/src/app/showcase/components/inputtext/inputtextdemo.html
+++ b/src/app/showcase/components/inputtext/inputtextdemo.html
@@ -77,7 +77,7 @@ import &#123;InputTextModule&#125; from 'primeng/inputtext';
 </app-code>
 
             <h5>Float Label</h5>
-            <p>A floating label is implemented by wrapping the input and the label inside a container with <i>.p-float-label class</i>.</p>
+            <p>A floating label is implemented by wrapping the input and the label inside a container with <i>.p-float-label</i> class.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;span class="p-float-label"&gt;
     &lt;input id="float-input" type="text" pInputText&gt; 


### PR DESCRIPTION
This PR makes a small improvement to the showcase for InputText:

![image](https://user-images.githubusercontent.com/20914054/100252921-3b480780-2f1f-11eb-9fce-f7dcb0d7366c.png)
