### PR TITLE
Avoid an unsubscription error in the Steps component

### DIFF
--- a/src/app/components/steps/steps.ts
+++ b/src/app/components/steps/steps.ts
@@ -50,7 +50,7 @@ export class Steps implements OnInit, OnDestroy {
 
     constructor(private router: Router, private route:ActivatedRoute, private cd: ChangeDetectorRef) { }
     
-    subscription: Subscription;
+    subscription = Subscription.EMPTY;
 
     ngOnInit() {
         this.subscription = this.router.events.subscribe(() => this.cd.markForCheck());


### PR DESCRIPTION
If the Steps component is created, but not initialized, then the unsubscription in the ngDestroy method fails, because the subscription property is not set.

This happens for instance in the default tests created by angular-cli which just test if a component can be created. If the component uses Steps, then you get an error in the console log and start to wonder what's happening here.

I think it's good practice to initialize the subscription property, see for instance the [code of the stepper component](https://github.com/angular/components/blob/master/src/material/stepper/stepper.ts) of Angular Material.