### PR TITLE
Input field icon capability to autocomplete

### DIFF
--- a/src/app/components/autocomplete/autocomplete.css
+++ b/src/app/components/autocomplete/autocomplete.css
@@ -87,6 +87,12 @@
     width: 100%;
 }
 
+.p-input-icon-left > i {
+    position: absolute;
+    top: 50%;
+    margin-top: -.5rem;
+}
+
 .p-fluid .p-autocomplete {
     display: flex;
 }

--- a/src/app/components/autocomplete/autocomplete.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.spec.ts
@@ -95,6 +95,25 @@ describe('AutoComplete', () => {
 		expect(multiContainer.nativeElement.className).toContain('p-disabled');
 	});
 
+	it('should show icon', () => {
+		autocomplete.showIcon = true;
+		fixture.detectChanges();
+
+		const spanEl = fixture.debugElement.query(By.css('span'));
+		const iEl = fixture.debugElement.query(By.css('i'));
+		expect(spanEl.nativeElement.className).toContain('p-input-icon-left');
+		expect(iEl.nativeNode.outerHTML).toContain("pi pi-search");
+	});
+
+	it('should change icon', () => {
+		autocomplete.showIcon = true;
+		autocomplete.icon = "Primeng ROCKS!";
+		fixture.detectChanges();
+
+		const iEl = fixture.debugElement.query(By.css('i'));
+		expect(iEl.nativeNode.outerHTML).toContain("Primeng ROCKS!");
+	});
+
 	it('should display dropdown icon', () => {
 		autocomplete.dropdown = true;
 		fixture.detectChanges();

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -19,7 +19,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
 @Component({
     selector: 'p-autoComplete',
     template: `
-        <span #container [ngClass]="{'p-autocomplete p-component':true,'p-autocomplete-dd':dropdown,'p-autocomplete-multiple':multiple}" [ngStyle]="style" [class]="styleClass">
+        <span #container [ngClass]="{'p-autocomplete p-component':true,'p-autocomplete-dd':dropdown,'p-autocomplete-multiple':multiple, 'p-input-icon-left':showIcon}" [ngStyle]="style" [class]="styleClass">
+            <i [class]="icon" *ngIf="showIcon"></i>
             <input *ngIf="!multiple" #in [attr.type]="type" [attr.id]="inputId" [ngStyle]="inputStyle" [class]="inputStyleClass" [autocomplete]="autocomplete" [attr.required]="required" [attr.name]="name"
             class="p-autocomplete-input p-inputtext p-component" [ngClass]="{'p-autocomplete-dd-input':dropdown,'p-disabled': disabled}" [value]="inputFieldValue" aria-autocomplete="list" [attr.aria-controls]="listId" role="searchbox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'"
             (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
@@ -146,6 +147,10 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
     @Input() appendTo: any;
 
     @Input() autoHighlight: boolean;
+
+    @Input() showIcon: boolean;
+
+    @Input() icon: string = 'pi pi-search';
 
     @Input() forceSelection: boolean;
 

--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -235,6 +235,12 @@ export class AutoCompleteDemo &#123;
                             <td>Maximum height of the suggestions panel.</td>
                         </tr>
                         <tr>
+                            <td>showIcon</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>When enabled, displays an icon inside the input field.</td>
+                        </tr>
+                        <tr>
                             <td>dropdown</td>
                             <td>boolean</td>
                             <td>false</td>
@@ -251,6 +257,12 @@ export class AutoCompleteDemo &#123;
                             <td>string</td>
                             <td>pi pi-chevron-down</td>
                             <td>Icon class of the dropdown icon.</td>
+                        </tr>
+                        <tr>
+                            <td>icon</td>
+                            <td>string</td>
+                            <td>pi pi-search</td>
+                            <td>Name of the icon to be displayed in the input field.</td>
                         </tr>
                         <tr>
                             <td>minLength</td>


### PR DESCRIPTION
Related issue #10563 

Added 2 input properties:
showIcon - when enabled, displays icon inside (left) the input field of autocomplete. Defaults to false.
icon - the icon to be displayed when showIcon is true. Defaults to 'pi pi-search'.

Implementation is based on that used when adding an icon to InputText. (Takes advantage of the existing theme overrides for p-input-icon-left, while not being dependant on the InputText component)

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.