### PR TITLE
[13322] - Fixed OrderList component (multiple selection and metakey)

### DIFF
--- a/src/app/components/orderlist/orderlist.ts
+++ b/src/app/components/orderlist/orderlist.ts
@@ -309,7 +309,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
 
     public _value: any[] | undefined;
 
-    constructor(@Inject(DOCUMENT) private document: Document, @Inject(PLATFORM_ID) private platformId: any, private renderer: Renderer2, public el: ElementRef, public cd: ChangeDetectorRef, public filterService: FilterService) {}
+    constructor(@Inject(DOCUMENT) private document: Document, @Inject(PLATFORM_ID) private platformId: any, private renderer: Renderer2, public el: ElementRef, public cd: ChangeDetectorRef, public filterService: FilterService) { }
 
     ngOnInit() {
         if (this.responsive) {
@@ -393,25 +393,19 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     onItemClick(event: Event, item: any, index: number) {
         this.itemTouched = false;
         let selectedIndex = ObjectUtils.findIndexInList(item, this.selection);
-        let selected = selectedIndex != -1;
+        let selected = selectedIndex !== -1;
         let metaSelection = this.itemTouched ? false : this.metaKeySelection;
 
-        if (metaSelection && event instanceof KeyboardEvent) {
+        if (metaSelection && event instanceof MouseEvent) {
             let metaKey = event.metaKey || event.ctrlKey || event.shiftKey;
 
             if (selected && metaKey) {
-                this._selection = this._selection.filter((val, index) => index !== selectedIndex);
+                this._selection = this._selection.filter((val) => val !== item);
             } else {
-                this._selection = metaKey ? (this._selection ? [...this._selection] : []) : [];
-                ObjectUtils.insertIntoOrderedArray(item, index, this._selection, this.value as any[]);
+                this._selection = metaKey ? [...this._selection, item] : [item];
             }
         } else {
-            if (selected) {
-                this._selection = this._selection.filter((val, index) => index !== selectedIndex);
-            } else {
-                this._selection = this._selection ? [...this._selection] : [];
-                ObjectUtils.insertIntoOrderedArray(item, index, this._selection, this.value as any[]);
-            }
+            this._selection = [item];
         }
 
         //binding
@@ -462,7 +456,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     }
 
     isSelected(item: any) {
-        return ObjectUtils.findIndexInList(item, this.selection) != -1;
+        return ObjectUtils.findIndexInList(item, this.selection) !== -1;
     }
 
     isEmpty() {
@@ -682,4 +676,4 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     exports: [OrderList, SharedModule, DragDropModule],
     declarations: [OrderList]
 })
-export class OrderListModule {}
+export class OrderListModule { }


### PR DESCRIPTION
Fix #13322.

Fixed functions itemClick and isSelected. 
-  If **metaKeySelection** is set to **true**, the user can click on a row, and while holding down the meta key (e.g., Ctrl, Cmd, or Meta), they can continue clicking on other rows to select multiple rows simultaneously.
- If **metaKeySelection** is set to **false**, the user can only select one row at a time. Clicking on a new row will deselect the previously selected row.
    
## PROBLEM

(By default and adding **metaKeySelection="true"** or **metaKeySelection="false"** the behaviour was select multiple rows)

![problem orderlist](https://github.com/primefaces/primeng/assets/19764334/5e3e53ed-f3ba-46e9-9a55-78ade1acf753)

## SOLUTION 1 (Using **metaKeySelection="false"**)

![fixed orderlist](https://github.com/primefaces/primeng/assets/19764334/31fb0f75-332d-4225-9be5-3df129fd5503)

## SOLUTION 2 (Using **metaKeySelection="true"** and **pressing my metakey**)

![fixed orderlist2](https://github.com/primefaces/primeng/assets/19764334/2af37b17-b400-4b4a-8790-74f41a82c65d)