### PR TITLE
fix: #13560 || DropDown clear or close icon on click dropDown option show

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1057,10 +1057,12 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     isInputClick(event: MouseEvent): boolean {
+        const target: HTMLElement = event.target as HTMLElement;
         return (
-            DomHandler.hasClass(event.target, 'p-dropdown-clear-icon') ||
-            (event.target as HTMLInputElement).isSameNode(this.accessibleViewChild?.nativeElement) ||
-            ((this.editableInputViewChild && (event.target as HTMLInputElement).isSameNode(this.editableInputViewChild.nativeElement)) as boolean)
+            DomHandler.hasClass(target, 'p-dropdown-clear-icon') ||
+            target.closest('.p-dropdown-clear-icon') !== null ||
+            (target as HTMLInputElement).isSameNode(this.accessibleViewChild?.nativeElement) ||
+            ((this.editableInputViewChild && (target as HTMLInputElement).isSameNode(this.editableInputViewChild.nativeElement)) as boolean)
         );
     }
 


### PR DESCRIPTION
Addressing issue || #13560


After solution video for details and test result

[Video for details ](https://www.awesomescreenshot.com/video/20319610?key=85c4631d632aa11cfba66d782ebb670c)




## Code explain

Previously  we was checking ONLY 

``DomHandler.hasClass(event.target, 'p-dropdown-clear-icon')``

this case event  don't get all the time same element, some time it's also get path from svg element or others .

So I also check closest class has '.p-dropdown-clear-icon'
 

