### PR TITLE
Update inputnumber.ts

### DIFF
--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -147,7 +147,7 @@ export class InputNumber implements OnInit, ControlValueAccessor {
 
     @Input() maxlength: number;
 
-    @Input() tabindex: string;
+    @Input() tabindex: number;
 
     @Input() title: string;
 


### PR DESCRIPTION
for InputNumber, for tabindex:

PrimeNG documentation (available at https://primeng.org/inputnumber) writes that the tabindex is of type number

opening the source code of inputnumber.d.ts, I see that the type is string

when I use it, the compiler generates the error "Type 'number' is not assignable to type "string" ngtsc(2322)

my code:
<p-inputNumber
[tabindex]="2*i+1"
....
/>

note that the same [tabindex]="2*i+1" works great for other PrimeNG components

My resolution:
edit inputnumber.d.ts, and change the declaration (on line 20 in my version of it) to tabindex: number;

then my code compiles

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
