### PR TITLE
Fixed #10052 - Icon support for TriStateCheckBox

### DIFF
--- a/src/app/components/tristatecheckbox/tristatecheckbox.ts
+++ b/src/app/components/tristatecheckbox/tristatecheckbox.ts
@@ -17,7 +17,7 @@ export const TRISTATECHECKBOX_VALUE_ACCESSOR: any = {
             </div>
             <div class="p-checkbox-box" (click)="onClick($event,input)"  role="checkbox" [attr.aria-checked]="value === true"
                 [ngClass]="{'p-highlight':value!=null,'p-disabled':disabled,'p-focus':focused}">
-                <span class="p-checkbox-icon pi" [ngClass]="{'pi-check':value==true,'pi-times':value==false}"></span>
+                <span class="p-checkbox-icon" [ngClass]="value==true ? checkboxTrueIcon : checkboxFalseIcon"></span>
             </div>
         </div>
         <label class="p-checkbox-label" (click)="onClick($event,input)"
@@ -49,6 +49,10 @@ export class TriStateCheckbox implements ControlValueAccessor  {
     @Input() label: string;
 
     @Input() readonly: boolean;
+
+    @Input() checkboxTrueIcon: string = 'pi pi-check';
+
+    @Input() checkboxFalseIcon: string = 'pi pi-times';
 
     @Output() onChange: EventEmitter<any> = new EventEmitter();
 

--- a/src/app/showcase/components/tristatecheckbox/tristatecheckboxdemo.html
+++ b/src/app/showcase/components/tristatecheckbox/tristatecheckboxdemo.html
@@ -12,6 +12,10 @@
             <p-triStateCheckbox [(ngModel)]="value"></p-triStateCheckbox>
             <label>{{value == null ? 'null' : value}}</label>
         </div>
+        <div class="p-field-checkbox p-m-0 p-pt-2">
+            <p-triStateCheckbox [(ngModel)]="value" checkboxTrueIcon="pi pi-directions" checkboxFalseIcon="pi pi-directions-alt"></p-triStateCheckbox>
+            <label>{{value == null ? 'null' : value}}</label>
+        </div>
     </div>
 </div>
 
@@ -108,6 +112,18 @@ export class ModelComponent &#123;
                             <td>boolean</td>
                             <td>false</td>
                             <td>When present, it specifies that the component cannot be edited.</td>
+                        </tr>
+                        <tr>
+                            <td>checkboxTrueIcon</td>
+                            <td>string</td>
+                            <td>pi pi-check</td>
+                            <td>Specifies the icon for checkbox true value.</td>
+                        </tr>
+                        <tr>
+                            <td>checkboxFalseIcon</td>
+                            <td>string</td>
+                            <td>pi pi-times</td>
+                            <td>Specifies the icon for checkbox false value.</td>
                         </tr>
                     </tbody>
                 </table>


### PR DESCRIPTION
Added icons in the tristatcheckbox. Two parameters were created to define the correct icons. 
 - By default, strings (pi-check and pi-pi-times) remain.