### PR TITLE
Button Docs Update: <p-button> examples should use onClick instead of click

### DIFF
--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -112,7 +112,7 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
         </defs>
     </svg>`;
 
-    constructor(public el: ElementRef, @Inject(DOCUMENT) private document: Document) {}
+    constructor(public el: ElementRef, @Inject(DOCUMENT) private document: Document) { }
 
     ngAfterViewInit() {
         DomHandler.addMultipleClasses(this.htmlElement, this.getStyleClass().join(' '));
@@ -329,19 +329,22 @@ export class Button implements AfterContentInit {
      */
     @Input() ariaLabel: string | undefined;
     /**
-     * Callback to execute when button is clicked.
+     * Callback to execute when button is clicked. 
+     * This event is intended to be used with the <p-button> component. Using a regular <button> element, use (click).
      * @param {MouseEvent} event - Mouse event.
      * @group Emits
      */
     @Output() onClick: EventEmitter<MouseEvent> = new EventEmitter();
     /**
      * Callback to execute when button is focused.
+     * This event is intended to be used with the <p-button> component. Using a regular <button> element, use (focus).
      * @param {FocusEvent} event - Focus event.
      * @group Emits
      */
     @Output() onFocus: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
     /**
      * Callback to execute when button loses focus.
+     * This event is intended to be used with the <p-button> component. Using a regular <button> element, use (blur).
      * @param {FocusEvent} event - Focus event.
      * @group Emits
      */
@@ -417,4 +420,4 @@ export class Button implements AfterContentInit {
     exports: [ButtonDirective, Button, SharedModule],
     declarations: [ButtonDirective, Button]
 })
-export class ButtonModule {}
+export class ButtonModule { }

--- a/src/app/showcase/doc/button/loadingdoc.ts
+++ b/src/app/showcase/doc/button/loadingdoc.ts
@@ -8,9 +8,9 @@ import { Code } from '../../domain/code';
             <p>Busy state is controlled with the <i>loading</i> property.</p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">
-            <p-button label="Submit" [loading]="loading" (click)="load()"></p-button>
+            <p-button label="Submit" [loading]="loading" (onClick)="load()"></p-button>
 
-            <p-button label="Loading custom icon" [loading]="loading" loadingIcon="pi pi-bell" (click)="load()"></p-button>
+            <p-button label="Loading custom icon" [loading]="loading" loadingIcon="pi pi-bell" (onClick)="load()"></p-button>
         </div>
         <app-code [code]="code" selector="button-loading-demo"></app-code>
     </section>`
@@ -22,7 +22,7 @@ export class LoadingDoc {
 
     loading: boolean = false;
 
-    constructor(private readonly cdr: ChangeDetectorRef) {}
+    constructor(private readonly cdr: ChangeDetectorRef) { }
 
     load() {
         this.loading = true;
@@ -35,13 +35,13 @@ export class LoadingDoc {
 
     code: Code = {
         basic: `
-<p-button label="Submit" [loading]="loading" (click)="load()"></p-button>
-<p-button label="Loading custom icon" [loading]="loading" loadingIcon="pi pi-bell" (click)="load()"></p-button>`,
+<p-button label="Submit" [loading]="loading" (onClick)="load()"></p-button>
+<p-button label="Loading custom icon" [loading]="loading" loadingIcon="pi pi-bell" (onClick)="load()"></p-button>`,
 
         html: `
 <div class="card flex justify-content-center">
-    <p-button label="Submit" [loading]="loading" (click)="load()"></p-button>
-    <p-button label="Loading custom icon" [loading]="loading" loadingIcon="pi pi-bell" (click)="load()"></p-button>
+    <p-button label="Submit" [loading]="loading" (onClick)="load()"></p-button>
+    <p-button label="Loading custom icon" [loading]="loading" loadingIcon="pi pi-bell" (onClick)="load()"></p-button>
 </div>`,
 
         typescript: `


### PR DESCRIPTION
Fix [#13342 ](https://github.com/primefaces/primeng/issues/13342).

Fixed documentation for `<p-button>` examples, replacing `click` with `onClick`. Also, added comments in the Button API.
For example: If you use `<p-button>` with `(click)` with the property disabled, the click is triggered. And for that is better specify in the docs the correct use.

![image](https://github.com/primefaces/primeng/assets/19764334/d73efffe-8817-469e-be32-df914c12878e)



