### PR TITLE
Fix #13525 inputNumber not showing clear when 0

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -921,9 +921,9 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
     overlayVisible: Nullable<boolean>;
 
-    onModelChange: Function = () => { };
+    onModelChange: Function = () => {};
 
-    onModelTouched: Function = () => { };
+    onModelTouched: Function = () => {};
 
     calendarElement: Nullable<HTMLElement | ElementRef>;
 
@@ -2912,12 +2912,12 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
         let iFormat!: any;
         const lookAhead = (match: string) => {
-            const matches = iFormat + 1 < format.length && format.charAt(iFormat + 1) === match;
-            if (matches) {
-                iFormat++;
-            }
-            return matches;
-        },
+                const matches = iFormat + 1 < format.length && format.charAt(iFormat + 1) === match;
+                if (matches) {
+                    iFormat++;
+                }
+                return matches;
+            },
             formatNumber = (match: string, value: any, len: any) => {
                 let num = '' + value;
                 if (lookAhead(match)) {
@@ -3403,4 +3403,4 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     exports: [Calendar, ButtonModule, SharedModule],
     declarations: [Calendar]
 })
-export class CalendarModule { }
+export class CalendarModule {}

--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -85,7 +85,7 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
                 (focus)="onInputFocus($event)"
                 (blur)="onInputBlur($event)"
             />
-            <ng-container *ngIf="buttonLayout != 'vertical' && showClear && value">
+            <ng-container *ngIf="buttonLayout != 'vertical' && showClear && (value || value === 0)">
                 <TimesIcon *ngIf="!clearIconTemplate" [ngClass]="'p-inputnumber-clear-icon'" (click)="clear()" />
                 <span *ngIf="clearIconTemplate" (click)="clear()" class="p-inputnumber-clear-icon">
                     <ng-template *ngTemplateOutlet="clearIconTemplate"></ng-template>


### PR DESCRIPTION
Fix for issue #13525 

If we want the option of treating 0 as falsy, maybe we can add another property for that option. As it exists, I think 0 should be treated as a value and the clear icon should show. 

SOLVED:

https://github.com/primefaces/primeng/assets/104391407/170c5ea7-84ae-4099-9c70-0063d51f9063
