### PR TITLE
fix(primeng/confirmDialog): remove moveOnTop call from confirmdialog mousedown

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -23,7 +23,7 @@ const hideAnimation = animation([
     selector: 'p-confirmDialog',
     template: `
         <div [class]="maskStyleClass" [ngClass]="getMaskClass()" *ngIf="maskVisible">
-            <div [ngClass]="{'p-dialog p-confirm-dialog p-component':true,'p-dialog-rtl':rtl}" [ngStyle]="style" [class]="styleClass" (mousedown)="moveOnTop()"
+            <div [ngClass]="{'p-dialog p-confirm-dialog p-component':true,'p-dialog-rtl':rtl}" [ngStyle]="style" [class]="styleClass"
                 [@animation]="{value: 'visible', params: {transform: transformOptions, transition: transitionOptions}}" (@animation.start)="onAnimationStart($event)" (@animation.done)="onAnimationEnd($event)" *ngIf="visible">
                 <div class="p-dialog-header" *ngIf="headerTemplate">
                     <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>


### PR DESCRIPTION
fixes https://github.com/primefaces/primeng/issues/11523

Remove the moveOnTop from mousedown because it if it's there it keeps
raising the z-index of the modals in the application. It was removed
from dialog already in https://github.com/primefaces/primeng/issues/6857