### PR TITLE
[#13251] - Fix timeline component, updated docs and examples

### DIFF
--- a/src/app/components/timeline/timeline.css
+++ b/src/app/components/timeline/timeline.css
@@ -5,11 +5,11 @@
 }
 
 .p-timeline-left .p-timeline-event-opposite {
-    text-align: right;
+    text-align: left;
 }
 
 .p-timeline-left .p-timeline-event-content {
-    text-align: left;
+    text-align: right;
 }
 
 .p-timeline-right .p-timeline-event {
@@ -17,11 +17,11 @@
 }
 
 .p-timeline-right .p-timeline-event-opposite {
-    text-align: left;
+    text-align: right;
 }
 
 .p-timeline-right .p-timeline-event-content {
-    text-align: right;
+    text-align: left;
 }
 
 .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(even) {
@@ -29,19 +29,19 @@
 }
 
 .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(odd) .p-timeline-event-opposite {
-    text-align: right;
+    text-align: left;
 }
 
 .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(odd) .p-timeline-event-content {
-    text-align: left;
+    text-align: right;
 }
 
 .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(even) .p-timeline-event-opposite {
-    text-align: left;
+    text-align: right;
 }
 
 .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(even) .p-timeline-event-content {
-    text-align: right;
+    text-align: left;
 }
 
 .p-timeline-event {
@@ -97,7 +97,7 @@
     flex-direction: row;
 }
 
-.p-timeline-horizontal .p-timeline-event-connector  {
+.p-timeline-horizontal .p-timeline-event-connector {
     width: 100%;
 }
 

--- a/src/app/components/timeline/timeline.ts
+++ b/src/app/components/timeline/timeline.ts
@@ -24,8 +24,8 @@ import { Nullable } from 'primeng/ts-helpers';
             }"
         >
             <div *ngFor="let event of value; let last = last" class="p-timeline-event">
-                <div class="p-timeline-event-opposite">
-                    <ng-container *ngTemplateOutlet="oppositeTemplate; context: { $implicit: event }"></ng-container>
+            <div class="p-timeline-event-content">
+                    <ng-container *ngTemplateOutlet="contentTemplate; context: { $implicit: event }"></ng-container>
                 </div>
                 <div class="p-timeline-event-separator">
                     <ng-container *ngIf="markerTemplate; else marker">
@@ -36,8 +36,8 @@ import { Nullable } from 'primeng/ts-helpers';
                     </ng-template>
                     <div *ngIf="!last" class="p-timeline-event-connector"></div>
                 </div>
-                <div class="p-timeline-event-content">
-                    <ng-container *ngTemplateOutlet="contentTemplate; context: { $implicit: event }"></ng-container>
+                <div class="p-timeline-event-opposite">
+                    <ng-container *ngTemplateOutlet="oppositeTemplate; context: { $implicit: event }"></ng-container>
                 </div>
             </div>
         </div>
@@ -66,10 +66,10 @@ export class Timeline implements AfterContentInit, BlockableUI {
      */
     @Input() styleClass: string | undefined;
     /**
-     * Position of the timeline bar relative to the content. Valid values are "left", "right" for vertical layout and "top", "bottom" for horizontal layout.
+     * Position of the timeline bar relative to the content. Valid values are "left", "right", "alternate" for vertical layout and "top", "bottom", "alternate" for horizontal layout.
      * @group Props
      */
-    @Input() align: string = 'left';
+    @Input() align: 'left' | 'right' | 'alternate' | 'top' | 'bottom' = 'left';
     /**
      * Orientation of the timeline.
      * @group Props
@@ -84,7 +84,7 @@ export class Timeline implements AfterContentInit, BlockableUI {
 
     markerTemplate: Nullable<TemplateRef<any>>;
 
-    constructor(private el: ElementRef) {}
+    constructor(private el: ElementRef) { }
 
     getBlockableElement(): HTMLElement {
         return this.el.nativeElement.children[0];
@@ -114,4 +114,4 @@ export class Timeline implements AfterContentInit, BlockableUI {
     exports: [Timeline, SharedModule],
     declarations: [Timeline]
 })
-export class TimelineModule {}
+export class TimelineModule { }

--- a/src/app/showcase/data/news.json
+++ b/src/app/showcase/data/news.json
@@ -1,6 +1,6 @@
 {
     "id": 56,
-    "content": "PrimeNG v16.0.1 is out now!",
+    "content": "PrimeNG v16.0.2 is out now!",
     "linkText": "Learn More",
     "linkHref": "https://www.primefaces.org/store",
     "backgroundStyle": "background-color:#3B82F6",
@@ -8,4 +8,3 @@
     "linkStyle": "color:#ffffff;font-weight:700",
     "linkHoverStyle": "text-decoration: underline"
 }
-

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -21638,7 +21638,7 @@
                             "readonly": false,
                             "type": "string",
                             "default": "left",
-                            "description": "Position of the timeline bar relative to the content. Valid values are \"left\", \"right\" for vertical layout and \"top\", \"bottom\" for horizontal layout."
+                            "description": "Position of the timeline bar relative to the content. Valid values are \"left\", \"right\", \"alternate\" for vertical layout and \"top\", \"bottom\", \"alternate\" for horizontal layout."
                         },
                         {
                             "name": "layout",

--- a/src/app/showcase/doc/timeline/templatedoc.ts
+++ b/src/app/showcase/doc/timeline/templatedoc.ts
@@ -23,7 +23,7 @@ interface EventItem {
                     </span>
                 </ng-template>
                 <ng-template pTemplate="content" let-event>
-                    <p-card [header]="event.status" [subheader]="event.date">
+                    <p-card styleClass="mb-4" [header]="event.status" [subheader]="event.date">
                         <img *ngIf="event.image" [src]="'https://primefaces.org/cdn/primeng/images/demo/product/' + event.image" [alt]="event.name" width="200" class="shadow-2" />
                         <p>
                             Lorem ipsum dolor sit amet, consectetur adipisicing elit. Inventore sed consequuntur error repudiandae numquam deserunt quisquam repellat libero asperiores earum nam nobis, culpa ratione quam perferendis esse, cupiditate
@@ -62,7 +62,7 @@ export class TemplateDoc {
         </span>
     </ng-template>
     <ng-template pTemplate="content" let-event>
-        <p-card [header]="event.status" [subheader]="event.date">
+        <p-card styleClass="mb-4" [header]="event.status" [subheader]="event.date">
             <img *ngIf="event.image" [src]="'https://primefaces.org/cdn/primeng/images/demo/product/' + event.image" [alt]="event.name" width="200" class="shadow-2" />
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipisicing elit. Inventore sed consequuntur error repudiandae numquam deserunt quisquam repellat libero asperiores earum nam nobis, culpa ratione quam perferendis esse, cupiditate
@@ -82,7 +82,7 @@ export class TemplateDoc {
             </span>
         </ng-template>
         <ng-template pTemplate="content" let-event>
-            <p-card [header]="event.status" [subheader]="event.date">
+            <p-card styleClass="mb-4" [header]="event.status" [subheader]="event.date">
                 <img *ngIf="event.image" [src]="'https://primefaces.org/cdn/primeng/images/demo/product/' + event.image" [alt]="event.name" width="200" class="shadow-2" />
                 <p>
                     Lorem ipsum dolor sit amet, consectetur adipisicing elit. Inventore sed consequuntur error repudiandae numquam deserunt quisquam repellat libero asperiores earum nam nobis, culpa ratione quam perferendis esse, cupiditate


### PR DESCRIPTION
Fix the issue: https://github.com/primefaces/primeng/issues/13251

- Fixed `align="left"` and `align="right"` in Timeline component.
- Documentation updated adding the property "alternate".
- Added `margin-bottom` when the cards in the Timeline are `align="left"` and `align="right"`.
