### PR TITLE
Resolved google maps error for no callback set

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,7 @@
   <link rel="stylesheet" type="text/css" href="assets/showcase/styles/splash.css">
   <link id="theme-link" rel="stylesheet" type="text/css" href="assets/components/themes/lara-light-blue/theme.css">
   <link id="home-table-link" rel="stylesheet" type="text/css" href="assets/showcase/styles/app/landing/themes/lara-light-blue/theme.css">
-  <script type="text/javascript" src="https://maps.google.com/maps/api/js?key=AIzaSyA6Ar0UymhiklJBzEPLKKn2QHwbjdz3XV0" async defer></script>
+  <script type="text/javascript" src="https://maps.google.com/maps/api/js?key=AIzaSyA6Ar0UymhiklJBzEPLKKn2QHwbjdz3XV0&callback=Function.prototype" async defer></script>
   <script src="https://www.google.com/recaptcha/api.js?render=explicit&onLoad=initRecaptcha" async defer></script>
 </head>
 <body>


### PR DESCRIPTION
Google recently updated the required parameters when initializing the google maps javascript API.  The `callback` parameter is now required.  When this parameter is not set the following error is logged to the console: 

![image](https://user-images.githubusercontent.com/40581638/216149164-fb40cb35-634f-4643-9b0d-dbbc8fd602fe.png)

https://developers.google.com/maps/documentation/javascript/url-params#required_parameters

