### PR TITLE
Unsubscribe subscriptions on component unmount to prevent memory leaks

### DIFF
--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -26,9 +26,11 @@ import { Footer, SharedModule, PrimeTemplate, PrimeNGConfig, TranslationKeys, Co
 import { ButtonModule } from 'primeng/button';
 import { Confirmation } from 'primeng/api';
 import { ConfirmationService } from 'primeng/api';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject } from 'rxjs';
 import { UniqueComponentId, ZIndexUtils } from 'primeng/utils';
 import { RippleModule } from 'primeng/ripple';
+
+import { takeUntil } from "rxjs/operators";
 
 const showAnimation = animation([style({ transform: '{{transform}}', opacity: 0 }), animate('{{transition}}', style({ transform: 'none', opacity: 1 }))]);
 
@@ -104,6 +106,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
     }
 })
 export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
+    private destroy$: Subject<any> = new Subject<any>();
     @Input() header: string;
 
     @Input() icon: string;
@@ -539,6 +542,8 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
+        this.destroy$.next(true);
+        this.destroy$.complete();
         this.restoreAppend();
         this.onOverlayHide();
         this.subscription.unsubscribe();

--- a/src/app/components/confirmpopup/confirmpopup.ts
+++ b/src/app/components/confirmpopup/confirmpopup.ts
@@ -1,11 +1,13 @@
 import { NgModule, Component, ChangeDetectionStrategy, ViewEncapsulation, ElementRef, ChangeDetectorRef, OnDestroy, Input, EventEmitter, Renderer2 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Confirmation, ConfirmationService, OverlayService, PrimeNGConfig, TranslationKeys } from 'primeng/api';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject } from 'rxjs';
 import { ButtonModule } from 'primeng/button';
 import { ZIndexUtils } from 'primeng/utils';
 import { trigger, state, style, transition, animate, AnimationEvent } from '@angular/animations';
 import { DomHandler, ConnectedOverlayScrollHandler } from 'primeng/dom';
+
+import { takeUntil } from "rxjs/operators";
 
 @Component({
     selector: 'p-confirmPopup',
@@ -78,6 +80,7 @@ import { DomHandler, ConnectedOverlayScrollHandler } from 'primeng/dom';
     }
 })
 export class ConfirmPopup implements OnDestroy {
+    private destroy$: Subject<any> = new Subject<any>();
     @Input() key: string;
 
     @Input() defaultFocus: string = 'accept';
@@ -340,6 +343,8 @@ export class ConfirmPopup implements OnDestroy {
     }
 
     ngOnDestroy() {
+        this.destroy$.next(true);
+        this.destroy$.complete();
         this.restoreAppend();
 
         if (this.subscription) {

--- a/src/app/components/contextmenu/contextmenu.ts
+++ b/src/app/components/contextmenu/contextmenu.ts
@@ -1,5 +1,23 @@
 import { CommonModule } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, forwardRef, Inject, Input, NgModule, NgZone, OnDestroy, Output, Renderer2, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    EventEmitter,
+    forwardRef,
+    Inject,
+    Input,
+    NgModule,
+    NgZone,
+    OnDestroy,
+    Output,
+    Renderer2,
+    ViewChild,
+    ViewEncapsulation,
+    HostListener,
+} from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ContextMenuService, MenuItem, PrimeNGConfig } from 'primeng/api';
 import { DomHandler } from 'primeng/dom';
@@ -84,7 +102,7 @@ import { takeUntil } from 'rxjs/operators';
         class: 'p-element'
     }
 })
-export class ContextMenuSub {
+export class ContextMenuSub implements OnDestroy {
     @Input() item: MenuItem;
 
     @Input() root: boolean;
@@ -206,6 +224,11 @@ export class ContextMenuSub {
 
     isActive(key) {
         return this.activeItemKey && (this.activeItemKey.startsWith(key + '_') || this.activeItemKey === key);
+    }
+
+    @HostListener('unloaded')
+    public ngOnDestroy(): void {
+        this.activeItemKeyChangeSubscription?.unsubscribe();
     }
 }
 

--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -27,7 +27,9 @@ import { DomHandler } from 'primeng/dom';
 import { MessagesModule } from 'primeng/messages';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { RippleModule } from 'primeng/ripple';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject } from 'rxjs';
+
+import { takeUntil } from "rxjs/operators";
 
 @Component({
     selector: 'p-fileUpload',
@@ -103,6 +105,7 @@ import { Subscription } from 'rxjs';
     }
 })
 export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDestroy, BlockableUI {
+    private destroy$: Subject<any> = new Subject<any>();
     @Input() name: string;
 
     @Input() url: string;
@@ -435,7 +438,7 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
                 reportProgress: true,
                 observe: 'events',
                 withCredentials: this.withCredentials
-            }).subscribe(
+            }).pipe(takeUntil(this.destroy$)).subscribe(
                 (event: HttpEvent<any>) => {
                     switch (event.type) {
                         case HttpEventType.Sent:
@@ -634,6 +637,8 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
     }
 
     ngOnDestroy() {
+        this.destroy$.next(true);
+        this.destroy$.complete();
         if (this.content && this.content.nativeElement) {
             this.content.nativeElement.removeEventListener('dragover', this.onDragOver);
         }

--- a/src/app/showcase/app.config.component.ts
+++ b/src/app/showcase/app.config.component.ts
@@ -1,9 +1,11 @@
 import { Component, ElementRef, OnDestroy, OnInit } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { DomHandler } from 'primeng/dom';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject } from 'rxjs';
 import { AppConfig } from './domain/appconfig';
 import { AppConfigService } from './service/appconfigservice';
+
+import { takeUntil } from "rxjs/operators";
 
 @Component({
     selector: 'app-config',
@@ -490,6 +492,7 @@ import { AppConfigService } from './service/appconfigservice';
     `
 })
 export class AppConfigComponent implements OnInit, OnDestroy {
+    private destroy$: Subject<any> = new Subject<any>();
     active: boolean;
 
     scale: number = 14;
@@ -513,7 +516,7 @@ export class AppConfigComponent implements OnInit, OnDestroy {
             this.applyScale();
         });
 
-        this.router.events.subscribe((event) => {
+        this.router.events.pipe(takeUntil(this.destroy$)).subscribe((event) => {
             if (event instanceof NavigationEnd) {
                 this.active = false;
             }
@@ -584,6 +587,8 @@ export class AppConfigComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
+        this.destroy$.next(true);
+        this.destroy$.complete();
         if (this.subscription) {
             this.subscription.unsubscribe();
         }

--- a/src/app/showcase/app.main.component.ts
+++ b/src/app/showcase/app.main.component.ts
@@ -2,9 +2,11 @@ import { Component, OnInit } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { AppConfigService } from './service/appconfigservice';
 import { AppConfig } from './domain/appconfig';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject } from 'rxjs';
 import { PrimeNGConfig } from 'primeng/api';
 import { AppComponent } from './app.component';
+
+import { takeUntil } from "rxjs/operators";
 
 declare let gtag: Function;
 
@@ -13,6 +15,7 @@ declare let gtag: Function;
     templateUrl: './app.main.component.html'
 })
 export class AppMainComponent implements OnInit {
+    private destroy$: Subject<any> = new Subject<any>();
     menuActive: boolean;
 
     newsActive: boolean = true;
@@ -34,7 +37,7 @@ export class AppMainComponent implements OnInit {
             this.config = config;
         });
 
-        this.router.events.subscribe((event) => {
+        this.router.events.pipe(takeUntil(this.destroy$)).subscribe((event) => {
             if (event instanceof NavigationEnd) {
                 gtag('config', 'UA-93461466-1', {
                     page_path: '/primeng' + event.urlAfterRedirects
@@ -106,6 +109,8 @@ export class AppMainComponent implements OnInit {
     }
 
     ngOnDestroy() {
+        this.destroy$.next(true);
+        this.destroy$.complete();
         if (this.subscription) {
             this.subscription.unsubscribe();
         }

--- a/src/app/showcase/app.topbar.component.ts
+++ b/src/app/showcase/app.topbar.component.ts
@@ -3,8 +3,10 @@ import { trigger, style, transition, animate, AnimationEvent } from '@angular/an
 import { Router, NavigationEnd } from '@angular/router';
 import { AppConfigService } from './service/appconfigservice';
 import { AppConfig } from './domain/appconfig';
-import { Subscription } from 'rxjs';
+import { Subscription, Subject } from 'rxjs';
 import Versions from './data/versions.json';
+
+import { takeUntil } from "rxjs/operators";
 
 @Component({
     selector: 'app-topbar',
@@ -386,6 +388,7 @@ import Versions from './data/versions.json';
     ]
 })
 export class AppTopBarComponent implements OnInit, OnDestroy {
+    private destroy$: Subject<any> = new Subject<any>();
     @Output() menuButtonClick: EventEmitter<any> = new EventEmitter();
 
     @ViewChild('topbarMenu') topbarMenu: ElementRef;
@@ -462,7 +465,7 @@ export class AppTopBarComponent implements OnInit, OnDestroy {
         this.config = this.configService.config;
         this.subscription = this.configService.configUpdate$.subscribe((config) => (this.config = config));
 
-        this.router.events.subscribe((event) => {
+        this.router.events.pipe(takeUntil(this.destroy$)).subscribe((event) => {
             if (event instanceof NavigationEnd) {
                 this.activeMenuIndex = null;
             }
@@ -544,6 +547,8 @@ export class AppTopBarComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
+        this.destroy$.next(true);
+        this.destroy$.complete();
         if (this.subscription) {
             this.subscription.unsubscribe();
         }

--- a/src/app/showcase/components/dynamicdialog/dynamicdialogdemo.ts
+++ b/src/app/showcase/components/dynamicdialog/dynamicdialogdemo.ts
@@ -5,11 +5,15 @@ import { ProductListDemo } from './productlistdemo';
 import { DynamicDialogRef } from '../../../components/dynamicdialog/dynamicdialog-ref';
 import { Product } from '../../domain/product';
 
+import { takeUntil } from "rxjs/operators";
+import { Subject } from "rxjs";
+
 @Component({
     templateUrl: './dynamicdialogdemo.html',
     providers: [DialogService, MessageService]
 })
 export class DynamicDialogDemo implements OnDestroy {
+    private destroy$: Subject<any> = new Subject<any>();
     constructor(public dialogService: DialogService, public messageService: MessageService) {}
 
     ref: DynamicDialogRef;
@@ -23,18 +27,20 @@ export class DynamicDialogDemo implements OnDestroy {
             maximizable: true
         });
 
-        this.ref.onClose.subscribe((product: Product) => {
+        this.ref.onClose.pipe(takeUntil(this.destroy$)).subscribe((product: Product) => {
             if (product) {
                 this.messageService.add({ severity: 'info', summary: 'Product Selected', detail: product.name });
             }
         });
 
-        this.ref.onMaximize.subscribe((value) => {
+        this.ref.onMaximize.pipe(takeUntil(this.destroy$)).subscribe((value) => {
             this.messageService.add({ severity: 'info', summary: 'Maximized', detail: `maximized: ${value.maximized}` });
         });
     }
 
     ngOnDestroy() {
+        this.destroy$.next(true);
+        this.destroy$.complete();
         if (this.ref) {
             this.ref.close();
         }

--- a/src/app/showcase/components/icons/icons.component.ts
+++ b/src/app/showcase/components/icons/icons.component.ts
@@ -1,11 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 import { IconService } from '../../service/iconservice';
+
+import { takeUntil } from "rxjs/operators";
+import { Subject } from "rxjs";
 
 @Component({
     templateUrl: './icons.component.html',
     styleUrls: ['./icons.component.scss']
 })
-export class IconsComponent implements OnInit {
+export class IconsComponent implements OnInit, OnDestroy {
+    private destroy$: Subject<any> = new Subject<any>();
     icons: any[];
 
     filteredIcons: any[];
@@ -15,7 +19,7 @@ export class IconsComponent implements OnInit {
     constructor(private iconService: IconService) {}
 
     ngOnInit() {
-        this.iconService.getIcons().subscribe((data) => {
+        this.iconService.getIcons().pipe(takeUntil(this.destroy$)).subscribe((data) => {
             data = data.filter((value) => {
                 return value.icon.tags.indexOf('deprecate') === -1;
             });
@@ -42,5 +46,11 @@ export class IconsComponent implements OnInit {
                 return it.icon.tags[0].includes(searchText);
             });
         }
+    }
+
+    @HostListener('unloaded')
+    public ngOnDestroy(): void {
+        this.destroy$.next(true);
+        this.destroy$.complete();
     }
 }


### PR DESCRIPTION
Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications and their libraries. While running the tool and analyzing the code of primeng, we saw that your project does a very good job of ensuring that all async operations are cancelled when components destroy. However, as per Memlab execution results, we found some unsubscribed subscriptions, causing the memory to leak (screenshots below).

[before]
<img width="1037" alt="prime-before Screen Shot 2023-02-12 at 7 26 01 PM" src="https://user-images.githubusercontent.com/56495631/218309708-5e581629-6eef-47f8-ac07-690d5d3c4315.png">

Hence we added the fix by unsubscribing the subscriptions on component unload, and you can see the count of leaks reducing noticeably:
 <br />
<img width="1111" alt="prime-after-subscribe Screen Shot 2023-02-12 at 3 06 46 PM" src="https://user-images.githubusercontent.com/56495631/218309713-d650fe34-13a1-46c1-8836-5d1568c885c0.png">

Note. Host listener is used to ensure that ngOnDestroy is called not only when the class destroy, but also when the page refreshes, tab or browser closes or the user navigates away from the page [1]

We executed the unit test suite after the fixes and it passed TOTAL: 788 successfully (in and outside headless mode). 

You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering maximum count of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[primeeng-scenario-memlab.txt](https://github.com/primefaces/primeng/files/10716015/primeeng-scenario-memlab.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.

References:
[1] https://wesleygrimes.com/angular/2019/03/29/making-upgrades-to-angular-ngondestroy.html