### PR TITLE
chore(dropdown): allow to change `searchTimeout`

### DIFF
--- a/src/app/components/dropdown/dropdown.spec.ts
+++ b/src/app/components/dropdown/dropdown.spec.ts
@@ -1,528 +1,645 @@
 import { ScrollingModule } from '@angular/cdk/scrolling';
-import { TestBed, ComponentFixture, async } from '@angular/core/testing';
+import {
+    TestBed,
+    ComponentFixture,
+    async,
+    fakeAsync,
+    tick,
+    flush,
+} from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { Dropdown, DropdownItem} from './dropdown';
+import { Dropdown, DropdownItem, SearchTimeoutDefault } from './dropdown';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule } from '@angular/forms';
 import { Component } from '@angular/core';
 import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
-	template: `
-		<p-dropdown [(ngModel)]="selectedCity" [options]="groupedCars" [editable]="editable" [disabled]="disabled" [placeholder]="placeholder" [group]="true">
-			<ng-template let-group pTemplate="group">
-				<span>{{group.label}}</span>
-			</ng-template>
-		</p-dropdown>
-		<p-dropdown [(ngModel)]="selectedCity"></p-dropdown>
-		<button (click)="setValue()"></button>
-	`
+    template: `
+        <p-dropdown
+            [(ngModel)]="selectedCity"
+            [options]="groupedCars"
+            [editable]="editable"
+            [disabled]="disabled"
+            [placeholder]="placeholder"
+            [group]="true"
+        >
+            <ng-template let-group pTemplate="group">
+                <span>{{ group.label }}</span>
+            </ng-template>
+        </p-dropdown>
+        <p-dropdown [(ngModel)]="selectedCity"></p-dropdown>
+        <button (click)="setValue()"></button>
+    `,
 })
 class TestDropdownComponent {
-	selectedCity: any;
+    selectedCity: any;
 
-	groupedCars = [
-		{
-			label: 'Germany', value: 'germany.png', 
-			items: [
-				{label: 'Audi', value: 'Audi'},
-				{label: 'BMW', value: 'BMW'},
-				{label: 'Mercedes', value: 'Mercedes'}
-			]
-		},
-		{
-			label: 'USA', value: 'usa.png', 
-			items: [
-				{label: 'Cadillac', value: 'Cadillac'},
-				{label: 'Ford', value: 'Ford'},
-				{label: 'GMC', value: 'GMC'}
-			]
-		},
-		{
-			label: 'Japan', value: 'japan.png', 
-			items: [
-				{label: 'Honda', value: 'Honda'},
-				{label: 'Mazda', value: 'Mazda'},
-				{label: 'Toyota', value: 'Toyota'}
-			]
-		}
-	];
+    groupedCars = [
+        {
+            label: 'Germany',
+            value: 'germany.png',
+            items: [
+                { label: 'Audi', value: 'Audi' },
+                { label: 'BMW', value: 'BMW' },
+                { label: 'Mercedes', value: 'Mercedes' },
+            ],
+        },
+        {
+            label: 'USA',
+            value: 'usa.png',
+            items: [
+                { label: 'Cadillac', value: 'Cadillac' },
+                { label: 'Ford', value: 'Ford' },
+                { label: 'GMC', value: 'GMC' },
+            ],
+        },
+        {
+            label: 'Japan',
+            value: 'japan.png',
+            items: [
+                { label: 'Honda', value: 'Honda' },
+                { label: 'Mazda', value: 'Mazda' },
+                { label: 'Toyota', value: 'Toyota' },
+            ],
+        },
+    ];
 
-	disabled: boolean;
+    disabled: boolean;
 
-	editable: boolean;
+    editable: boolean;
 
-	placeholder: string = "Select a Car";
+    placeholder = 'Select a Car';
 
-	setValue() {
-		this.selectedCity = {name: 'New York', code: 'NY'};
-	}
+    setValue() {
+        this.selectedCity = { name: 'New York', code: 'NY' };
+    }
 }
 describe('Dropdown', () => {
-    
     let dropdown: Dropdown;
     let testDropdown: Dropdown;
     let groupDropdown: Dropdown;
-	let fixture: ComponentFixture<Dropdown>;
-	let groupFixture: ComponentFixture<TestDropdownComponent>;
-    
+    let fixture: ComponentFixture<Dropdown>;
+    let groupFixture: ComponentFixture<TestDropdownComponent>;
+
     beforeEach(() => {
-      TestBed.configureTestingModule({
-        imports: [
-          NoopAnimationsModule,
-          FormsModule,
-		  ScrollingModule,
-		  TooltipModule
-        ],
-        declarations: [
-          Dropdown,
-		  DropdownItem,
-		  TestDropdownComponent
-        ]
-      }).compileComponents();
-      
-	  fixture = TestBed.createComponent(Dropdown);
-	  groupFixture = TestBed.createComponent(TestDropdownComponent);
-	  groupDropdown = groupFixture.debugElement.children[0].componentInstance;
-	  testDropdown = groupFixture.debugElement.children[1].componentInstance;
-      dropdown = fixture.componentInstance;
+        TestBed.configureTestingModule({
+            imports: [
+                NoopAnimationsModule,
+                FormsModule,
+                ScrollingModule,
+                TooltipModule,
+            ],
+            declarations: [Dropdown, DropdownItem, TestDropdownComponent],
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(Dropdown);
+        groupFixture = TestBed.createComponent(TestDropdownComponent);
+        groupDropdown = groupFixture.debugElement.children[0].componentInstance;
+        testDropdown = groupFixture.debugElement.children[1].componentInstance;
+        dropdown = fixture.componentInstance;
     });
 
-	it('should disabled', () => {
-		fixture.componentInstance.disabled=true;
-		fixture.componentInstance.editable=true;
-		fixture.detectChanges();
+    it('should disabled', () => {
+        fixture.componentInstance.disabled = true;
+        fixture.componentInstance.editable = true;
+        fixture.detectChanges();
 
-		dropdown.cd.detectChanges();
-		const containerEl = fixture.debugElement.query(By.css('.p-dropdown')).nativeElement;
-		const hiddenEl = fixture.debugElement.queryAll(By.css('.p-hidden-accessible'))[0].children[0].nativeElement;
-		const editableInputEl = fixture.debugElement.queryAll(By.css('input'))[1].nativeElement;
-		expect(containerEl.className).toContain('p-disabled')
-		expect(hiddenEl.disabled).toEqual(true);
-		expect(editableInputEl.disabled).toEqual(true);
-	});
+        dropdown.cd.detectChanges();
+        const containerEl = fixture.debugElement.query(
+            By.css('.p-dropdown')
+        ).nativeElement;
+        const hiddenEl = fixture.debugElement.queryAll(
+            By.css('.p-hidden-accessible')
+        )[0].children[0].nativeElement;
+        const editableInputEl = fixture.debugElement.queryAll(
+            By.css('input')
+        )[1].nativeElement;
+        expect(containerEl.className).toContain('p-disabled');
+        expect(hiddenEl.disabled).toEqual(true);
+        expect(editableInputEl.disabled).toEqual(true);
+    });
 
-	it('should change dropdown icon', () => {
-		dropdown.dropdownIcon = "Primeng";
-		fixture.detectChanges();
+    it('should change dropdown icon', () => {
+        dropdown.dropdownIcon = 'Primeng';
+        fixture.detectChanges();
 
-		const dropdownSpanEl = fixture.debugElement.query(By.css('.p-dropdown-trigger-icon')).nativeElement;
-		expect(dropdownSpanEl.className).toContain("Primeng")
-	});
+        const dropdownSpanEl = fixture.debugElement.query(
+            By.css('.p-dropdown-trigger-icon')
+        ).nativeElement;
+        expect(dropdownSpanEl.className).toContain('Primeng');
+    });
 
-	it('should change style and styleClass', () => {
-		dropdown.styleClass = "Primeng";
-		dropdown.style = {'height':'300px'}
-		fixture.detectChanges();
+    it('should change style and styleClass', () => {
+        dropdown.styleClass = 'Primeng';
+        dropdown.style = { height: '300px' };
+        fixture.detectChanges();
 
-		const containerEl = fixture.debugElement.query(By.css('.p-dropdown'));
-		expect(containerEl.nativeElement.className).toContain("Primeng");
-		expect(containerEl.nativeElement.style.height).toEqual("300px");
-	});
+        const containerEl = fixture.debugElement.query(By.css('.p-dropdown'));
+        expect(containerEl.nativeElement.className).toContain('Primeng');
+        expect(containerEl.nativeElement.style.height).toEqual('300px');
+    });
 
-	it('should change panelStyleClass', () => {
-		dropdown.panelStyleClass = "Primeng";
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		fixture.detectChanges();
+    it('should change panelStyleClass', () => {
+        dropdown.panelStyleClass = 'Primeng';
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        fixture.detectChanges();
 
-		const container = fixture.debugElement.query(By.css('div')).nativeElement;
-		container.click();
-		fixture.detectChanges();
+        const container = fixture.debugElement.query(
+            By.css('div')
+        ).nativeElement;
+        container.click();
+        fixture.detectChanges();
 
-		const dropdownPanel = fixture.debugElement.query(By.css('.p-dropdown-panel'));
-		expect(dropdownPanel).toBeTruthy();
-		expect(dropdownPanel.nativeElement.className).toContain("Primeng");
-	});
+        const dropdownPanel = fixture.debugElement.query(
+            By.css('.p-dropdown-panel')
+        );
+        expect(dropdownPanel).toBeTruthy();
+        expect(dropdownPanel.nativeElement.className).toContain('Primeng');
+    });
 
-	it('should open when clicked', () => {
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		fixture.detectChanges();
-		
-		const container = fixture.debugElement.query(By.css('.p-dropdown')).nativeElement;
-		container.click();
-		fixture.detectChanges();
+    it('should open when clicked', () => {
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        fixture.detectChanges();
 
-		const dropdownPanel = fixture.debugElement.query(By.css('.p-dropdown-panel'));
-		expect(container.className).toContain('p-dropdown-open');
-		expect(dropdownPanel).toBeTruthy();
-	});
+        const container = fixture.debugElement.query(
+            By.css('.p-dropdown')
+        ).nativeElement;
+        container.click();
+        fixture.detectChanges();
 
-	it('should close', () => {
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		fixture.detectChanges();
-		
-		const container = fixture.debugElement.query(By.css('.p-dropdown')).nativeElement;
-		container.click();
-		fixture.detectChanges();
+        const dropdownPanel = fixture.debugElement.query(
+            By.css('.p-dropdown-panel')
+        );
+        expect(container.className).toContain('p-dropdown-open');
+        expect(dropdownPanel).toBeTruthy();
+    });
 
-		container.click();
-		fixture.detectChanges();
+    it('should close', () => {
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        fixture.detectChanges();
 
-		const dropdownPanel = fixture.debugElement.query(By.css('.p-dropdown-panel'));
-		expect(container.className).not.toContain('p-dropdown-open');
-		expect(dropdownPanel).toBeFalsy();
-	});
+        const container = fixture.debugElement.query(
+            By.css('.p-dropdown')
+        ).nativeElement;
+        container.click();
+        fixture.detectChanges();
 
-	it('should item selected', () => {
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		fixture.detectChanges();
-		
-		const container = fixture.debugElement.query(By.css('.p-dropdown')).nativeElement;
-		container.click();
-		fixture.detectChanges();
+        container.click();
+        fixture.detectChanges();
 
-		const items = fixture.debugElement.query(By.css('.p-dropdown-items'));
-		items.children[2].children[0].nativeElement.click();
-		fixture.detectChanges();
-		expect(dropdown.selectedOption.name).toEqual('London');
-	});
+        const dropdownPanel = fixture.debugElement.query(
+            By.css('.p-dropdown-panel')
+        );
+        expect(container.className).not.toContain('p-dropdown-open');
+        expect(dropdownPanel).toBeFalsy();
+    });
 
-	it('should item clear', () => {
-		dropdown.options = [
-			{label:'Select City', value:null},
-			{label:'New York', value:{id:1, name: 'New York', code: 'NY'}},
-			{label:'Rome', value:{id:2, name: 'Rome', code: 'RM'}},
-			{label:'London', value:{id:3, name: 'London', code: 'LDN'}},
-			{label:'Istanbul', value:{id:4, name: 'Istanbul', code: 'IST'}},
-			{label:'Paris', value:{id:5, name: 'Paris', code: 'PRS'}}
-		];
-		dropdown.showClear=true;
-		fixture.detectChanges();
-		
-		const container = fixture.debugElement.query(By.css('.p-dropdown')).nativeElement;
-		container.click();
-		fixture.detectChanges();
+    it('should item selected', () => {
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        fixture.detectChanges();
 
-		const items = fixture.debugElement.query(By.css('.p-dropdown-items'));
-		items.children[2].children[0].nativeElement.click();
-		fixture.detectChanges();
-		const itemCloseIcon = fixture.debugElement.query(By.css('.p-dropdown-clear-icon'));
-		itemCloseIcon.nativeElement.click();
-		fixture.detectChanges();
+        const container = fixture.debugElement.query(
+            By.css('.p-dropdown')
+        ).nativeElement;
+        container.click();
+        fixture.detectChanges();
 
-		expect(dropdown.selectedOption).toEqual({ label: 'Select City', value: null });
-		expect(items.children[2].nativeElement.className).not.toContain('p-highlight')
-	});
+        const items = fixture.debugElement.query(By.css('.p-dropdown-items'));
+        items.children[2].children[0].nativeElement.click();
+        fixture.detectChanges();
+        expect(dropdown.selectedOption.name).toEqual('London');
+    });
 
-	it('should filtered', async(() => {
-		dropdown.filter = true;
-		dropdown.filterValue = "n";
-		fixture.detectChanges();
+    it('should item clear', () => {
+        dropdown.options = [
+            { label: 'Select City', value: null },
+            {
+                label: 'New York',
+                value: { id: 1, name: 'New York', code: 'NY' },
+            },
+            { label: 'Rome', value: { id: 2, name: 'Rome', code: 'RM' } },
+            { label: 'London', value: { id: 3, name: 'London', code: 'LDN' } },
+            {
+                label: 'Istanbul',
+                value: { id: 4, name: 'Istanbul', code: 'IST' },
+            },
+            { label: 'Paris', value: { id: 5, name: 'Paris', code: 'PRS' } },
+        ];
+        dropdown.showClear = true;
+        fixture.detectChanges();
 
-		dropdown.options = [
-			{label: 'New York', code: 'NY'},
-			{label: 'Rome', code: 'RM'},
-			{label: 'London', code: 'LDN'},
-			{label: 'Istanbul', code: 'IST'},
-			{label: 'Paris', code: 'PRS'}
-		];
-		fixture.detectChanges();
-		
-		const container = fixture.debugElement.query(By.css('.p-dropdown')).nativeElement;
-		container.click();
-		fixture.detectChanges();
+        const container = fixture.debugElement.query(
+            By.css('.p-dropdown')
+        ).nativeElement;
+        container.click();
+        fixture.detectChanges();
 
-		let items=fixture.debugElement.query(By.css('.p-dropdown-items'));
-		expect(items.nativeElement.children.length).toEqual(3);
-		const filterDiv = fixture.debugElement.query(By.css('.p-dropdown-filter-container'));
-		expect(filterDiv).toBeTruthy();
-		const filterInputEl = fixture.debugElement.query(By.css('.p-dropdown-filter'));
-		filterInputEl.nativeElement.value = "n";
-		filterInputEl.nativeElement.dispatchEvent(new Event('keydown'));
-		const event = {'target':{'value':'n'}};
-		dropdown.onFilterInputChange(event)
-		fixture.detectChanges();
+        const items = fixture.debugElement.query(By.css('.p-dropdown-items'));
+        items.children[2].children[0].nativeElement.click();
+        fixture.detectChanges();
+        const itemCloseIcon = fixture.debugElement.query(
+            By.css('.p-dropdown-clear-icon')
+        );
+        itemCloseIcon.nativeElement.click();
+        fixture.detectChanges();
 
-		items=fixture.debugElement.query(By.css('.p-dropdown-items'));
-		expect(items.nativeElement.children.length).toEqual(3);
-	}));
+        expect(dropdown.selectedOption).toEqual({
+            label: 'Select City',
+            value: null,
+        });
+        expect(items.children[2].nativeElement.className).not.toContain(
+            'p-highlight'
+        );
+    });
 
-	it('should filtered and display not found warning', async(() => {
-		dropdown.options = [
-			{label: 'New York', code: 'NY'},
-			{label: 'Rome', code: 'RM'},
-			{label: 'London', code: 'LDN'},
-			{label: 'Istanbul', code: 'IST'},
-			{label: 'Paris', code: 'PRS'}
-		];
-		dropdown.filter = true;
-		fixture.detectChanges();
-		
-		const container = fixture.debugElement.query(By.css('.p-dropdown')).nativeElement;
-		container.click();
-		fixture.detectChanges();
+    it('should filtered', async(() => {
+        dropdown.filter = true;
+        dropdown.filterValue = 'n';
+        fixture.detectChanges();
 
-		const filterDiv = fixture.debugElement.query(By.css('.p-dropdown-filter-container'));
-		expect(filterDiv).toBeTruthy();
-		const filterInputEl = fixture.debugElement.query(By.css('.p-dropdown-filter'));
-		filterInputEl.nativeElement.value = "primeng";
-		filterInputEl.nativeElement.dispatchEvent(new Event('keydown'));
-		const event = {'target':{'value':'primeng'}};
-		dropdown.onFilterInputChange(event)
-		fixture.detectChanges();
+        dropdown.options = [
+            { label: 'New York', code: 'NY' },
+            { label: 'Rome', code: 'RM' },
+            { label: 'London', code: 'LDN' },
+            { label: 'Istanbul', code: 'IST' },
+            { label: 'Paris', code: 'PRS' },
+        ];
+        fixture.detectChanges();
 
-		const items = fixture.debugElement.query(By.css('.p-dropdown-items'));
-		const emptyMesage = items.children[0]; 
-		expect(items.nativeElement.children.length).toEqual(1);
-		expect(emptyMesage).toBeTruthy();
-		expect(emptyMesage.nativeElement.textContent).toContain("No results found");
-	}));
+        const container = fixture.debugElement.query(
+            By.css('.p-dropdown')
+        ).nativeElement;
+        container.click();
+        fixture.detectChanges();
 
-	it('should open with down and altkey', () => {
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		dropdown.appendTo = 'body';
-		fixture.detectChanges();
-		
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+        let items = fixture.debugElement.query(By.css('.p-dropdown-items'));
+        expect(items.nativeElement.children.length).toEqual(3);
+        const filterDiv = fixture.debugElement.query(
+            By.css('.p-dropdown-filter-container')
+        );
+        expect(filterDiv).toBeTruthy();
+        const filterInputEl = fixture.debugElement.query(
+            By.css('.p-dropdown-filter')
+        );
+        filterInputEl.nativeElement.value = 'n';
+        filterInputEl.nativeElement.dispatchEvent(new Event('keydown'));
+        const event = { target: { value: 'n' } };
+        dropdown.onFilterInputChange(event);
+        fixture.detectChanges();
+
+        items = fixture.debugElement.query(By.css('.p-dropdown-items'));
+        expect(items.nativeElement.children.length).toEqual(3);
+    }));
+
+    it('should filtered and display not found warning', async(() => {
+        dropdown.options = [
+            { label: 'New York', code: 'NY' },
+            { label: 'Rome', code: 'RM' },
+            { label: 'London', code: 'LDN' },
+            { label: 'Istanbul', code: 'IST' },
+            { label: 'Paris', code: 'PRS' },
+        ];
+        dropdown.filter = true;
+        fixture.detectChanges();
+
+        const container = fixture.debugElement.query(
+            By.css('.p-dropdown')
+        ).nativeElement;
+        container.click();
+        fixture.detectChanges();
+
+        const filterDiv = fixture.debugElement.query(
+            By.css('.p-dropdown-filter-container')
+        );
+        expect(filterDiv).toBeTruthy();
+        const filterInputEl = fixture.debugElement.query(
+            By.css('.p-dropdown-filter')
+        );
+        filterInputEl.nativeElement.value = 'primeng';
+        filterInputEl.nativeElement.dispatchEvent(new Event('keydown'));
+        const event = { target: { value: 'primeng' } };
+        dropdown.onFilterInputChange(event);
+        fixture.detectChanges();
+
+        const items = fixture.debugElement.query(By.css('.p-dropdown-items'));
+        const emptyMesage = items.children[0];
+        expect(items.nativeElement.children.length).toEqual(1);
+        expect(emptyMesage).toBeTruthy();
+        expect(emptyMesage.nativeElement.textContent).toContain(
+            'No results found'
+        );
+    }));
+
+    it('should open with down and altkey', () => {
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        dropdown.appendTo = 'body';
+        fixture.detectChanges();
+
+        const inputEl = fixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
-		keydownEvent.initEvent('keydown', true, true);
-		keydownEvent.altKey = true;
-		inputEl.dispatchEvent(new Event("focus"));
-		inputEl.dispatchEvent(keydownEvent);
-		inputEl.dispatchEvent(new Event("blur"));
-		fixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        keydownEvent.altKey = true;
+        inputEl.dispatchEvent(new Event('focus'));
+        inputEl.dispatchEvent(keydownEvent);
+        inputEl.dispatchEvent(new Event('blur'));
+        fixture.detectChanges();
 
-		const dropdownPanel = fixture.debugElement.query(By.css('.p-dropdown-panel'));
-		expect(dropdownPanel).toBeTruthy();
-		expect(dropdown.overlayVisible).toBeTruthy();
-	});
+        const dropdownPanel = fixture.debugElement.query(
+            By.css('.p-dropdown-panel')
+        );
+        expect(dropdownPanel).toBeTruthy();
+        expect(dropdown.overlayVisible).toBeTruthy();
+    });
 
-	it('should open with space key and close with esc key', () => {
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		dropdown.appendTo = 'body';
-		fixture.detectChanges();
-		
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+    it('should open with space key and close with esc key', () => {
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        dropdown.appendTo = 'body';
+        fixture.detectChanges();
+
+        const inputEl = fixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 32;
-		keydownEvent.initEvent('keydown', true, true);
-		keydownEvent.altKey = true;
-		inputEl.dispatchEvent(keydownEvent);
-		fixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        keydownEvent.altKey = true;
+        inputEl.dispatchEvent(keydownEvent);
+        fixture.detectChanges();
 
-		const dropdownPanel = fixture.debugElement.query(By.css('.p-dropdown-panel'));
-		expect(dropdownPanel).toBeTruthy();
-		expect(dropdown.overlayVisible).toBeTruthy();
-		keydownEvent.which = 27;
-		inputEl.dispatchEvent(keydownEvent);
-		fixture.detectChanges();
+        const dropdownPanel = fixture.debugElement.query(
+            By.css('.p-dropdown-panel')
+        );
+        expect(dropdownPanel).toBeTruthy();
+        expect(dropdown.overlayVisible).toBeTruthy();
+        keydownEvent.which = 27;
+        inputEl.dispatchEvent(keydownEvent);
+        fixture.detectChanges();
 
-		expect(dropdown.overlayVisible).toBeFalsy();
-	});
+        expect(dropdown.overlayVisible).toBeFalsy();
+    });
 
-	it('should select with down key', () => {
-		groupFixture.detectChanges();
+    it('should select with down key', () => {
+        groupFixture.detectChanges();
 
-		testDropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		testDropdown.appendTo = document.body;
-		testDropdown.optionValue = "code";
-		testDropdown.optionLabel = "name";
-		testDropdown.filter = true;
-		testDropdown.filterValue = "n";
-		groupFixture.detectChanges();
+        testDropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        testDropdown.appendTo = document.body;
+        testDropdown.optionValue = 'code';
+        testDropdown.optionLabel = 'name';
+        testDropdown.filter = true;
+        testDropdown.filterValue = 'n';
+        groupFixture.detectChanges();
 
-		groupFixture.debugElement.children[2].nativeElement.click();
-		groupFixture.detectChanges();
-		
-		expect(testDropdown.selectedOption.name).toEqual("New York");
-		const inputEl = groupFixture.debugElement.children[1].query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+        groupFixture.debugElement.children[2].nativeElement.click();
+        groupFixture.detectChanges();
+
+        expect(testDropdown.selectedOption.name).toEqual('New York');
+        const inputEl = groupFixture.debugElement.children[1].query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
-		keydownEvent.initEvent('keydown', true, true);
-		keydownEvent.altKey = true;
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        keydownEvent.altKey = true;
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		keydownEvent.altKey = false;
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        keydownEvent.altKey = false;
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		expect(testDropdown.selectedOption.name).toEqual("London");
-	});
+        expect(testDropdown.selectedOption.name).toEqual('London');
+    });
 
-	it('should select with enter key and close the overlay', () => {
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		dropdown.appendTo = document.body;
-		fixture.detectChanges();
-		
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+    it('should select with enter key and close the overlay', () => {
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        dropdown.appendTo = document.body;
+        fixture.detectChanges();
+
+        const inputEl = fixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
-		keydownEvent.initEvent('keydown', true, true);
-		keydownEvent.altKey = true;
-		inputEl.dispatchEvent(keydownEvent);
-		fixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        keydownEvent.altKey = true;
+        inputEl.dispatchEvent(keydownEvent);
+        fixture.detectChanges();
 
-		keydownEvent.which = 13;
-		inputEl.dispatchEvent(keydownEvent);
-		fixture.detectChanges();
+        keydownEvent.which = 13;
+        inputEl.dispatchEvent(keydownEvent);
+        fixture.detectChanges();
 
-		expect(dropdown.overlayVisible).toBeFalsy();
-	});
+        expect(dropdown.overlayVisible).toBeFalsy();
+    });
 
-	it('should select with up key', () => {
-		dropdown.options = [
-			{name: 'New York', code: 'NY'},
-			{name: 'Rome', code: 'RM'},
-			{name: 'London', code: 'LDN'},
-			{name: 'Istanbul', code: 'IST'},
-			{name: 'Paris', code: 'PRS'}
-		];
-		fixture.detectChanges();
-		
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
-        keydownEvent.which = 38 ;
-		keydownEvent.initEvent('keydown', true, true);
-		inputEl.dispatchEvent(keydownEvent);
-		fixture.detectChanges();
+    it('should select with up key', () => {
+        dropdown.options = [
+            { name: 'New York', code: 'NY' },
+            { name: 'Rome', code: 'RM' },
+            { name: 'London', code: 'LDN' },
+            { name: 'Istanbul', code: 'IST' },
+            { name: 'Paris', code: 'PRS' },
+        ];
+        fixture.detectChanges();
 
-		expect(dropdown.selectedOption.name).toEqual("Paris");
-	});
+        const inputEl = fixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
+        keydownEvent.which = 38;
+        keydownEvent.initEvent('keydown', true, true);
+        inputEl.dispatchEvent(keydownEvent);
+        fixture.detectChanges();
 
-	it('should select with filter', () => {
-		dropdown.options = [
-			{label: 'New York', value: 'NY'},
-			{label: 'Rome', value: 'RM'},
-			{label: 'London', value: 'LDN'},
-			{label: 'Istanbul', value: 'IST'},
-			{label: 'Paris', value: 'PRS'}
-		];
-		fixture.detectChanges();
-		
-		const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+        expect(dropdown.selectedOption.name).toEqual('Paris');
+    });
+
+    it('should select with filter', () => {
+        dropdown.options = [
+            { label: 'New York', value: 'NY' },
+            { label: 'Rome', value: 'RM' },
+            { label: 'London', value: 'LDN' },
+            { label: 'Istanbul', value: 'IST' },
+            { label: 'Paris', value: 'PRS' },
+        ];
+        fixture.detectChanges();
+
+        const inputEl = fixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
         keydownEvent.altKey = true;
-		keydownEvent.initEvent('keydown', true, true);
-		inputEl.dispatchEvent(keydownEvent);
-		fixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        inputEl.dispatchEvent(keydownEvent);
+        fixture.detectChanges();
 
-		keydownEvent.which = 76;
-		keydownEvent.keyCode = 76;
-		keydownEvent.key = "l";
-		inputEl.dispatchEvent(keydownEvent);
-		fixture.detectChanges();
+        keydownEvent.which = 76;
+        keydownEvent.keyCode = 76;
+        keydownEvent.key = 'l';
+        inputEl.dispatchEvent(keydownEvent);
+        fixture.detectChanges();
 
-		expect(dropdown.selectedOption.label).toEqual("London");
-	});
+        expect(dropdown.selectedOption.label).toEqual('London');
+    });
 
-	it('should groupSelect with down key', () => {
-		groupFixture.detectChanges();
-		
+    it('should groupSelect with down key', () => {
+        groupFixture.detectChanges();
 
-		const inputEl = groupFixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+        const inputEl = groupFixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
-		keydownEvent.initEvent('keydown', true, true);
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		expect(groupDropdown.selectedOption.label).toEqual("Audi");
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        expect(groupDropdown.selectedOption.label).toEqual('Audi');
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		expect(groupDropdown.selectedOption.label).toEqual("BMW");
-		inputEl.dispatchEvent(keydownEvent);
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        expect(groupDropdown.selectedOption.label).toEqual('BMW');
+        inputEl.dispatchEvent(keydownEvent);
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		expect(groupDropdown.selectedOption.label).toEqual("Cadillac");
-	});
+        expect(groupDropdown.selectedOption.label).toEqual('Cadillac');
+    });
 
-	it('should groupSelect with up key', () => {
-		groupFixture.detectChanges();
-		
+    it('should groupSelect with up key', () => {
+        groupFixture.detectChanges();
 
-		const inputEl = groupFixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+        const inputEl = groupFixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
-		keydownEvent.initEvent('keydown', true, true);
-		inputEl.dispatchEvent(keydownEvent);
-		inputEl.dispatchEvent(keydownEvent);
-		inputEl.dispatchEvent(keydownEvent);
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        inputEl.dispatchEvent(keydownEvent);
+        inputEl.dispatchEvent(keydownEvent);
+        inputEl.dispatchEvent(keydownEvent);
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		expect(groupDropdown.selectedOption.label).toEqual("Cadillac");
-		keydownEvent.which = 38;
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        expect(groupDropdown.selectedOption.label).toEqual('Cadillac');
+        keydownEvent.which = 38;
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		expect(groupDropdown.selectedOption.label).toEqual("Mercedes");
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        expect(groupDropdown.selectedOption.label).toEqual('Mercedes');
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		expect(groupDropdown.selectedOption.label).toEqual("BMW");
-	});
+        expect(groupDropdown.selectedOption.label).toEqual('BMW');
+    });
 
-	it('should groupSelect with filter', () => {
-		groupFixture.detectChanges();
-		
+    it('should groupSelect with filter', () => {
+        groupFixture.detectChanges();
 
-		const inputEl = groupFixture.debugElement.query(By.css('input')).nativeElement;
-		const keydownEvent: any = document.createEvent('CustomEvent');
+        const inputEl = groupFixture.debugElement.query(
+            By.css('input')
+        ).nativeElement;
+        const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
         keydownEvent.altKey = true;
-		keydownEvent.initEvent('keydown', true, true);
-		inputEl.dispatchEvent(keydownEvent);
-		groupFixture.detectChanges();
+        keydownEvent.initEvent('keydown', true, true);
+        inputEl.dispatchEvent(keydownEvent);
+        groupFixture.detectChanges();
 
-		keydownEvent.which = 77;
-		keydownEvent.keyCode = 77;
-		keydownEvent.key = "m";
-		keydownEvent.altKey = false;
-		inputEl.dispatchEvent(keydownEvent);
+        keydownEvent.which = 77;
+        keydownEvent.keyCode = 77;
+        keydownEvent.key = 'm';
+        keydownEvent.altKey = false;
+        inputEl.dispatchEvent(keydownEvent);
 
-		expect(groupDropdown.selectedOption.label).toEqual("Mercedes");
-	});
+        expect(groupDropdown.selectedOption.label).toEqual('Mercedes');
+    });
+
+    describe('searchTimeout', () => {
+        it('should use default search timeout', () => {
+            expect(dropdown.searchTimeout).toBe(SearchTimeoutDefault);
+            expect(SearchTimeoutDefault).toBe(250);
+        });
+
+        it('should allow to change search timeout', () => {
+            dropdown.searchTimeout = 500;
+            fixture.detectChanges();
+
+            expect(dropdown.searchTimeout).toBe(500);
+        });
+
+        it('should reset search value after current timeout elapses', fakeAsync(() => {
+            dropdown.options = [
+                { label: 'New York', code: 'NY' },
+                { label: 'Rome', code: 'RM' },
+                { label: 'London', code: 'LDN' },
+                { label: 'Istanbul', code: 'IST' },
+                { label: 'Paris', code: 'PRS' },
+            ];
+            testDropdown.optionValue = 'code';
+            fixture.detectChanges();
+            const event = { key: 'N' } as unknown as KeyboardEvent;
+
+            dropdown.search(event);
+
+            expect(dropdown.searchValue).toEqual('N');
+            tick(100);
+            expect(dropdown.searchValue).toEqual('N');
+            tick(200);
+            expect(dropdown.searchValue).toEqual(null);
+        }));
+    });
 });

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -17,6 +17,8 @@ export const DROPDOWN_VALUE_ACCESSOR: any = {
   multi: true
 };
 
+export const SearchTimeoutDefault = 250;
+
 @Component({
     selector: 'p-dropdownItem',
     template: `
@@ -256,6 +258,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
 
     @Input() autofocusFilter: boolean = true;
 
+    @Input() searchTimeout = SearchTimeoutDefault;
+
     @Output() onChange: EventEmitter<any> = new EventEmitter();
 
     @Output() onFilter: EventEmitter<any> = new EventEmitter();
@@ -285,6 +289,7 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     @ContentChildren(PrimeTemplate) templates: QueryList<any>;
 
     private _disabled: boolean;
+    private searchTimeoutID: number | null;
 
     @Input() get disabled(): boolean {
         return this._disabled;
@@ -359,8 +364,6 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     searchValue: string;
 
     searchIndex: number;
-
-    searchTimeout: any;
 
     previousSearchChar: string;
 
@@ -989,8 +992,8 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
     }
 
     search(event: KeyboardEvent) {
-        if (this.searchTimeout) {
-            clearTimeout(this.searchTimeout);
+        if (this.searchTimeoutID) {
+            clearTimeout(this.searchTimeoutID);
         }
 
         const char = event.key;
@@ -1017,9 +1020,9 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             this.selectedOptionUpdated = true;
         }
 
-        this.searchTimeout = setTimeout(() => {
+        this.searchTimeoutID = setTimeout(() => {
             this.searchValue = null;
-        }, 250);
+        }, this.searchTimeout) as unknown as number;
     }
 
     searchOption(index) {

--- a/src/app/showcase/components/dropdown/dropdowndemo.html
+++ b/src/app/showcase/components/dropdown/dropdowndemo.html
@@ -296,6 +296,12 @@ export class DropdownDemo &#123;
                             <td>Inline style of the overlay panel element.</td>
                         </tr>
                         <tr>
+                            <td>searchTimeout</td>
+                            <td>number</td>
+                            <td>250</td>
+                            <td>When filtering, resets search value, if no keyboard event input happens within search timeout. Value in milliseconds. Increase to accept slower inputs.</td>
+                        </tr>
+                        <tr>
                             <td>styleClass</td>
                             <td>string</td>
                             <td>null</td>


### PR DESCRIPTION
This changes detail of `dropdown` component, allowign to specify
(per-instance) different search timeout that resets search value when
filtering options based on user input. This should allow to accept
slower typing users.
- implementation
- docs
- tests
- (formatting applied in updated spec file)

/cc @morula for optional review

Thanks!

Closes #10806

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.