### PR TITLE
Fixes -  Table: global filter doesn't reset on Table.clear() #10246

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -4374,6 +4374,7 @@ export class ColumnFilter implements AfterContentInit {
 
     initFieldFilterConstraint() {
         let defaultMatchMode = this.getDefaultMatchMode();
+        this.dt.filters['global']  = { value: null, matchMode: defaultMatchMode};
         this.dt.filters[this.field] = this.display == 'row' ? {value: null, matchMode: defaultMatchMode} : [{value: null, matchMode: defaultMatchMode, operator: this.operator}];
     }
 


### PR DESCRIPTION
Fixes - Table: global filter doesn't reset on Table.clear() #10246
Set default value of global filter in table.

