### PR TITLE
Hide Blank div if don't have any image

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -63,7 +63,7 @@ import { Subscription } from 'rxjs';
                 <div class="p-fileupload-files" *ngIf="hasFiles()">
                     <div *ngIf="!fileTemplate">
                         <div class="p-fileupload-row" *ngFor="let file of files; let i = index">
-                            <div><img [src]="file.objectURL" *ngIf="isImage(file)" [width]="previewWidth" (error)="imageError($event)" /></div>
+                            <div *ngIf="isImage(file)"><img [src]="file.objectURL" [width]="previewWidth" (error)="imageError($event)" /></div>
                             <div class="p-fileupload-filename">{{ file.name }}</div>
                             <div>{{ formatSize(file.size) }}</div>
                             <div>


### PR DESCRIPTION
### Feature Requests
#### **Fileupload** component hide blank div
As per current implementation, the **FileUpload** module is best for image upload. But if there is a situation where other types of files can be uploaded apart from images, in that case the first column is blank as the file is not an image, which put an extra blank space. I think this needs an update. Please review and merge.