### PR TITLE
docs: fix typo in StyleClass showcase

### DIFF
--- a/src/app/showcase/components/styleclass/styleclassdemo.html
+++ b/src/app/showcase/components/styleclass/styleclassdemo.html
@@ -23,7 +23,7 @@
         <p-tabPanel header="Documentation">
             <h5>Import</h5>
 <app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
-import &#123;StyleClassModulde&#125; from 'primeng/styleclass';
+import &#123;StyleClassModule&#125; from 'primeng/styleclass';
 </app-code>
 
             <h5>Getting Started</h5>


### PR DESCRIPTION
change `import {StyleClassModulde} from 'primeng/styleclass';` to `import {StyleClassModule} from 'primeng/styleclass';`

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.