### PR TITLE
fixed test failure "Expected '133px' to be greater than '37px'"

### DIFF
--- a/src/app/components/inputtextarea/inputtextarea.spec.ts
+++ b/src/app/components/inputtextarea/inputtextarea.spec.ts
@@ -52,12 +52,12 @@ describe('InputTextarea', () => {
         fixture.detectChanges();
 
         const inputTextEl = fixture.debugElement.query(By.css('textarea'));
-        let cachedHeight = inputTextEl.nativeElement.style.height;
+        let cachedHeight = parseInt(inputTextEl.nativeElement.style.height);
         inputTextEl.nativeElement.value = 'primeng';
         inputTextEl.nativeElement.dispatchEvent(new Event('input'));
         fixture.detectChanges();
 
-        expect(inputTextEl.nativeElement.style.height).toBeGreaterThan(cachedHeight);
+        expect(parseInt(inputTextEl.nativeElement.style.height)).toBeGreaterThan(cachedHeight);
         expect(inputTextEl.nativeElement.style.overflow).toEqual('hidden');
     });
 


### PR DESCRIPTION
This is a very quick fix for a broken test. I did not check whether this pattern is used in other tests because this is the only test that fails for me.
