### PR TITLE
Add additional properties to the ColumnFilterFormElement ngTemplateOutlet context

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -4817,7 +4817,29 @@ export class ColumnFilter implements AfterContentInit {
     selector: 'p-columnFilterFormElement',
     template: `
         <ng-container *ngIf="filterTemplate; else builtInElement">
-            <ng-container *ngTemplateOutlet="filterTemplate; context: { $implicit: filterConstraint.value, filterCallback: filterCallback }"></ng-container>
+            <ng-container
+                *ngTemplateOutlet="
+                    filterTemplate;
+                    context: {
+                        $implicit: filterConstraint.value,
+                        filterCallback: filterCallback,
+                        type: type,
+                        field: field,
+                        filterConstraint: filterConstraint,
+                        placeholder: placeholder,
+                        minFractionDigits: minFractionDigits,
+                        maxFractionDigits: maxFractionDigits,
+                        prefix: prefix,
+                        suffix: suffix,
+                        locale: locale,
+                        localeMatcher: localeMatcher,
+                        currency: currency,
+                        currencyDisplay: currencyDisplay,
+                        useGrouping: useGrouping,
+                        showButtons: showButtons
+                    }
+                "
+            ></ng-container>
         </ng-container>
         <ng-template #builtInElement>
             <ng-container [ngSwitch]="type">


### PR DESCRIPTION
fixes #11466

This PR adds all relevant properties to be able to fully customize the `ColumnFilter` **filter** template to the `ColumnFilterFormElement` **ngTemplateOutlet context**. 
Without this, it is for example _not even possible to recreate/customize_ the `#builtInElement` `ColumnFilterFormElement` template. 
**This adds no breaking change!**

The formatting style of the context is the same as https://github.com/primefaces/primeng/blob/v14.2.1/src/app/components/table/table.ts#L2502-L2513