### PR TITLE
fix(multiselect): typo in the templating demo 

### DIFF
--- a/src/app/showcase/doc/multiselect/templatedoc.ts
+++ b/src/app/showcase/doc/multiselect/templatedoc.ts
@@ -15,11 +15,11 @@ interface Country {
         <div class="card flex justify-content-center">
             <p-multiSelect [options]="countries" [(ngModel)]="selectedCountries" defaultLabel="Select a Country" optionLabel="name">
                 <ng-template let-value pTemplate="selectedItems">
-                    <div class="flex align-items-center gap-2" *ngFor="let option of selectedCountries1">
+                    <div class="flex align-items-center gap-2" *ngFor="let option of selectedCountries">
                         <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + option.code.toLowerCase()" style="width: 18px" />
                         <div>{{ option.name }}</div>
                     </div>
-                    <div *ngIf="!selectedCountries1 || selectedCountries1.length === 0">Select Countries</div>
+                    <div *ngIf="!selectedCountries || selectedCountries.length === 0">Select Countries</div>
                 </ng-template>
                 <ng-template let-country pTemplate="item">
                     <div class="flex align-items-center gap-2">
@@ -60,11 +60,11 @@ export class TemplateDoc implements OnInit {
         basic: `
 <p-multiSelect [options]="countries" [(ngModel)]="selectedCountries" defaultLabel="Select a Country" optionLabel="name" >
         <ng-template let-value pTemplate="selectedItems">
-            <div class="flex align-items-center gap-2" *ngFor="let option of selectedCountries1">
+            <div class="flex align-items-center gap-2" *ngFor="let option of selectedCountries">
                 <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + option.code.toLowerCase()" style="width: 18px"/>
                 <div>{{ option.name }}</div>
             </div>
-            <div *ngIf="!selectedCountries1 || selectedCountries1.length === 0">Select Countries</div>
+            <div *ngIf="!selectedCountries || selectedCountries.length === 0">Select Countries</div>
         </ng-template>
         <ng-template let-country pTemplate="item">
             <div class="flex align-items-center gap-2">
@@ -78,11 +78,11 @@ export class TemplateDoc implements OnInit {
 <div class="card flex justify-content-center">
     <p-multiSelect [options]="countries" [(ngModel)]="selectedCountries" defaultLabel="Select a Country" optionLabel="name" >
         <ng-template let-value pTemplate="selectedItems">
-            <div class="flex align-items-center gap-2" *ngFor="let option of selectedCountries1">
+            <div class="flex align-items-center gap-2" *ngFor="let option of selectedCountries">
                 <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + option.code.toLowerCase()" style="width: 18px"/>
                 <div>{{ option.name }}</div>
             </div>
-            <div *ngIf="!selectedCountries1 || selectedCountries1.length === 0">Select Countries</div>
+            <div *ngIf="!selectedCountries || selectedCountries.length === 0">Select Countries</div>
         </ng-template>
         <ng-template let-country pTemplate="item">
             <div class="flex align-items-center gap-2">


### PR DESCRIPTION
Fix #13356


Fix MultiSelect Template example

```
<p-multiSelect [options]="countries" [(ngModel)]="selectedCountries" defaultLabel="Select a Country" optionLabel="name" >
        <ng-template let-value pTemplate="selectedItems">
            <div class="flex align-items-center gap-2" *ngFor="let option of selectedCountries1">
                <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + option.code.toLowerCase()" style="width: 18px"/>
                <div>{{ option.name }}</div>
            </div>
            <div *ngIf="!selectedCountries1 || selectedCountries1.length === 0">Select Countries</div>
        </ng-template>
        <ng-template let-country pTemplate="item">
            <div class="flex align-items-center gap-2">
                <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + country.code.toLowerCase()" style="width: 18px"/>
                <div>{{ country.name }}</div>
            </div>
        </ng-template>
</p-multiSelect>
```

Change `selectedCountries1` -> `selectedCountries`
