### PR TITLE
fix: Menubar: Don't show icon on mobile if model has no items

### DIFF
--- a/src/app/components/menubar/menubar.css
+++ b/src/app/components/menubar/menubar.css
@@ -46,7 +46,7 @@
     z-index: 1;
 }
 
-.p-menubar .p-submenu-list > .p-menuitem-active > p-menubarsub > .p-submenu-list  {
+.p-menubar .p-submenu-list > .p-menuitem-active > p-menubarsub > .p-submenu-list {
     display: block;
     left: 100%;
     top: 0;
@@ -67,4 +67,8 @@
     cursor: pointer;
     align-items: center;
     justify-content: center;
+}
+
+.p-menubar-button-hidden {
+    display: none !important;
 }

--- a/src/app/components/menubar/menubar.ts
+++ b/src/app/components/menubar/menubar.ts
@@ -213,7 +213,7 @@ export class MenubarSub implements OnDestroy {
             <div class="p-menubar-start" *ngIf="startTemplate">
                 <ng-container *ngTemplateOutlet="startTemplate"></ng-container>
             </div>
-            <a #menubutton tabindex="0" class="p-menubar-button" (click)="toggle($event)">
+            <a #menubutton tabindex="0" class="p-menubar-button" [ngClass]="{'p-menubar-button-hidden': !model?.length}" (click)="toggle($event)">
                 <i class="pi pi-bars"></i>
             </a>
             <p-menubarSub #rootmenu [item]="model" root="root" [baseZIndex]="baseZIndex" (leafClick)="onLeafClick()" [autoZIndex]="autoZIndex" [mobileActive]="mobileActive" [autoDisplay]="autoDisplay"></p-menubarSub>


### PR DESCRIPTION
Fixes #12084

This MR tries to fix an issue for the MenuBar as described in #12084

Previously: Even though the model was empty or held no items, the menu icon was shown on mobile views.

With this MR: When the model input on menubar is falsely or an empty array, the menu icon is never visible.
