### PR TITLE
Docs: Replace p-header and p-footer with pTemplate

### DIFF
--- a/src/app/components/card/card.spec.ts
+++ b/src/app/components/card/card.spec.ts
@@ -1,14 +1,15 @@
+import { CardDemo } from './../../showcase/components/card/carddemo';
 import { TestBed, ComponentFixture, async } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { Card } from './card';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Component, NO_ERRORS_SCHEMA } from '@angular/core';
-import { Footer, Header } from 'primeng/api';
+import { PrimeTemplate } from 'primeng/api';
 import { ButtonModule } from '../button/button';
 
 @Component({
 	template: `<p-card [header]="header" [subheader]="subheader" [style]="style" [styleClass]="styleClass">
-  <ng-template pTemplate="header">
+  <ng-template pTemplate="header">CardDemo
       <img src="Card" src="assets/showcase/images/usercard.png">
   </ng-template>
   <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Inventore sed consequuntur error repudiandae numquam deserunt
@@ -45,8 +46,7 @@ describe('Card', () => {
 			declarations: [
 				Card,
 				TestCardComponent,
-				Header,
-				Footer
+				PrimeTemplate,
 			],
 		})
 	}));
@@ -93,25 +93,21 @@ describe('Card', () => {
 	it('should have a header', () => {
 		fixture.detectChanges();
 
-		const headerEl = fixture.debugElement.query(By.css('p-header')).nativeElement;
 		const cardHeaderEl = fixture.debugElement.query(By.css('.p-card-header')).nativeElement;
-		expect(headerEl).toBeTruthy();
 		expect(cardHeaderEl).toBeTruthy();
-		expect(cardHeaderEl.children[0].children.length).toEqual(1);
+		expect(cardHeaderEl.children.length).toEqual(1);
 	});
 
 	it('should have a footer', () => {
 		fixture.detectChanges();
 
-		const footerEl = fixture.debugElement.query(By.css('p-footer')).nativeElement;
 		const cardFooterEl = fixture.debugElement.query(By.css('.p-card-footer')).nativeElement;
-		expect(footerEl).toBeTruthy();
 		expect(cardFooterEl).toBeTruthy();
-		expect(cardFooterEl.children[0].children.length).toEqual(2);
+		expect(cardFooterEl.children.length).toEqual(2);
 	});
 
 	it('should not have a header', () => {
-		card.headerFacet = null;
+		card.headerFacet = card.headerTemplate = null;
 		fixture.componentInstance.header = null;
 		fixture.detectChanges();
 

--- a/src/app/components/card/card.spec.ts
+++ b/src/app/components/card/card.spec.ts
@@ -8,15 +8,15 @@ import { ButtonModule } from '../button/button';
 
 @Component({
 	template: `<p-card [header]="header" [subheader]="subheader" [style]="style" [styleClass]="styleClass">
-  <p-header>
+  <ng-template pTemplate="header">
       <img src="Card" src="assets/showcase/images/usercard.png">
-  </p-header>
+  </ng-template>
   <div>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Inventore sed consequuntur error repudiandae numquam deserunt
       quisquam repellat libero asperiores earum nam nobis, culpa ratione quam perferendis esse, cupiditate neque quas!</div>
-  <p-footer>
+  <ng-template pTemplate="footer">
       <button  type="button" label="Save" icon="pi pi-check" style="margin-right: .25em"></button>
       <button  type="button" label="Cancel" icon="pi pi-times" class="ui-button-secondary"></button>
-  </p-footer>
+  </ng-template>
 </p-card>`
 })
 class TestCardComponent {

--- a/src/app/components/dialog/dialog.spec.ts
+++ b/src/app/components/dialog/dialog.spec.ts
@@ -10,10 +10,10 @@ import { ButtonModule } from '../button/button';
 @Component({
     template: `
     <p-dialog [(visible)]="display">
-    <p-footer>
+    <ng-template pTemplate="footer">
             <button type="button" pButton icon="pi pi-check" (click)="display=false" label="Yes"></button>
             <button type="button" pButton icon="pi pi-times" (click)="display=false" label="No" class="ui-button-secondary"></button>
-    </p-footer>
+    </ng-template>
     </p-dialog>
     <button type="button" (click)="showDialog()" pButton icon="pi pi-info-circle" label="Show"></button>
     `

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -203,8 +203,8 @@ export class MyModel &#123;
             <p>Calendar UI accepts custom content using p-header and p-footer components.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-calendar [(ngModel)]="dateValue"&gt;
-    &lt;p-header&gt;Header&lt;/p-header&gt;
-    &lt;p-footer&gt;Footer&lt;/p-footer&gt;
+    &lt;ng-template pTemplate="header"&gt;Header&lt;/ng-template&gt;
+    &lt;ng-template pTemplate="footer"&gt;Footer&lt;/ng-template&gt;
 &lt;/p-calendar&gt;
 </app-code>
 

--- a/src/app/showcase/components/card/carddemo.html
+++ b/src/app/showcase/components/card/carddemo.html
@@ -51,13 +51,13 @@ import &#123;CardModule&#125; from 'primeng/card';
             <p>Header and Footers sections can be customized using <i>p-header</i> and <i>p-footer</i> components.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-card&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         Header content here
-    &lt;/p-header&gt;
+    &lt;/ng-template&gt;
     Body Content
-    &lt;p-footer&gt;
+    &lt;ng-template pTemplate="footer"&gt;
         Footer content here
-    &lt;/p-footer&gt;
+    &lt;/ng-template&gt;
 &lt;/p-card&gt;
 </app-code>
 
@@ -158,9 +158,9 @@ import &#123;CardModule&#125; from 'primeng/card';
 &lt;/p-card&gt;
 
 &lt;p-card header="Advanced Card" subheader="Card Subheader" [style]="&#123;width: '360px'&#125;" styleClass="p-card-shadow"&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         &lt;img alt="Card" src="assets/showcase/images/usercard.png"&gt;
-    &lt;/p-header&gt;
+    &lt;/ng-template&gt;
     &lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipisicing elit. Inventore sed consequuntur error repudiandae numquam deserunt
         quisquam repellat libero asperiores earum nam nobis, culpa ratione quam perferendis esse, cupiditate neque quas!&lt;/p&gt;
     &lt;ng-template pTemplate="footer"&gt;

--- a/src/app/showcase/components/carousel/carouseldemo.html
+++ b/src/app/showcase/components/carousel/carouseldemo.html
@@ -157,9 +157,9 @@ export class CarouselDemo &#123;
             <p>Custom content projection is available using the <i>p-header</i> and <i>p-footer</i> components.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-carousel [value]="cars"&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         &lt;h5&gt;Vertical&lt;/h5&gt;
-    &lt;/p-header&gt;
+    &lt;/ng-template&gt;
     &lt;ng-template let-car pTemplate="item"&gt;
         Content to display
     &lt;/ng-template&gt;
@@ -180,9 +180,9 @@ export class CarouselDemo &#123;
             <p>When <i>autoplayInterval</i> is defined in milliseconds, items are scrolled automatically. In addition, for infinite scrolling <i>circular</i> property needs to be enabled. Note that in autoplay mode, circular is enabled by default.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-carousel [value]="cars" [autoplayInterval]="3000" [circular]="true"&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         &lt;h5&gt;Vertical&lt;/h5&gt;
-    &lt;/p-header&gt;
+    &lt;/ng-template&gt;
     &lt;ng-template let-car pTemplate="item"&gt;
         Content to display
     &lt;/ng-template&gt;

--- a/src/app/showcase/components/confirmdialog/confirmdialogdemo.html
+++ b/src/app/showcase/components/confirmdialog/confirmdialogdemo.html
@@ -248,10 +248,10 @@ export class ConfirmDialogDemo &#123;
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-confirmDialog #cd header="Confirmation" icon="pi pi-exclamation-triangle"&gt;
-    &lt;p-footer&gt;
+    &lt;ng-template pTemplate="footer"&gt;
         &lt;button type="button" pButton icon="pi pi-times" label="No" (click)="cd.reject()"&gt;&lt;/button&gt;
         &lt;button type="button" pButton icon="pi pi-check" label="Yes" (click)="cd.accept()"&gt;&lt;/button&gt;
-    &lt;/p-footer&gt;
+    &lt;/ng-template&gt;
 &lt;/p-confirmDialog&gt;
 </app-code>
 

--- a/src/app/showcase/components/dataview/dataviewdemo.html
+++ b/src/app/showcase/components/dataview/dataviewdemo.html
@@ -156,8 +156,8 @@ export class DataViewDemo implements OnInit &#123;
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-dataView [value]="cars"&gt;
-    &lt;p-header&gt;List of Cars&lt;/p-header&gt;
-    &lt;p-footer&gt;Choose from the list.&lt;/p-footer&gt;
+    &lt;ng-template pTemplate="header"&gt;List of Cars&lt;/ng-template&gt;
+    &lt;ng-template pTemplate="footer"&gt;Choose from the list.&lt;/ng-template&gt;
     &lt;ng-template let-car pTemplate="listItem"&gt;
         &lt;div&gt;
             &#123;&#123;car.id&#125;&#125;
@@ -179,12 +179,12 @@ export class DataViewDemo implements OnInit &#123;
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-dataView [value]="cars"&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         &lt;p-dataViewLayoutOptions&gt;&lt;/p-dataViewLayoutOptions&gt;
-    &lt;/p-header&gt;
-    &lt;p-footer&gt;
+    &lt;/ng-template&gt;
+    &lt;ng-template pTemplate="footer"&gt;
         &lt;p-dataViewLayoutOptions&gt;&lt;/p-dataViewLayoutOptions&gt;
-    &lt;/p-footer&gt;
+    &lt;/ng-template&gt;
 
     &lt;ng-template let-car pTemplate="listItem"&gt;
         &lt;div&gt;
@@ -264,10 +264,10 @@ loadData(event) &#123;
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-dataView [value]="cars" [sortField]="sortField" [sortOrder]="sortOrder"&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         &lt;p-dropdown [options]="sortOptions" [(ngModel)]="sortKey" placeholder="Sort By"
             (onChange)="onSortChange($event)" [style]="&#123;'min-width':'15em'&#125;"&gt;&lt;/p-dropdown&gt;
-    &lt;/p-header&gt;
+    &lt;/ng-template&gt;
     &lt;ng-template let-car pTemplate="listItem"&gt;
         &lt;div&gt;
             &#123;&#123;car.id&#125;&#125;
@@ -329,9 +329,9 @@ export class DataViewSortDemo implements OnInit &#123;
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-dataView #dv [value]="cars" filterBy="brand"&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         &lt;input type="search" pInputText placeholder="Search by brand" (input)="dv.filter($event.target.value, "contains")"&gt;
-    &lt;/p-header&gt;
+    &lt;/ng-template&gt;
     &lt;ng-template let-car pTemplate="listItem"&gt;
         &#123;&#123;car.id&#125;&#125;
     &lt;/ng-template&gt;

--- a/src/app/showcase/components/dialog/dialogdemo.html
+++ b/src/app/showcase/components/dialog/dialogdemo.html
@@ -9,11 +9,14 @@
     <div class="card">
         <h5>Basic</h5>
         <p-button (click)="showBasicDialog()" icon="pi pi-external-link" label="Show"></p-button>
-        <p-dialog header="Header" [(visible)]="displayBasic" [style]="{width: '50vw'}" [baseZIndex]="10000">
+        <p-dialog [(visible)]="displayBasic" [style]="{width: '50vw'}" [baseZIndex]="10000">
+            <ng-template pTemplate="header">Header</ng-template>
+            <ng-template pTemplate>
             <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
                 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
                 Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
                 cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+            </ng-template>
             <ng-template pTemplate="footer">
                 <p-button icon="pi pi-check" (click)="displayBasic=false" label="Ok" styleClass="p-button-text"></p-button>
             </ng-template>
@@ -159,17 +162,18 @@ Content
 </app-code>
 
             <h5>Header and Footer</h5>
-            <p>Header and Footer sections are useful to include custom content. Note that <i>Header</i> and <i>Footer</i> components should be imported and defined
-            at directives section of your component for this to work.</p>
+            <p>Header and footer sections are useful to include custom content. You can specify the sections using the <i>pTemplate</i> attribute directive.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-dialog [(visible)]="display"&gt;
-    &lt;p-header&gt;
-        Header content here
-    &lt;/p-header&gt;
-    Content
-    &lt;p-footer&gt;
-        //buttons
-    &lt;/p-footer&gt;
+    &lt;ng-template pTemplate="header"&gt;
+        Header content here (e.g. heading)
+    &lt;/ng-template&gt;
+    &lt;ng-template pTemplate="content"&gt;
+        Body content here
+    &lt;/ng-template&gt;
+    &lt;ng-template pTemplate="footer"&gt;
+        Footer content here (e.g. buttons)
+    &lt;/ng-template&gt;
 &lt;/p-dialog&gt;
 </app-code>
 

--- a/src/app/showcase/components/editor/editordemo.html
+++ b/src/app/showcase/components/editor/editordemo.html
@@ -56,7 +56,7 @@ export class EditorDemo &#123;
             <p>Editor provides a default toolbar with common options, to customize it define your elements inside the header element. Refer to <a href="http://quilljs.com/docs/modules/toolbar/">Quill documentation</a> for available controls.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-editor [(ngModel)]="text2" [style]="&#123;'height':'320px'&#125;"&gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         &lt;span class="ql-format-group"&gt;
             &lt;span title="Bold" class="ql-format-button ql-bold"&gt;&lt;/span&gt;
             &lt;span class="ql-format-separator"&gt;&lt;/span&gt;
@@ -66,7 +66,7 @@ export class EditorDemo &#123;
             &lt;span class="ql-format-separator"&gt;&lt;/span&gt;
             &lt;span title="Strikethrough" class="ql-format-button ql-strike"&gt;&lt;/span&gt;
         &lt;/span&gt;
-    &lt;/p-header&gt;
+    &lt;/ng-template&gt;
 &lt;/p-editor&gt;
 </app-code>
 

--- a/src/app/showcase/components/fieldset/fieldsetdemo.html
+++ b/src/app/showcase/components/fieldset/fieldsetdemo.html
@@ -53,7 +53,7 @@ import &#123;FieldsetModule&#125; from 'primeng/fieldset';
             <p>Legend content can be customized with <i>p-header</i> component.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-fieldset&gt;
-    &lt;p-header&gt;Custom Legend Content&lt;/p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;Custom Legend Content&lt;/ng-template&gt;
     Content
 &lt;/p-fieldset&gt;
 </app-code>

--- a/src/app/showcase/components/panel/paneldemo.html
+++ b/src/app/showcase/components/panel/paneldemo.html
@@ -57,16 +57,18 @@ import &#123;PanelModule&#125; from 'primeng/panel';
 </app-code>
 
             <h5>Header and Footer Content</h5>
-            <p>Header and Footers sections can be customized using <i>p-header</i> and <i>p-footer</i> components.</p>
+            <p>Header and footer sections can be customized using the <i>pTemplate</i> attribute directive.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-panel &gt;
-    &lt;p-header&gt;
+    &lt;ng-template pTemplate="header"&gt;
         Header content here
-    &lt;/p-header&gt;
-    Body Content
-    &lt;p-footer&gt;
+    &lt;/ng-template&gt;
+    &lt;ng-template pTemplate="content"&gt;
+        Body Content here
+    &lt;/ng-template&gt;
+    &lt;ng-template pTemplate="footer"&gt;
         Footer content here
-    &lt;/p-footer&gt;
+    &lt;/ng-template&gt;
 &lt;/p-panel&gt;
 </app-code>
 

--- a/src/app/showcase/components/table/tabledemo.html
+++ b/src/app/showcase/components/table/tabledemo.html
@@ -2179,10 +2179,10 @@ export class TableExportDemo implements OnInit &#123;
             &lt;/tr&gt;
         &lt;/ng-template&gt;
     &lt;/p-table&gt;
-    &lt;p-footer&gt;
+    &lt;ng-template pTemplate="footer"&gt;
         &lt;button type="button" pButton icon="pi pi-check" (click)="dialogVisible=false" label="Yes"&gt;&lt;/button&gt;
         &lt;button type="button" pButton icon="pi pi-times" (click)="dialogVisible=false" label="No" class="ui-button-secondary"&gt;&lt;/button&gt;
-    &lt;/p-footer&gt;
+    &lt;/ng-template&gt;
 &lt;/p-dialog&gt;
 </app-code>
 

--- a/src/app/showcase/components/treetable/treetabledemo.html
+++ b/src/app/showcase/components/treetable/treetabledemo.html
@@ -1253,10 +1253,10 @@ export class TreeTableSelectionDemo &#123;
             &lt;/tr&gt;
         &lt;/ng-template&gt;
     &lt;/p-treeTable&gt;
-    &lt;p-footer&gt;
+    &lt;ng-template pTemplate="footer"&gt;
         &lt;button type="button" pButton icon="pi pi-check" (click)="dialogVisible=false" label="Yes"&gt;&lt;/button&gt;
         &lt;button type="button" pButton icon="pi pi-times" (click)="dialogVisible=false" label="No" class="p-button-secondary"&gt;&lt;/button&gt;
-    &lt;/p-footer&gt;
+    &lt;/ng-template&gt;
 &lt;/p-dialog&gt;
 </app-code>
 

--- a/src/app/showcase/components/virtualscroller/virtualscrollerdemo.html
+++ b/src/app/showcase/components/virtualscroller/virtualscrollerdemo.html
@@ -152,8 +152,8 @@ export class VirtualScrollerDemo implements OnInit &#123;
             <p>Header and Footer are the two sections that are capable of displaying custom content.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-virtualScroller [value]="cars" scrollHeight="500px" [itemSize]="150"&gt;
-    &lt;p-header&gt;Header Content&lt;/p-header&gt;
-    &lt;p-footer&gt;Footer Content&lt;/p-footer&gt;
+    &lt;ng-template pTemplate="header"&gt;Header Content&lt;/ng-template&gt;
+    &lt;ng-template pTemplate="footer"&gt;Footer Content&lt;/ng-template&gt;
     &lt;ng-template pTemplate="item" let-car&gt;
         Car content
     &lt;/ng-template&gt;


### PR DESCRIPTION
I noticed that the documentation still uses the depracated `<p-header>` and `<p-footer>` tags. This PR replaces all of thse occurences with the new way of defining sections solely via `pTemplate`.