### PR TITLE
feat(autocomplete): add the prop overlayFitWidth

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -118,6 +118,8 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     @Input() size: number;
 
+    @Input() overlayFitWidth: boolean;
+
     @Input() appendTo: any;
 
     @Input() autoHighlight: boolean;
@@ -496,6 +498,9 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
             if (!this.overlay.style.minWidth) {
                 this.overlay.style.minWidth = DomHandler.getWidth(this.el.nativeElement.children[0]) + 'px';
+                if (this.overlayFitWidth) {
+                    this.overlay.style.maxWidth = this.overlay.style.minWidth;
+                }
             }
         }
     }

--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -83,6 +83,12 @@ export class AutoCompleteDemo &#123;
 &lt;p-autoComplete formControlName="city" [suggestions]="results" (completeMethod)="search($event)"&gt;&lt;/p-autoComplete&gt;
 </app-code>
 
+            <h5>Panel Width and appendTo</h5>
+            <p>When using <i>appendTo</i>, it becomes impossible to style the panel's dimensions according to the input field. You can pass <i>overlayFitWidth</i> to make the panel fit perfectly the width of the input.</p>
+<app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
+&lt;p-autoComplete [overlayFitWidth]="true" [suggestions]="results" (completeMethod)="search($event)"&gt;&lt;/p-autoComplete&gt;
+</app-code>
+
             <h5>Dropdown</h5>
             <p>Enabling <i>dropdown</i> property displays a button next to the input field where click behavior of the button is defined using dropdownMode
                 property that takes "blank" or "current" as possible values. "blank" is the default mode to send a query with an empty string
@@ -361,6 +367,12 @@ export class AutoCompleteDemo &#123;
                             <td>number</td>
                             <td>null</td>
                             <td>Size of the input field.</td>
+                        </tr>
+                        <tr>
+                            <td>overlayFitWidth</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>When using <i>appendTo</i>, set the overlay width to be exactly the same as the input field.</td>
                         </tr>
                         <tr>
                             <td>appendTo</td>

--- a/src/assets/components/themes/arya-blue/theme.css
+++ b/src/assets/components/themes/arya-blue/theme.css
@@ -116,6 +116,7 @@ p-autocomplete.ng-dirty.ng-invalid > .p-autocomplete > .p-inputtext {
   background: transparent;
   transition: box-shadow 0.2s;
   border-radius: 0;
+  white-space: break-spaces;
 }
 .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item:hover {
   color: rgba(255, 255, 255, 0.87);


### PR DESCRIPTION
### Defect Fixes
When using `appendTo`, it becomes impossible to style the width of the overlay panel according to the input field. The panel can thus grow bigger than required, which can be a problem. I added an @input `overlayFitWidth` to perfectly fit the width of the overlay according to the input field when `appendTo` is used.

Related: https://github.com/primefaces/primeng/issues/8033