### PR TITLE
#8853, #9172 | Table Adds BOM option to CSV export

### DIFF
--- a/src/app/components/table/table.spec.ts
+++ b/src/app/components/table/table.spec.ts
@@ -1407,6 +1407,20 @@ describe('Table', () => {
         expect(onRowDragLeaveSpy).toHaveBeenCalled();
     });
 
+    it('should export csv with bom', () => {
+        fixture.detectChanges();
+
+        let spyObj:HTMLElement = document.createElement("a");
+        spyOn(document, 'createElement').and.returnValue(spyObj);
+        fixture.detectChanges();
+
+        basicSelectionTable.exportCSV({bom:true});
+        fixture.detectChanges();
+
+        expect(document.createElement).toHaveBeenCalledTimes(1);
+        expect(document.createElement).toHaveBeenCalledWith('a');
+    });
+
     it('should export csv selection only', () => {
         fixture.detectChanges();
 

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1681,6 +1681,11 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         let csv = '';
         let columns = this.columns;
 
+        //UTF-8 BOM
+        if (options && options.bom) {
+            csv = '\uFEFF';
+        }
+
         if (options && options.selectionOnly) {
             data = this.selection || [];
         }


### PR DESCRIPTION
Adds changes proposed in #8853 and #9172
Adds new option to export CSV file with BOM (Byte Order Mark).