### PR TITLE
Picklist: Added dragConfig to assign zIndex

### DIFF
--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -213,7 +213,7 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
         public zone: NgZone,
         public primeNGConfig: PrimeNGConfig,
         @SkipSelf() @Optional() private parentDialog: DynamicDialogComponent
-    ) { }
+    ) {}
 
     ngAfterViewInit() {
         this.loadChildComponent(this.childComponentType!);
@@ -637,4 +637,4 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
     declarations: [DynamicDialogComponent, DynamicDialogContent],
     exports: [SharedModule]
 })
-export class DynamicDialogModule { }
+export class DynamicDialogModule {}

--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -23,7 +23,7 @@ import { ButtonModule } from 'primeng/button';
 import { SharedModule, PrimeTemplate, FilterService } from 'primeng/api';
 import { DomHandler } from 'primeng/dom';
 import { RippleModule } from 'primeng/ripple';
-import { CdkDragDrop, DragDropModule, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
+import { CDK_DRAG_CONFIG, CdkDragDrop, DragDropModule, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
 import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
 import { AngleDoubleDownIcon } from 'primeng/icons/angledoubledown';
 import { AngleDoubleLeftIcon } from 'primeng/icons/angledoubleleft';
@@ -1296,9 +1296,14 @@ export class PickList implements AfterViewChecked, AfterContentInit {
     }
 }
 
+const DragConfig = {
+    zIndex: 1200
+};
+
 @NgModule({
     imports: [CommonModule, ButtonModule, SharedModule, RippleModule, DragDropModule, AngleDoubleDownIcon, AngleDoubleLeftIcon, AngleDoubleRightIcon, AngleDoubleUpIcon, AngleDownIcon, AngleLeftIcon, AngleRightIcon, AngleUpIcon, SearchIcon, HomeIcon],
     exports: [PickList, SharedModule, DragDropModule],
-    declarations: [PickList]
+    declarations: [PickList],
+    providers: [{ provide: CDK_DRAG_CONFIG, useValue: DragConfig }]
 })
 export class PickListModule {}


### PR DESCRIPTION
Fix #13513

Added `dragConfig` to assign a `zIndex` value. More info here: https://material.angular.io/cdk/drag-drop/api#DragRefConfig
I added `1200` because dynamic modal and others always init in `1100, 1101, 1102`.
If you consider another number, let me know and I will change.

Note: Also I formatted the file dynamicdialog.ts to pass the test.

### CURRENT PROBLEM
![problem picklist](https://github.com/primefaces/primeng/assets/19764334/bd6b1689-1a58-4939-bc2a-bd154294af8d)

### AFTER SOLUTION
![fixed picklist](https://github.com/primefaces/primeng/assets/19764334/ac8062c8-c37f-4021-bacf-6ed3b8bdc517)

