### PR TITLE
Fixed #8585 - ConfirmDialog throws exception during onDestroy

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -343,7 +343,7 @@ export class ConfirmDialog implements AfterContentInit,OnDestroy {
             this.unbindMaskClickListener();
         }
 
-        if (this.container) {
+        if (this.container && !this.cd['destroyed']) {
             this.cd.detectChanges();
         }
     }


### PR DESCRIPTION
Checks if the ChangeDetectorRef instance "destroyed" the flag before the call to avoid the exception (EXCEPTION: attempt to use a destroyed view: detectChanges).


###Defect Fixes
Resolves the issue related in #8661 and #8585