### PR TITLE
Sidebar: Fixed typo error on function onKeyDown

### DIFF
--- a/src/app/components/sidebar/sidebar.ts
+++ b/src/app/components/sidebar/sidebar.ts
@@ -250,7 +250,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
 
     closeIconTemplate: Nullable<TemplateRef<any>>;
 
-    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig) {}
+    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig) { }
 
     ngAfterViewInit() {
         this.initialized = true;
@@ -279,7 +279,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
         });
     }
 
-    onKeydown(event: KeyboardEvent) {
+    onKeyDown(event: KeyboardEvent) {
         if (event.code === 'Escape') {
             this.hide();
         }
@@ -452,4 +452,4 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
     exports: [Sidebar, SharedModule],
     declarations: [Sidebar]
 })
-export class SidebarModule {}
+export class SidebarModule { }


### PR DESCRIPTION
Fix #13509 

Changed function name `onKeydown` to `onKeyDown` and fixed the problem.

## CURRENT BEHAVIOUR
![sidebar input error](https://github.com/primefaces/primeng/assets/19764334/b984c682-a755-4d30-8a20-ad8c2ef0ba6a)

## AFTER SOLUTION
![sidebar input fixed](https://github.com/primefaces/primeng/assets/19764334/09806814-e711-4fe1-af6f-2bc98a54313e)
