### PR TITLE
#10270 Fixed breakpoints of dialog

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -122,7 +122,7 @@ export class Dialog implements AfterContentInit,OnInit,OnDestroy {
 
     @Input() appendTo: any;
 
-    @Input() breakpoints: any[];
+    @Input() breakpoints: {};
 
     @Input() styleClass: string;
 


### PR DESCRIPTION
Breakpoints should be an object instead of any array. The key of the breakpoint is used to determine screen width of the current breakpoint, and the value is the expected width of the dialog.

Fix for the issue #10270 