### PR TITLE
Allow hiding of sort icon for unsorted columns

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2649,7 +2649,7 @@ export class SortableColumn implements OnInit, OnDestroy {
 @Component({
     selector: 'p-sortIcon',
     template: `
-        <i class="p-sortable-column-icon pi pi-fw" [ngClass]="{'pi-sort-amount-up-alt': sortOrder === 1, 'pi-sort-amount-down': sortOrder === -1, 'pi-sort-alt': sortOrder === 0}"></i>
+        <i *ngIf="visible" class="p-sortable-column-icon pi pi-fw" [ngClass]="{'pi-sort-amount-up-alt': sortOrder === 1, 'pi-sort-amount-down': sortOrder === -1, 'pi-sort-alt': sortOrder === 0}"></i>
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
@@ -2657,10 +2657,15 @@ export class SortableColumn implements OnInit, OnDestroy {
 export class SortIcon implements OnInit, OnDestroy {
 
     @Input() field: string;
+    @Input() showSortable = true;
 
     subscription: Subscription;
 
     sortOrder: number;
+
+    get visible() {
+        return !!this.sortOrder || this.showSortable;
+    }
 
     constructor(public dt: Table, public cd: ChangeDetectorRef) {
         this.subscription = this.dt.tableService.sortSource$.subscribe(sortMeta => {


### PR DESCRIPTION
To reduce visual clutter it sometimes makes sense to hide the "sortable" icon from table columns headers. This PR allows such functionality. The defaults settings preserve previous behaviour.