### PR TITLE
Fixed #11035-BlockUI | BlockUI requires targeted component to be unblocked during page load

### DIFF
--- a/src/app/components/blockui/blockui.ts
+++ b/src/app/components/blockui/blockui.ts
@@ -58,8 +58,14 @@ export class BlockUI implements AfterViewInit,OnDestroy {
     }
 
     ngAfterViewInit() {
-        if (this.target && !this.target.getBlockableElement) {
-            throw 'Target of BlockUI must implement BlockableUI interface';
+        if (this.target) {
+            if (!this.target.getBlockableElement) {
+                throw 'Target of BlockUI must implement BlockableUI interface';
+            }
+
+            if (this._blocked) {
+                this.block();
+            }
         }
     }
 


### PR DESCRIPTION
Fix for https://github.com/primefaces/primeng/issues/11035

This change ensures that when BlockUI targets a component with blocked set to true on page load, only the targeted component is masked rather than the entire body.