### PR TITLE
[13306] - Added .p-fileupload-highlight class

### DIFF
--- a/src/app/components/fileupload/fileupload.css
+++ b/src/app/components/fileupload/fileupload.css
@@ -23,16 +23,23 @@
     left: 0;
 }
 
+.p-fileupload-content.p-fileupload-highlight {
+    border-color: var(--primary-color);
+    border-width: 2px;
+    border-style: dashed;
+    background-color: var(--primary-100);
+}
+
 .p-button.p-fileupload-choose {
     position: relative;
     overflow: hidden;
 }
 
-.p-button.p-fileupload-choose input[type=file] {
+.p-button.p-fileupload-choose input[type='file'] {
     display: none;
 }
 
-.p-fileupload-choose.p-fileupload-choose-selected input[type=file] {
+.p-fileupload-choose.p-fileupload-choose-selected input[type='file'] {
     display: none;
 }
 


### PR DESCRIPTION
Fix #13306 

Added .p-fileupload-highlight class following the same solution suggested in PrimeReact https://github.com/primefaces/primereact/pull/4646 and PrimeVUE https://github.com/primefaces/primevue/pull/4130 for the same problem.

## BEFORE
when I'm trying to drag over my file in the component (nothing was happening)

![problem fileupload](https://github.com/primefaces/primeng/assets/19764334/85430299-7f81-4171-8533-6bc3c48bca08)

## AFTER
![fixed fileupload](https://github.com/primefaces/primeng/assets/19764334/a77161de-e688-40cc-b0c9-9d0555c19f67)
