### PR TITLE
Do not swallow Enter key press event

### DIFF
--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -597,11 +597,14 @@ export class InputNumber implements OnInit,ControlValueAccessor {
             return;
         }
 
-        event.preventDefault();
         let code = event.which || event.keyCode;
         let char = String.fromCharCode(code);
         const isDecimalSign = this.isDecimalSign(char);
         const isMinusSign = this.isMinusSign(char);
+        
+        if (code != 13) {
+            event.preventDefault();
+        }
 
         if ((48 <= code && code <= 57) || isMinusSign || isDecimalSign) {
             this.insert(event, char, { isDecimalSign, isMinusSign });


### PR DESCRIPTION
Allow the `Enter` key press event to bubble up from InputNumber. This is more in line with the behavior of other controls (e.g. InputText). Also, this allows for submit form on `Enter` key press.
