### PR TITLE
fix: #13572 || AutoComplete showClear close icon overlap with loader icon

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -89,7 +89,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 [attr.aria-labelledby]="ariaLabelledBy"
                 [attr.aria-required]="required"
             />
-            <ng-container *ngIf="filled && !disabled && showClear">
+            <ng-container *ngIf="filled && !disabled && showClear && !loading">
                 <TimesIcon *ngIf="!clearIconTemplate" [styleClass]="'p-autocomplete-clear-icon'" (click)="clear()" />
                 <span *ngIf="clearIconTemplate" class="p-autocomplete-clear-icon" (click)="clear()">
                     <ng-template *ngTemplateOutlet="clearIconTemplate"></ng-template>


### PR DESCRIPTION
Fix || #13572

I just add condition `!loader`to show close icon so close or clear icon will not show if is loading.