### PR TITLE
Fix titles of Toast and CodeHighlighter demos

### DIFF
--- a/src/app/showcase/components/codehighlighter/codehighlighterdemo.html
+++ b/src/app/showcase/components/codehighlighter/codehighlighterdemo.html
@@ -1,6 +1,6 @@
 <div class="content-section introduction">
     <div>
-        <span class="feature-title">CodeHighlighter</span>
+        <h1>CodeHighlighter</h1>
         <span>CodeHighlighter is an attribute directive to highlight code blocks using PrismJS</span>
     </div>
 </div>

--- a/src/app/showcase/components/toast/toastdemo.html
+++ b/src/app/showcase/components/toast/toastdemo.html
@@ -1,6 +1,6 @@
 <div class="content-section introduction">
     <div>
-        <span class="feature-title">Toast</span>
+        <h1>Toast</h1>
         <span>Toast is used to display messages in an overlay.</span>
     </div>
 </div>


### PR DESCRIPTION
The titles in the demo pages for [Toast](https://primefaces.org/primeng/showcase/#/toast) and [CodeHighlighter](https://primefaces.org/primeng/showcase/#/codehighlighter) do not show up properly any more, because the `feature-title` CSS class has been removed. This PR fixes this to use the semantic h1 tag like in the other demos.

Btw, it seems the menu entry for the CodeHighlighter demo is missing, so that this feature is kind of undocumented currently.