### PR TITLE
fix: #13578 || Autocomplete Force Selection case sensitive issue

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -1164,7 +1164,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
                 for (let suggestion of suggestions) {
                     let itemValue = this.field ? ObjectUtils.resolveFieldData(suggestion, this.field) : suggestion;
-                    if (itemValue && inputValue === itemValue.trim()) {
+                    if (itemValue && inputValue.toLowerCase() === itemValue.toLowerCase().trim()) {
                         valid = true;
                         this.forceSelectionUpdateModelTimeout = setTimeout(() => {
                             this.selectItem(suggestion, false);


### PR DESCRIPTION
Fix: #13578 

## Code Explain 
Previously we check just two string that's why it was return not equal.
So know I am doing lowercase item and input value before check so both it ensure same case.