### PR TITLE
Fix Issue 12493: Last slot of reorderable table breaks when page is scrolled

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2134,7 +2134,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
     onRowDragOver(event, index, rowElement) {
         if (this.rowDragging && this.draggedRowIndex !== index) {
-            let rowY = DomHandler.getOffset(rowElement).top + DomHandler.getWindowScrollTop();
+            let rowY = DomHandler.getOffset(rowElement).top;
             let pageY = event.pageY;
             let rowMidY = rowY + DomHandler.getOuterHeight(rowElement) / 2;
             let prevRowElement = rowElement.previousElementSibling;


### PR DESCRIPTION
### Defect Fixes

Fixes #12493
Fixes #10003

### Solution

Apparently the `rowY` value was being offset by the window scroll twice:

![image](https://user-images.githubusercontent.com/2349393/229217901-f7e1db22-90ce-45e0-8c72-7ba52bc0ddaa.png)
![image](https://user-images.githubusercontent.com/2349393/229217997-84d8b6ff-d55e-4f4f-954b-9329fba2c32f.png)

Which wouldn't allow the condition `pageY < rowMidY` to be `true`, so no bottom slots would work after a certain scroll amount.

Both sections trace back to the [same commit](https://github.com/primefaces/primeng/commit/94e7c5b3fdf816e3cd4f20afcf36467adb15a6bc).

However, no other occurrence of `getOffset` on the project required an extra `getWindowScrollTop`:
![image](https://user-images.githubusercontent.com/2349393/229218466-adbd3c89-0942-43b9-b044-e6967759e5ab.png)

There were no tests related to this to be updated, but manual tests on the `showcase` indicate the fix works.