### PR TITLE
🐛 Fix: Resolves TypeError by renaming onKeyDown function to match its definition

### DIFF
--- a/src/app/components/sidebar/sidebar.ts
+++ b/src/app/components/sidebar/sidebar.ts
@@ -279,7 +279,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
         });
     }
 
-    onKeydown(event: KeyboardEvent) {
+    onKeyDown(event: KeyboardEvent) {
         if (event.code === 'Escape') {
             this.hide();
         }


### PR DESCRIPTION
### Description
This commit addresses the issue where a `TypeError` was occurring due to an incorrect function name. The `onKeydown` function in the `Sidebar` component has been correctly renamed to `onKeyDown` to match its definition. This fix resolves the error and ensures the proper execution of the keyboard event handling in the component.