### PR TITLE
[#13238] Fixed tooltip position and updated documentation

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -20,7 +20,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
      * Position of the tooltip.
      * @group Props
      */
-    @Input() tooltipPosition: 'right' | 'left' | 'top' | 'bottom' | undefined;
+    @Input() tooltipPosition: 'right' | 'left' | 'top' | 'bottom' | string | undefined;
     /**
      * Event to show the tooltip.
      * @group Props
@@ -163,7 +163,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     resizeListener: any;
 
-    constructor(@Inject(PLATFORM_ID) private platformId: any, public el: ElementRef, public zone: NgZone, public config: PrimeNGConfig, private renderer: Renderer2, private changeDetector: ChangeDetectorRef) {}
+    constructor(@Inject(PLATFORM_ID) private platformId: any, public el: ElementRef, public zone: NgZone, public config: PrimeNGConfig, private renderer: Renderer2, private changeDetector: ChangeDetectorRef) { }
 
     ngAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
@@ -687,4 +687,4 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     exports: [Tooltip],
     declarations: [Tooltip]
 })
-export class TooltipModule {}
+export class TooltipModule { }

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -22059,6 +22059,7 @@
                             "optional": false,
                             "readonly": false,
                             "type": "\"left\" | \"top\" | \"bottom\" | \"right\"| string",
+                            "default": "right",
                             "description": "Position of the tooltip."
                         },
                         {

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -22058,14 +22058,14 @@
                             "name": "tooltipPosition",
                             "optional": false,
                             "readonly": false,
-                            "type": "\"left\" | \"top\" | \"bottom\" | \"right\"",
+                            "type": "\"left\" | \"top\" | \"bottom\" | \"right\"| string",
                             "description": "Position of the tooltip."
                         },
                         {
                             "name": "tooltipEvent",
                             "optional": false,
                             "readonly": false,
-                            "type": "any",
+                            "type": "\"hover\" | \"focus\" | string",
                             "default": "hover",
                             "description": "Event to show the tooltip."
                         },


### PR DESCRIPTION
Fixed the issue: https://github.com/primefaces/primeng/issues/13238

- Following the same concept of `tooltipEvent`, I added `string` on `tooltipPosition` and the problem was solved.
- I updated the docs adding the default `right` to `tooltipPosition` and adding the new type `string` too.  
In `tooltipEvent` I added the type (before was indicated like `any`) and I following the same concept as `tooltipPosition` adding `"hover" | "focus" | string`

## SOLUTION
![1](https://github.com/primefaces/primeng/assets/19764334/f0666f6e-30fa-47e9-b7f1-1db8985c6667)

## TESTING (Doesn't show the error anymore)
![2](https://github.com/primefaces/primeng/assets/19764334/6501d233-b8dc-4af3-8d24-d275699a071e)

## TESTING 2
![3](https://github.com/primefaces/primeng/assets/19764334/3d1633ed-f568-4191-9ff5-286575087d01)

## BEFORE UPDATE DOCS
![image](https://github.com/primefaces/primeng/assets/19764334/418e071d-cf79-4bd9-b49d-7dbd64cbf0e5)

## AFTER UPDATE DOCS
![image](https://github.com/primefaces/primeng/assets/19764334/e8a115b4-20e1-4fb9-82cb-fa7db1a990ad)



