### PR TITLE
add p-inputtext class to cascadeSelect component

### DIFF
--- a/src/app/components/cascadeselect/cascadeselect.ts
+++ b/src/app/components/cascadeselect/cascadeselect.ts
@@ -714,6 +714,7 @@ export class CascadeSelect implements OnInit, AfterContentInit, OnDestroy {
     labelClass() {
         return {
             'p-cascadeselect-label': true,
+            'p-inputtext': true,
             'p-placeholder': this.label() === this.placeholder,
             'p-cascadeselect-label-empty': !this.value && (this.label() === 'p-emptylabel' || this.label().length === 0)
         };


### PR DESCRIPTION
All form components are affected by `p-inputtext-lg` css class and become larger except the `cascadeSelect`. Based on css styles, I add a `p-inputtext` class to `cascadeSelect` component.