### PR TITLE
Listbox: Fixed aria-multiselectable attribute binding. Fixes #11743

### DIFF
--- a/src/app/components/listbox/listbox.ts
+++ b/src/app/components/listbox/listbox.ts
@@ -46,7 +46,7 @@ export interface ListboxFilterOptions {
         </ng-template>
       </div>
       <div [ngClass]="'p-listbox-list-wrapper'" [ngStyle]="listStyle" [class]="listStyleClass">
-        <ul class="p-listbox-list" role="listbox" aria-multiselectable="multiple">
+        <ul class="p-listbox-list" role="listbox" [attr.aria-multiselectable]="multiple">
             <ng-container *ngIf="group">
                 <ng-template ngFor let-optgroup [ngForOf]="optionsToRender">
                     <li class="p-listbox-item-group">


### PR DESCRIPTION
Fixed binding of "aria-multiselectable" for "ul.p-listbox-list" to use evaluated boolean value instead of string containing variable name.

#11743 
