### PR TITLE
Fix inplace close icon

### DIFF
--- a/src/app/components/inplace/inplace.ts
+++ b/src/app/components/inplace/inplace.ts
@@ -11,7 +11,7 @@ import { TimesIcon } from 'primeng/icons/times';
         class: 'p-element'
     }
 })
-export class InplaceDisplay {}
+export class InplaceDisplay { }
 
 @Component({
     selector: 'p-inplaceContent',
@@ -20,7 +20,7 @@ export class InplaceDisplay {}
         class: 'p-element'
     }
 })
-export class InplaceContent {}
+export class InplaceContent { }
 /**
  * Inplace provides an easy to do editing and display at the same time where clicking the output displays the actual content.
  * @group Components
@@ -38,8 +38,8 @@ export class InplaceContent {}
                 <ng-container *ngTemplateOutlet="contentTemplate"></ng-container>
 
                 <ng-container *ngIf="closable">
-                    <button *ngIf="icon" type="button" [icon]="icon" pButton (click)="onDeactivateClick($event)"></button>
-                    <button *ngIf="!icon" type="button" pButton [ngClass]="'p-button-icon-only'" (click)="onDeactivateClick($event)">
+                    <button *ngIf="closeIcon" type="button" [icon]="closeIcon" pButton (click)="onDeactivateClick($event)"></button>
+                    <button *ngIf="!closeIcon" type="button" pButton [ngClass]="'p-button-icon-only'" (click)="onDeactivateClick($event)">
                         <TimesIcon *ngIf="!closeIconTemplate" />
                         <ng-template *ngTemplateOutlet="closeIconTemplate"></ng-template>
                     </button>
@@ -113,7 +113,7 @@ export class Inplace implements AfterContentInit {
 
     closeIconTemplate: TemplateRef<any> | undefined;
 
-    constructor(public cd: ChangeDetectorRef) {}
+    constructor(public cd: ChangeDetectorRef) { }
 
     ngAfterContentInit() {
         this.templates?.forEach((item) => {
@@ -179,4 +179,4 @@ export class Inplace implements AfterContentInit {
     exports: [Inplace, InplaceDisplay, InplaceContent, ButtonModule, SharedModule],
     declarations: [Inplace, InplaceDisplay, InplaceContent]
 })
-export class InplaceModule {}
+export class InplaceModule { }

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -11232,7 +11232,6 @@
                             "optional": false,
                             "readonly": false,
                             "type": "boolean",
-                            "default": "false",
                             "description": "Allows to prevent clicking."
                         },
                         {


### PR DESCRIPTION
Fix the issue: https://github.com/primefaces/primeng/issues/13277

I deleted the default value of  `preventClick` following the same concept in the others properties that doesn't have an init value (`style`, `styleClass`, `closeIcon`).

## BEFORE INPLACE
![before inplace](https://github.com/primefaces/primeng/assets/19764334/1d5da78e-ba27-4dde-b508-c4a27efaf52d)

# AFTER
![after inplace](https://github.com/primefaces/primeng/assets/19764334/2399eee1-b9d9-4c9d-af3a-c6b2cc898747)


## BEFORE / AFTER DOCS
![image](https://github.com/primefaces/primeng/assets/19764334/62f350be-2b49-4df4-810c-156c5f306a14)
