### PR TITLE
Fix Dataview Documentation rowIndex

### DIFF
--- a/src/app/showcase/components/dataview/dataviewdemo.html
+++ b/src/app/showcase/components/dataview/dataviewdemo.html
@@ -593,12 +593,12 @@ export class DataViewSortDemo implements OnInit &#123;
                         <tr>
                             <td>gridItem</td>
                             <td>$implicit: Data of the grid <br />
-                                index: Index of the grid</td>
+                                rowIndex: Index of the grid</td>
                         </tr>
                         <tr>
-                            <td>listItemTemplate</td>
+                            <td>listItem</td>
                             <td>$implicit: Data of the row <br />
-                                index: Index of the row</td>
+                                rowIndex: Index of the row</td>
                         </tr>
                         <tr>
                             <td>empty</td>


### PR DESCRIPTION
Fixed some errors in Dataview documentation.

index in templating can be accessed with "rowIndex" and the pTemplate parameter for list has to be "listItem"