### PR TITLE
Fixed #12785: Icon constants code block not accurate on new docs

### DIFF
--- a/src/app/showcase/doc/icons/constantsdoc.ts
+++ b/src/app/showcase/doc/icons/constantsdoc.ts
@@ -35,12 +35,6 @@ export class ConstantsDoc {
     }
 
     code: Code = {
-        basic: `
-<p-menu [model]="items"></p-menu>`,
-        html: `
-<div class="card flex justify-content-center">
-    <p-menu [model]="items"></p-menu>
-</div>`,
         typescript: `
 import { Component } from '@angular/core';
 import { PrimeIcons, MenuItem } from 'primeng/api';
@@ -64,6 +58,12 @@ export class PrimeIconsConstantsDemo {
             }
         ];
     }
-}`
+}`,
+        basic: `
+<p-menu [model]="items"></p-menu>`,
+        html: `
+<div class="card flex justify-content-center">
+    <p-menu [model]="items"></p-menu>
+</div>`
     };
 }


### PR DESCRIPTION
### Defect Fixes
fixes #12785 

### Summary

- 🐛 Move typescript block first so that it is the one that is displayed by default.

### Gallery

<img width="1137" alt="Screenshot 2023-03-22 at 11 55 20 AM" src="https://user-images.githubusercontent.com/6710794/226980015-c5324055-6c5f-4769-88c8-418c66aa2fff.png">

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
