### PR TITLE
Fixed #13455 - TieredMenu does not show sub menus when mouse is hovered over the parent menu item

### DIFF
--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -639,7 +639,7 @@ export class TieredMenu implements OnInit, AfterContentInit, OnDestroy {
             this.activeItemPath.set(this.activeItemPath().filter((p) => key !== p.key && key.startsWith(p.key)));
             this.focusedItemInfo.set({ index, level, parentKey });
 
-            this.dirty = !root;
+            this.dirty = true;
             DomHandler.focus(this.rootmenu.sublistViewChild.nativeElement);
         } else {
             if (grouped) {
@@ -960,6 +960,7 @@ export class TieredMenu implements OnInit, AfterContentInit, OnDestroy {
             isFocus && DomHandler.focus(this.rootmenu.sublistViewChild.nativeElement);
         }
         this.cd.markForCheck();
+        this.dirty = true;
     }
 
     searchItems(event: any, char: string) {


### PR DESCRIPTION
Fixes: https://github.com/primefaces/primeng/issues/13455

To fix the problem the `isDirty` flag needs to be set to `true` when the popup is shown or an item is clicked. 
This will ensure that `onItemChange(..)` is called when a `MenuItem` is hovered by the mouse, which will mark the `MenuItem` as active and therefore uncover the sub `MenuItem`s (children).