### PR TITLE
Fix for confirmPopup setTimeout issues

### DIFF
--- a/src/app/components/confirmpopup/confirmpopup.ts
+++ b/src/app/components/confirmpopup/confirmpopup.ts
@@ -21,8 +21,8 @@ import { DomHandler, ConnectedOverlayScrollHandler } from 'primeng/dom';
             (@animation.done)="onAnimationEnd($event)"
         >
             <div #content class="p-confirm-popup-content">
-                <i [ngClass]="'p-confirm-popup-icon'" [class]="confirmation.icon" *ngIf="confirmation.icon"></i>
-                <span class="p-confirm-popup-message">{{ confirmation.message }}</span>
+                <i [ngClass]="'p-confirm-popup-icon'" [class]="confirmation?.icon" *ngIf="confirmation?.icon"></i>
+                <span class="p-confirm-popup-message">{{ confirmation?.message }}</span>
             </div>
             <div class="p-confirm-popup-footer">
                 <button
@@ -31,11 +31,11 @@ import { DomHandler, ConnectedOverlayScrollHandler } from 'primeng/dom';
                     [label]="rejectButtonLabel"
                     (click)="reject()"
                     [ngClass]="'p-confirm-popup-reject p-button-sm'"
-                    [class]="confirmation.rejectButtonStyleClass || 'p-button-text'"
-                    *ngIf="confirmation.rejectVisible !== false"
+                    [class]="confirmation?.rejectButtonStyleClass || 'p-button-text'"
+                    *ngIf="confirmation?.rejectVisible !== false"
                     [attr.aria-label]="rejectButtonLabel"
                 >
-                    <i [class]="confirmation.rejectIcon" *ngIf="confirmation.rejectIcon; else rejecticon"></i>
+                    <i [class]="confirmation?.rejectIcon" *ngIf="confirmation?.rejectIcon; else rejecticon"></i>
                     <ng-template #rejecticon *ngTemplateOutlet="rejectIconTemplate"></ng-template>
                 </button>
                 <button
@@ -44,11 +44,11 @@ import { DomHandler, ConnectedOverlayScrollHandler } from 'primeng/dom';
                     [label]="acceptButtonLabel"
                     (click)="accept()"
                     [ngClass]="'p-confirm-popup-accept p-button-sm'"
-                    [class]="confirmation.acceptButtonStyleClass"
-                    *ngIf="confirmation.acceptVisible !== false"
+                    [class]="confirmation?.acceptButtonStyleClass"
+                    *ngIf="confirmation?.acceptVisible !== false"
                     [attr.aria-label]="acceptButtonLabel"
                 >
-                    <i [class]="confirmation.acceptIcon" *ngIf="confirmation.acceptIcon; else accepticon"></i>
+                    <i [class]="confirmation?.acceptIcon" *ngIf="confirmation?.acceptIcon; else accepticon"></i>
                     <ng-template #accepticon *ngTemplateOutlet="acceptIconTemplate"></ng-template>
                 </button>
             </div>
@@ -236,7 +236,7 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
     }
 
     accept() {
-        if (this.confirmation.acceptEvent) {
+        if (this.confirmation?.acceptEvent) {
             this.confirmation.acceptEvent.emit();
         }
 
@@ -244,7 +244,7 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
     }
 
     reject() {
-        if (this.confirmation.rejectEvent) {
+        if (this.confirmation?.rejectEvent) {
             this.confirmation.rejectEvent.emit();
         }
 
@@ -283,9 +283,11 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
             const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : this.document;
 
             this.documentClickListener = this.renderer.listen(documentTarget, documentEvent, (event) => {
-                let targetElement = <HTMLElement>this.confirmation.target;
-                if (this.container !== event.target && !this.container.contains(event.target) && targetElement !== event.target && !targetElement.contains(event.target)) {
-                    this.hide();
+                if (this.confirmation) {
+                    let targetElement = <HTMLElement>this.confirmation.target;
+                    if (this.container !== event.target && !this.container.contains(event.target) && targetElement !== event.target && !targetElement.contains(event.target)) {
+                        this.hide();
+                    }
                 }
             });
         }
@@ -319,7 +321,7 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
 
     bindScrollListener() {
         if (!this.scrollHandler) {
-            this.scrollHandler = new ConnectedOverlayScrollHandler(this.confirmation.target, () => {
+            this.scrollHandler = new ConnectedOverlayScrollHandler(this.confirmation?.target, () => {
                 if (this.visible) {
                     this.hide();
                 }
@@ -368,11 +370,11 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
     }
 
     get acceptButtonLabel(): string {
-        return this.confirmation.acceptLabel || this.config.getTranslation(TranslationKeys.ACCEPT);
+        return this.confirmation?.acceptLabel || this.config.getTranslation(TranslationKeys.ACCEPT);
     }
 
     get rejectButtonLabel(): string {
-        return this.confirmation.rejectLabel || this.config.getTranslation(TranslationKeys.REJECT);
+        return this.confirmation?.rejectLabel || this.config.getTranslation(TranslationKeys.REJECT);
     }
 
     ngOnDestroy() {


### PR DESCRIPTION
Fix for errors thrown when the setTimeout queued in bindListeners() ends up running after the popup has been closed, and the confirmation on the confirmpopup component has already been set to null. Added null checks to the confirmation property.

Fixes #13034
