### PR TITLE
#10059 - default dateFormat based on i18n API

### DIFF
--- a/src/app/components/api/primengconfig.ts
+++ b/src/app/components/api/primengconfig.ts
@@ -76,7 +76,9 @@ export class PrimeNGConfig {
         strong: 'Strong',
         passwordPrompt: 'Enter a password',
         emptyMessage: 'No results found',
-        emptyFilterMessage: 'No results found'
+        emptyFilterMessage: 'No results found',
+        dateFormat: 'mm/dd/yy',
+        hourFormat: '24'
     }
 
     private translationSource = new Subject<any>();

--- a/src/app/components/api/translation.ts
+++ b/src/app/components/api/translation.ts
@@ -42,4 +42,6 @@ export interface Translation {
     passwordPrompt?: string;
     emptyMessage?: string;
     emptyFilterMessage?: string;
+    dateFormat?: string;
+    hourFormat?: string;
 }

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -141,7 +141,7 @@ export interface LocaleSettings {
                             <span class="pi pi-chevron-down"></span>
                         </button>
                     </div>
-                    <div class="p-ampm-picker" *ngIf="hourFormat=='12'">
+                    <div class="p-ampm-picker" *ngIf="getHourFormat() =='12'">
                         <button class="p-link" type="button" (keydown)="onContainerButtonKeydown($event)" (click)="toggleAMPM($event)" (keydown.enter)="toggleAMPM($event)" pRipple>
                             <span class="pi pi-chevron-up"></span>
                         </button>
@@ -215,7 +215,7 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
 
     @Input() disabled: any;
 
-    @Input() dateFormat: string = 'mm/dd/yy';
+    @Input() dateFormat: string = null;
 
     @Input() multipleSeparator: string = ',';
 
@@ -241,7 +241,7 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
 
     @Input() yearNavigator: boolean;
 
-    @Input() hourFormat: string = '24';
+    @Input() hourFormat: string = null;
 
     @Input() timeOnly: boolean;
 
@@ -903,7 +903,9 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     }
 
     setCurrentHourPM(hours: number) {
-        if (this.hourFormat == '12') {
+        const hourFormat = this.getHourFormat();
+
+        if (hourFormat == '12') {
             this.pm = hours > 11;
             if (hours >= 12) {
                 this.currentHour = (hours == 12) ? 12 : hours - 12;
@@ -918,10 +920,12 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     }
 
     selectDate(dateMeta) {
+        const hourFormat = this.getHourFormat();
+
         let date = new Date(dateMeta.year, dateMeta.month, dateMeta.day);
 
         if (this.showTime) {
-            if (this.hourFormat == '12') {
+            if (hourFormat == '12') {
                 if (this.currentHour === 12)
                     date.setHours(this.pm ? 12 : 0);
                 else
@@ -1623,7 +1627,8 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     }
 
     convertTo24Hour = function (hours: number, pm: boolean) {
-        if (this.hourFormat == '12') {
+        const hourFormat = this.getHourFormat();
+        if (hourFormat == '12') {
             if (hours === 12) {
                 return (pm ? 12 : 0);
             } else {
@@ -1682,10 +1687,11 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
         const prevHour = this.currentHour;
         let newHour = this.currentHour + this.stepHour;
         let newPM = this.pm;
+        const hourFormat = this.getHourFormat();
 
-        if (this.hourFormat == '24')
+        if (hourFormat == '24')
             newHour = (newHour >= 24) ? (newHour - 24) : newHour;
-        else if (this.hourFormat == '12') {
+        else if (hourFormat == '12') {
             // Before the AM/PM break, now after
             if (prevHour < 12 && newHour > 11) {
                 newPM= !this.pm;
@@ -1766,10 +1772,11 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     decrementHour(event) {
         let newHour = this.currentHour - this.stepHour;
         let newPM = this.pm
+        const hourFormat = this.getHourFormat();
 
-        if (this.hourFormat == '24')
+        if (hourFormat == '24')
             newHour = (newHour < 0) ? (24 + newHour) : newHour;
-        else if (this.hourFormat == '12') {
+        else if (hourFormat == '12') {
             // If we were at noon/midnight, then switch
             if (this.currentHour === 12) {
                 newPM = !this.pm;
@@ -1835,7 +1842,8 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
         }
         value = value ? new Date(value.getTime()) : new Date();
 
-        if (this.hourFormat == '12') {
+        const hourFormat = this.getHourFormat();
+        if (hourFormat == '12') {
             if (this.currentHour === 12)
                 value.setHours(this.pm ? 12 : 0);
             else
@@ -1949,7 +1957,8 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
         else {
             const dateFormat = this.getDateFormat();
             if (this.showTime) {
-                let ampm = this.hourFormat == '12' ? parts.pop() : null;
+                const hourFormat = this.getHourFormat();
+                let ampm = hourFormat == '12' ? parts.pop() : null;
                 let timeString = parts.pop();
 
                 date = this.parseDate(parts.join(' '), dateFormat);
@@ -1964,7 +1973,8 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     }
 
     populateTime(value, timeString, ampm) {
-        if (this.hourFormat == '12' && !ampm) {
+        const hourFormat = this.getHourFormat();
+        if (hourFormat == '12' && !ampm) {
             throw 'Invalid Time';
         }
 
@@ -2154,7 +2164,17 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     }
 
     getDateFormat() {
-        return this.dateFormat;
+        if (!!this.dateFormat){
+            return this.dateFormat;
+        }
+        else return this.config.getTranslation("dateFormat");
+    }
+    
+    getHourFormat() {
+        if (!!this.hourFormat){
+            return this.hourFormat;
+        }
+        else return this.config.getTranslation("hourFormat");
     }
 
     // Ported from jquery-ui datepicker formatDate
@@ -2248,12 +2268,12 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
         let hours = date.getHours();
         let minutes = date.getMinutes();
         let seconds = date.getSeconds();
-
-        if (this.hourFormat == '12' && hours > 11 && hours != 12) {
+        const hourFormat = this.getHourFormat();
+        if (hourFormat == '12' && hours > 11 && hours != 12) {
             hours-=12;
         }
 
-        if (this.hourFormat == '12') {
+        if (hourFormat == '12') {
             output += hours === 0 ? 12 : (hours < 10) ? '0' + hours : hours;
         } else {
             output += (hours < 10) ? '0' + hours : hours;
@@ -2266,7 +2286,7 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
             output += (seconds < 10) ? '0' + seconds : seconds;
         }
 
-        if (this.hourFormat == '12') {
+        if (hourFormat == '12') {
             output += date.getHours() > 11 ? ' PM' : ' AM';
         }
 
@@ -2284,12 +2304,13 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
         let h = parseInt(tokens[0]);
         let m = parseInt(tokens[1]);
         let s = this.showSeconds ? parseInt(tokens[2]) : null;
+        const hourFormat = this.getHourFormat();
 
-        if (isNaN(h) || isNaN(m) || h > 23 || m > 59 || (this.hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
+        if (isNaN(h) || isNaN(m) || h > 23 || m > 59 || (hourFormat == '12' && h > 12) || (this.showSeconds && (isNaN(s) || s > 59))) {
             throw "Invalid time";
         }
         else {
-            if (this.hourFormat == '12') {
+            if (hourFormat == '12') {
                 if (h !== 12 && this.pm) {
                     h += 12;
                 }

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -4005,7 +4005,7 @@ export class ReorderableRow implements AfterViewInit {
                     [minFractionDigits]="minFractionDigits" [maxFractionDigits]="maxFractionDigits" [prefix]="prefix" [suffix]="suffix" [placeholder]="placeholder"
                     [mode]="currency ? 'currency' : 'decimal'" [locale]="locale" [localeMatcher]="localeMatcher" [currency]="currency" [currencyDisplay]="currencyDisplay" [useGrouping]="useGrouping"></p-inputNumber>
                 <p-triStateCheckbox *ngSwitchCase="'boolean'" [ngModel]="filterConstraint?.value" (ngModelChange)="onModelChange($event)"></p-triStateCheckbox>
-                <p-calendar *ngSwitchCase="'date'" [ngModel]="filterConstraint?.value" (ngModelChange)="onModelChange($event)"></p-calendar>
+                <p-calendar *ngSwitchCase="'date'" [ngModel]="filterConstraint?.value" [dateFormat]="dateFormat" (ngModelChange)="onModelChange($event)"></p-calendar>
             </ng-container>
         </ng-template>
     `,
@@ -4034,6 +4034,8 @@ export class ColumnFilterFormElement implements OnInit {
     @Input() locale: string;
 
     @Input() localeMatcher: string;
+
+    @Input() dateFormat: string = null;
 
     @Input() currency: string;
 
@@ -4078,7 +4080,7 @@ export class ColumnFilterFormElement implements OnInit {
     template: `
         <div class="p-column-filter" [ngClass]="{'p-column-filter-row': display === 'row', 'p-column-filter-menu': display === 'menu'}">
             <p-columnFilterFormElement *ngIf="display === 'row'" class="p-fluid" [type]="type" [field]="field" [filterConstraint]="dt.filters[field]" [filterTemplate]="filterTemplate" [placeholder]="placeholder" [minFractionDigits]="minFractionDigits" [maxFractionDigits]="maxFractionDigits" [prefix]="prefix" [suffix]="suffix"
-                                    [locale]="locale"  [localeMatcher]="localeMatcher" [currency]="currency" [currencyDisplay]="currencyDisplay" [useGrouping]="useGrouping"></p-columnFilterFormElement>
+                                    [locale]="locale"  [localeMatcher]="localeMatcher" [currency]="currency" [currencyDisplay]="currencyDisplay" [dateFormat]="dateFormat" [useGrouping]="useGrouping"></p-columnFilterFormElement>
             <button #icon *ngIf="showMenuButton" type="button" class="p-column-filter-menu-button p-link" aria-haspopup="true" [attr.aria-expanded]="overlayVisible"
                 [ngClass]="{'p-column-filter-menu-button-open': overlayVisible, 'p-column-filter-menu-button-active': hasFilter()}"
                 (click)="toggleMenu()" (keydown)="onToggleButtonKeyDown($event)"><span class="pi pi-filter-icon pi-filter"></span></button>
@@ -4101,7 +4103,7 @@ export class ColumnFilterFormElement implements OnInit {
                             <p-dropdown  *ngIf="showMatchModes && matchModes" [options]="matchModes" [ngModel]="fieldConstraint.matchMode" (ngModelChange)="onMenuMatchModeChange($event, fieldConstraint)" styleClass="p-column-filter-matchmode-dropdown"></p-dropdown>
                             <p-columnFilterFormElement [type]="type" [field]="field" [filterConstraint]="fieldConstraint" [filterTemplate]="filterTemplate" [placeholder]="placeholder"
                             [minFractionDigits]="minFractionDigits" [maxFractionDigits]="maxFractionDigits" [prefix]="prefix" [suffix]="suffix"
-                            [locale]="locale"  [localeMatcher]="localeMatcher" [currency]="currency" [currencyDisplay]="currencyDisplay" [useGrouping]="useGrouping"></p-columnFilterFormElement>
+                            [locale]="locale"  [localeMatcher]="localeMatcher" [currency]="currency" [currencyDisplay]="currencyDisplay" [dateFormat]="dateFormat" [useGrouping]="useGrouping"></p-columnFilterFormElement>
                             <div>
                                 <button *ngIf="showRemoveIcon" type="button" pButton icon="pi pi-trash" class="p-column-filter-remove-button p-button-text p-button-danger p-button-sm" (click)="removeConstraint(fieldConstraint)" pRipple [label]="removeRuleButtonLabel"></button>
                             </div>
@@ -4175,6 +4177,8 @@ export class ColumnFilter implements AfterContentInit {
     @Input() locale: string;
 
     @Input() localeMatcher: string;
+
+    @Input() dateFormat: string  = null;
 
     @Input() currency: string;
 

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -163,6 +163,7 @@ export class MyModel &#123;
     			<li>'' - single quote</li>
     			<li>anything else - literal text</li>
             </ul>
+            <p>You can also set the default date format with <a href="#" [routerLink]="['/i18n']">I18N API</a>.</p>
             
             <h5>I18N</h5>
             <p>Translations for the calendar are defined with the <a href="#" [routerLink]="['/i18n']">I18N API</a>.</p>
@@ -318,8 +319,8 @@ export class MyModel &#123;
                         <tr>
                             <td>dateFormat</td>
                             <td>string</td>
-                            <td>mm/dd/yy</td>
-                            <td>Format of the date which can also be defined at locale settings.</td>
+                            <td>null</td>
+                            <td>Format of the date which can also be defined at locale settings. If empty (null) it will use the default value defined with <a href="#" [routerLink]="['/i18n']">I18N API</a>.</td>
                         </tr>
                         <tr>
                             <td>inline</td>
@@ -432,8 +433,8 @@ export class MyModel &#123;
                         <tr>
                             <td>hourFormat</td>
                             <td>string</td>
-                            <td>24</td>
-                            <td>Specifies 12 or 24 hour format.</td>
+                            <td>null</td>
+                            <td>Specifies 12 or 24 hour format. If empty (null) it will use the default value defined with <a href="#" [routerLink]="['/i18n']">I18N API</a>.</td>
                         </tr>
                         <tr>
                             <td>locale</td>

--- a/src/app/showcase/components/i18n/i18n.component.html
+++ b/src/app/showcase/components/i18n/i18n.component.html
@@ -74,7 +74,9 @@ export class AppComponent implements OnInit, OnDestroy &#123;
         "strong": 'Strong',
         "passwordPrompt": 'Enter a password',
         "emptyMessage": 'No results found',
-        "emptyFilterMessage": 'No results found'
+        "emptyFilterMessage": 'No results found',
+        "dateFormat": 'mm/dd/yy',
+        "hourFormat": '24'
     &#125;
 &#125;
 </app-code>
@@ -270,6 +272,14 @@ export class AppComponent implements OnInit, OnDestroy &#123;
                     <tr>
                         <td>emptyFilterMessage</td>
                         <td>No results found</td>
+                    </tr>
+                    <tr>
+                        <td>dateFormat</td>
+                        <td>mm/dd/yy</td>
+                    </tr>
+                    <tr>
+                        <td>hourFormat</td>
+                        <td>24</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/app/showcase/components/table/tabledemo.html
+++ b/src/app/showcase/components/table/tabledemo.html
@@ -1249,6 +1249,12 @@ export class TableFilterDemo implements OnInit &#123;
                             <td>true</td>
                             <td>Whether to use grouping separators for "numeric" type, such as thousands separators or thousand/lakh/crore separators.</td>
                         </tr>
+                        <tr>
+                            <td>dateFormat</td>
+                            <td>string</td>
+                            <td>null</td>
+                            <td>Date format to be used in formatting for "date" type. If empty (null) it will use the default value defined with <a href="#" [routerLink]="['/i18n']">I18N API</a>.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>


### PR DESCRIPTION
###Defect Fixes
https://github.com/primefaces/primeng/issues/10059
I need change date format in calendar inside table filters. 

###Feature Requests
- two new properties in i18n API: dateFormat and hourFormat
- use i18n API properties dateFormat and hourFormat as defaults in Calendar component (when these properties has value NULL)
- add new property in Table filters dateFormat and pass this property to Calendar inside filters controls