### PR TITLE
fix autofocus inputmask

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -11,9 +11,9 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {Scroller, ScrollerModule, ScrollerOptions} from 'primeng/scroller';
 
 export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
-    provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => AutoComplete),
-    multi: true
+  provide: NG_VALUE_ACCESSOR,
+  useExisting: forwardRef(() => AutoComplete),
+  multi: true
 };
 
 @Component({
@@ -96,10 +96,10 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             transition(':enter', [
                 style({opacity: 0, transform: 'scaleY(0.8)'}),
                 animate('{{showTransitionParams}}')
-            ]),
-            transition(':leave', [
+              ]),
+              transition(':leave', [
                 animate('{{hideTransitionParams}}', style({ opacity: 0 }))
-            ])
+              ])
         ])
     ],
     host: {
@@ -241,7 +241,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     @Output() onDropdownClick: EventEmitter<any> = new EventEmitter();
 
-    @Output() onClear: EventEmitter<any> = new EventEmitter();
+	@Output() onClear: EventEmitter<any> = new EventEmitter();
 
     @Output() onKeyUp: EventEmitter<any> = new EventEmitter();
 
@@ -402,35 +402,35 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
             switch(item.getType()) {
                 case 'item':
                     this.itemTemplate = item.template;
-                    break;
+                break;
 
                 case 'group':
                     this.groupTemplate = item.template;
-                    break;
+                break;
 
                 case 'selectedItem':
                     this.selectedItemTemplate = item.template;
-                    break;
+                break;
 
                 case 'header':
                     this.headerTemplate = item.template;
-                    break;
+                break;
 
                 case 'empty':
                     this.emptyTemplate = item.template;
-                    break;
+                break;
 
                 case 'footer':
                     this.footerTemplate = item.template;
-                    break;
+                break;
 
                 case 'loader':
                     this.loaderTemplate = item.template;
-                    break;
+                break;
 
                 default:
                     this.itemTemplate = item.template;
-                    break;
+                break;
             }
         });
     }
@@ -482,7 +482,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
         if (value.length === 0 && !this.multiple) {
             this.hide();
             this.onClear.emit(event);
-            this.onModelChange(value);
+	        this.onModelChange(value);
         }
 
         if (value.length >= this.minLength) {
@@ -505,16 +505,16 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     search(event: any, query: string) {
         //allow empty string but not undefined or null
-        if (query === undefined || query === null) {
-            return;
-        }
+       if (query === undefined || query === null) {
+           return;
+       }
 
-        this.loading = true;
+       this.loading = true;
 
-        this.completeMethod.emit({
-            originalEvent: event,
-            query: query
-        });
+       this.completeMethod.emit({
+           originalEvent: event,
+           query: query
+       });
     }
 
     selectItem(option: any, focus: boolean = true) {
@@ -589,11 +589,11 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                 this.bindDocumentResizeListener();
                 this.bindScrollListener();
                 this.onShow.emit(event);
-                break;
+            break;
 
             case 'void':
                 this.onOverlayHide();
-                break;
+            break;
         }
     }
 
@@ -603,7 +603,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                 if (this.autoZIndex) {
                     ZIndexUtils.clear(event.element);
                 }
-                break;
+            break;
         }
     }
 
@@ -729,7 +729,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                     }
 
                     event.preventDefault();
-                    break;
+                break;
 
                 //up
                 case 38:
@@ -761,7 +761,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                     }
 
                     event.preventDefault();
-                    break;
+                break;
 
                 //enter
                 case 13:
@@ -770,13 +770,13 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                         this.hide();
                     }
                     event.preventDefault();
-                    break;
+                break;
 
                 //escape
                 case 27:
                     this.hide();
                     event.preventDefault();
-                    break;
+                break;
 
 
                 //tab
@@ -785,7 +785,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                         this.selectItem(this.highlightOption);
                     }
                     this.hide();
-                    break;
+                break;
             }
         } else {
             if (event.which === 40 && this.suggestions) {
@@ -812,7 +812,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                         this.updateFilledState();
                         this.onUnselect.emit(removedValue);
                     }
-                    break;
+                break;
             }
         }
 
@@ -929,9 +929,9 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     updateFilledState() {
         if (this.multiple)
-            this.filled = (this.value && this.value.length) || (this.multiInputEL && this.multiInputEL.nativeElement && this.multiInputEL.nativeElement.value != '');
+            this.filled = (this.value && this.value.length) || (this.multiInputEL && this.multiInputEL.nativeElement && this.multiInputEL.nativeElement.value != '');
         else
-            this.filled = (this.inputFieldValue && this.inputFieldValue != '') || (this.inputEL && this.inputEL.nativeElement && this.inputEL.nativeElement.value != '');
+            this.filled = (this.inputFieldValue && this.inputFieldValue != '') || (this.inputEL && this.inputEL.nativeElement && this.inputEL.nativeElement.value != '');
     }
 
     updateInputField() {

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -11,9 +11,9 @@ import {NG_VALUE_ACCESSOR, ControlValueAccessor} from '@angular/forms';
 import {Scroller, ScrollerModule, ScrollerOptions} from 'primeng/scroller';
 
 export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
-  provide: NG_VALUE_ACCESSOR,
-  useExisting: forwardRef(() => AutoComplete),
-  multi: true
+    provide: NG_VALUE_ACCESSOR,
+    useExisting: forwardRef(() => AutoComplete),
+    multi: true
 };
 
 @Component({
@@ -22,7 +22,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
         <span #container [ngClass]="{'p-autocomplete p-component':true,'p-autocomplete-dd':dropdown,'p-autocomplete-multiple':multiple}" [ngStyle]="style" [class]="styleClass">
             <input *ngIf="!multiple" #in [attr.type]="type" [attr.id]="inputId" [ngStyle]="inputStyle" [class]="inputStyleClass" [autocomplete]="autocomplete" [attr.required]="required" [attr.name]="name"
             class="p-autocomplete-input p-inputtext p-component" [ngClass]="{'p-autocomplete-dd-input':dropdown,'p-disabled': disabled}" [value]="inputFieldValue" aria-autocomplete="list" role="searchbox"
-            (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
+            (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
             [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required">
             <i *ngIf="!multiple && filled && !disabled && showClear" class="p-autocomplete-clear-icon pi pi-times" (click)="clear()"></i>
             <i *ngIf="multiple && filled && !disabled && showClear" class="p-autocomplete-clear-icon pi pi-times" (click)="clear()"></i>
@@ -34,7 +34,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 </li>
                 <li class="p-autocomplete-input-token">
                     <input #multiIn [attr.type]="type" [attr.id]="inputId" [disabled]="disabled" [attr.placeholder]="(value&&value.length ? null : placeholder)" [attr.tabindex]="tabindex" [attr.maxlength]="maxlength" (input)="onInput($event)"  (click)="onInputClick($event)"
-                            (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" [autocomplete]="autocomplete"
+                            (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" [autocomplete]="autocomplete"
                             [ngStyle]="inputStyle" [class]="inputStyleClass" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required"
                             aria-autocomplete="list" [attr.aria-controls]="listId" role="searchbox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'">
                 </li>
@@ -96,10 +96,10 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             transition(':enter', [
                 style({opacity: 0, transform: 'scaleY(0.8)'}),
                 animate('{{showTransitionParams}}')
-              ]),
-              transition(':leave', [
+            ]),
+            transition(':leave', [
                 animate('{{hideTransitionParams}}', style({ opacity: 0 }))
-              ])
+            ])
         ])
     ],
     host: {
@@ -205,7 +205,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     @Input() hideTransitionOptions: string = '.1s linear';
 
-    @Input() autofocus: boolean;
+    @Input() autofocus: boolean = false;
 
     @Input() autocomplete: string = 'off';
 
@@ -241,7 +241,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     @Output() onDropdownClick: EventEmitter<any> = new EventEmitter();
 
-	@Output() onClear: EventEmitter<any> = new EventEmitter();
+    @Output() onClear: EventEmitter<any> = new EventEmitter();
 
     @Output() onKeyUp: EventEmitter<any> = new EventEmitter();
 
@@ -395,39 +395,42 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
     }
 
     ngAfterContentInit() {
+        if (this.autofocus) {
+            setTimeout(() => this.focusInput(), 0);
+        }
         this.templates.forEach((item) => {
             switch(item.getType()) {
                 case 'item':
                     this.itemTemplate = item.template;
-                break;
+                    break;
 
                 case 'group':
                     this.groupTemplate = item.template;
-                break;
+                    break;
 
                 case 'selectedItem':
                     this.selectedItemTemplate = item.template;
-                break;
+                    break;
 
                 case 'header':
                     this.headerTemplate = item.template;
-                break;
+                    break;
 
                 case 'empty':
                     this.emptyTemplate = item.template;
-                break;
+                    break;
 
                 case 'footer':
                     this.footerTemplate = item.template;
-                break;
+                    break;
 
                 case 'loader':
                     this.loaderTemplate = item.template;
-                break;
+                    break;
 
                 default:
                     this.itemTemplate = item.template;
-                break;
+                    break;
             }
         });
     }
@@ -479,7 +482,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
         if (value.length === 0 && !this.multiple) {
             this.hide();
             this.onClear.emit(event);
-	        this.onModelChange(value);
+            this.onModelChange(value);
         }
 
         if (value.length >= this.minLength) {
@@ -502,16 +505,16 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     search(event: any, query: string) {
         //allow empty string but not undefined or null
-       if (query === undefined || query === null) {
-           return;
-       }
+        if (query === undefined || query === null) {
+            return;
+        }
 
-       this.loading = true;
+        this.loading = true;
 
-       this.completeMethod.emit({
-           originalEvent: event,
-           query: query
-       });
+        this.completeMethod.emit({
+            originalEvent: event,
+            query: query
+        });
     }
 
     selectItem(option: any, focus: boolean = true) {
@@ -586,11 +589,11 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                 this.bindDocumentResizeListener();
                 this.bindScrollListener();
                 this.onShow.emit(event);
-            break;
+                break;
 
             case 'void':
                 this.onOverlayHide();
-            break;
+                break;
         }
     }
 
@@ -600,7 +603,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                 if (this.autoZIndex) {
                     ZIndexUtils.clear(event.element);
                 }
-            break;
+                break;
         }
     }
 
@@ -726,7 +729,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                     }
 
                     event.preventDefault();
-                break;
+                    break;
 
                 //up
                 case 38:
@@ -758,7 +761,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                     }
 
                     event.preventDefault();
-                break;
+                    break;
 
                 //enter
                 case 13:
@@ -767,13 +770,13 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                         this.hide();
                     }
                     event.preventDefault();
-                break;
+                    break;
 
                 //escape
                 case 27:
                     this.hide();
                     event.preventDefault();
-                break;
+                    break;
 
 
                 //tab
@@ -782,7 +785,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                         this.selectItem(this.highlightOption);
                     }
                     this.hide();
-                break;
+                    break;
             }
         } else {
             if (event.which === 40 && this.suggestions) {
@@ -809,7 +812,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
                         this.updateFilledState();
                         this.onUnselect.emit(removedValue);
                     }
-                break;
+                    break;
             }
         }
 

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -22,7 +22,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
         <span #container [ngClass]="{'p-autocomplete p-component':true,'p-autocomplete-dd':dropdown,'p-autocomplete-multiple':multiple}" [ngStyle]="style" [class]="styleClass">
             <input *ngIf="!multiple" #in [attr.type]="type" [attr.id]="inputId" [ngStyle]="inputStyle" [class]="inputStyleClass" [autocomplete]="autocomplete" [attr.required]="required" [attr.name]="name"
             class="p-autocomplete-input p-inputtext p-component" [ngClass]="{'p-autocomplete-dd-input':dropdown,'p-disabled': disabled}" [value]="inputFieldValue" aria-autocomplete="list" role="searchbox"
-            (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
+            (click)="onInputClick($event)" (input)="onInput($event)" (keydown)="onKeydown($event)" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)"
             [attr.placeholder]="placeholder" [attr.size]="size" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [readonly]="readonly" [disabled]="disabled" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required">
             <i *ngIf="!multiple && filled && !disabled && showClear" class="p-autocomplete-clear-icon pi pi-times" (click)="clear()"></i>
             <i *ngIf="multiple && filled && !disabled && showClear" class="p-autocomplete-clear-icon pi pi-times" (click)="clear()"></i>
@@ -34,7 +34,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 </li>
                 <li class="p-autocomplete-input-token">
                     <input #multiIn [attr.type]="type" [attr.id]="inputId" [disabled]="disabled" [attr.placeholder]="(value&&value.length ? null : placeholder)" [attr.tabindex]="tabindex" [attr.maxlength]="maxlength" (input)="onInput($event)"  (click)="onInputClick($event)"
-                            (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" [autocomplete]="autocomplete"
+                            (keydown)="onKeydown($event)" [readonly]="readonly" (keyup)="onKeyup($event)" [attr.autofocus]="autofocus" (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (change)="onInputChange($event)" (paste)="onInputPaste($event)" [autocomplete]="autocomplete"
                             [ngStyle]="inputStyle" [class]="inputStyleClass" [attr.aria-label]="ariaLabel" [attr.aria-labelledby]="ariaLabelledBy" [attr.aria-required]="required"
                             aria-autocomplete="list" [attr.aria-controls]="listId" role="searchbox" [attr.aria-expanded]="overlayVisible" aria-haspopup="true" [attr.aria-activedescendant]="'p-highlighted-option'">
                 </li>
@@ -205,7 +205,7 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     @Input() hideTransitionOptions: string = '.1s linear';
 
-    @Input() autofocus: boolean = false;
+    @Input() autofocus: boolean;
 
     @Input() autocomplete: string = 'off';
 
@@ -395,9 +395,6 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
     }
 
     ngAfterContentInit() {
-        if (this.autofocus) {
-            setTimeout(() => this.focusInput(), 0);
-        }
         this.templates.forEach((item) => {
             switch(item.getType()) {
                 case 'item':
@@ -929,9 +926,9 @@ export class AutoComplete implements AfterViewChecked,AfterContentInit,OnDestroy
 
     updateFilledState() {
         if (this.multiple)
-            this.filled = (this.value && this.value.length) || (this.multiInputEL && this.multiInputEL.nativeElement && this.multiInputEL.nativeElement.value != '');
+            this.filled = (this.value && this.value.length) || (this.multiInputEL && this.multiInputEL.nativeElement && this.multiInputEL.nativeElement.value != '');
         else
-            this.filled = (this.inputFieldValue && this.inputFieldValue != '') || (this.inputEL && this.inputEL.nativeElement && this.inputEL.nativeElement.value != '');
+            this.filled = (this.inputFieldValue && this.inputFieldValue != '') || (this.inputEL && this.inputEL.nativeElement && this.inputEL.nativeElement.value != '');
     }
 
     updateInputField() {

--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -42,8 +42,7 @@ export const INPUTMASK_VALUE_ACCESSOR: any = {
     template: `
         <input #input pInputText class="p-inputmask" [attr.id]="inputId" [attr.type]="type" [attr.name]="name" [ngStyle]="style" [ngClass]="styleClass" [attr.placeholder]="placeholder" [attr.title]="title"
             [attr.size]="size" [attr.autocomplete]="autocomplete" [attr.maxlength]="maxlength" [attr.tabindex]="tabindex" [attr.aria-label]="ariaLabel" [attr.aria-required]="ariaRequired" [disabled]="disabled" [readonly]="readonly" [attr.required]="required"
-            (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (keydown)="onInputKeydown($event)" (keypress)="onKeyPress($event)" [attr.autofocus]="autoFocus"
-            (input)="onInputChange($event)" (paste)="handleInputChange($event)">
+            (focus)="onInputFocus($event)" (blur)="onInputBlur($event)" (keydown)="onInputKeydown($event)" (keypress)="onKeyPress($event)" (input)="onInputChange($event)" (paste)="handleInputChange($event)">
         <i *ngIf="value != null && filled && showClear && !disabled" class="p-inputmask-clear-icon pi pi-times" (click)="clear()"></i>
     `,
     host: {
@@ -99,7 +98,7 @@ export class InputMask implements OnInit,ControlValueAccessor {
 
     @Input() characterPattern: string = '[A-Za-z]';
 
-    @Input() autoFocus: boolean;
+    @Input() autofocus: boolean = false;
 
     @Input() autocomplete: string;
 
@@ -651,6 +650,12 @@ export class InputMask implements OnInit,ControlValueAccessor {
 
     updateFilledState() {
         this.filled = this.inputViewChild.nativeElement && this.inputViewChild.nativeElement.value != '';
+    }
+
+    ngAfterViewInit() {
+        if (this.autofocus) {
+            setTimeout(() => this.focus(), 0);
+        }
     }
 
     focus() {

--- a/src/app/showcase/components/inputmask/inputmaskdemo.html
+++ b/src/app/showcase/components/inputmask/inputmaskdemo.html
@@ -202,7 +202,7 @@ import &#123;InputMaskModule&#125; from 'primeng/inputmask';
                             <td>Regex pattern for alpha characters</td>
                         </tr>
                         <tr>
-                            <td>autoFocus</td>
+                            <td>autofocus</td>
                             <td>boolean</td>
                             <td>false</td>
                             <td>When present, the input gets a focus automatically on load.</td>


### PR DESCRIPTION
This solves issue #11783.

Using the `[autofocus]` attribute on an `<p-inputMask>` element was having no effect.
It did not change the behaviour, no matter of values.

Not working:
`<input [attr.autofocus]="true"/>`

Working:
`<input autofocus/>`

The element seems to only support that you have the attribute `autofocus` or not, which this PR now fixes.