### PR TITLE
Add HTML5 datalist Autocomplete to Chips

### DIFF
--- a/src/app/components/chips/chips.ts
+++ b/src/app/components/chips/chips.ts
@@ -21,9 +21,9 @@ export const CHIPS_VALUE_ACCESSOR: any = {
                     <span *ngIf="!disabled" class="p-chips-token-icon pi pi-times-circle" (click)="removeItem($event,i)"></span>
                 </li>
                 <li class="p-chips-input-token">
-                    <input #inputtext type="text" [attr.id]="inputId" [attr.placeholder]="(value && value.length ? null : placeholder)" [attr.tabindex]="tabindex" [attr.list]="suggestionId" (keydown)="onKeydown($event)"
+                    <input #inputtext type="text" [attr.id]="inputId" [attr.placeholder]="(value && value.length ? null : placeholder)" [attr.tabindex]="tabindex" [attr.list]="datalistId" (keydown)="onKeydown($event)"
                     (input)="onInput()" (paste)="onPaste($event)" [attr.aria-labelledby]="ariaLabelledBy" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" [disabled]="disabled" [ngStyle]="inputStyle" [class]="inputStyleClass">
-                    <datalist id="{{suggestionId}}">
+                    <datalist id="{{datalistId}}">
                         <option *ngFor="let suggestion of suggestions" [attr.value]="suggestion"></option>
                     </datalist>
                 </li>
@@ -102,15 +102,15 @@ export class Chips implements AfterContentInit,AfterViewInit,ControlValueAccesso
 
     filled: boolean;
 
-    suggestionId: any;
+    datalistId: any;
 
     static instanceCounter: number = 0;
 
     constructor(public el: ElementRef, public cd: ChangeDetectorRef) {
         if (this.inputId == null) {
-            this.inputId = "chips-".concat((++Chips.instanceCounter).toString());
+            this.inputId = "p-chips-".concat((++Chips.instanceCounter).toString());
         }
-        this.suggestionId = this.inputId.concat("-suggestions");
+        this.datalistId = this.inputId.concat("-datalist");
     }
 
     ngAfterContentInit() {
@@ -130,12 +130,12 @@ export class Chips implements AfterContentInit,AfterViewInit,ControlValueAccesso
     }
 
     ngAfterViewInit() {
-        const suggestions = document.getElementById(this.inputId);
+        const inputEl = document.getElementById(this.inputId);
         let eventSource = null;
-        suggestions.addEventListener('keydown', (e: any) => {
+        inputEl.addEventListener('keydown', (e: any) => {
             eventSource = e.key ? 'input' : 'list';
         });
-        suggestions.addEventListener('input', (e: any) => {
+        inputEl.addEventListener('input', (e: any) => {
             const value = e.target.value;
             if (eventSource === 'list') {
                 this.addItem(event, value, true);


### PR DESCRIPTION
###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.

==============================================
This would be a Feature Request.  It's a minor one however.  Instead of **p-chips** having a simple HTML **input**, we can leverage the HTML5 **datalist** and the _list_ attribute for the **input** tag.
 
We need to know the **input** tag _id_, so it cannot be null.  Typically I'd use a uuid, but I didn't want to include other packages so the _id_ is based on a simple static counter.  This also allows us to then know and set the **datalist** _id_ to bind to the **input** _list_ attribute.

Usage example:

tags: string[];
autocompleteResults: string[];
search($event); // some method that sets autocompleteResults

<p-chips [(ngModel)]="tags" (keyup)="search($event)" [suggestions]="autocompleteResults" [allowDuplicate]="false"></p-chips>

![AC-Chips](https://user-images.githubusercontent.com/86887231/156932273-48a93925-e261-4360-bc55-1ad28b49a463.png)
![AC-Chips-Pulldown](https://user-images.githubusercontent.com/86887231/156932274-076c889d-6e1e-413a-85d6-225529beea29.png)
![AC-Chips-typing](https://user-images.githubusercontent.com/86887231/156932275-f76836ba-f481-47fe-81e0-c2f292b7927b.png)

