### PR TITLE
Table: Catch exception if multiSortMeta array is empty

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1055,6 +1055,9 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
     }
 
     multisortField(data1, data2, multiSortMeta, index) {
+        if (typeof multiSortMeta[index] === 'undefined') {
+            return 1;
+        }
         let value1 = ObjectUtils.resolveFieldData(data1, multiSortMeta[index].field);
         let value2 = ObjectUtils.resolveFieldData(data2, multiSortMeta[index].field);
         let result = null;

--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -774,6 +774,9 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
     }
 
     multisortField(node1, node2, multiSortMeta, index) {
+        if (typeof multiSortMeta[index] === 'undefined') {
+            return 1;
+        }
         let value1 = ObjectUtils.resolveFieldData(node1.data, multiSortMeta[index].field);
         let value2 = ObjectUtils.resolveFieldData(node2.data, multiSortMeta[index].field);
         let result = null;


### PR DESCRIPTION
Currently, an exception occurs if an empty multiSortMeta array is passed. However, there are use cases where the sort criteria are set after rendering. Therefore, it should be possible to pass an empty multiSortMeta array and change it during the lifecycle.

This PR fix issue #11868.