### PR TITLE
Adding property [showClear] in p-autocomplete to let user clear by clicking easily

### DIFF
--- a/src/app/components/autocomplete/autocomplete.css
+++ b/src/app/components/autocomplete/autocomplete.css
@@ -92,3 +92,14 @@
 .p-fluid .p-autocomplete-dd .p-autocomplete-input {
     width: 1%;
 }
+
+.p-autocomplete-clear-icon {
+    position: absolute;
+    top: 50%;
+    margin-top: -.5rem;
+    right: .393rem;    
+}
+
+.p-autocomplete-clearable.p-autocomplete-dd .p-autocomplete-clear-icon {
+    right: 2.750rem;    
+}

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -18,7 +18,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
 @Component({
     selector: 'p-autoComplete',
     template: `
-        <span #container [ngClass]="{'p-autocomplete p-component':true,'p-autocomplete-dd':dropdown,'p-autocomplete-multiple':multiple}" [ngStyle]="style" [class]="styleClass">
+        <span #container [ngClass]="{'p-autocomplete p-component':true,'p-autocomplete-dd':dropdown,'p-autocomplete-multiple':multiple,'p-autocomplete-clearable': showClear && !disabled && !multiple}" [ngStyle]="style" [class]="styleClass">
             <input *ngIf="!multiple" #in [attr.type]="type" [attr.id]="inputId" [ngStyle]="inputStyle" [class]="inputStyleClass" [autocomplete]="autocomplete" [attr.required]="required" [attr.name]="name"
             class="p-autocomplete-input p-inputtext p-component" [ngClass]="{'p-autocomplete-dd-input':dropdown,'p-disabled': disabled}" [value]="inputFieldValue" aria-autocomplete="list" [attr.aria-controls]="listId" role="searchbox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'"
             (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
@@ -36,6 +36,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                             aria-autocomplete="list" [attr.aria-controls]="listId" role="searchbox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'">
                 </li>
             </ul>
+            <i class="p-autocomplete-clear-icon pi pi-times" (click)="clear($event)" *ngIf="value != null && showClear && !disabled && !multiple"></i>
             <i *ngIf="loading" class="p-autocomplete-loader pi pi-spinner pi-spin"></i><button #ddBtn type="button" pButton [icon]="dropdownIcon" class="p-autocomplete-dropdown" [disabled]="disabled" pRipple
                 (click)="handleDropdownClick($event)" *ngIf="dropdown" [attr.tabindex]="tabindex"></button>
             <div #panel *ngIf="overlayVisible" [ngClass]="['p-autocomplete-panel p-component']" [style.max-height]="scrollHeight" [ngStyle]="panelStyle" [class]="panelStyleClass"
@@ -125,6 +126,8 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
     @Input() unique: boolean = true;
 
     @Input() completeOnFocus: boolean = false;
+
+    @Input() showClear: boolean;
 
     @Output() completeMethod: EventEmitter<any> = new EventEmitter();
 
@@ -798,6 +801,15 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
         }
         this.restoreOverlayAppend();
         this.onOverlayHide();
+    }
+
+    clear(event: Event) {
+        this.value = null;
+        this.inputEL.nativeElement.value = '';
+        this.hide();
+        this.onClear.emit(event);
+        this.onModelChange(null);
+        this.updateFilledState();
     }
 }
 

--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -9,10 +9,10 @@
 <div class="content-section implementation">
     <div class="card">
         <h5>Basic</h5>
-        <p-autoComplete [(ngModel)]="selectedCountry" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" [minLength]="1"></p-autoComplete>
+        <p-autoComplete [(ngModel)]="selectedCountry" [showClear]="true" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" [minLength]="1"></p-autoComplete>
     
-        <h5>Dropdown and Templating</h5>
-        <p-autoComplete [(ngModel)]="selectedCountryAdvanced" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" [dropdown]="true">
+        <h5>Dropdown, Templating and Clear Icon</h5>
+        <p-autoComplete [(ngModel)]="selectedCountryAdvanced" [showClear]="true" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" [dropdown]="true">
             <ng-template let-country pTemplate="item">
                 <div class="country-item">
                     <img src="assets/showcase/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + country.code.toLowerCase()" />


### PR DESCRIPTION
###Defect Fixes
#3660 

###Feature Requests
Just add [showClear] option do p-autocomplete, appending the same behavior as found in p-dropdown, letting user clear current selected item easily.

https://www.loom.com/share/38216dbe1cab47e3895d91035fc25e9b
