### PR TITLE
Fixed #11438 - p-colorPicker onInputClick using a button not working

### DIFF
--- a/src/app/components/colorpicker/colorpicker.ts
+++ b/src/app/components/colorpicker/colorpicker.ts
@@ -322,6 +322,7 @@ export class ColorPicker implements ControlValueAccessor, OnDestroy {
 
     show() {
         this.overlayVisible = true;
+        this.cd.markForCheck();
     }
 
     onOverlayAnimationStart(event: AnimationEvent) {


### PR DESCRIPTION
Fixes a bug in Primeng `colorPicker` when will try open manually by `ViewChild` ref.

Fixes #11438.