### PR TITLE
Update splitbutton.css

### DIFF
--- a/src/app/components/splitbutton/splitbutton.css
+++ b/src/app/components/splitbutton/splitbutton.css
@@ -10,7 +10,7 @@
     border-right: 0 none;
 }
 
-.p-splitbutton-menubutton {
+.p-splitbutton .p-splitbutton-menubutton {
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
I've tried creating my own theme (using Serenity) and for some reason the .p-splitbutton-menubutton selector is not specific enough. It is basically falling below the .p-button from the "theme.css" and border-radius is then overwritten, making it appear wrong.

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.