### PR TITLE
BlockUI's baseZIndex usable without autoZIndex

### DIFF
--- a/src/app/components/blockui/blockui.ts
+++ b/src/app/components/blockui/blockui.ts
@@ -81,6 +81,8 @@ export class BlockUI implements AfterViewInit,OnDestroy {
         
         if (this.autoZIndex) {
             this.mask.nativeElement.style.zIndex = String(this.baseZIndex + (++DomHandler.zindex));
+        } else {
+            this.mask.nativeElement.style.zIndex = String(this.baseZIndex);
         }
     }
     


### PR DESCRIPTION
According to the documentation,  

baseZIndex	number	0	Base zIndex value to use in layering.  
autoZIndex	boolean	true	Whether to automatically manage layering.  

there is no relation between baseZIndex and autoZIndex.  

In reality, baseZIndex is used only when autoZIndex is enabled, creating an effective zIndex of baseZIndex+something else

It seems more straightforward that blockUI's zIndex should be baseZIndex alone when autolayering is disabled; otherwise the documentation should be updated accordingly.

###Defect Fixes
baseZIndex is not used when autoZIndex is disabled  