### PR TITLE
Change removeIconClass to removeIcon. 

### DIFF
--- a/src/app/showcase/components/chip/chipdemo.html
+++ b/src/app/showcase/components/chip/chipdemo.html
@@ -121,7 +121,7 @@ import &#123; ChipModule &#125; from 'primeng/chip';
                                 <td>Style class of the component.</td>
                             </tr>
 							<tr>
-								<td>removeIconClass</td>
+								<td>removeIcon</td>
 								<td>string</td>
 								<td>pi pi-times-circle</td>
 								<td>Icon of the remove element.</td>


### PR DESCRIPTION
Change removeIconClass to removeIcon, because the showcase page does not fit with the actual implementation.
