### PR TITLE
fix double assignment

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -624,7 +624,7 @@ export class Calendar implements OnInit,OnDestroy,ControlValueAccessor {
     }
 
     createMonths(month: number, year: number) {
-        this.months = this.months = [];
+        this.months = [];
         for (let i = 0 ; i < this.numberOfMonths; i++) {
             let m = month + i;
             let y = year;


### PR DESCRIPTION
### Defect Fixes
On component calendar, the method createMonths has a double assignment unnecessary