### PR TITLE
resolves #12637 -- uses proper group children property in dropdown autoselect

### DIFF
--- a/src/app/components/dropdown/dropdown.spec.ts
+++ b/src/app/components/dropdown/dropdown.spec.ts
@@ -17,6 +17,7 @@ import { OverlayModule } from 'primeng/overlay';
         </p-dropdown>
         <p-dropdown [(ngModel)]="selectedCity"></p-dropdown>
         <button (click)="setValue()"></button>
+        <p-dropdown [(ngModel)]="selectedCity" [options]="groupedCarsAlternate" optionGroupChildren="children" [group]="true"></p-dropdown>
     `
 })
 class TestDropdownComponent {
@@ -52,6 +53,12 @@ class TestDropdownComponent {
         }
     ];
 
+    groupedCarsAlternate = this.groupedCars.map(city => ({
+      label: city.label,
+      value: city.value,
+      children: city.items
+    }));
+
     disabled: boolean;
 
     editable: boolean;
@@ -66,6 +73,7 @@ describe('Dropdown', () => {
     let dropdown: Dropdown;
     let testDropdown: Dropdown;
     let groupDropdown: Dropdown;
+    let alternateGroupDropdown: Dropdown;
     let fixture: ComponentFixture<Dropdown>;
     let groupFixture: ComponentFixture<TestDropdownComponent>;
 
@@ -79,6 +87,7 @@ describe('Dropdown', () => {
         groupFixture = TestBed.createComponent(TestDropdownComponent);
         groupDropdown = groupFixture.debugElement.children[0].componentInstance;
         testDropdown = groupFixture.debugElement.children[1].componentInstance;
+        alternateGroupDropdown = groupFixture.debugElement.children[3].componentInstance;
         dropdown = fixture.componentInstance;
     });
 
@@ -536,6 +545,12 @@ describe('Dropdown', () => {
         inputEl.dispatchEvent(keydownEvent);
 
         expect(groupDropdown.selectedOption.label).toEqual('Mercedes');
+    });
+
+    it('should alternateGroup auto select with alternate children field', () => {
+      groupFixture.detectChanges();
+
+      expect(alternateGroupDropdown.selectedOption.label).toEqual('Audi')
     });
 
     [null, undefined, ''].map((value) =>

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -773,7 +773,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
         if (this.autoDisplayFirst && !this.placeholder && !this.selectedOption && this.optionsToDisplay && this.optionsToDisplay.length && !this.editable) {
             if (this.group) {
-                this.selectedOption = this.optionsToDisplay[0].items[0];
+                this.selectedOption = this.getOptionGroupChildren(this.optionsToDisplay[0])[0];
             } else {
                 this.selectedOption = this.optionsToDisplay[0];
             }


### PR DESCRIPTION
addresses https://github.com/primefaces/primeng/issues/12637
test added to cover this issue, confirmed it fails prior to fix

there may be a remaining bug if the first group does not have any children but it is out of scope for what i wanted to resolve here