### PR TITLE
Dropdown escape key event default prevented

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1316,6 +1316,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             case 27:
             case 9:
                 this.hide();
+                event.preventDefault();
                 break;
 
             //search item based on keyboard input


### PR DESCRIPTION
When closing the dropdown overlay via 'Escape' key the event should also be default prevented to give parent elements a chance to detect that the event was already processed

### Defect Fixes
Fixes #13463
