### PR TITLE
Remove &nbsp; from empty button label

### DIFF
--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -69,7 +69,7 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
         this._label = val;
         
         if (this.initialized) {
-            DomHandler.findSingle(this.el.nativeElement, '.p-button-label').textContent = this._label || '&nbsp;';
+            DomHandler.findSingle(this.el.nativeElement, '.p-button-label').textContent = this._label === undefined || this._label === null ? '': this._label;
             this.setStyleClass();
         }
     }


### PR DESCRIPTION
### Defect Fixes
This fixes the issue where `&nbsp;` was displayed in plain text when implementing a `p-button` with no label. The issue for this PR is #9482 