### PR TITLE
fix(DataView): css class for PrimeFlex 3

### DIFF
--- a/src/app/components/dataview/dataview.ts
+++ b/src/app/components/dataview/dataview.ts
@@ -24,7 +24,7 @@ import { Subscription } from 'rxjs';
                 [dropdownAppendTo]="paginatorDropdownAppendTo" [dropdownScrollHeight]="paginatorDropdownScrollHeight" [templateLeft]="paginatorLeftTemplate" [templateRight]="paginatorRightTemplate"
                 [currentPageReportTemplate]="currentPageReportTemplate" [showFirstLastIcon]="showFirstLastIcon" [dropdownItemTemplate]="paginatorDropdownItemTemplate" [showCurrentPageReport]="showCurrentPageReport" [showJumpToPageDropdown]="showJumpToPageDropdown" [showPageLinks]="showPageLinks"></p-paginator>
             <div class="p-dataview-content">
-                <div class="p-grid p-nogutter">
+                <div class="grid grid-nogutter">
                     <ng-template ngFor let-rowData let-rowIndex="index" [ngForOf]="paginator ? ((filteredValue||value) | slice:(lazy ? 0 : first):((lazy ? 0 : first) + rows)) : (filteredValue||value)" [ngForTrackBy]="trackBy">
                         <ng-container *ngTemplateOutlet="itemTemplate; context: {$implicit: rowData, rowIndex: rowIndex}"></ng-container>
                     </ng-template>


### PR DESCRIPTION
PrimeNG's DataView component is not compatible with PrimeFlex 3
The pTemplate gridItem generates a p-grid class and p-nogutter

###Defect Fixes
Alignment does not work properly with PrimeFlex 3

###Feature Requests
Compatibility PrimeFlex 3