### PR TITLE
fix: remove duplicate class in button example

### DIFF
--- a/src/app/showcase/components/button/buttondemo.html
+++ b/src/app/showcase/components/button/buttondemo.html
@@ -231,7 +231,7 @@ export class Model &#123;
 &lt;button pButton type="button" label="Submit" class="p-button-text"&gt;&lt;/button&gt;
 &lt;button pButton type="button" icon="pi pi-check" class="p-button-text"&gt;&lt;/button&gt;
 &lt;button pButton type="button" label="Cancel" icon="pi pi-times" class="p-button-text"&gt;&lt;/button&gt;
-&lt;button pButton type="button" label="Search" icon="pi pi-search" iconPos="right" class="p-button-text p-button-text"&gt;&lt;/button&gt;
+&lt;button pButton type="button" label="Search" icon="pi pi-search" iconPos="right" class="p-button-text"&gt;&lt;/button&gt;
 </app-code>
             <h5>Raised and Rounded Buttons</h5>
 				<p>A button can be raised by having "p-button-raised" style class and similarly borders can be made rounded using "p-button-rounded" class.</p>


### PR DESCRIPTION
Example button component included the `p-button-text` class twice.