### PR TITLE
Don't set icon class without icon in button

### DIFF
--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -106,7 +106,7 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
 
     removeIconElement() {
         let iconElement = DomHandler.findSingle(this.el.nativeElement, '.p-button-icon');
-        this.el.nativeElement.removeChild(iconElement)
+        this.el.nativeElement.removeChild(iconElement);
     }
 
     @Input() get label(): string {
@@ -118,7 +118,10 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
 
         if (this.initialized) {
             DomHandler.findSingle(this.el.nativeElement, '.p-button-label').textContent = this._label || '&nbsp;';
-            this.setIconClass();
+
+            if (this.loading || this.icon) {
+                this.setIconClass();
+            }
             this.setStyleClass();
         }
     }


### PR DESCRIPTION
### Defect Fixes
Without this check the following exception is thrown when the label is changed for a button that has no icon:

```
core.js:6456 ERROR TypeError: Cannot read property 'trim' of undefined
    at Function.addMultipleClasses (domhandler.ts:29)
    at ButtonDirective.createIconEl (button.ts:81)
    at ButtonDirective.setIconClass (button.ts:103)
    at ButtonDirective.set label [as label] (button.ts:123)
    at setInputsForProperty (core.js:10940)
    at elementPropertyInternal (core.js:9984)
    at ɵɵpropertyInterpolate1 (core.js:15551)
    at Module.ɵɵpropertyInterpolate (core.js:15514)
    at ButtonDemo_Template (buttondemo.html:22)
    at executeTemplate (core.js:9579)
```
