### PR TITLE
Remove the redundant tag from the showcase menu

### DIFF
--- a/src/app/showcase/app.menu.component.ts
+++ b/src/app/showcase/app.menu.component.ts
@@ -302,7 +302,7 @@ declare let gtag: Function;
                     <a [routerLink]=" ['/progressspinner']" routerLinkActive="router-link-exact-active">ProgressSpinner</a>
                     <a [routerLink]=" ['/scrolltop']" routerLinkActive="router-link-exact-active">ScrollTop</a>
                     <a [routerLink]=" ['/skeleton']" routerLinkActive="router-link-exact-active">Skeleton</a>
-                    <a [routerLink]=" ['/tag']" routerLinkActive="router-link-exact-active">Tag <span class="p-tag">Tag</span></a>
+                    <a [routerLink]=" ['/tag']" routerLinkActive="router-link-exact-active">Tag</a>
                     <a [routerLink]=" ['/terminal']" routerLinkActive="router-link-exact-active">Terminal</a>
                 </div>
 


### PR DESCRIPTION
The tag displayed in the menu was apparently added to indicate introduction of the new component.
However it displays 'Tag' instead of 'New' and is rather old component by now having been added 6 months ago.
It is apparently an error.
