### PR TITLE
Take into account that options can be grouped when validating input.

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -890,7 +890,14 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
             let inputValue = event.target.value.trim();
 
             if (this.suggestions) {
-                for (let suggestion of this.suggestions) {
+                let suggestions = [...this.suggestions];
+                if (this.group) {
+                    let groupedSuggestions = this.suggestions.filter(s => s[this.optionGroupChildren])
+                        .flatMap(s => s[this.optionGroupChildren]);
+                    suggestions = suggestions.concat(groupedSuggestions);
+                }
+
+                for (let suggestion of suggestions) {
                     let itemValue = this.field ? ObjectUtils.resolveFieldData(suggestion, this.field) : suggestion;
                     if (itemValue && inputValue === itemValue.trim()) {
                         valid = true;


### PR DESCRIPTION
### Defect Fixes
This fixes a problem with validation grouped options. AutoComplete.onInputChange now also looks at grouped options when deciding on validity of the selected option.

This fixes https://github.com/primefaces/primeng/issues/12624