### PR TITLE
Replaced deprecated Schedule with FullCalendar on dependency list.

### DIFF
--- a/src/app/showcase/components/setup/setup.component.html
+++ b/src/app/showcase/components/setup/setup.component.html
@@ -85,7 +85,7 @@ primeng/resources/themes/rhea/theme.css
             </thead>
             <tbody>
                 <tr>
-                    <td>Schedule</td>
+                    <td>FullCalendar</td>
                     <td>FullCalendar 4.1.0</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
On the "Getting started" page there is still the deprecated Schedule component listed which had a dependency. to fullcalendar.js This component was replaced with the FullCalendar.