### PR TITLE
fix: dont update `p-inputnumber` cursor when value is 0

### DIFF
--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -910,7 +910,13 @@ export class InputNumber implements OnInit,ControlValueAccessor {
             }
             else if (newLength === currentLength) {
                 if (operation === 'insert' || operation === 'delete-back-single')
-                    this.input.nativeElement.setSelectionRange(selectionEnd + 1, selectionEnd + 1);
+                {
+                    // should just replace zero, not move cursor position
+                    if (this.parseValue(inputValue) === 0)
+                        this.input.nativeElement.setSelectionRange(selectionEnd, selectionEnd);
+                    else
+                        this.input.nativeElement.setSelectionRange(selectionEnd + 1, selectionEnd + 1);
+                }
                 else if (operation === 'delete-single')
                     this.input.nativeElement.setSelectionRange(selectionEnd - 1, selectionEnd - 1);
                 else if (operation === 'delete-range' || operation === 'spin')


### PR DESCRIPTION
### What

This is a fix to the `p-inputnumber` component. The bug caused by the component is due to the fact that when an `p-inputnumber` component has a suffix & its value is 0. 

Example:
![image](https://user-images.githubusercontent.com/26849064/125154790-bbb72380-e110-11eb-9971-3be28ebdf57e.png)

After typing some numbers in, the cursor goes behind the suffix like so and does not allow the user to backspace to delete any number any more.
![image](https://user-images.githubusercontent.com/26849064/125154825-dab5b580-e110-11eb-9875-f76593a6c999.png)

### Why

Within the `updateInput` function, the case for inserting a value when `newLength===oldLength` & the current operation is `insert`, always moves the cursor position up 1 regardless of the value. In the case of zero this should not occur (the value zero should simple be replaced).

### Fix

Add a simple `if` to check if the value is zero, otherwise proceed as usual.