### PR TITLE
Type fix for field input in p-autocomplete

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -187,7 +187,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     @Output() onHide: EventEmitter<any> = new EventEmitter();
 
-    @Input() field: any;
+    @Input() field: string | ((input: any) => any);
 
     @Input() scrollHeight: string = '200px';
 

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -187,7 +187,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     @Output() onHide: EventEmitter<any> = new EventEmitter();
 
-    @Input() field: string;
+    @Input() field: any;
 
     @Input() scrollHeight: string = '200px';
 


### PR DESCRIPTION
field can be a function and is passed as any when used in object utils:
https://github.com/primefaces/primeng/blob/master/src/app/components/utils/objectutils.ts#L60
https://github.com/primefaces/primeng/blob/master/src/app/components/autocomplete/autocomplete.ts#L591

###Defect Fixes
See my comment on this issue : [https://github.com/primefaces/primeng/issues/4269#issuecomment-918287258](https://github.com/primefaces/primeng/issues/4269#issuecomment-918287258)

N.B : I did not edit the documentation for autocomplete