### PR TITLE
Fix for #10178 - Range slider handles get stuck at maximum with non-default max value

### DIFF
--- a/src/app/components/slider/slider.spec.ts
+++ b/src/app/components/slider/slider.spec.ts
@@ -413,4 +413,25 @@ describe('Slider', () => {
 
         expect(slider.values[1]).toEqual(80);
     });
+
+    it('should use correct handle when both are at max',() => {
+        slider.range = true;
+        slider.handleValues = [0,100];
+        slider.values = [20,80];
+        slider.min = 20;
+        slider.max = 80;
+        slider.handleIndex = 0
+        fixture.detectChanges();
+
+        slider.updateValue(110);
+        fixture.detectChanges();
+        
+        const sliderHandlers = fixture.debugElement.queryAll(By.css(".p-slider-handle"));
+        const firstSliderHandler = sliderHandlers[1];
+        firstSliderHandler.nativeElement.dispatchEvent(new Event("mousedown"));
+
+        expect(slider.handleIndex).toEqual(0);
+        slider.ngOnDestroy();
+        fixture.detectChanges();
+    });
 });

--- a/src/app/components/slider/slider.ts
+++ b/src/app/components/slider/slider.ts
@@ -118,12 +118,7 @@ export class Slider implements OnDestroy,ControlValueAccessor {
         this.dragging = true;
         this.updateDomData();
         this.sliderHandleClick = true;
-        if (this.range && this.handleValues && this.handleValues[0] === this.max) {
-            this.handleIndex = 0;
-        }
-        else {
-            this.handleIndex = index;
-        }
+        this.setStartingHandleIndex(index);
 
         this.bindDragListeners();
         event.target.focus();
@@ -142,12 +137,7 @@ export class Slider implements OnDestroy,ControlValueAccessor {
         var touchobj = event.changedTouches[0];
         this.startHandleValue = (this.range) ? this.handleValues[index] : this.handleValue;
         this.dragging = true;
-        if (this.range && this.handleValues && this.handleValues[0] === this.max) {
-            this.handleIndex = 0;
-        }
-        else {
-            this.handleIndex = index;
-        }
+        this.setStartingHandleIndex(index);
 
         if (this.orientation === 'horizontal') {
             this.startx = parseInt(touchobj.clientX, 10);
@@ -248,6 +238,15 @@ export class Slider implements OnDestroy,ControlValueAccessor {
     handleChange(event: Event) {
         let handleValue = this.calculateHandleValue(event);
         this.setValueFromHandle(event, handleValue);
+    }
+
+    setStartingHandleIndex(index?: number){
+        if (this.range && this.handleValues && this.handleValues[0] === 100) {
+            this.handleIndex = 0;
+        }
+        else {
+            this.handleIndex = index;
+        }
     }
 
     bindDragListeners() {


### PR DESCRIPTION
Sliders will now use the lower handle when both are set to max, irregardless of the value passed to max. 

Fixes #10178