### PR TITLE
In primeng calendar, date can be lined through or disabled using date… there is no way to disable years

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -197,7 +197,8 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
                         </span>
                     </div>
                     <div class="p-yearpicker" *ngIf="currentView === 'year'">
-                        <span *ngFor="let y of yearPickerValues()" (click)="onYearSelect($event, y)" (keydown)="onYearCellKeydown($event, y)" class="p-yearpicker-year" [ngClass]="{ 'p-highlight': isYearSelected(y) }" pRipple>
+                        <span *ngFor="let y of yearPickerValues()" (click)="onYearSelect($event, y)" (keydown)="onYearCellKeydown($event, y)"
+                              class="p-yearpicker-year" [ngClass]="{ 'p-highlight': isYearSelected(y), 'p-disabled': isYearDisabled(y) }" pRipple>
                             {{ y }}
                         </span>
                     </div>
@@ -1648,6 +1649,10 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
             }
         }
         return true;
+    }
+
+    isYearDisabled(year) {
+        return !this.isSelectable(1, this.currentMonth, year, false);
     }
 
     isYearSelected(year: number) {


### PR DESCRIPTION
When maxDate or minDate is used, particular date or month gets disabled but there is no way to disable years outside the range of max or min date.

Related issue id: #12151, #12583

