### PR TITLE
Remove IE11 from browserslist

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -11,4 +11,3 @@ last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
-IE 11


### PR DESCRIPTION
### Defect Fixes

Angular 13 does not support IE anymore.

Fix:
Warning: Support was requested for Internet Explorer in the project's browserslist configuration. Internet Explorer is no longer officially supported.
For more information, see https://angular.io/guide/browser-support