### PR TITLE
Fix defect #4986 - Set visibility: hidden on collapsed accordion tab content

### DIFF
--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -37,7 +37,8 @@ let idx: number = 0;
         trigger('tabContent', [
             state('hidden', style({
                 height: '0',
-                overflow: 'hidden'
+                overflow: 'hidden',
+                visibility: 'hidden'
             })),
             state('visible', style({
                 height: '*'


### PR DESCRIPTION
###Defect Fixes
Fixes defect #4986 - Setting `visibility: hidden` in the `hidden` state of the collapse animation of the accordion to prevent tab stop on the elements in the content
