### PR TITLE
Fixed #11191 - Multiselect overlay bug - baseZIndex property is unused

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -681,7 +681,7 @@ export class MultiSelect implements OnInit,AfterViewInit,AfterContentInit,AfterV
                 this.overlay = event.element;
                 this.appendOverlay();
                 if (this.autoZIndex) {
-                    ZIndexUtils.set('overlay', this.overlay, this.config.zIndex.overlay);
+                    ZIndexUtils.set('overlay', this.overlay, this.baseZIndex + this.config.zIndex.overlay);
                 }
                 this.alignOverlay();
                 this.bindDocumentClickListener();


### PR DESCRIPTION
### Defect Fixes
This fixes the overlay bug from issue #11191