### PR TITLE
Multiselect item select with arrow keys @filter

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -240,6 +240,7 @@ export class MultiSelectItem {
                                         role="textbox"
                                         [value]="filterValue || ''"
                                         (input)="onFilterInputChange($event)"
+                                        (keydown.arrowdown)="onFilterArrowDown($event)"
                                         class="p-multiselect-filter p-inputtext p-component"
                                         [disabled]="disabled"
                                         [attr.placeholder]="filterPlaceHolder"
@@ -1206,6 +1207,17 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         event.stopPropagation();
     }
 
+    onFilterArrowDown(event: KeyboardEvent) {
+        if (this.itemsViewChild.nativeElement.children) {
+            // jump to options with arrowDown from filterInput
+            var nextItem = this.findNextItem({ nextElementSibling: this.itemsViewChild.nativeElement.children[0] });
+            if (nextItem) {
+                nextItem.focus();
+                event.preventDefault();
+            }
+        }
+    }
+
     onMouseclick(event: MouseEvent, input: HTMLInputElement) {
         if (this.disabled || this.readonly || (<Node>event.target).isSameNode(this.accessibleViewChild?.nativeElement)) {
             return;
@@ -1269,6 +1281,9 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
                 var prevItem = this.findPrevItem((event.originalEvent.target as any).parentElement);
                 if (prevItem) {
                     prevItem.focus();
+                } else if (this.filterInputChild && this.filterInputChild.nativeElement) {
+                    // jump to filterInput with arrowUp from options[0]
+                    this.filterInputChild.nativeElement.focus();
                 }
 
                 event.originalEvent.preventDefault();

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1208,9 +1208,9 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     }
 
     onFilterArrowDown(event: KeyboardEvent) {
-        if (this.itemsViewChild.nativeElement.children) {
+        if (this.itemsViewChild?.nativeElement && this.itemsViewChild.nativeElement.children) {
             // jump to options with arrowDown from filterInput
-            var nextItem = this.findNextItem({ nextElementSibling: this.itemsViewChild.nativeElement.children[0] });
+            let nextItem = this.findNextItem({ nextElementSibling: this.itemsViewChild.nativeElement.children[0] });
             if (nextItem) {
                 nextItem.focus();
                 event.preventDefault();
@@ -1268,7 +1268,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         switch ((<KeyboardEvent>event.originalEvent).which) {
             //down
             case 40:
-                var nextItem = this.findNextItem((event.originalEvent.target as any).parentElement);
+                let nextItem = this.findNextItem((event.originalEvent.target as any).parentElement);
                 if (nextItem) {
                     nextItem.focus();
                 }
@@ -1278,7 +1278,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
 
             //up
             case 38:
-                var prevItem = this.findPrevItem((event.originalEvent.target as any).parentElement);
+                let prevItem = this.findPrevItem((event.originalEvent.target as any).parentElement);
                 if (prevItem) {
                     prevItem.focus();
                 } else if (this.filterInputChild && this.filterInputChild.nativeElement) {


### PR DESCRIPTION
### Feature Requests
It shoud be possible to select the items in the multiselect component, without using mouse

Added - arrowDown to filterInput to focus options
Changed - arrowUp to onOptionKeydown to focus filterInput if already at 0
Changed - 2 var usages to let

<img width="290" alt="image" src="https://github.com/primefaces/primeng/assets/1029173/26d4ee39-1646-4462-831e-db7841055b1c">

previously submitted at #12723 