### PR TITLE
Add onDuplicate-event to chips-component

### DIFF
--- a/src/app/components/chips/chips.spec.ts
+++ b/src/app/components/chips/chips.spec.ts
@@ -146,6 +146,9 @@ describe('Chips', () => {
 		chips.allowDuplicate = false;
 		fixture.detectChanges();
 
+		let data;
+		chips.onDuplicate.subscribe(value => data = value);
+
 		const inputEl = fixture.debugElement.query(By.css('input'));
 		inputEl.nativeElement.value = "primeng";
 		fixture.detectChanges();
@@ -161,6 +164,7 @@ describe('Chips', () => {
 		fixture.detectChanges();
 
 		expect(chips.value.length).toEqual(1);
+		expect(data).toBeTruthy();
 		expect(chips.value[0]).toEqual("primeng");
 	});
 

--- a/src/app/components/chips/chips.ts
+++ b/src/app/components/chips/chips.ts
@@ -1,4 +1,5 @@
 import {NgModule,Component,ElementRef,Input,Output,EventEmitter,AfterContentInit,ContentChildren,QueryList,TemplateRef,forwardRef,ViewChild,ChangeDetectionStrategy, ViewEncapsulation, ChangeDetectorRef} from '@angular/core';
+
 import {CommonModule} from '@angular/common';
 import {SharedModule,PrimeTemplate} from 'primeng/api';
 import {InputTextModule} from 'primeng/inputtext';
@@ -69,6 +70,8 @@ export class Chips implements AfterContentInit,ControlValueAccessor {
     @Input() separator: string;
 
     @Output() onAdd: EventEmitter<any> = new EventEmitter();
+
+    @Output() onDuplicate: EventEmitter<any> = new EventEmitter();
 
     @Output() onRemove: EventEmitter<any> = new EventEmitter();
 
@@ -227,6 +230,12 @@ export class Chips implements AfterContentInit,ControlValueAccessor {
                     originalEvent: event,
                     value: item
                 });
+            }
+            else if (!this.allowDuplicate && this.value.indexOf(item) > -1) {
+                this.onDuplicate.emit({
+                    originalEvent: event,
+                    value: item
+                })
             }
         }
         this.updateFilledState();

--- a/src/app/showcase/components/chips/chipsdemo.html
+++ b/src/app/showcase/components/chips/chipsdemo.html
@@ -207,6 +207,11 @@ export class MyModel &#123;
                             <td>originalEvent: Browser event</td>
                             <td>Callback to invoke when a input loses focus.</td>
                         </tr>
+                        <tr>
+                            <td>onDuplicate</td>
+                            <td>originalEvent: Browser event</td>
+                            <td>Callback to invoke when a duplicate chip has been inserted.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
Currently when inserting a duplicate chip when allowDuplicate = false, the new entry just disappears with no additional feedback. With onDuplicate-event more detailed notification can be brought up.