### PR TITLE
fix: Fixed autocomplete empty message in the documentation

### DIFF
--- a/src/app/showcase/components/autocomplete/autocompletedemo.html
+++ b/src/app/showcase/components/autocomplete/autocompletedemo.html
@@ -406,7 +406,7 @@ export class AutoCompleteDemo &#123;
                         <tr>
                             <td>emptyMessage</td>
                             <td>string</td>
-                            <td>No records found.</td>
+                            <td>No results found</td>
                             <td>Text to display when there is no data. Defaults to global value in i18n translation configuration.</td>
                         </tr>
                         <tr>


### PR DESCRIPTION
### Defect Fixes
The default `emptyMessage` was incorrect.

