### PR TITLE
Fix issue 11736 - Toggleable fieldset inside another toggleable field…

### DIFF
--- a/src/app/components/fieldset/fieldset.css
+++ b/src/app/components/fieldset/fieldset.css
@@ -16,7 +16,7 @@
     line-height: 1;
 }
 
-.p-fieldset-toggleable.p-fieldset-expanded .p-toggleable-content:not(.ng-animating) {
+.p-fieldset-toggleable.p-fieldset-expanded > .p-toggleable-content:not(.ng-animating) {
     overflow: visible;
 }
 


### PR DESCRIPTION
Fix for issue #11736. Similar to issue #11848 (with corresponding PR #12145). The expanded fieldset should only set the visibility of its direct children, not of any sub fieldsets.