### PR TITLE
docs(primeng/p-speeddial): typos in tooltip and accessibility sections

### DIFF
--- a/src/app/showcase/doc/speeddial/accessibilitydoc.ts
+++ b/src/app/showcase/doc/speeddial/accessibilitydoc.ts
@@ -68,7 +68,7 @@ import { Code } from '../../domain/code';
                         <td>
                             <i>enter</i>
                         </td>
-                        <td>Actives the menuitem, closes the menu and sets focus on the menu button.</td>
+                        <td>Activates the menuitem, closes the menu and sets focus on the menu button.</td>
                     </tr>
                     <tr>
                         <td>

--- a/src/app/showcase/doc/speeddial/tooltipdoc.ts
+++ b/src/app/showcase/doc/speeddial/tooltipdoc.ts
@@ -6,7 +6,7 @@ import { Code } from '../../domain/code';
     selector: 'tooltip-doc',
     template: ` <section>
         <app-docsectiontext [title]="title" [id]="id">
-            <p>Items display a tooltip on hober when a standalone <a href="#" [routerLink]="['/tooltip']">Tooltip</a> is present with a target that matches the items.</p>
+            <p>Items display a tooltip on hover when a standalone <a href="#" [routerLink]="['/tooltip']">Tooltip</a> is present with a target that matches the items.</p>
         </app-docsectiontext>
         <div class="card">
             <div style="height: 350px; position: relative;" class="speeddial-tooltip-demo">


### PR DESCRIPTION
### Typos in p-speeddial documentation

- on hober => on hover
- actives => activates
