### PR TITLE
Update slider eventsdoc for onSlideEnd event.values

### DIFF
--- a/src/app/showcase/doc/slider/eventsdoc.ts
+++ b/src/app/showcase/doc/slider/eventsdoc.ts
@@ -27,7 +27,8 @@ import { Component, Input } from '@angular/core';
                         <td>onSlideEnd</td>
                         <td>
                             event.originalEvent: Mouseup event<br />
-                            event.value: New value
+                            event.value: New value <br />
+                            event.values: Values in range mode <br />
                         </td>
                         <td>Callback to invoke when slide stops.</td>
                     </tr>


### PR DESCRIPTION
Updates the slider documentation for the _onSlideEnd_ event to include the _values_ property
resolves #13058 