### PR TITLE
Calendar Week Number Fix

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -412,6 +412,8 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
     @Input() showWeek: boolean = false;
 
+    @Input() startWeekFromFirstDayOfYear: boolean = false;
+
     @Input() showClear: boolean = false;
 
     @Input() dataType: string = 'date';
@@ -878,7 +880,12 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
     getWeekNumber(date: Date) {
         let checkDate = new Date(date.getTime());
-        checkDate.setDate(checkDate.getDate() + 4 - (checkDate.getDay() || 7));
+        if (this.startWeekFromFirstDayOfYear) {
+            let firstDayOfWeek: number = +this.getFirstDateOfWeek();
+            checkDate.setDate(checkDate.getDate() + 6 + firstDayOfWeek - checkDate.getDay());
+        } else {
+            checkDate.setDate(checkDate.getDate() + 4 - (checkDate.getDay() || 7));
+        }
         let time = checkDate.getTime();
         checkDate.setMonth(0);
         checkDate.setDate(1);

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -91,7 +91,7 @@
         </div>
 
         <h5>Inline</h5>
-        <p-calendar [(ngModel)]="date14" [inline]="true" [showWeek]="true" [startWeekFromFirstDayOfYear]="true"></p-calendar>
+        <p-calendar [(ngModel)]="date14" [inline]="true" [showWeek]="true"></p-calendar>
     </div>
 
 </div>

--- a/src/app/showcase/components/calendar/calendardemo.html
+++ b/src/app/showcase/components/calendar/calendardemo.html
@@ -91,7 +91,7 @@
         </div>
 
         <h5>Inline</h5>
-        <p-calendar [(ngModel)]="date14" [inline]="true" [showWeek]="true"></p-calendar>
+        <p-calendar [(ngModel)]="date14" [inline]="true" [showWeek]="true" [startWeekFromFirstDayOfYear]="true"></p-calendar>
     </div>
 
 </div>
@@ -362,6 +362,12 @@ export class MyModel &#123;
                             <td>boolean</td>
                             <td>false</td>
                             <td>When enabled, calendar will show week numbers.</td>
+                        </tr>
+                        <tr>
+                            <td>startWeekFromFirstDayOfYear</td>
+                            <td>boolean</td>
+                            <td>false</td>
+                            <td>When enabled, calendar will show week numbers starting from day one of the year instead of week numbers continued from previous year.</td>
                         </tr>
                         <tr>
                             <td>icon</td>


### PR DESCRIPTION
Adds an option to start week number from Day 1 of the year, which fixes the week numbers from January for that year.

Fixes #12711
