### PR TITLE
allow Ripple class to handle icons being SVGs

### DIFF
--- a/src/app/components/ripple/ripple.ts
+++ b/src/app/components/ripple/ripple.ts
@@ -60,9 +60,13 @@ export class Ripple implements AfterViewInit, OnDestroy {
     }
 
     getInk() {
-        for (let i = 0; i < this.el.nativeElement.children.length; i++) {
-            if (this.el.nativeElement.children[i].className.indexOf('p-ink') !== -1) {
-                return this.el.nativeElement.children[i];
+        const children = this.el.nativeElement.children;
+        for (let i = 0; i < children.length; i++) {
+            if (
+                typeof children[i].className === "string" &&
+                children[i].className.indexOf("p-ink") !== -1
+            ) {
+                return children[i];
             }
         }
         return null;


### PR DESCRIPTION
This will fix #9853

When using font-awesome pro this replaces the icon with a SVG and therefore `children[i]` becomes a SVGElement which means that `children[i].className` is a object which you cannot perform .indexOf on.