### PR TITLE
[tablelazydemo] remove unused `cols` property

### DIFF
--- a/src/app/showcase/components/table/tablelazydemo.ts
+++ b/src/app/showcase/components/table/tablelazydemo.ts
@@ -12,8 +12,6 @@ export class TableLazyDemo implements OnInit {
 
     totalRecords: number;
 
-    cols: any[];
-
     loading: boolean;
 
     representatives: Representative[];


### PR DESCRIPTION
removing unused `cols` property in tablelazydemo sample 