### PR TITLE
Added property labelEscape in Checkbox component, allowing to use HTML labels

### DIFF
--- a/src/app/components/checkbox/checkbox.ts
+++ b/src/app/components/checkbox/checkbox.ts
@@ -23,7 +23,8 @@ export const CHECKBOX_VALUE_ACCESSOR: any = {
         </div>
         <label (click)="onClick($event,cb,true)" [class]="labelStyleClass"
                 [ngClass]="{'p-checkbox-label': true, 'p-checkbox-label-active':checked, 'p-disabled':disabled, 'p-checkbox-label-focus':focused}"
-                *ngIf="label" [attr.for]="inputId">{{label}}</label>
+                *ngIf="label" [attr.for]="inputId" [textContent]="labelEscape ? label : null"  [innerHTML]="!labelEscape ? label : null">
+        </label>
     `,
     providers: [CHECKBOX_VALUE_ACCESSOR],
    changeDetection: ChangeDetectionStrategy.OnPush,
@@ -37,9 +38,9 @@ export class Checkbox implements ControlValueAccessor {
     @Input() name: string;
 
     @Input() disabled: boolean;
-    
+
     @Input() binary: boolean;
-    
+
     @Input() label: string;
 
     @Input() ariaLabelledBy: string;
@@ -49,17 +50,19 @@ export class Checkbox implements ControlValueAccessor {
     @Input() tabindex: number;
 
     @Input() inputId: string;
-    
+
     @Input() style: any;
 
     @Input() styleClass: string;
 
     @Input() labelStyleClass: string;
-    
+
+    @Input() labelEscape: boolean = false;
+
     @Input() formControl: FormControl;
-    
+
     @Input() checkboxIcon: string = 'pi pi-check';
-    
+
     @Input() readonly: boolean;
 
     @Input() required: boolean;
@@ -67,34 +70,34 @@ export class Checkbox implements ControlValueAccessor {
     @ViewChild('cb') inputViewChild: ElementRef;
 
     @Output() onChange: EventEmitter<any> = new EventEmitter();
-    
+
     model: any;
-    
+
     onModelChange: Function = () => {};
-    
+
     onModelTouched: Function = () => {};
-        
+
     focused: boolean = false;
-    
+
     checked: boolean = false;
 
     constructor(private cd: ChangeDetectorRef) {}
 
     onClick(event,checkbox,focus:boolean) {
         event.preventDefault();
-        
+
         if (this.disabled || this.readonly) {
             return;
         }
-        
+
         this.checked = !this.checked;
         this.updateModel(event);
-        
+
         if (focus) {
             checkbox.focus();
         }
     }
-    
+
     updateModel(event) {
         if (!this.binary) {
             if (this.checked)
@@ -103,7 +106,7 @@ export class Checkbox implements ControlValueAccessor {
                 this.removeValue();
 
             this.onModelChange(this.model);
-            
+
             if (this.formControl) {
                 this.formControl.setValue(this.model);
             }
@@ -111,10 +114,10 @@ export class Checkbox implements ControlValueAccessor {
         else {
             this.onModelChange(this.checked);
         }
-        
+
         this.onChange.emit({checked:this.checked, originalEvent: event});
     }
-    
+
     handleChange(event) {
         if (!this.readonly) {
             this.checked = event.target.checked;
@@ -139,7 +142,7 @@ export class Checkbox implements ControlValueAccessor {
         else
             this.model = [this.value];
     }
-    
+
     onFocus() {
         this.focused = true;
     }
@@ -152,13 +155,13 @@ export class Checkbox implements ControlValueAccessor {
     focus() {
         this.inputViewChild.nativeElement.focus();
     }
-     
+
     writeValue(model: any) : void {
         this.model = model;
         this.checked = this.isChecked();
         this.cd.markForCheck();
     }
-    
+
     registerOnChange(fn: Function): void {
         this.onModelChange = fn;
     }
@@ -166,7 +169,7 @@ export class Checkbox implements ControlValueAccessor {
     registerOnTouched(fn: Function): void {
         this.onModelTouched = fn;
     }
-    
+
     setDisabledState(val: boolean): void {
         this.disabled = val;
         this.cd.markForCheck();

--- a/src/app/showcase/components/checkbox/checkboxdemo.html
+++ b/src/app/showcase/components/checkbox/checkboxdemo.html
@@ -49,7 +49,7 @@ import &#123;CheckboxModule&#125; from 'primeng/checkbox';
 
             <h5>Getting Started</h5>
             <p>Checkbox can either be used in multiple selection with other checkboxes or as a single checkbox to provide a boolean value.</p>
-            
+
             <h4>Multiple Values</h4>
             <p>Multiple mode is enabled by default, ngModel property refers to an array to bind the selected values.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
@@ -97,7 +97,7 @@ export class ModelComponent &#123;
 </app-code>
 
         <h5>Model Driven Forms</h5>
-        <p>Checkbox can be used in a model driven form as well. In this case, due to an <a href="https://github.com/angular/angular/issues/17685">issue</a> in Angular bind the formControl instance 
+        <p>Checkbox can be used in a model driven form as well. In this case, due to an <a href="https://github.com/angular/angular/issues/17685">issue</a> in Angular bind the formControl instance
             instead of using formControlName.</p>
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;!-- Wrong --&gt;
@@ -190,6 +190,12 @@ export class ModelComponent &#123;
                             <td>string</td>
                             <td>null</td>
                             <td>Style class of the label.</td>
+                        </tr>
+                        <tr>
+                            <td>labelEscape</td>
+                            <td>boolean</td>
+                            <td>true</td>
+                            <td>By default the label contents are rendered as text. Set to false to support html tags in the content.</td>
                         </tr>
                         <tr>
                             <td>checkboxIcon</td>


### PR DESCRIPTION
I added the property _labelEscape_ in the **Checkbox** component.
As in the **Tooltip** component  by default the label contents are rendered as text.
Setting to false it's possible to support html tags in the label content.

I found it's very useful in some cases.

For example:  Use checkbox to agree the Privacy policy, providing the privacy policy link directly inside the label.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.