### PR TITLE
docs: Fix emptyFilterMessage repeated in Multiselect

### DIFF
--- a/src/app/showcase/doc/multiselect/propsdoc.ts
+++ b/src/app/showcase/doc/multiselect/propsdoc.ts
@@ -94,7 +94,13 @@ import { Component, Input } from '@angular/core';
                         <td>emptyFilterMessage</td>
                         <td>string</td>
                         <td>No results found</td>
-                        <td>Text to display when filtering does not return any results.</td>
+                        <td>Text to display when filtering does not return any results. Defaults to global value in i18n translation configuration.</td>
+                    </tr>
+                    <tr>
+                        <td>emptyMessage</td>
+                        <td>string</td>
+                        <td>No records found.</td>
+                        <td>Text to display when there is no data. Defaults to global value in i18n translation configuration.</td>
                     </tr>
                     <tr>
                         <td>filter</td>
@@ -221,18 +227,6 @@ import { Component, Input } from '@angular/core';
                         <td>boolean</td>
                         <td>false</td>
                         <td>When present, it specifies that the component cannot be edited.</td>
-                    </tr>
-                    <tr>
-                        <td>emptyMessage</td>
-                        <td>string</td>
-                        <td>No records found.</td>
-                        <td>Text to display when there is no data. Defaults to global value in i18n translation configuration.</td>
-                    </tr>
-                    <tr>
-                        <td>emptyFilterMessage</td>
-                        <td>string</td>
-                        <td>No results found</td>
-                        <td>Text to display when filtering does not return any results. Defaults to global value in i18n translation configuration.</td>
                     </tr>
                     <tr>
                         <td>resetFilterOnHide</td>


### PR DESCRIPTION
- One of the `emptyFilterMessage` was removed. The one that remains is the most updated one.
- `emptyFilterMessage` and `emptyMessage` are alphabetically ordered now.

Resolves #13038