### PR TITLE
Fixed #9614 InputText documentation wrong usage for i element

### DIFF
--- a/src/app/showcase/components/inputtext/inputtextdemo.html
+++ b/src/app/showcase/components/inputtext/inputtextdemo.html
@@ -90,12 +90,12 @@ import &#123;InputTextModule&#125; from 'primeng/inputtext';
             or <i>p-input-icon-left</i> class depending on the icon location.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;span class="p-input-icon-left"&gt;
-    &lt;i class="pi pi-search" /&gt;
+    &lt;i class="pi pi-search"&gt;&lt;/i&gt;
     &lt;input type="text" pInputText [(ngModel)]="value1" placeholder="Search"&gt;         
 &lt;/span&gt;
 
 &lt;span class="p-input-icon-right"&gt;
-    &lt;i class="pi pi-spin pi-spinner" /&gt;
+    &lt;i class="pi pi-spin pi-spinner"&gt;&lt;/i&gt;
     &lt;input type="text" pInputText [(ngModel)]="value2" &gt;        
 &lt;/span&gt; 
 </app-code>


### PR DESCRIPTION
###Defect Fixes
Fixed: InputText documentation wrong usage for i element  [#9614](https://github.com/primefaces/primeng/issues/9614)