### PR TITLE
generateCsv option to generate the whole entire data

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1736,7 +1736,11 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
         if (options && options.selectionOnly) {
             data = this.selection || [];
-        } else {
+        } 
+        else if(options && options.allValues) {
+            data = this.value || [];
+        }
+        else {
             data = this.filteredValue || this.value;
 
             if (this.frozenValue) {

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1736,11 +1736,9 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
         if (options && options.selectionOnly) {
             data = this.selection || [];
-        } 
-        else if(options && options.allValues) {
+        } else if (options && options.allValues) {
             data = this.value || [];
-        }
-        else {
+        } else {
             data = this.filteredValue || this.value;
 
             if (this.frozenValue) {


### PR DESCRIPTION
fixed #12436 

Current behavior
Does not have options to generate the whole data in generating CSV in filter time 

Expected behavior
giving the user options to export the whole entire data even if the table is filtered


- Angular version: 13.3

- PrimeNG version: 13.4.1
