### PR TITLE
autofocus by default dynamic dialog

### DIFF
--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -341,10 +341,19 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
     }
 
     focus() {
-        const focusable = DomHandler.getFocusableElements(this.container as HTMLDivElement);
-        if (focusable && focusable.length > 0) {
+        const autoFocusElement = DomHandler.findSingle(this.container, '[autofocus]');
+        if (autoFocusElement) {
             this.zone.runOutsideAngular(() => {
-                setTimeout(() => focusable[0].focus(), 5);
+                setTimeout(() => autoFocusElement.focus(), 5);
+            });
+
+            return;
+        } 
+
+        const focusableElements = DomHandler.getFocusableElements(this.container);
+        if(focusableElements && focusableElements.length > 0) {
+            this.zone.runOutsideAngular(() => {
+                setTimeout(() => focusableElements[0].focus(), 5);
             });
         }
     }


### PR DESCRIPTION
### Defect Fix
This PR is linked to issue #12720. This exists since the fix for #12319, as [autofocus] elements were no longer taken into account; only the first focusable element is considered now.