### PR TITLE
Autocomplete: enable multiple selection at once

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -216,6 +216,8 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     inputKeyDown: boolean;
 
+    itemClick: boolean;
+
     noResults: boolean;
 
     differ: any;
@@ -398,6 +400,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
         }
 
         if (this.multiple) {
+            this.itemClick = true;
             this.multiInputEL.nativeElement.value = '';
             this.value = this.value||[];
             if (!this.isSelected(option) || !this.unique) {
@@ -717,11 +720,12 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                     return;
                 }
 
-                if (!this.inputClick && !this.isDropdownClick(event)) {
+                if (!this.inputClick && !this.isDropdownClick(event) && (!this.multiple || this.multiple && !this.itemClick)) {
                     this.hide();
                 }
 
                 this.inputClick = false;
+                this.itemClick = false;
                 this.cd.markForCheck();
             });
         }


### PR DESCRIPTION
###Defect Fixes
The PR aims to solve this issue: https://github.com/primefaces/primeng/issues/4016.

###Feature Requests

##Current behavior
Given an autocomplete with the multiple attribute set to true, the values have to be selected one at the time with the panel closing each time.

##Expected behavior
It would useful to be able to select multiple values at once similar to the MultiSelect behavior.

##Note: 
The first PR was rejected because of a lack of demand. Enough requests have been made in the issue. Can it be reconsidered?