### PR TITLE
Dynamic Dialog: Fixed errors when is opened

### DIFF
--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -94,7 +94,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
         </div>
     `,
     animations: [trigger('animation', [transition('void => visible', [useAnimation(showAnimation)]), transition('visible => void', [useAnimation(hideAnimation)])])],
-    changeDetection: ChangeDetectionStrategy.Default,
+    changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     styleUrls: ['../dialog/dialog.css'],
     host: {
@@ -213,7 +213,7 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
         public zone: NgZone,
         public primeNGConfig: PrimeNGConfig,
         @SkipSelf() @Optional() private parentDialog: DynamicDialogComponent
-    ) {}
+    ) { }
 
     ngAfterViewInit() {
         this.loadChildComponent(this.childComponentType!);
@@ -637,4 +637,4 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
     declarations: [DynamicDialogComponent, DynamicDialogContent],
     exports: [SharedModule]
 })
-export class DynamicDialogModule {}
+export class DynamicDialogModule { }


### PR DESCRIPTION
Fix #13497

Changed the changeDetection to `onPush` solves the problem. I don't know if it's the best solution. If you have another, let me know.

Note: Ignore the warning message `responsive property is deprecated as table is always responsive with scrollable behavior.`

## CURRENT BEHAVIOUR
![problem dynamic dialog](https://github.com/primefaces/primeng/assets/19764334/f54eb214-8bf4-4603-b426-6f31d9ee335b)

## AFTER SOLUTION
![fixed dynamic dialog](https://github.com/primefaces/primeng/assets/19764334/9081ae8c-8343-437d-80ae-dbd903480e07)
