### PR TITLE
SplitButton menu options not working correctly in v16.1.0

### DIFF
--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -951,6 +951,7 @@ export class TieredMenu implements OnInit, AfterContentInit, OnDestroy {
             this.visible = true;
             this.target = this.target || event.currentTarget;
             this.relatedTarget = event.relatedTarget || null;
+            this.relativeAlign = event?.relativeAlign || null;
         }
 
         this.focusedItemInfo.set({ index: this.findFirstFocusedItemIndex(), level: 0, parentKey: '' });


### PR DESCRIPTION
Fix #13389 SplitButton menu options not working correctly in v16.1.0

Fix: The position was getting set as 'absolute' as the 'relativeAlign' was null.


https://www.youtube.com/watch?v=56PQLJgv9-s