### PR TITLE
Added basic option to close tooltips with Escape

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AfterViewInit, ChangeDetectorRef, Directive, ElementRef, Input, NgModule, NgZone, OnDestroy, Renderer2, SimpleChanges } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Directive, ElementRef, HostListener, Input, NgModule, NgZone, OnDestroy, Renderer2, SimpleChanges } from '@angular/core';
 import { PrimeNGConfig } from 'primeng/api';
 import { ConnectedOverlayScrollHandler, DomHandler } from 'primeng/dom';
 import { ZIndexUtils } from 'primeng/utils';
@@ -20,6 +20,7 @@ export interface TooltipOptions {
     positionLeft?: number;
     life?: number;
     autoHide?: boolean;
+    hideOnEscape?: boolean;
 }
 
 @Directive({
@@ -56,6 +57,8 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     @Input() autoHide: boolean = true;
 
     @Input() fitContent: boolean = true;
+    
+    @Input() hideOnEscape: boolean = true;
 
     @Input('pTooltip') text: string;
 
@@ -77,7 +80,8 @@ export class Tooltip implements AfterViewInit, OnDestroy {
         escape: true,
         positionTop: 0,
         positionLeft: 0,
-        autoHide: true
+        autoHide: true,
+        hideOnEscape: false
     };
 
     _disabled: boolean;
@@ -254,6 +258,13 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     onInputClick(e: Event) {
         this.deactivate();
+    }
+
+    @HostListener('document:keydown.escape', ['$event']) 
+    onPressEscape() {
+        if (this.hideOnEscape) {
+            this.deactivate();
+          }
     }
 
     activate() {


### PR DESCRIPTION
- This change was implemented to help tooltips comply with (WCAG Success Criterion 1.4.13)[https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html]
- It adds a flag to tooltip options that simply allow the user to close the tooltip when pressing Escape (using a HostListener)
- The relevant issue is available [here](https://github.com/primefaces/primeng/issues/12603)