### PR TITLE
Add proper generic type specifier to ElementRefs

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -266,15 +266,15 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
 
     @Output() onHide: EventEmitter<any> = new EventEmitter();
 
-    @ViewChild('container') containerViewChild: ElementRef;
+    @ViewChild('container') containerViewChild: ElementRef<HTMLDivElement>;
 
-    @ViewChild('filter') filterViewChild: ElementRef;
+    @ViewChild('filter') filterViewChild: ElementRef<HTMLInputElement>;
 
-    @ViewChild('in') accessibleViewChild: ElementRef;
+    @ViewChild('in') accessibleViewChild: ElementRef<HTMLInputElement>;
 
     @ViewChild(CdkVirtualScrollViewport) viewPort: CdkVirtualScrollViewport;
 
-    @ViewChild('editableInput') editableInputViewChild: ElementRef;
+    @ViewChild('editableInput') editableInputViewChild: ElementRef<HTMLInputElement>;
 
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
 


### PR DESCRIPTION
Added a proper type specifier to the ElementRefs used in the Dropdown component.

This allows proper type support (IDE suggestions, linting errors) for the native elements.

This PR is only for one component (Dropdown), but I can extend it to the other components in PrimeNG if you like the idea.