### PR TITLE
fix(dialog): maximizable responsive dialog

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -632,7 +632,7 @@ export class Dialog implements AfterContentInit, OnInit, OnDestroy {
                 for (let breakpoint in this.breakpoints) {
                     innerHTML += `
                         @media screen and (max-width: ${breakpoint}) {
-                            .p-dialog[${this.id}] {
+                            .p-dialog[${this.id}]:not(.p-dialog-maximized) {
                                 width: ${this.breakpoints[breakpoint]} !important;
                             }
                         }


### PR DESCRIPTION
Fixed an issue where dialogs with `breakpoints` set were unable to successfully be maximized using the maximize button when `[maximizable]="true"`.

 #13268 