### PR TITLE
Table ctrl meta selection with keydown

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3009,6 +3009,7 @@ export class SelectableRow implements OnInit, OnDestroy {
 
     @HostListener('keydown.enter', ['$event'])
     @HostListener('keydown.shift.enter', ['$event'])
+    @HostListener('keydown.control.enter', ['$event'])
     @HostListener('keydown.meta.enter', ['$event'])
     onEnterKeyDown(event: KeyboardEvent) {
         if (!this.isEnabled()) {


### PR DESCRIPTION
### Defect Fixes
https://github.com/primefaces/primeng/issues/12621 - Component: Table - Multiple Selection with MetaKey does not support CTRL + ENTER

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
