### PR TITLE
Fix issue 11848 - Accordion Panel within an Accordion Panel is broken

### DIFF
--- a/src/app/components/accordion/accordion.css
+++ b/src/app/components/accordion/accordion.css
@@ -19,6 +19,6 @@
     overflow: hidden;
 }
 
-.p-accordion .p-accordion-tab-active .p-toggleable-content:not(.ng-animating) {
+.p-accordion .p-accordion-tab-active > .p-toggleable-content:not(.ng-animating) {
     overflow: inherit;
 }


### PR DESCRIPTION
Issue #11848 was fixed in 4.1.0 but was reintroduced in 4.1.1+ after PR #11935 (see https://stackblitz.com/edit/angular-ivy-q8x2la?file=package.json). This PR should now fix #11848 again while also making sure #11924 (which PR #11935 aimed to fix) is not reintroduced.

The active accordion tab should only affect the styling of the .p-toggleable-content for the direct children and not of any sub-accordions, which is what this css change fixes.