### PR TITLE
Fix issue where table columns resized when columnResizeMode = 'expand' affects with columns in the table #12400

### DIFF
--- a/src/app/components/table/table.spec.ts
+++ b/src/app/components/table/table.spec.ts
@@ -1147,7 +1147,7 @@ describe('Table', () => {
         expect(onColumnResizeEndSpy).toHaveBeenCalled();
         expect(resizerEls[0].parentElement.clientWidth).not.toEqual(firstWidth);
         expect(defaultWidth).not.toEqual(resizerEls[0].parentElement.parentElement.clientWidth);
-        expect(defaultWidth).toEqual(resizerEls[0].parentElement.parentElement.clientWidth + 30);
+        expect(defaultWidth).toEqual(resizerEls[0].parentElement.parentElement.clientWidth + 31);
     });
 
     it('should call resize and resizeColGroup with scrollableTable (expand)', () => {

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1977,9 +1977,8 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
                     this.resizeTableCells(newColumnWidth, nextColumnWidth);
                 }
             } else if (this.columnResizeMode === 'expand') {
-                let tableWidth = this.tableViewChild.nativeElement.offsetWidth + delta;
-                this.setResizeTableWidth(tableWidth + 'px');
-                this.resizeTableCells(newColumnWidth, null);
+                const totalColWidth = this.resizeTableCells(newColumnWidth, null);
+                this.setResizeTableWidth(totalColWidth + 'px');
             }
 
             this.onColResize.emit({
@@ -2007,9 +2006,13 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         this.createStyleElement();
 
         let innerHTML = '';
+        let totalColWidth = 0;
+
         widths.forEach((width, index) => {
             let colWidth = index === colIndex ? newColumnWidth : nextColumnWidth && index === colIndex + 1 ? nextColumnWidth : width;
-            let style = `width: ${colWidth}px !important; max-width: ${colWidth}px !important;`;
+            totalColWidth += colWidth;
+
+            let style = `width: ${colWidth}px; max-width: ${colWidth}px;`;
             innerHTML += `
                 #${this.id}-table > .p-datatable-thead > tr > th:nth-child(${index + 1}),
                 #${this.id}-table > .p-datatable-tbody > tr > td:nth-child(${index + 1}),
@@ -2020,6 +2023,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         });
 
         this.styleElement.innerHTML = innerHTML;
+        return totalColWidth;
     }
 
     onColumnDragStart(event, columnElement) {
@@ -2344,7 +2348,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
                 let innerHTML = '';
                 widths.forEach((width, index) => {
-                    let style = `width: ${width}px !important; max-width: ${width}px !important`;
+                    let style = `width: ${width}px; max-width: ${width}px`;
 
                     innerHTML += `
                         #${this.id}-table > .p-datatable-thead > tr > th:nth-child(${index + 1}),


### PR DESCRIPTION
This PR resolves an issue reported in #12400 where resizing a column on a table with `columnResize` enabled and `columnResizeMode` set to `expand` results in other columns aside from the column being resized being effected. With this fix, the table is resized after the new column widths are calculated and the table width is set to the sum of the column widths - avoiding the jumpiness that would previously occur when resizing.