### PR TITLE
Fix #13522: Menu is not closing when click on outside

### DIFF
--- a/src/app/components/splitbutton/splitbutton.ts
+++ b/src/app/components/splitbutton/splitbutton.ts
@@ -191,6 +191,22 @@ export class SplitButton {
 
     onDropdownButtonClick(event?: MouseEvent) {
         this.onDropdownClick.emit(event);
+
+        const clickOutsideHandler = (e: MouseEvent) => {
+            if (!this.containerViewChild.nativeElement.contains(e.target)) {
+                this.menu.hide();
+                this.isExpanded.set(this.menu.visible);
+                document.removeEventListener('click', clickOutsideHandler);
+            }
+        };
+
+        if (!this.menu.visible) {
+            document.addEventListener('click', clickOutsideHandler);
+        } else {
+            this.menu.hide();
+            this.isExpanded.set(this.menu.visible);
+        }
+
         this.menu?.toggle({ currentTarget: this.containerViewChild?.nativeElement, relativeAlign: this.appendTo == null });
         this.isExpanded.set(this.menu.visible);
     }
@@ -208,4 +224,4 @@ export class SplitButton {
     exports: [SplitButton, ButtonModule, TieredMenuModule],
     declarations: [SplitButton]
 })
-export class SplitButtonModule {}
+export class SplitButtonModule { }


### PR DESCRIPTION
Fix #13522

## CURRENT BEHAVIOUR
![problem splitbutton](https://github.com/primefaces/primeng/assets/19764334/cdec5c2d-d3b2-4e25-920e-3af16272c449)

## AFTER SOLUTION
![fixed splitbutton](https://github.com/primefaces/primeng/assets/19764334/8d89a4ea-2753-4500-8b03-435868433986)
