### PR TITLE
Calculate scrollable width accounting for frozen columns

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1768,7 +1768,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
         const scrollableBodyTableWidth = column ? scrollableBodyTable.offsetWidth + delta : newColumnWidth;
         const scrollableHeaderTableWidth = column ? scrollableHeaderTable.offsetWidth + delta : newColumnWidth;
-        const isContainerInViewport = this.containerViewChild.nativeElement.offsetWidth >= scrollableBodyTableWidth;
+        const isContainerInViewport = scrollableView.offsetWidth >= scrollableBodyTableWidth;
 
         let setWidth = (container, table, width, isContainerInViewport) => {
             if (container && table) {


### PR DESCRIPTION
Use the correct scrollableView to calculate when columns are wider than viewport when there are frozen columns, instead of always comparing to the overall grid container.

###Defect Fixes
Fixes #8241