### PR TITLE
(WIP) Update Chart.js to v3.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@fullcalendar/timegrid": "4.1.0",
     "@types/jasmine": "~3.6.0",
     "@types/node": "^12.11.1",
-    "chart.js": "2.7.3",
+    "chart.js": "3.4.1",
     "codelyzer": "^6.0.0",
     "del": "^2.2.0",
     "file-saver": "^2.0.2",

--- a/src/app/components/chart/chart.spec.ts
+++ b/src/app/components/chart/chart.spec.ts
@@ -166,7 +166,7 @@ describe('UIChart', () => {
         expect(initChartSpy).toHaveBeenCalled();
     });
 
-    it('should get canvas, image and generateLegend', () => {
+    it('should get canvas and image', () => {
         chart.data = {
             datasets: [{
                 data: [
@@ -196,12 +196,10 @@ describe('UIChart', () => {
         chart.type = "polarArea";
         fixture.detectChanges();
 
-        const legend = chart.generateLegend();
         const image = chart.getBase64Image();
         const canvas = chart.getCanvas();
 
         expect(canvas.tagName).toEqual("CANVAS");
         expect(image).toContain("data");
-        expect(legend).toContain("legend");
     });
 });

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -1,13 +1,13 @@
 <div class="content-section introduction">
     <div class="feature-intro">
         <h1>Charts</h1>
-        <p>Chart components are based on <a style="color:#68d4f9" href="http://www.chartjs.org/">Charts.js</a> 2.7.x, an open source HTML5 based charting library.</p>
+        <p>Chart components are based on <a style="color:#68d4f9" href="http://www.chartjs.org/">Chart.js</a> 3.4.x, an open source HTML5 based charting library.</p>
     </div>
 </div>
 
 <div class="content-section documentation">
-    <h5 style="margin-top:0px">Charts.js</h5>
-    <p>To begin with, first you must install the charts.js package using npm and then include 
+    <h5 style="margin-top:0px">Chart.js</h5>
+    <p>To begin with, first you must install the Chart.js package using npm and then include
         it in your project. An example with CLI would be;</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 npm install chart.js --save

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -125,7 +125,7 @@ update(event: Event) &#123;
 
 
     <h5>Chart Types</h5>
-    <p>Chart type is defined using the type property. Currently there are 6 options available; pie, doughnut, line (line or horizontalBar), bar, radar and polarArea.</p>
+    <p>Chart type is defined using the type property. Currently there are 9 options available; pie, doughnut, line (line or horizontalBar), bar, radar, polarArea, bubble and scatter.</p>
 
     <h5>Data</h5>
     <p>Data of a chart is provided using a binding to the data property, each type has its own format of data. Here is an example of a line chart.</p>

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -125,7 +125,7 @@ update(event: Event) &#123;
 
 
     <h5>Chart Types</h5>
-    <p>Chart type is defined using the type property. Currently there are 6 options available; pie, doughtnut, line(line or horizontalBar), bar, radar and polarArea.</p>
+    <p>Chart type is defined using the type property. Currently there are 6 options available; pie, doughnut, line (line or horizontalBar), bar, radar and polarArea.</p>
 
     <h5>Data</h5>
     <p>Data of a chart is provided using a binding to the data property, each type has its own format of data. Here is an example of a line chart.</p>

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -127,11 +127,6 @@ update(event: Event) &#123;
                     <td>-</td>
                     <td>Destroys the graph first and then creates it again.</td>
                 </tr>
-                <tr>
-                    <td>generateLegend</td>
-                    <td>-</td>
-                    <td>Returns an HTML string of a legend for that chart. The legend is generated from the legendCallback in the options.</td>
-                </tr>
             </tbody>
         </table>
     </div>
@@ -223,9 +218,9 @@ export class LineChartDemo &#123;
 <app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
 selectData(event) &#123;
     //event.dataset = Selected dataset
-    //event.element = Selected element
-    //event.element._datasetIndex = Index of the dataset in data
-    //event.element._index = Index of the data in dataset
+    //event.element.element = Selected element
+    //event.element.datasetIndex = Index of the dataset in data
+    //event.element.index = Index of the data in dataset
 &#125;
 </app-code>  
 

--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -7,22 +7,14 @@
 
 <div class="content-section documentation">
     <h5 style="margin-top:0px">Chart.js</h5>
-    <p>To begin with, first you must install the Chart.js package using npm and then include
-        it in your project. An example with CLI would be;</p>
+    <p>To begin with, first you must install the Chart.js package using npm. An example with CLI would be;</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 npm install chart.js --save
-</app-code>
-        
-<app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
-"scripts": [
-    "../node_modules/chart.js/dist/Chart.js",
-    //..others
-],
 </app-code>
 
     <h5>Chart Component</h5>
     <p>Chart component is used to display a chart on page. The classname is UIChart and element tag is p-chart.</p>
-    
+
 <h5>Import</h5>
 <app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
 import &#123;ChartModule&#125; from 'primeng/chart';
@@ -130,7 +122,7 @@ update(event: Event) &#123;
             </tbody>
         </table>
     </div>
-    
+
 
     <h5>Chart Types</h5>
     <p>Chart type is defined using the type property. Currently there are 6 options available; pie, doughtnut, line(line or horizontalBar), bar, radar and polarArea.</p>
@@ -146,7 +138,7 @@ update(event: Event) &#123;
 export class LineChartDemo &#123;
 
     data: any;
-    
+
     constructor() &#123;
         this.data = &#123;
             labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
@@ -166,7 +158,7 @@ export class LineChartDemo &#123;
 </app-code>
 
     <h5>Options</h5>
-    <p>While a series can be customized per dataset, general chart options are defined with options property. 
+    <p>While a series can be customized per dataset, general chart options are defined with options property.
         Example below adds a title and customizes the legend position of the chart. For all available options refer to the charts.js documentation.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
@@ -177,9 +169,9 @@ export class LineChartDemo &#123;
 export class LineChartDemo &#123;
 
     data: any;
-    
+
     options: any;
-    
+
     constructor() &#123;
         this.data = &#123;
             labels: ['January', 'February', 'March', 'April', 'May', 'June', 'July'],
@@ -194,7 +186,7 @@ export class LineChartDemo &#123;
                 &#125;
             ]
         &#125;
-        
+
         this.options = &#123;
             title: &#123;
                 display: true,
@@ -222,7 +214,7 @@ selectData(event) &#123;
     //event.element.datasetIndex = Index of the dataset in data
     //event.element.index = Index of the data in dataset
 &#125;
-</app-code>  
+</app-code>
 
     <h5>Responsive</h5>
     <p>Charts are responsive by default and vw-vh units should be used when customizing the width and height of the chart.</p>

--- a/src/app/showcase/components/setup/setup.component.html
+++ b/src/app/showcase/components/setup/setup.component.html
@@ -98,7 +98,7 @@ primeng/resources/themes/rhea/theme.css
                 </tr>
                 <tr>
                     <td>Charts</td>
-                    <td>Charts.js 2.7.x</td>
+                    <td>Chart.js 3.4.x</td>
                 </tr>
                 <tr>
                     <td>Captcha</td>


### PR DESCRIPTION
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.
Upgrade to ChartJS 3 #10078 (changes are based on the [Chart.js 3.x migration guide](https://www.chartjs.org/docs/latest/getting-started/v3-migration.html))

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.

### The following still needs work:
- [ ] Make demo page for new chart types: 
  - [ ] [`bubble`](https://www.chartjs.org/docs/latest/charts/bubble.html)
  - [ ] [`scatter`](https://www.chartjs.org/docs/latest/charts/scatter.html)
- [x] Update documentation
- [ ] Proper support for legacy chart type `horizontalBar`?
- [ ] Proper support for [tree-shaking](https://www.chartjs.org/docs/master/getting-started/integration.html#bundlers-webpack-rollup-etc)?
- [ ] Update PrimeNG [changelog](https://github.com/primefaces/primeng/blob/master/CHANGELOG.md) to reflect:
  - [ ] the removal of the p-chart `generateLegend()` method, because this was removed in Chart.js 3.x
  - [ ] (and possibly the removal of chart type `horizontalBar`, replacing it with instructions on how to make [horizontal bar charts](https://www.chartjs.org/docs/latest/charts/bar.html#horizontal-bar-chart) using chart type `bar` with `options.indexAxis = 'y'`)
- [ ] Repeat for PrimeNG [migration guide](https://github.com/primefaces/primeng/wiki/Migration-Guide)
