### PR TITLE
Fixed wrong style classes in showcase of toast component

### DIFF
--- a/src/app/showcase/components/toast/toastdemo.html
+++ b/src/app/showcase/components/toast/toastdemo.html
@@ -432,11 +432,11 @@ this.messageService.clear('myKey1');    //clears messages of the first toast onl
                             <td>Container of message texts.</td>
                         </tr>
                         <tr>
-                            <td>p-toast-title</td>
+                            <td>p-toast-summary</td>
                             <td>Summary of the message.</td>
                         </tr>
                         <tr>
-                            <td>p-toast-title</td>
+                            <td>p-toast-detail</td>
                             <td>Detail of the message.</td>
                         </tr>
                     </tbody>


### PR DESCRIPTION
I fixed a small error in the documentation / showcase of the toast component.

I got the correct classes from the [actual component](https://github.com/primefaces/primeng/blob/master/src/app/components/toast/toast.ts#L51)

I didn't open an issue first for this, because it seems like a very small documentation error, but I can create and link one if necessary.