### PR TITLE
Changed KeyDown enter handling

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -963,6 +963,10 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
             //enter
             case 13:
                 if (this.overlayVisible && (!this.filter || (this.optionsToDisplay && this.optionsToDisplay.length > 0))) {
+                    if (this.filterValue && this.filterValue.length) {
+                        let selectedItemIndex = this.optionsToDisplay[0];
+                        this.selectItem(event, selectedItemIndex);
+                    }
                     this.hide();
                 }
 


### PR DESCRIPTION
###Feature Requests
When using filtering on a dropdown, allow enter key downs for selecting the first filtered item (will not happen if search term is empty).