### PR TITLE
Added support for immutable table filters

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -300,6 +300,8 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
     @Input() breakpoint: string = '960px';
 
+    @Input() areTableFiltersImmutableObject :boolean =false
+
     @Output() onRowSelect: EventEmitter<any> = new EventEmitter();
 
     @Output() onRowUnselect: EventEmitter<any> = new EventEmitter();
@@ -341,6 +343,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
     @Output() onStateSave: EventEmitter<any> = new EventEmitter();
 
     @Output() onStateRestore: EventEmitter<any> = new EventEmitter();
+    @Output () onTableFiltersImmutableChange :EventEmitter<{ [s: string]: FilterMetadata | FilterMetadata[] }> = new EventEmitter()
 
     @ViewChild('container') containerViewChild: ElementRef;
 
@@ -4556,7 +4559,15 @@ export class ColumnFilter implements AfterContentInit {
 
     initFieldFilterConstraint() {
         let defaultMatchMode = this.getDefaultMatchMode();
-        this.dt.filters[this.field] = this.display == 'row' ? {value: null, matchMode: defaultMatchMode} : [{value: null, matchMode: defaultMatchMode, operator: this.operator}];
+        const rowFilterDefaults:FilterMetadata = { value: null, matchMode: defaultMatchMode };
+        const menuFilterDefaults:FilterMetadata[] = [{ value: null, matchMode: defaultMatchMode, operator: this.operator }]
+
+        if(this.dt.areTableFiltersImmutableObject){
+            this.dt.onTableFiltersImmutableChange.emit(this.display == 'row' ? rowFilterDefaults : menuFilterDefaults)
+        }
+        else{
+            this.dt.filters[this.field] = this.display == 'row' ? rowFilterDefaults : menuFilterDefaults;
+        }
     }
 
     onMenuMatchModeChange(value: any, filterMeta: FilterMetadata) {


### PR DESCRIPTION
###Defect Fixes
I noticed when I use `NgRx store`to save table filters in state object I cannot add column filters (name of column is `surname` and I get error 'Cannot add property surname, object is not extensible', because `p-columnFilter` mutates data table filters object by initializing filter object for that column I want to define `p-column-filter` in method `initFieldFilterConstraint` in `OnInit ` on `ColumnFilter` component.

Another possible solution (without new Input and Output properties) would be that `p-columnFilter` does not mutate filters, instead it uses spread operator or deep copy to create new instance of an filters object and by doing so we are forcing immutability.

I had to dig in table.ts code to see what an actual implementation of initializing `p-columnFilter` is. And I don't like that "hidden filter mutation" it should be explicitly exposed to outer world outside of table component.

 So in order to support immutability i have added 1 input that indicates if table column filters are immutable object , if so, we should delegate initializing of filter object to the component that uses `p-table` and `p-columnFilter` ( in NgRx manner we should disptch `action `that will trigger `reducer` to update state accordingly 

