### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -2786,7 +2786,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
                 for (let i = 0; i < names.length; i++) {
                     let name = names[i][1];
-                    if (value.substr(iValue, name.length).toLowerCase() === name.toLowerCase()) {
+                    if (value.slice(iValue, iValue + name.length).toLowerCase() === name.toLowerCase()) {
                         index = names[i][0];
                         iValue += name.length;
                         break;
@@ -2863,7 +2863,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         }
 
         if (iValue < value.length) {
-            extra = value.substr(iValue);
+            extra = value.slice(iValue);
             if (!/^\s+/.test(extra)) {
                 throw 'Extra/unparsed characters found in date: ' + extra;
             }

--- a/src/app/components/keyfilter/keyfilter.ts
+++ b/src/app/components/keyfilter/keyfilter.ts
@@ -100,9 +100,9 @@ export class KeyFilter implements Validator {
         let delta = '';
 
         for (let i = 0; i < value.length; i++) {
-            let str = value.substr(0, i) + value.substr(i + value.length - prevValue.length);
+            let str = value.slice(0, i) + value.slice(i + value.length - prevValue.length);
 
-            if (str === prevValue) delta = value.substr(i, value.length - prevValue.length);
+            if (str === prevValue) delta = value.slice(i, -prevValue.length);
         }
 
         return delta;
@@ -114,7 +114,7 @@ export class KeyFilter implements Validator {
 
     isValidString(str: string) {
         for (let i = 0; i < str.length; i++) {
-            if (!this.isValidChar(str.substr(i, 1))) {
+            if (!this.isValidChar(str.slice(i, i + 1))) {
                 return false;
             }
         }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.