### PR TITLE
docs: fix button with badge snippet

### DIFF
--- a/src/app/showcase/components/button/buttondemo.html
+++ b/src/app/showcase/components/button/buttondemo.html
@@ -255,8 +255,8 @@ export class Model &#123;
                 <p>Badge is a small status indicator for a button. Refer to the <a href="#" [routerLink]="['/badge']">badge</a>. documentation for available styling options.</p>
 
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
-&lt;button pButton type="button" label="Emails" badge="8"&gt;&lt;/button&gt;
-&lt;button pButton type="button" label="Messages" icon="pi pi-users" class="p-button-warning" badge="8" badgeClass="p-badge-info"&gt;&lt;/button&gt;
+&lt;p-button type="button" label="Emails" badge="8"&gt;&lt;/p-button&gt;
+&lt;p-button type="button" label="Messages" icon="pi pi-users" class="p-button-warning" badge="8" badgeClass="p-badge-info"&gt;&lt;/p-button&gt;
 </app-code>
 
                 <h5>ButtonSet</h5>


### PR DESCRIPTION
###Defect Fixes

Hi, thanks for the primeNG component library.
While copy-pasting the snippets of the button docs, we've encountered a problem.

The `pButton` directive doesn't implement a `badge`count.
This PR modifies the snippet to use the `p-button` element.

Example:

https://stackblitz.com/edit/primeng-button-demo-9pb9ks?file=src%2Fapp%2Fapp.component.html

![image](https://user-images.githubusercontent.com/28659384/157872999-f56a9f9d-994d-4354-af18-f6a721d7affe.png)

Another option is to implement the badge count in the directive.
