### PR TITLE
GalleriaItem activeItem getter to avoid stale references

### DIFF
--- a/src/app/components/galleria/galleria.ts
+++ b/src/app/components/galleria/galleria.ts
@@ -456,12 +456,13 @@ export class GalleriaItem implements OnInit {
 
     set activeIndex(activeIndex) {
         this._activeIndex = activeIndex;
-        this.activeItem = this.value[this._activeIndex];
+    }
+
+    get activeItem() {
+        return this.value[this._activeIndex];
     }
 
     _activeIndex: number = 0;
-
-    activeItem: any;
 
     ngOnInit() {
         if (this.autoPlay) {


### PR DESCRIPTION
This PR introduces using a getter for the `GalleriaItem.activeItem` to prevent the case where the `value` array has been changed, but the reference is still pointing to the previous value. This occurs because the `activeItem` reference is only changed whenever the `activeIndex` is set. 

###Defect Fixes
Fixes #11882 