### PR TITLE
we can add now customimage too for tree node dynamically

### DIFF
--- a/src/app/components/api/treenode.ts
+++ b/src/app/components/api/treenode.ts
@@ -16,4 +16,5 @@ export interface TreeNode<T = any> {
     droppable?: boolean;
     selectable?: boolean;
     key?: string;
+    customImage?: boolean;
 }

--- a/src/app/components/tree/tree.css
+++ b/src/app/components/tree/tree.css
@@ -154,3 +154,10 @@
 .p-scroller .p-tree-container {
     overflow: visible;
 }
+
+.tree-custom-img{
+    height: 20px;
+    margin-right: 7px;
+    width: 20px;
+    border-radius: 4px;
+}

--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -74,7 +74,10 @@ import { Subscription } from 'rxjs';
                             <span class="p-checkbox-icon pi" [ngClass]="{ 'pi-check': isSelected(), 'pi-minus': node.partialSelected }"></span>
                         </div>
                     </div>
-                    <span [class]="getIcon()" *ngIf="node.icon || node.expandedIcon || node.collapsedIcon"></span>
+                    <span  [class]="getIcon()" *ngIf="(node.icon || node.expandedIcon || node.collapsedIcon) && !node.customImage "></span>
+                    <span  *ngIf="node.customImage">
+                        <img class="tree-custom-img" [src]="node.icon"/>
+                    </span>
                     <span class="p-treenode-label">
                         <span *ngIf="!tree.getTemplateForNode(node)">{{ node.label }}</span>
                         <span *ngIf="tree.getTemplateForNode(node)">
@@ -195,6 +198,9 @@ export class UITreeNode implements OnInit {
         this.node.parent = this.parentNode;
         if (this.parentNode) {
             this.tree.syncNodeOption(this.node, this.tree.value, 'parent', this.tree.getNodeWithKey(this.parentNode.key, this.tree.value));
+        }
+        if (this.node.customImage == undefined || !this.node.customImage) {
+            this.node.customImage = false;
         }
     }
 

--- a/src/app/showcase/components/tree/treedemo.html
+++ b/src/app/showcase/components/tree/treedemo.html
@@ -11,6 +11,9 @@
         <h5>Basic</h5>
         <p-tree [value]="files1"></p-tree>
 
+        <h5>Basic Tree with Custom Image Icon</h5>
+        <p-tree [value]="files1withCustomImageIcon"></p-tree>
+
         <h5>Programmatic</h5>
         <div style="margin-bottom: 1rem">
             <button pButton type="button" label="Expand all" (click)="expandAll()" style="margin-right: .5rem"></button>

--- a/src/app/showcase/components/tree/treedemo.ts
+++ b/src/app/showcase/components/tree/treedemo.ts
@@ -9,12 +9,19 @@ export class TreeDemo implements OnInit {
     files1: TreeNode[];
 
     files2: TreeNode[];
+    files1withCustomImageIcon: TreeNode[]
 
     constructor(private nodeService: NodeService) {}
 
     ngOnInit() {
         this.nodeService.getFiles().then((files) => (this.files1 = files));
         this.nodeService.getFiles().then((files) => (this.files2 = files));
+        this.nodeService.getFiles().then((files) => {
+            this.files1withCustomImageIcon = files;
+            this.files1withCustomImageIcon[0].customImage = true;
+            this.files1withCustomImageIcon[0].icon = "../assets/components/images/password-meter.png";
+        });
+
     }
 
     expandAll() {


### PR DESCRIPTION
### Defect Fixes
we cannot able to add custom image icons 
issue link [issue no 12467](https://github.com/primefaces/primeng/issues/12467)
### Feature Requests
I solve this issue by adding customImage Property now user can add image icon node by customImage property true and use it.
Steps to Add CustomImage Icon
1. customImage Icon :true in node Model
2. then just give image path to node-icon


![customImageProperty](https://user-images.githubusercontent.com/49456702/211134280-57a6b82c-2bdd-4860-b55a-4841a5aed1ac.png)

