### PR TITLE
Fix #13323 - Splitter: added min-width: 0 to nested panels

### DIFF
--- a/src/app/components/splitter/splitter.css
+++ b/src/app/components/splitter/splitter.css
@@ -13,6 +13,7 @@
 
 .p-splitter-panel-nested {
     display: flex;
+    min-width: 0;
 }
 
 .p-splitter-panel p-splitter {


### PR DESCRIPTION
### Defect Fixes
Fixes: https://github.com/primefaces/primeng/issues/13323

More info about flex-basis and min-width: https://stackoverflow.com/questions/49747825/flex-basis-behavior-not-as-expected-but-max-width-works