### PR TITLE
Fix DomHandler.relativePosition() to correctly align elements to viewport

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -143,7 +143,7 @@ export class DomHandler {
         if (elementDimensions.width > viewport.width) {
             // element wider then viewport and cannot fit on screen (align at left side of viewport)
             left = (targetOffset.left - relativeElementOffset.left) * -1;
-        } else if (targetOffset.left - relativeElementOffset.left + elementDimensions.width > viewport.width) {
+        } else if (targetOffset.left + elementDimensions.width > viewport.width) {
             // element wider then viewport but can be fit on screen (align at right side of viewport)
             left = (targetOffset.left - relativeElementOffset.left + elementDimensions.width - viewport.width) * -1;
         } else {

--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -145,7 +145,7 @@ export class DomHandler {
             left = (targetOffset.left - relativeElementOffset.left) * -1;
         } else if (targetOffset.left + elementDimensions.width > viewport.width) {
             // element wider then viewport but can be fit on screen (align at right side of viewport)
-            left = (targetOffset.left - relativeElementOffset.left + elementDimensions.width - viewport.width) * -1;
+            left = viewport.width - elementDimensions.width - relativeElementOffset.left;
         } else {
             // element fits on screen (align with target)
             left = targetOffset.left - relativeElementOffset.left;


### PR DESCRIPTION
Fixes #13008 

## Description
A bug was introduced in the commit: https://github.com/primefaces/primeng/commit/7633038b5c1ca76f91bf86ac2c5719b5b28c63d4

And since then (the last 6 months) every new version has carried this bug where the calendar is no longer able to align to fit within the viewport, but rather is allowed to overflow outside of the screen making interacting with it impossible.

## A one-line fix
This is a really simple one-line fix resolving an oversight that should fix the calendar component. This is a bug existing since v14.2.0, and if I may request it, the fix should go into the next patch version of every major version since 14.

Thanks for your review and I hope this can be resolved soon as it is affecting my project and customers.