### PR TITLE
#10964. Fix dropdown is filled when an empty text value is provided.

### DIFF
--- a/src/app/components/dropdown/dropdown.spec.ts
+++ b/src/app/components/dropdown/dropdown.spec.ts
@@ -546,4 +546,11 @@ describe('Dropdown', () => {
 
 		expect(groupDropdown.selectedOption.label).toEqual("Mercedes");
 	});
+
+	[null, undefined, ''].map(value => it('should return filled false when value is not provided', () => {
+		dropdown.value = value;
+		fixture.detectChanges();
+
+		expect(dropdown.filled).toBeFalsy();
+	}));
 });

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -475,7 +475,9 @@ export class Dropdown implements OnInit,AfterViewInit,AfterContentInit,AfterView
         return this.emptyFilterMessage || this.config.getTranslation(TranslationKeys.EMPTY_FILTER_MESSAGE);
     }
 
-    get filled() {
+    get filled(): boolean {
+        if (typeof this.value === 'string') return !!this.value;
+        
         return this.value || this.value != null || this.value != undefined;
     }
 


### PR DESCRIPTION
As many Angular developers provide empty string to an input's value it's good to have check on empty string too to avoid visual issues.

new FormControl('') would lead to filled getter to be true.