### PR TITLE
fix(primeng/p-table): the scroller is on initial load undefined when filters are set

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1947,7 +1947,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
     }
 
     public scrollToVirtualIndex(index: number) {
-        this.virtualScroll && this.scroller.scrollToIndex(index);
+        this.scroller && this.scroller.scrollToIndex(index);
     }
 
     public scrollTo(options) {
@@ -2559,24 +2559,24 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         #${this.id}-table > .p-datatable-tfoot > tr > td {
             display: none !important;
         }
-    
+
         #${this.id}-table > .p-datatable-tbody > tr > td {
             display: flex;
             width: 100% !important;
             align-items: center;
             justify-content: space-between;
         }
-    
+
         #${this.id}-table > .p-datatable-tbody > tr > td:not(:last-child) {
             border: 0 none;
         }
-    
+
         #${this.id}.p-datatable-gridlines > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tbody > tr > td:last-child {
             border-top: 0;
             border-right: 0;
             border-left: 0;
         }
-    
+
         #${this.id}-table > .p-datatable-tbody > tr > td > .p-column-title {
             display: block;
         }

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2559,24 +2559,24 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         #${this.id}-table > .p-datatable-tfoot > tr > td {
             display: none !important;
         }
-
+    
         #${this.id}-table > .p-datatable-tbody > tr > td {
             display: flex;
             width: 100% !important;
             align-items: center;
             justify-content: space-between;
         }
-
+    
         #${this.id}-table > .p-datatable-tbody > tr > td:not(:last-child) {
             border: 0 none;
         }
-
+    
         #${this.id}.p-datatable-gridlines > .p-datatable-wrapper > .p-datatable-table > .p-datatable-tbody > tr > td:last-child {
             border-top: 0;
             border-right: 0;
             border-left: 0;
         }
-
+    
         #${this.id}-table > .p-datatable-tbody > tr > td > .p-column-title {
             display: block;
         }


### PR DESCRIPTION
### Defect Fixes

Fixes #12880

The scroller is initialized in the template when `virtualScroll = true`. However, during the initial load, when filters are set and the filter method is called, the scroll moves to the initial position. At the moment, the scroller is not yet created. 
In this line, checking for `scroller != undefined` is equivalent to checking for `virtualScroll != undefined`. 
