### PR TITLE
Generic data property of DynamicDialogConfig

### DIFF
--- a/src/app/components/dynamicdialog/dynamicdialog-config.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog-config.ts
@@ -1,5 +1,5 @@
-export class DynamicDialogConfig {
-	data?: any;
+export class DynamicDialogConfig<T = any> {
+	data?: T;
 	header?: string;
 	footer?: string;
 	width?: string;


### PR DESCRIPTION
Add support for custom typing the `data` property of a `DynamicDialogConfig` with a generic.

### Related issue

#11665 