### PR TITLE
Add ability to template dynamic dialogs.

### DIFF
--- a/src/app/components/dynamicdialog/dynamicdialog-config.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog-config.ts
@@ -26,4 +26,5 @@ export class DynamicDialogConfig<T = any> {
     maximizeIcon?: string;
     minimizeIcon?: string;
     position?: string;
+    minimal?: string;
 }


### PR DESCRIPTION
###Defect Fixes
Solves #9235 and #7603

Backward compatible, simply set `config.minimal` to true and you can use dialog templates as follows:

    <p-dialog-title>
      <h3>Example title</h3>
    </p-dialog-title>
    <p-dialog-content><p>example content here</p></p-dialog-content>
    <p-dialog-actions>
      <button (click)="cancel()">Cancel</button>
      <button (click)="delete()">Delete</button>
    </p-dialog-actions>
