### PR TITLE
🚀 chore(menu.ts): export SafeHtmlPipe class to be able to use it

### DIFF
--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -32,7 +32,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 @Pipe({
     name: 'safeHtml'
 })
-class SafeHtmlPipe implements PipeTransform {
+export class SafeHtmlPipe implements PipeTransform {
     constructor(@Inject(PLATFORM_ID) private readonly platformId: any, private readonly sanitizer: DomSanitizer) {}
 
     public transform(value: string): SafeHtml {


### PR DESCRIPTION
The SafeHtmlPipe class was not exported, which made it impossible to use it in other components. Exporting the class makes it available for use in other components.

### Issue
https://github.com/primefaces/primeng/issues/13218
