### PR TITLE
Add aria label on menu

### DIFF
--- a/src/app/components/api/menuitem.ts
+++ b/src/app/components/api/menuitem.ts
@@ -9,6 +9,10 @@ export interface MenuItem {
      */
     label?: string;
     /**
+     * aria-label of the item.
+     */
+    ariaLabel?: string;
+    /**
      * Icon of the item.
      */
     icon?: string;

--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -280,7 +280,7 @@ export class Menu implements OnDestroy {
         private cd: ChangeDetectorRef,
         public config: PrimeNGConfig,
         public overlayService: OverlayService
-    ) { }
+    ) {}
 
     toggle(event: Event) {
         if (this.visible) this.hide();
@@ -495,4 +495,4 @@ export class Menu implements OnDestroy {
     exports: [Menu, RouterModule, TooltipModule],
     declarations: [Menu, MenuItemContent]
 })
-export class MenuModule { }
+export class MenuModule {}

--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -26,6 +26,7 @@ import { VoidListener } from 'primeng/ts-helpers';
             (click)="menu.itemClick($event, item)"
             role="menuitem"
             [target]="item.target"
+            [attr.aria-label]="item.ariaLabel"
         >
             <span class="p-menuitem-icon" *ngIf="item.icon" [ngClass]="item.icon" [class]="item.iconClass" [ngStyle]="item.iconStyle"></span>
             <span class="p-menuitem-text" *ngIf="item.escape !== false; else htmlLabel">{{ item.label }}</span>
@@ -55,6 +56,7 @@ import { VoidListener } from 'primeng/ts-helpers';
             [skipLocationChange]="item.skipLocationChange"
             [replaceUrl]="item.replaceUrl"
             [state]="item.state"
+            [attr.aria-label]="item.ariaLabel"
         >
             <span class="p-menuitem-icon" *ngIf="item.icon" [ngClass]="item.icon"></span>
             <span class="p-menuitem-text" *ngIf="item.escape !== false; else htmlRouteLabel">{{ item.label }}</span>
@@ -278,7 +280,7 @@ export class Menu implements OnDestroy {
         private cd: ChangeDetectorRef,
         public config: PrimeNGConfig,
         public overlayService: OverlayService
-    ) {}
+    ) { }
 
     toggle(event: Event) {
         if (this.visible) this.hide();
@@ -493,4 +495,4 @@ export class Menu implements OnDestroy {
     exports: [Menu, RouterModule, TooltipModule],
     declarations: [Menu, MenuItemContent]
 })
-export class MenuModule {}
+export class MenuModule { }

--- a/src/app/showcase/doc/menu/basicdoc.ts
+++ b/src/app/showcase/doc/menu/basicdoc.ts
@@ -25,11 +25,11 @@ export class BasicDoc implements OnInit {
         this.items = [
             {
                 label: 'New',
-                icon: 'pi pi-fw pi-plus',
+                icon: 'pi pi-fw pi-plus'
             },
             {
                 label: 'Delete',
-                icon: 'pi pi-fw pi-trash',
+                icon: 'pi pi-fw pi-trash'
             }
         ];
     }

--- a/src/app/showcase/doc/menu/basicdoc.ts
+++ b/src/app/showcase/doc/menu/basicdoc.ts
@@ -25,11 +25,11 @@ export class BasicDoc implements OnInit {
         this.items = [
             {
                 label: 'New',
-                icon: 'pi pi-fw pi-plus'
+                icon: 'pi pi-fw pi-plus',
             },
             {
                 label: 'Delete',
-                icon: 'pi pi-fw pi-trash'
+                icon: 'pi pi-fw pi-trash',
             }
         ];
     }

--- a/src/app/showcase/doc/menu/menuitemdoc.ts
+++ b/src/app/showcase/doc/menu/menuitemdoc.ts
@@ -30,6 +30,12 @@ import { Component, Input } from '@angular/core';
                         <td>Text of the item.</td>
                     </tr>
                     <tr>
+                        <td>ariaLabel</td>
+                        <td>string</td>
+                        <td>null</td>
+                        <td>aria-label of the item.</td>
+                    </tr>
+                    <tr>
                         <td>icon</td>
                         <td>string</td>
                         <td>null</td>


### PR DESCRIPTION
This change was implemented to add an optional arial-label on Menu Component Items (for **Accessibility**).

It's neccessary to ensure that elements, labels and names correspond with accessible names like aria-label so that users using dictation software are able to access them.

More info here: https://www.w3.org/WAI/WCAG21/Techniques/failures/F96

The relevant issue is available here: https://github.com/primefaces/primeng/issues/13165
