### PR TITLE
[#13368] Fixed OrganizationChart is not refreshing

### DIFF
--- a/src/app/components/organizationchart/organizationchart.ts
+++ b/src/app/components/organizationchart/organizationchart.ts
@@ -64,7 +64,7 @@ import { Nullable } from 'primeng/ts-helpers';
     `,
     animations: [trigger('childState', [state('in', style({ opacity: 1 })), transition('void => *', [style({ opacity: 0 }), animate(150)]), transition('* => void', [animate(150, style({ opacity: 0 }))])])],
     encapsulation: ViewEncapsulation.None,
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.Default,
     styleUrls: ['./organizationchart.css'],
     host: {
         class: 'p-element'
@@ -133,7 +133,7 @@ export class OrganizationChartNode implements OnDestroy {
             <table class="p-organizationchart-table" pOrganizationChartNode [node]="root" *ngIf="root"></table>
         </div>
     `,
-    changeDetection: ChangeDetectionStrategy.OnPush,
+    changeDetection: ChangeDetectionStrategy.Default,
     host: {
         class: 'p-element'
     }
@@ -221,7 +221,7 @@ export class OrganizationChart implements AfterContentInit {
 
     selectionSource$ = this.selectionSource.asObservable();
 
-    constructor(public el: ElementRef, public cd: ChangeDetectorRef) {}
+    constructor(public el: ElementRef, public cd: ChangeDetectorRef) { }
 
     get root(): TreeNode<any> | null {
         return this.value && this.value.length ? this.value[0] : null;
@@ -313,4 +313,4 @@ export class OrganizationChart implements AfterContentInit {
     exports: [OrganizationChart, SharedModule],
     declarations: [OrganizationChart, OrganizationChartNode]
 })
-export class OrganizationChartModule {}
+export class OrganizationChartModule { }


### PR DESCRIPTION
Fix #13368

Changed the changeDetector to `Default`.

## CURRENTLY
![problem organization chart](https://github.com/primefaces/primeng/assets/19764334/dbc8a4d9-5082-4351-9adf-d57a57c72b95)

## SOLUTION
![fixed organization chart](https://github.com/primefaces/primeng/assets/19764334/a18711fa-300d-403e-8a63-c4174ff2aad8)

