### PR TITLE
Fixed #9895 - Avatar-Images are overflowing circle-shaped parent-Div

### DIFF
--- a/src/app/components/avatar/avatar.css
+++ b/src/app/components/avatar/avatar.css
@@ -13,13 +13,14 @@
 
 .p-avatar.p-avatar-circle {
     border-radius: 50%;
+    overflow: hidden;
 }
 
 .p-avatar .p-avatar-icon {
     font-size: 1rem;
 }
 
-.p-avatar img { 
+.p-avatar img {
     width: 100%;
     height: 100%;
 }


### PR DESCRIPTION
Fixes: https://github.com/primefaces/primeng/issues/9895