### PR TITLE
Hovering on ScrollPanel with nested ScrollPanels causes all scrollbars to be displayed

### DIFF
--- a/src/app/components/scrollpanel/scrollpanel.css
+++ b/src/app/components/scrollpanel/scrollpanel.css
@@ -40,8 +40,8 @@
     visibility: hidden;
 }
 
-.p-scrollpanel:hover .p-scrollpanel-bar,
-.p-scrollpanel:active .p-scrollpanel-bar {
+.p-scrollpanel:hover > .p-scrollpanel-bar,
+.p-scrollpanel:active > .p-scrollpanel-bar {
     opacity: 1;
 }
 

--- a/src/app/components/scrollpanel/scrollpanel.css
+++ b/src/app/components/scrollpanel/scrollpanel.css
@@ -8,12 +8,28 @@
 }
 
 .p-scrollpanel-content {
-    height: calc(100% + 18px);
-    width: calc(100% + 18px);
-    padding: 0 18px 18px 0;
+    height: 100%;
+    width: 100%;
+    padding: 0;
     position: relative;
     overflow: auto;
     box-sizing: border-box;
+
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+}
+
+
+.p-scrollpanel-content::-webkit-scrollbar {
+    display: none;
+}
+
+.p-scrollpanel-x > .p-scrollpanel-wrapper > .p-scrollpanel-content {
+    padding-bottom: 18px;
+}
+
+.p-scrollpanel-y > .p-scrollpanel-wrapper > .p-scrollpanel-content {
+    padding-right: 18px;
 }
 
 .p-scrollpanel-bar {

--- a/src/app/components/scrollpanel/scrollpanel.ts
+++ b/src/app/components/scrollpanel/scrollpanel.ts
@@ -134,8 +134,10 @@ export class ScrollPanel implements AfterViewInit, AfterContentInit, OnDestroy {
 
         this.requestAnimationFrame(() => {
             if (this.scrollXRatio >= 1) {
+                DomHandler.removeClass(container, 'p-scrollpanel-x');
                 DomHandler.addClass(xBar, 'p-scrollpanel-hidden');
             } else {
+                DomHandler.addClass(container, 'p-scrollpanel-x');
                 DomHandler.removeClass(xBar, 'p-scrollpanel-hidden');
                 const xBarWidth = Math.max(this.scrollXRatio * 100, 10);
                 const xBarLeft = (content.scrollLeft * (100 - xBarWidth)) / (totalWidth - ownWidth);
@@ -143,8 +145,10 @@ export class ScrollPanel implements AfterViewInit, AfterContentInit, OnDestroy {
             }
 
             if (this.scrollYRatio >= 1) {
+                DomHandler.removeClass(container, 'p-scrollpanel-y');
                 DomHandler.addClass(yBar, 'p-scrollpanel-hidden');
             } else {
+                DomHandler.addClass(container, 'p-scrollpanel-y');
                 DomHandler.removeClass(yBar, 'p-scrollpanel-hidden');
                 const yBarHeight = Math.max(this.scrollYRatio * 100, 10);
                 const yBarTop = (content.scrollTop * (100 - yBarHeight)) / (totalHeight - ownHeight);

--- a/src/app/showcase/components/scrollpanel/scrollpaneldemo.html
+++ b/src/app/showcase/components/scrollpanel/scrollpaneldemo.html
@@ -189,6 +189,14 @@ import &#123;ScrollPanelModule&#125; from 'primeng/scrollpanel';
                             <td>Container element.</td>
                         </tr>
                         <tr>
+                            <td>p-scrollpanel-x</td>
+                            <td>Indicates that the x-axis scrollbar is active.</td>
+                        </tr>
+                        <tr>
+                            <td>p-scrollpanel-y</td>
+                            <td>Indicates that the y-axis scrollbar is active.</td>
+                        </tr>
+                        <tr>
                             <td>p-scrollpanel-wrapper</td>
                             <td>Wrapper of content section.</td>
                         </tr>

--- a/src/app/showcase/components/scrollpanel/scrollpaneldemo.scss
+++ b/src/app/showcase/components/scrollpanel/scrollpaneldemo.scss
@@ -7,7 +7,7 @@
 
     &.custombar1 {
         .p-scrollpanel-wrapper {
-            border-right: 9px solid var(--layer-1);
+            border-right: 9px solid var(--surface-ground);
         }
 
         .p-scrollpanel-bar {
@@ -16,19 +16,19 @@
             transition: background-color .2s;
 
             &:hover {
-                background-color: #007ad9;
+                background-color: var(--primary-400);
             }
         }
     }
 
     &.custombar2 {
         .p-scrollpanel-wrapper {
-            border-right: 9px solid var(--layer-1);
-            border-bottom: 9px solid var(--layer-1);
+            border-right: 9px solid var(--surface-ground);
+            border-bottom: 9px solid var(--surface-ground);
         }
 
         .p-scrollpanel-bar {
-            background-color: var(--layer-2);
+            background-color: var(--surface-border);
             border-radius: 0;
             opacity: 1;
             transition: background-color .2s;


### PR DESCRIPTION
I'm developing an Kanban component on my projetct. So, on my Kanban Board, I have an horizontal scrollbar to scroll the board horizontally (the columns). And every column on this board have a vertical scroll too. So, a have an nested scrollbars scenario.

To develop this, I'm using the ScrollPanel component. But when my arrow is hover the board, all scrollbars is displayed.

I correct this and I'm proposing a pull request.

I've made some improvements to remove the tricks to hide the scrollbar in the ScrollPanel and fix the demos too.

Issue: #12588 