### PR TITLE
Fix #10756 - spelling and grammar updates in Table Docs

### DIFF
--- a/src/app/showcase/components/table/tabledemo.html
+++ b/src/app/showcase/components/table/tabledemo.html
@@ -176,7 +176,7 @@ import &#123;TableModule&#125; from 'primeng/table';
 </app-code>
 
             <h5>Getting Started</h5>
-            <p>Table requires a value as an array of objects and templates for the presentation. Throughout the samples, a car interface having
+            <p>Table requires a value as an array of objects and templates for the presentation. Throughout the samples, a car interface having a
             vin, brand, year and color properties is used to define an object to be displayed by the table. Cars are loaded by a CarService that
             connects to a server to fetch the data.</p>
 
@@ -248,8 +248,8 @@ export class TableDemo implements OnInit &#123;
 </app-code>
 
         <h5>Dynamic Columns</h5>
-        <p>Instead of configuring columns one by one, a simple ngFor can be used to implement dynamic columns. cols property below is an array of objects that represent a column,
-            only property that table component uses is field, rest of the properties like <i>header</i> depend on your choice.
+        <p>Instead of configuring columns one by one, a simple ngFor can be used to implement dynamic columns. cols property below is an array of objects that represent a column.
+            The only property that the table component uses is field, and the rest of the properties like <i>header</i> depend on your choice.
         </p>
 
 <app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
@@ -274,7 +274,7 @@ export class DynamicColumnsDemo implements OnInit &#123;
 &#125;
 </app-code>
 
-        <p>There are two ways to render dynamic columns, since cols property is in the scope of component you can just simply bind it to ngFor directive to generate the structure.</p>
+        <p>There are two ways to render dynamic columns. Since the cols property is in the scope of component, you can simply bind it to the ngFor directive to generate the structure.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-table [value]="cars"&gt;
@@ -295,8 +295,8 @@ export class DynamicColumnsDemo implements OnInit &#123;
 &lt;/p-table&gt;
 </app-code>
 
-            <p>Other alternative is binding the cols array to the <i>columns</i> property and then defining a template variable to access it within your templates.
-                There are 3 cases where this is required which are csv export, reorderable columns and global filtering without the <i>globalFilterFields</i> property.
+            <p>The other alternative is binding the cols array to the <i>columns</i> property and then defining a template variable to access within your templates.
+                There are 3 cases where this is required which are: csv export, reorderable columns, and global filtering without the <i>globalFilterFields</i> property.
             </p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
@@ -321,13 +321,13 @@ export class DynamicColumnsDemo implements OnInit &#123;
             <p>Tip: Use ngSwitch to customize the column content per dynamic column.</p>
 
             <h5>Table Layout</h5>
-            <p>For performance reasons, default table-layout is fixed meaning the cell widths do not depend on their content. If you require cells to scale based on their contents
+            <p>For performance reasons, default table-layout is fixed meaning the cell widths do not depend on their content. If you require cells to scale based on their contents,
                 set <i>autoLayout</i> property to true. Note that Scrollable and/or Resizable tables do not support auto layout due to technical reasons.
             </p>
 
             <h5>Templates</h5>
             <p>Table is a template driven component with named templates such as header and body that we've used so far. Templates grant a great level of customization and flexibility
-                where you have total control over the presentation while table handles the features such as paging, sorting, filtering and more. This speeds up development without sacrifing
+                where you have total control over the presentation while table handles the features such as paging, sorting, filtering and more. This speeds up development without sacrificing
                 flexibility. Here is the full list of available templates.</p>
 
             <div class="doc-tablewrapper">
@@ -468,8 +468,8 @@ export class DynamicColumnsDemo implements OnInit &#123;
             </div>
 
             <h5>Change Detection</h5>
-            <p>Table may need to be aware of changes in its value in some cases such as reapplying sort. For the sake of performance, this is only done when the reference of the value changes meaning a
-                setter is used instead of ngDoCheck/IterableDiffers which can reduce performance. So when you manipulate the value such as removing or adding an item, instead of using array methods such as push, splice
+            <p>Table may need to be aware of changes in its value in some cases such as reapplying sort. For the sake of performance, this is only done when the reference of the value changes, meaning a
+                setter is used instead of ngDoCheck/IterableDiffers which can reduce performance. So when you manipulate the value such as removing or adding an item, instead of using array methods such as push and splice, instead
                 create a new array reference using a spread operator or similar.
             </p>
 
@@ -575,11 +575,11 @@ export class TableColGroupDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/colgroup']">live example.</a></p>
 
             <h5>Row Group</h5>
-            <p>Row Grouping comes in two modes, in "subheader" mode rows are grouped by a header row along with an optional group footer. In addition, the groups can be use with
+            <p>Row Grouping comes in two modes. In "subheader" mode, rows are grouped by a header row along with an optional group footer. In addition, the groups can be use with
                 Expandable Rows too. On the other hand, the "rowspan" mode uses rowspans instead of a header to group rows. <i>groupRowsBy</i>
-                property defines the field to use in row grouping. Multiple row grouping is available in "rowspan" mode by specifying the <i>groupRowsBy</i> as an array of fields. Sticky Row Group avaiable with <i>pRowGroupHeader</i> directive.</p>
+                property defines the field to use in row grouping. Multiple row grouping is available in "rowspan" mode by specifying the <i>groupRowsBy</i> as an array of fields. Sticky Row Group is avaiable with <i>pRowGroupHeader</i> directive.</p>
 
-            <p>Example below demonstrates the all grouping alternatives. Note that data needs to be sorted for grouping which can also be done by the table itself by speficying the sort properties.</p>
+            <p>Example below demonstrates all the grouping alternatives. Note that data needs to be sorted for grouping, which can also be done by the table itself by speficying the sort properties.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;h5&gt;Subheader Grouping&lt;/h5&gt;
@@ -754,7 +754,7 @@ export class TableRowGroupDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/rowgroup']">live example.</a></p>
 
             <h5>Paginator</h5>
-            <p>Pagination is enabled by setting <i>paginator</i> property to true, rows property defines the number of rows per page and pageLinks specify the the number
+            <p>Pagination is enabled by setting the <i>paginator</i> property to true. Rows property defines the number of rows per page, and pageLinks specify the the number
                 of page links to display. See <a [routerLink]="['/paginator']">paginator</a> component for more information.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
@@ -847,7 +847,7 @@ export class TablePageDemo implements OnInit &#123;
 &lt;/p-table&gt;
 </app-code>
 
-            <p>Paginator templates gets the paginator state as an implicit variable that provides the following properties</p>
+            <p>Paginator templates get the paginator state as an implicit variable that provides the following properties</p>
             <ul>
                 <li>first</li>
                 <li>rows</li>
@@ -1059,9 +1059,9 @@ export class CustomTableSortDemo implements OnInit &#123;
 </app-code>
 
             <h4>Match modes</h4>
-            <p>Each filter data type has its own match modes, for example "text" type displays string matchers e.g. startsWith and "date" type has before/after matchers. Defaults
+            <p>Each filter data type has its own match modes. For example, "text" type displays string matchers, and startsWith and "date" type has before/after matchers. Defaults
                 are defined at the <i>PrimeNGConfig</i> instance to apply matchers for a certain type in the entire application with ability to override the global configuration using the <i>matchModeOptions</i> property that accepts a SelectItem array.
-                Global configuration can be changed during initialization of the root component. Here is an example that appclies options for data types, note that values used in this sample
+                Global configuration can be changed during initialization of the root component. Here is an example that applies options for data types. Note that values used in this sample
                 are the default values and this configuration is only required if you'd like to customize defaults globally.
             </p>
 
@@ -1146,7 +1146,7 @@ export class TableFilterDemo implements OnInit &#123;
 </app-code>
 
             <h4>Global Filtering</h4>
-            <p>Global filtering searches all the fields from a single form element, in order to implement global filtering call the <i>filterGlobal</i> of the table with a value and match mode. If you have static columns and need to use global filtering, <i>globalFilterFields</i> property must be defined to configure which fields should be used in global filtering. Another
+            <p>Global filtering searches all the fields from a single form element. In order to implement global filtering, call the <i>filterGlobal</i> of the table with a value and match mode. If you have static columns and need to use global filtering, <i>globalFilterFields</i> property must be defined to configure which fields should be used in global filtering. Another
                 use case of this property is to change the fields to utilize in global filtering with dynamic columns.
             </p>
 
@@ -1366,19 +1366,19 @@ export class TableFilterDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/filter']">live example.</a></p>
 
             <h5>Selection</h5>
-            <p>Table provides built-in single and multiple selection features where selected rows are bound to the selection property and onRowSelect-onRowUnselect events
-            are provided as optional callbacks. In order to enable this feature, define a <i>selectionMode</i>, bind a selection reference and add pSelectableRow directive
-            whose value is the rowData to the rows that can be selected. Additionally if you prefer double click use <i>pSelectableRowDblClick</i> directive instead and
-            to disable selection events on a particular row use pSelectableRowDisabled. In both cases optional
-            <i>pSelectableRowIndex</i> property is avaiable to access the row index. By default each row click adds or removes the row from the selection, if you prefer a classic
-            metaKey based selection approach enable <i>metaKeySelection</i> true so that multiple selection or unselection of a row requires metaKey to be pressed. Note that, on touch enabled
-            devices, metaKey based selection is turned off automatically as there is no metaKey in devices such as mobile phones.</p>
+            <p>Table provides built-in single and multiple selection features where selected rows are bound to the selection property and <i>onRowSelect</i> - <i>onRowUnselect</i> events
+            are provided as optional callbacks. In order to enable this feature, define a <i>selectionMode</i>, bind a selection reference and add <i>pSelectableRow</i> directive
+            whose value is the rowData to the rows that can be selected. Additionally, if you prefer double-click, use <i>pSelectableRowDblClick</i> directive instead and
+            to disable selection events on a particular row use <i>pSelectableRowDisabled</i>. In both cases optional
+            <i>pSelectableRowIndex</i> property is avaiable to access the row index. By default, each row click adds or removes the row from the selection. If you prefer a classic
+            metaKey based selection approach, enable <i>metaKeySelection</i> true so that multiple selection or unselection of a row requires metaKey to be pressed. Note that, on touch enabled
+            devices, metaKey based selection is turned off automatically as there is no metaKey on devices such as mobile phones.</p>
 
-            <p>Alternative to the row click, radiobutton or checkbox elements can be used to implement row selection.</p>
+            <p>As an alternative to the row click, radiobutton or checkbox elements can be used to implement row selection.</p>
 
-            <p>When resolving if a row is selected, by default Table compares selection array with the datasource which may cause a performance issue with huge datasets that do not use pagination.
-                If available the fastest way is to use dataKey property that identifies a unique row so that Table can avoid comparing arrays as internally a map instance is used instead of looping arrays, on the other hand
-                if dataKey cannot be provided consider using <i>compareSelectionBy</i> property as "equals" which uses reference comparison instead of the default "deepEquals" comparison. Latter is slower since it checks all properties.
+            <p>When resolving if a row is selected, by default, Table compares selection array with the datasource which may cause a performance issue with huge datasets that do not use pagination.
+                If available, the fastest way is to use dataKey property that identifies a unique row so that Table can avoid comparing arrays as internally a map instance is used instead of looping arrays. On the other hand,
+                if dataKey cannot be provided consider using <i>compareSelectionBy</i> property as "equals" which uses reference comparison instead of the default "deepEquals" comparison. The latter is slower since it checks all properties.
             </p>
 
             <p>In single mode, selection binding is an object reference.</p>
@@ -1512,7 +1512,7 @@ export class TableDemo implements OnInit &#123;
 </app-code>
 
 
-            <p>Both <i>p-tableCheckbox</i> and <i>p-tableRadioButton</i> components can be <i>disabled</i> using their property with the same name to prevent selection of a particular row. In addition, index of the row
+            <p>Both <i>p-tableCheckbox</i> and <i>p-tableRadioButton</i> components can be <i>disabled</i> using their property with the same name to prevent selection of a particular row. In addition, the index of the row
                 needs to be provided to the checkbox/radiobutton components so that they can be available at the <i>onRowSelect</i> or <i>onRowUnselect</i> events of the Table.
             </p>
 
@@ -1683,8 +1683,8 @@ export class TableDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/selection']">live example.</a></p>
 
             <h5>ContextMenu</h5>
-            <p>Table has exclusive integration with contextmenu component. In order to attach a menu to a table, add <i>pContextMenuRow</i> directive to the rows that can be selected with context menu, define a local template
-            variable for the menu and bind it to the contextMenu property of the table. This enables displaying the menu whenever a row is right clicked. Optional
+            <p>Table has exclusive integration with <i>contextmenu</i> component. In order to attach a menu to a table, add <i>pContextMenuRow</i> directive to the rows that can be selected with context menu, define a local template
+            variable for the menu and bind it to the <i>contextMenu</i> property of the table. This enables displaying the menu whenever a row is right clicked. Optional
             <i>pContextMenuRowIndex</i> property is avaiable to access the row index. A separate <i>contextMenuSelection</i>
             property is used to get a hold of the right clicked row. For dynamic columns, setting <i>pContextMenuRowDisabled</i> property as true disables context menu for that particular row.</p>
 
@@ -1711,7 +1711,7 @@ export class TableDemo implements OnInit &#123;
 </app-code>
 
 
-            <p>By default context menu uses a different property called <i>contextMenuSelection</i> as above, this means when row selection mode is also enabled, the two properties, both selection and <i>contextMenuSelection</i> need to be maintained.
+            <p>By default, context menu uses a different property called <i>contextMenuSelection</i> as above, this means when row selection mode is also enabled, the two properties, both selection and <i>contextMenuSelection</i> need to be maintained.
                 In case you prefer to configure Table to manage the same selection property both on row click and context menu, set <i>contextMenuSelectionMode</i> as "joint". Table below has both <i>selectionMode</i> and contextMenu enabled where
                 both of these features update the same selection object.</p>
 
@@ -1741,7 +1741,7 @@ export class TableDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/contextmenu']">live example.</a></p>
 
             <h5>Cell Editing</h5>
-            <p>Incell editing is enabled by adding <i>pEditableColumn</i> directive to an editable cell that has a <i>p-cellEditor</i> helper
+            <p>In-cell editing is enabled by adding <i>pEditableColumn</i> directive to an editable cell that has a <i>p-cellEditor</i> helper
                 component to define the input-output templates for the edit and view modes respectively.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
@@ -1809,8 +1809,8 @@ export class TableDemo implements OnInit &#123;
 </app-code>
 
 
-            <p>When opening a cell for editing, the table will automatically focus the first <i>input</i>, <i>textarea</i>, or <i>select</i> element inside the output template.
-               If you want to override this default behavior, you can pass a custom selector for the elements to focus into the pFocusCellSelector directive.
+            <p>When opening a cell for editing, the table will automatically focus on the first <i>input</i>, <i>textarea</i>, or <i>select</i> element inside the output template.
+               If you want to override this default behavior, you can pass a custom selector for the elements to focus into the <i>pFocusCellSelector</i> directive.
                This is useful when you would like the Tab and Shift+Tab keyboard navigation to focus on buttons or custom edit controls.
             </p>
 
@@ -1820,16 +1820,16 @@ export class TableDemo implements OnInit &#123;
 
 
             <h5>Row Editing</h5>
-            <p>Row editing toggles the visibility of the all editors in the row at once and provides additional options to save and cancel editing. Row editing functionality
-                is enabled by setting the <i>editMode</i> to "row" on table, defining a dataKey to uniquely identify a row, adding pEditableRow directive to the editable rows and defining the UI Controls with <i>pInitEditableRow</i>, <i>pSaveEditableRow</i> and <i>pCancelEditableRow</i> directives respectively.
+            <p>Row editing toggles the visibility of all the editors in the row at once and provides additional options to save and cancel editing. Row editing functionality
+                is enabled by setting the <i>editMode</i> to "row" on table, defining a dataKey to uniquely identify a row, adding <i>pEditableRow</i> directive to the editable rows and defining the UI Controls with <i>pInitEditableRow</i>, <i>pSaveEditableRow</i> and <i>pCancelEditableRow</i> directives respectively.
             </p>
             <p>
-                Save and Cancel functionality implementation is left to the page author to provide more control over the editing business logic, example below utilizes
+                Save and Cancel functionality implementation is left to the page author to provide more control over the editing business logic. Example below utilizes
                 a simple implementation where a row is cloned when editing is initialized and is saved or restored depending on the result of the editing. An implicit variable called "editing" is passed to the body template
                 so you may come up with your own UI controls that implement editing based on your own requirements such as adding validations and styling. Note that <i>pSaveEditableRow</i> only switches the row to back view mode when there are no validation errors.
             </p>
-            <p>Moreover you may use setting <i>pEditableRowDisabled</i> property as true to disable editing for that particular row and
-                in case you need to display rows in edit mode by default use <i>editingRowKeys</i> property which is a map whose key is the dataKey of the record where value is any arbitrary number greater than zero.</p>
+            <p>Moreover, you may use setting <i>pEditableRowDisabled</i> property as true to disable editing for that particular row and
+                in case you need to display rows in edit mode by default, use the <i>editingRowKeys</i> property which is a map whose key is the dataKey of the record where the value is any arbitrary number greater than zero.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-table [value]="cars" dataKey="vin" editMode="row"&gt;
@@ -1997,7 +1997,7 @@ export class TableEditDemo implements OnInit &#123;
 </app-code>
 
 
-            <p>Multiple rows can be expanded at the same time, if you prefer a single row expansion at any time set <i>rowExpandMode</i> property to "single". All rows
+            <p>Multiple rows can be expanded at the same time. If you prefer a single row expansion at any time, set <i>rowExpandMode</i> property to "single". All rows
                 are collapsed initially and providing <i>expandedRowKeys</i> property whose value is the dataKeys of the rows to be expanded enables rendering these rows as expanded. A dataKey must be defined
                 for this feature.</p>
 
@@ -2012,7 +2012,7 @@ export class TableEditDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/rowexpansion']">live example.</a></p>
 
             <h5>Column Resize</h5>
-            <p>Columns can be resized using drag drop by setting the <i>resizableColumns</i> to true. There are two resize modes; "fit" and "expand". Fit is the default one and
+            <p>Columns can be resized using drag drop by setting the <i>resizableColumns</i> to true. There are two resize modes: "fit", and "expand". Fit is the default one and
             the overall table width does not change when a column is resized. In "expand" mode, table width also changes along with the column width. <i>onColumnResize</i>
             is a callback that passes the resized column header as a parameter. For dynamic columns, setting <i>pResizableColumnDisabled</i> property as true disables resizing for that particular column.
             </p>
@@ -2119,8 +2119,8 @@ export class TableEditDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/reorder']">live example.</a></p>
 
             <h5>Data Export</h5>
-            <p>Table can export its data in CSV format using the built-in <i>exportCSV()</i> function. By default whole data is exported, if you'd like to export only the selection then pass a config object with selectionOnly property as true. Note that
-                columns should be dynamic for export functionality to work and column objects must define field/header properties.
+            <p>Table can export its data in CSV format using the built-in <i>exportCSV()</i> function. By default, all data is exported. If you'd like to export only the selection then pass a config object with <i>selectionOnly</i> property as true. Note that
+                columns should be dynamic for export functionality to work, and column objects must define field/header properties.
             </p>
 
             <p>PDF and EXCEL export are also available using 3rd party libraries such as jspdf. Example below demonstrates how to implement all three export options.</p>
@@ -2227,7 +2227,7 @@ export class TableExportDemo implements OnInit &#123;
             <h5>Scrolling</h5>
             <p>Table supports both horizontal and vertical scrolling as well as frozen columns and rows. Additionally, <i>virtualScroll</i> mode enables dealing with large datasets by rendering data on demand during scrolling.</p>
 
-            <p>Sample below uses vertical scrolling where headers are fixed and data is scrollable.</p>
+            <p>Sample below uses vertical scrolling where headers are fixed, and data is scrollable.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-table [columns]="cols" [value]="cars" [scrollable]="true" scrollHeight="200px"&gt;
@@ -2446,7 +2446,7 @@ export class TableExportDemo implements OnInit &#123;
 </app-code>
 
             <h6>Frozen Columns</h6>
-            <p>Certain columns can be frozen by using the <i>pFrozenColumn</i> directive of the table component. In addition <i>alignFrozen</i> is available to define whether the column should
+            <p>Certain columns can be frozen by using the <i>pFrozenColumn</i> directive of the table component. In addition, <i>alignFrozen</i> is available to define whether the column should
             be fixed on the left or right.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
@@ -2511,7 +2511,7 @@ export class TableExportDemo implements OnInit &#123;
 
             <h5>Virtual Scrolling</h5>
             <p>VirtualScroller is a performant approach to handle huge data efficiently. Setting <i>virtualScroll</i> property as true and providing a <i>virtualRowHeight</i> in pixels
-            would be enough to enable this functionality. It is also suggested to use the same virtualRowHeight value on the tr element inside the body template.</p>
+            would be enough to enable this functionality. It is also suggested to use the same <i>virtualRowHeight</i> value on the tr element inside the body template.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-table [columns]="cols" [value]="cars" [scrollable]="true" [rows]="100" scrollHeight="250px"
@@ -2558,8 +2558,8 @@ export class TableVirtualScrollDemo implements OnInit &#123;
 </app-code>
 
 
-            <p>Example above uses preloaded data, in order to load data on demand, lazy mode should be enabled where chunks of data are loaded from a datasource on scroll. To implement lazy loading,
-               enable <i>lazy</i> attribute, initialize your data as a placeholder collection with a length and finally implement a method callback using onLazyLoad that actually loads a chunk from a datasource. onLazyLoad gets a LazyLoadEvent object
+            <p>Example above uses preloaded data In order to load data on demand, lazy mode should be enabled where chunks of data are loaded from a datasource on scroll. To implement lazy loading,
+               enable <i>lazy</i> attribute, initialize your data as a placeholder collection with a length, and finally implement a method callback using <i>onLazyLoad</i> that actually loads a chunk from a datasource. <i>onLazyLoad</i> gets a LazyLoadEvent object
                that contains information about the chunk of data to load such as the index and number of items to load. Notice that a special "loadingbody" template is available to provide feedback to the users
                 about the loading status of a scroll event.
             </p>
@@ -2634,8 +2634,8 @@ export class TableVirtualScrollDemo implements OnInit &#123;
             <p>See the <a [routerLink]="['/table/scroll']">scroll</a> and <a [routerLink]="['/table/virtualscroll']">virtual scroll</a> examples.</p>
 
             <h5>Lazy Loading</h5>
-            <p>Lazy mode is handy to deal with large datasets, instead of loading the entire data, small chunks of data is loaded by invoking
-             onLazyLoad callback everytime paging, sorting and filtering happens. To implement lazy loading,
+            <p>Lazy mode is handy to deal with large datasets. Instead of loading the entire data, small chunks of data is loaded by invoking
+             <i>onLazyLoad</i> callback every time paging, sorting, and filtering happens. To implement lazy loading,
             enable <i>lazy</i> attribute and provide a method callback using <i>onLazyLoad</i> that actually loads the data from a remote datasource. <i>onLazyLoad</i> gets an event object
             that contains information about how the data should be loaded. It is also important to assign the logical number of rows to totalRecords by doing a projection query for paginator configuration so that paginator
             displays the UI assuming there are actually records of totalRecords size although in reality they aren't as in lazy mode, only the records that are displayed on the current page exist.</p>
@@ -2676,7 +2676,7 @@ loadData(event: LazyLoadEvent) &#123;
             <p>See the <a [routerLink]="['/table/lazy']">live example.</a></p>
 
             <h5>TableState</h5>
-            <p>Stateful table allows keeping the state such as page, sort and filtering either at local storage or session storage so that when the page is visited again, table would render the data using its last settings.
+            <p>Stateful table allows keeping the state such as page, sort, and filtering either at local storage or session storage so that when the page is visited again, table would render the data using its last settings.
                 Enabling state is easy as defining a unique <i>stateKey</i>, the storage to keep the state is defined with the <i>stateStorage</i> property that accepts session for sessionStorage and local for localStorage. Currently following features
                 are supported by TableState; paging, sorting, filtering, column resizing, column reordering, row expansion and row selection.
             </p>
@@ -2787,11 +2787,11 @@ export class TableDemo implements OnInit &#123;
 </app-code>
 
             <h5>Responsive</h5>
-            <p>DataTable responsive layout can be achieved in two ways; first approach is displaying a horizontal scrollbar for smaller screens
-                and second one is defining a breakpoint to display the cells of a row as stacked. Scrollable tables use the scroll layout approach internally and do not require additional configuration.</p>
+            <p>DataTable responsive layout can be achieved in two ways: first approach is displaying a horizontal scrollbar for smaller screens,
+                and the second one is defining a breakpoint to display the cells of a row as stacked. Scrollable tables use the scroll layout approach internally and do not require additional configuration.</p>
 
             <h5>Scroll Layout</h5>
-            <p>Set <i>responsiveLayout</i> to scroll to enabled this layout. Note that, when scroll mode is enabled table-layout automatically switches to auto from fixed
+            <p>Set <i>responsiveLayout</i> to scroll to enabled this layout. Note that when scroll mode is enabled, table-layout automatically switches to auto from fixed
             as a result table widths are likely to differ and resizable columns are not supported. Read more about <a href="https://www.w3schools.com/cssref/pr_tab_table-layout.asp">table-layout</a> for more details.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
@@ -2987,7 +2987,7 @@ export class TableDemo implements OnInit &#123;
                             <td>paginatorPosition</td>
                             <td>string</td>
                             <td>bottom</td>
-                            <td>Position of the paginator, options are "top","bottom" or "both".</td>
+                            <td>Position of the paginator, options are "top", "bottom" or "both".</td>
                         </tr>
                         <tr>
                             <td>currentPageReportTemplate</td>
@@ -3109,7 +3109,7 @@ export class TableDemo implements OnInit &#123;
                             <td>contextMenuSelectionMode</td>
                             <td>string</td>
                             <td>separate</td>
-                            <td>Defines the behavior of context menu selection, in "separate" mode context menu updates contextMenuSelection propertty whereas in joint mode
+                            <td>Defines the behavior of context menu selection, in "separate" mode context menu updates contextMenuSelection property whereas in joint mode
                                 selection property is used instead so that when row selection is enabled, both row selection and context menu selection use the same property.</td>
                         </tr>
                         <tr>
@@ -3122,7 +3122,7 @@ export class TableDemo implements OnInit &#123;
                             <td>metaKeySelection</td>
                             <td>boolean</td>
                             <td>true</td>
-                            <td>Defines whether metaKey is should be considered for the selection. On touch enabled devices, metaKeySelection is turned off automatically.</td>
+                            <td>Defines whether metaKey should be considered for the selection. On touch enabled devices, metaKeySelection is turned off automatically.</td>
                         </tr>
                         <tr>
                             <td>rowTrackBy</td>


### PR DESCRIPTION
Fixes #10756   according to the corrections and updates I saw worth changing.
Several spelling changes, and grammar changes (updating sentence structure). Also a few additions of `<i>`s to note properties and directives