### PR TITLE
Autocomplete: Issue with Virtual Scroll #12568

### DIFF
--- a/src/app/components/scroller/scroller.ts
+++ b/src/app/components/scroller/scroller.ts
@@ -684,8 +684,8 @@ export class Scroller implements OnInit, AfterContentInit, AfterViewChecked, OnD
 
     calculateNumItems() {
         const contentPos = this.getContentPosition();
-        const contentWidth = this.elementViewChild?.nativeElement ? this.elementViewChild.nativeElement.offsetWidth - contentPos.left : 0;
-        const contentHeight = this.elementViewChild?.nativeElement ? this.elementViewChild.nativeElement.offsetHeight - contentPos.top : 0;
+        const contentWidth  = (this.elementViewChild?.nativeElement ? this.elementViewChild.nativeElement.offsetWidth - contentPos.left : 0) || 0;
+        const contentHeight = (this.elementViewChild?.nativeElement ? this.elementViewChild.nativeElement.offsetHeight - contentPos.top : 0) || 0;
         const calculateNumItemsInViewport = (_contentSize, _itemSize) => Math.ceil(_contentSize / (_itemSize || _contentSize));
         const calculateNumToleratedItems = (_numItems) => Math.ceil(_numItems / 2);
         const numItemsInViewport: any = this.both


### PR DESCRIPTION
### Issue
When attempting to retrieve the height and width of our content to calculate the num items, it would sometimes return NaN when the computation failed.

### Solution
To resolve this issue, I added a check to return 0 whenever the result of the computation was invalid number.
