### PR TITLE
fix: added resources to package exports

### DIFF
--- a/src/app/components/package.json
+++ b/src/app/components/package.json
@@ -12,6 +12,9 @@
     "bugs": {
       "url": "https://github.com/primefaces/primeng/issues"
     },
+    "exports": {
+      "./resources/": "./resources/"
+    },
     "module": "primeng.js",
     "typings": "primeng.d.ts",
     "peerDependencies": {


### PR DESCRIPTION
Fixes #11172 

Added resources to package.json exports field according to Angular docs about managing assets https://angular.io/guide/creating-libraries#managing-assets-in-a-library