### PR TITLE
[#13433] - Fixed double tap to open submenu in tieredmenu component

### DIFF
--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -221,7 +221,7 @@ export class TieredMenuSub {
 
     @ViewChild('sublist', { static: true }) sublistViewChild: ElementRef;
 
-    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, public tieredMenu: TieredMenu) {}
+    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, public tieredMenu: TieredMenu) { }
 
     positionSubmenu() {
         let sublist = this.sublistViewChild && this.sublistViewChild.nativeElement;
@@ -631,26 +631,14 @@ export class TieredMenu implements OnInit, AfterContentInit, OnDestroy {
         const { originalEvent, processedItem } = event;
         const grouped = this.isProcessedItemGroup(processedItem);
         const root = ObjectUtils.isEmpty(processedItem.parent);
-        const selected = this.isSelected(processedItem);
 
-        if (selected) {
-            const { index, key, level, parentKey } = processedItem;
+        this.hide(originalEvent, true);
 
-            this.activeItemPath.set(this.activeItemPath().filter((p) => key !== p.key && key.startsWith(p.key)));
-            this.focusedItemInfo.set({ index, level, parentKey });
-
-            this.dirty = !root;
-            DomHandler.focus(this.rootmenu.sublistViewChild.nativeElement);
+        if (grouped) {
+            this.onItemChange(event);
         } else {
-            if (grouped) {
-                this.onItemChange(event);
-            } else {
-                const rootProcessedItem = root ? processedItem : this.activeItemPath().find((p) => p.parentKey === '');
-                this.hide(originalEvent);
-                this.changeFocusedItemIndex(originalEvent, rootProcessedItem ? rootProcessedItem.index : -1);
-
-                DomHandler.focus(this.rootmenu.sublistViewChild.nativeElement);
-            }
+            const rootProcessedItem = root ? processedItem : this.activeItemPath().find((p) => p.parentKey === '');
+            this.changeFocusedItemIndex(originalEvent, rootProcessedItem ? rootProcessedItem.index : -1);
         }
     }
 
@@ -1143,4 +1131,4 @@ export class TieredMenu implements OnInit, AfterContentInit, OnDestroy {
     exports: [TieredMenu, RouterModule, TooltipModule, SharedModule],
     declarations: [TieredMenu, TieredMenuSub]
 })
-export class TieredMenuModule {}
+export class TieredMenuModule { }


### PR DESCRIPTION
Fix #13433

## PROBLEM
### The issue was that tapping on a menu item required two taps to open the corresponding submenu on mobile (first tap was doing focus and second was opening the menu)

![tieredmenu problem](https://github.com/primefaces/primeng/assets/19764334/8587194e-8565-457e-89df-cec03a1d8112)

## SOLVED
![tieredmenu fixed](https://github.com/primefaces/primeng/assets/19764334/31f91833-f417-4b87-b73e-0b411e62b807)
