### PR TITLE
fix: remove redundant tag

### DIFF
--- a/src/app/showcase/components/focustrap/focustrapdemo.html
+++ b/src/app/showcase/components/focustrap/focustrapdemo.html
@@ -108,7 +108,6 @@ import &#123;FocusTrapModule&#125; from 'primeng/focustrap';
             </a>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
-&lt;div pFocusTrap&gt;
 &lt;div pFocusTrap class="card"&gt;
     &lt;h5&gt;Input&lt;/h5&gt;
     &lt;input id="input" type="text" size="30" pInputText&gt; 


### PR DESCRIPTION
There is an extra `<div pFocusTrap>` at the first line of the demo code