### PR TITLE
Correcting the template name typo

### DIFF
--- a/src/app/components/toolbar/toolbar.ts
+++ b/src/app/components/toolbar/toolbar.ts
@@ -14,7 +14,7 @@ import { BlockableUI, PrimeTemplate } from 'primeng/api';
                 <ng-container *ngTemplateOutlet="centerTemplate"></ng-container>
             </div>
             <div class="p-toolbar-group-right p-toolbar-group-end" *ngIf="endTemplate">
-                <ng-container *ngTemplateOutlet="rightTemplate"></ng-container>
+                <ng-container *ngTemplateOutlet="endTemplate"></ng-container>
             </div>
         </div>
     `,


### PR DESCRIPTION
### Defect Fixes
#12494 by @carcigenicate

### Fix
Correcting the typo in the source code from `rightTemplate` to `endTemplate`
