### PR TITLE
List of uploaded files has overlapping texts

### DIFF
--- a/src/app/components/fileupload/fileupload.css
+++ b/src/app/components/fileupload/fileupload.css
@@ -9,7 +9,6 @@
 
 .p-fileupload-row > div {
     flex: 1 1 auto;
-    width: 25%;
 }
 
 .p-fileupload-row > div:last-child {


### PR DESCRIPTION
There's no reason for this to be fixed at 25%, for example if there's no image to be displayed in the first row, there's just this blank space that looks silly and the only way is to implement a custom template for it.
It broke in our web app after upgrading from primeNG 9 to 11 and, when I came to the official site I was it was broken there as well (with a bit bigger names than a few characters)
I guess this was introduced somewhere along the way.

P.S. I couldn't back track to where it inherited the width, but when removed in my case it fixes it. :) also **width: auto;**  works the same way.