### PR TITLE
🐛 fix(table.ts): fix import path for FilterSlashIcon

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -71,7 +71,7 @@ import {
     TableSelectAllChangeEvent
 } from './table.interface';
 import { Nullable, VoidListener } from 'primeng/ts-helpers';
-import { FilterSlashIcon } from '../icons/filterslash/filterslash';
+import { FilterSlashIcon } from 'primeng/icons/filterslash';
 
 @Injectable()
 export class TableService {


### PR DESCRIPTION
The import path for FilterSlashIcon was incorrect and has been fixed to 'primeng/icons/filterslash'.

### Defect Fixes
File '/home/runner/work/primeng/primeng/src/app/components/icons/filterslash/filterslash.ngtypecheck.ts' is not under 'rootDir' '/home/runner/work/primeng/primeng/src/app/components/table'. 'rootDir' is expected to contain all source files.