### PR TITLE
Dropdown Disable Keyboard Selection

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -539,7 +539,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
      */
     @Input() overlayDirection: string = 'end';
 
-    @Input() enableKeyboardSelection: boolean = true;
+    @Input() disableKeyboardSelection: boolean = false;
     /**
      * When present, it specifies that the component should be disabled.
      * @group Props
@@ -1224,7 +1224,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             return;
         }
 
-        if (!this.enableKeyboardSelection) {
+        if (this.disableKeyboardSelection) {
             const printableCharacters = /[a-zA-Z]/;
             if (printableCharacters.test(event.key)) {
                 return;

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -538,6 +538,8 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
      * @group Props
      */
     @Input() overlayDirection: string = 'end';
+
+    @Input() keydownEnable: boolean = true;
     /**
      * When present, it specifies that the component should be disabled.
      * @group Props
@@ -1218,7 +1220,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     onKeydown(event: KeyboardEvent, search: boolean) {
-        if (this.readonly || !this.optionsToDisplay || this.optionsToDisplay.length === null) {
+        if (this.readonly || !this.optionsToDisplay || this.optionsToDisplay.length === null || !this.keydownEnable) {
             return;
         }
 

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -539,7 +539,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
      */
     @Input() overlayDirection: string = 'end';
 
-    @Input() keydownEnable: boolean = true;
+    @Input() enableKeyboardSelection: boolean = true;
     /**
      * When present, it specifies that the component should be disabled.
      * @group Props
@@ -1224,7 +1224,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             return;
         }
 
-        if (!this.keydownEnable) {
+        if (!this.enableKeyboardSelection) {
             const printableCharacters = /[a-zA-Z]/;
             if (printableCharacters.test(event.key)) {
                 return;

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1220,8 +1220,15 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     onKeydown(event: KeyboardEvent, search: boolean) {
-        if (this.readonly || !this.optionsToDisplay || this.optionsToDisplay.length === null || !this.keydownEnable) {
+        if (this.readonly || !this.optionsToDisplay || this.optionsToDisplay.length === null) {
             return;
+        }
+
+        if (!this.keydownEnable) {
+            const printableCharacters = /[a-zA-Z]/;
+            if (printableCharacters.test(event.key)) {
+                return;
+            }
         }
 
         switch (event.which) {


### PR DESCRIPTION
I would like a feature to disable keyboard selection in dropdowns. 

It should be possible to navigate a grid-like form with the keys WASD to go up/down and left/right instead of the classic "Tabbing".

I could use ```event.preventPropagation()```, but isn't a solution for me, since I need the event to bubble.

```event.preventDefault()``` is not working as well.

It is for an software that generates standardized texts dependent on the inputs selected by the user (only checkboxes, dropdowns or sliders, but never free text inputs).

#13166