### PR TITLE
Fixed #9289 chips, filled state is updating from model change

### DIFF
--- a/src/app/components/chips/chips.ts
+++ b/src/app/components/chips/chips.ts
@@ -135,7 +135,7 @@ export class Chips implements AfterContentInit,ControlValueAccessor {
 
     updateFilledState() {
         if (!this.value || this.value.length === 0) {
-            this.filled = (this.inputViewChild.nativeElement && this.inputViewChild.nativeElement.value != '');
+            this.filled = !!this.inputViewChild?.nativeElement?.value;
         }
         else {
             this.filled = true;
@@ -151,6 +151,7 @@ export class Chips implements AfterContentInit,ControlValueAccessor {
 
     writeValue(value: any) : void {
         this.value = value;
+        this.updateFilledState();
         this.updateMaxedOut();
         this.cd.markForCheck();
     }


### PR DESCRIPTION
###Defect Fixes
This is a fix for the issue https://github.com/primefaces/primeng/issues/9289.
Issue case: p-chips with a filled value on start (or we set the value from code). In this case p-chips has no p-inputwrapper-filled class. Hence you can't style this p-chips as a filled one.