### PR TITLE
OverlayPanel: Fixed does not hide after scrolling

### DIFF
--- a/src/app/components/overlaypanel/overlaypanel.ts
+++ b/src/app/components/overlaypanel/overlaypanel.ts
@@ -200,7 +200,7 @@ export class OverlayPanel implements AfterContentInit, OnDestroy {
         private zone: NgZone,
         public config: PrimeNGConfig,
         public overlayService: OverlayService
-    ) {}
+    ) { }
 
     ngAfterContentInit() {
         this.templates?.forEach((item) => {
@@ -225,20 +225,17 @@ export class OverlayPanel implements AfterContentInit, OnDestroy {
     bindDocumentClickListener() {
         if (isPlatformBrowser(this.platformId)) {
             if (!this.documentClickListener && this.dismissable) {
-                this.zone.runOutsideAngular(() => {
-                    let documentEvent = DomHandler.isIOS() ? 'touchstart' : 'click';
-                    const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : this.document;
+                let documentEvent = DomHandler.isIOS() ? 'touchstart' : 'click';
+                const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : this.document;
 
-                    this.documentClickListener = this.renderer.listen(documentTarget, documentEvent, (event) => {
-                        if (!this.container?.contains(event.target) && this.target !== event.target && !this.target.contains(event.target) && !this.selfClick) {
-                            this.zone.run(() => {
-                                this.hide();
-                            });
-                        }
+                this.documentClickListener = this.renderer.listen(documentTarget, documentEvent, (event) => {
+                    if (!this.container?.contains(event.target) && !this.target.contains(event.target)) {
+                        this.zone.run(() => {
+                            this.hide();
+                        });
+                    }
 
-                        this.selfClick = false;
-                        this.cd.markForCheck();
-                    });
+                    this.cd.markForCheck();
                 });
             }
         }
@@ -511,4 +508,4 @@ export class OverlayPanel implements AfterContentInit, OnDestroy {
     exports: [OverlayPanel, SharedModule],
     declarations: [OverlayPanel]
 })
-export class OverlayPanelModule {}
+export class OverlayPanelModule { }


### PR DESCRIPTION
Fix #13462 

## Problem
https://stackblitz.com/edit/ppug2d?file=src%2Fapp%2Fdemo%2Foverlay-panel-template-demo.html

#### If you do scroll clicking the scrollbar inside the overlay panel and then you try to click outside, the overlay panel doesn't close. The menu closes after 2 clicks. (The .GIF doesn't help here, but I'm doing two click outside to close)

![overlay panel problem](https://github.com/primefaces/primeng/assets/19764334/9944af9e-e3c8-4b31-9b61-8a6dd7518745)

## Solved
#### After do scroll clicking the scrollbar inside the overlay menu, the overlay panel closes after 1 click.
(The .GIF doesn't help here, but I'm doing one click outside to close)

![overlay panel fixed](https://github.com/primefaces/primeng/assets/19764334/cb459962-b149-4ce4-ae50-00f88e731416)
