### PR TITLE
Fixed #9664 - fix so that editor doesnt automatically autofocus

### DIFF
--- a/src/app/components/editor/editor.spec.ts
+++ b/src/app/components/editor/editor.spec.ts
@@ -41,8 +41,8 @@ describe('Editor', () => {
 
     it('should call quill paste event and setText event', () => {
         fixture.detectChanges();
-        
-        const quillPasteSpy = spyOn(editor.quill,"pasteHTML").and.callThrough();
+
+        const quillPasteSpy = spyOn(editor.quill,"setContents").and.callThrough();
         const setTextSpy = spyOn(editor.quill,"setText").and.callThrough();
         editor.writeValue("V");
         fixture.detectChanges();

--- a/src/app/components/editor/editor.ts
+++ b/src/app/components/editor/editor.ts
@@ -127,7 +127,7 @@ export class Editor implements AfterViewInit,AfterContentInit,ControlValueAccess
         });
                 
         if (this.value) {
-            this.quill.pasteHTML(this.value);
+            this.quill.setContents(this.quill.clipboard.convert(this.value));
         }
         
         this.quill.on('text-change', (delta, oldContents, source) => {
@@ -178,7 +178,7 @@ export class Editor implements AfterViewInit,AfterContentInit,ControlValueAccess
                 
         if (this.quill) {
             if (value)
-                this.quill.pasteHTML(value);
+                this.quill.setContents(this.quill.clipboard.convert(value));
             else
                 this.quill.setText('');
         }


### PR DESCRIPTION
###Defect Fixes
Issue is [here](https://github.com/primefaces/primeng/issues/9664)

When I tried to run the editor, there were compile errors for the cascadeselect.ts file. I did a quickfix locally to remove those errors and test my own changes, but didn't push them here, since I wasn't a 100% sure of the quickfix was also correct.  
