### PR TITLE
Fix issue 12713 - Toggleable Panel inside another toggleable panel

### DIFF
--- a/src/app/components/panel/panel.css
+++ b/src/app/components/panel/panel.css
@@ -18,7 +18,7 @@
     position: relative;
 }
 
-.p-panel-toggleable.p-panel-expanded .p-toggleable-content:not(.ng-animating) {
+.p-panel-toggleable.p-panel-expanded > .p-toggleable-content:not(.ng-animating) {
     overflow: visible;
 }
 


### PR DESCRIPTION
Fixes #12713 
When one toggleable panel has another toggleable panel inside, expanding the outer panel SHOULD NOT set the content of the inner panel to be visible when it is collapsed.

### Defect Fixes
#12713 

