### PR TITLE
DOCS: CSS Customization and Examples

### DIFF
--- a/src/app/showcase/components/dropdown/dropdowndemo.html
+++ b/src/app/showcase/components/dropdown/dropdowndemo.html
@@ -244,6 +244,15 @@ export class DropdownDemo &#123;
 <app-code lang="markup" ngNonBindable ngPreserveWhitespaces>
 &lt;p-dropdown [options]="cars" [(ngModel)]="selectedCar" [showTransitionOptions]="'0ms'" [hideTransitionOptions]="'0ms'"&gt;&lt;/p-dropdown&gt;
 </app-code>
+            
+<h5>CSS Customization</h5>   
+<p>In order to customize the building blocks of the Dropdown is necesarry to leverage the `::ng-deep` selector before the desired class to correctly hook the stile to the element.
+    This example shows how to customize the height of the dropdown</p> 
+<app-code lang="css" ngNonBindable ngPreserveWhitespaces> 
+::ng-deep .p-dropdown {
+  width: 15rem;
+}
+</app-code>
 
             <h5>Properties</h5>
             <div class="doc-tablewrapper">


### PR DESCRIPTION
I've been using PrimeNG for the first time in the last few week. I've been spending infinite amount of time trying to customize the look of certain HTML elements and constantly failing with a huge deal of frustration, until today i stumbled upon this stackoverflow answer: https://stackoverflow.com/questions/72871343/cant-apply-any-style-to-any-component-in-primeng

I really asked myself why that isn't in the docs, so here I am proposing to add a few examples on how to customize via CSS the inner elements of p-items.

