### PR TITLE
autoResize is a wrong type in docs

### DIFF
--- a/src/app/showcase/components/inputtextarea/inputtextareademo.html
+++ b/src/app/showcase/components/inputtextarea/inputtextareademo.html
@@ -139,7 +139,7 @@ import &#123;InputTextareaModule&#125; from 'primeng/inputtextarea';
 &lt;/span&gt;
 
 &lt;h5&gt;AutoResize&lt;/h5&gt;
-&lt;textarea rows="5" cols="30" pInputTextarea autoResize="autoResize"&gt;&lt;/textarea&gt;
+&lt;textarea rows="5" cols="30" pInputTextarea [autoResize]="true"&gt;&lt;/textarea&gt;
 </app-code>
         </p-tabPanel>
         <p-tabPanel header="StackBlitz">


### PR DESCRIPTION
The documentation has autoResize as a string in the example, it should be a boolean

Issue #12239
