### PR TITLE
fix(primeng/contextmenu): reset the status of the active item when the cursor is placed over the disabled item

### DIFF
--- a/src/app/components/contextmenu/contextmenu.ts
+++ b/src/app/components/contextmenu/contextmenu.ts
@@ -89,6 +89,7 @@ export class ContextMenuSub {
         }
 
         if (item.disabled) {
+            this.activeItemKey = null;
             return;
         }
 


### PR DESCRIPTION
Fixes #11588