### PR TITLE
Fixed typo in charts.js-documentation

### DIFF
--- a/src/app/showcase/components/chart/chartdemo.html
+++ b/src/app/showcase/components/chart/chartdemo.html
@@ -15,7 +15,7 @@ npm install chart.js --save
         
 <app-code lang="typescript" ngNonBindable ngPreserveWhitespaces>
 "scripts": [
-    "../node_modules/chart.js/dist/Chart.js",
+    "../node_modules/chart.js/dist/chart.js",
     //..others
 ],
 </app-code>


### PR DESCRIPTION
When you add this line to your angular.json-file, you get a "An unhandled exception occurred: Script file ./node_modules/chart.js/dist/Chart.js does not exist." error while building on linux systems.

### Defect Fixes
https://github.com/primefaces/primeng/issues/11554