### PR TITLE
Fix clear function not resetting all filters

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -52,7 +52,6 @@ export class TableService {
     private valueSource = new Subject<any>();
     private totalRecordsSource = new Subject<any>();
     private columnsSource = new Subject();
-    private resetSource = new Subject();
 
     sortSource$ = this.sortSource.asObservable();
     selectionSource$ = this.selectionSource.asObservable();
@@ -60,7 +59,6 @@ export class TableService {
     valueSource$ = this.valueSource.asObservable();
     totalRecordsSource$ = this.totalRecordsSource.asObservable();
     columnsSource$ = this.columnsSource.asObservable();
-    resetSource$ = this.resetSource.asObservable();
 
     onSort(sortMeta: SortMeta | SortMeta[]) {
         this.sortSource.next(sortMeta);
@@ -68,10 +66,6 @@ export class TableService {
 
     onSelectionChange() {
         this.selectionSource.next(null);
-    }
-
-    onResetChange() {
-        this.resetSource.next(null);
     }
 
     onContextMenu(data: any) {
@@ -1720,12 +1714,9 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         this._multiSortMeta = null;
         this.tableService.onSort(null);
 
-        if (this.filters['global']) {
-            (<FilterMetadata>this.filters['global']).value = null;
-        }
+        this.clearFilterValues();
 
         this.filteredValue = null;
-        this.tableService.onResetChange();
 
         this.first = 0;
         this.firstChange.emit(this.first);
@@ -1734,6 +1725,18 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
             this.onLazyLoad.emit(this.createLazyLoadMetadata());
         } else {
             this.totalRecords = this._value ? this._value.length : 0;
+        }
+    }
+
+    clearFilterValues() {
+        for (const [, filterMetadata] of Object.entries(this.filters)) {
+            if (Array.isArray(filterMetadata)) {
+                for (let filter of filterMetadata) {
+                    filter.value = null;
+                }
+            } else if (filterMetadata) {
+                filterMetadata.value = null;
+            }
         }
     }
 
@@ -4452,10 +4455,6 @@ export class ColumnFilter implements AfterContentInit {
         this.translationSubscription = this.config.translationObserver.subscribe(() => {
             this.generateMatchModeOptions();
             this.generateOperatorOptions();
-        });
-
-        this.resetSubscription = this.dt.tableService.resetSource$.subscribe(() => {
-            this.initFieldFilterConstraint();
         });
 
         this.generateMatchModeOptions();


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/12903

I have implemented that the clear function does now iterates over all filter keys and clears them


