### PR TITLE
Issues #13568/typeerror disabled menus

### DIFF
--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -608,7 +608,6 @@ export class Menu implements OnDestroy {
         const links = DomHandler.find(this.containerViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
 
         if(links.length > 0) {
-            console.log('hello')
             let order = index >= links.length ? links.length - 1 : index < 0 ? 0 : index;
             order > -1 && this.focusedOptionIndex.set(links[order].getAttribute('id'));
         }

--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -607,8 +607,11 @@ export class Menu implements OnDestroy {
     changeFocusedOptionIndex(index) {
         const links = DomHandler.find(this.containerViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
 
-        let order = index >= links.length ? links.length - 1 : index < 0 ? 0 : index;
-        order > -1 && this.focusedOptionIndex.set(links[order].getAttribute('id'));
+        if(links.length > 0) {
+            console.log('hello')
+            let order = index >= links.length ? links.length - 1 : index < 0 ? 0 : index;
+            order > -1 && this.focusedOptionIndex.set(links[order].getAttribute('id'));
+        }
     }
 
     itemClick(event: any) {


### PR DESCRIPTION
### Defect Fixes
#13568

### Explanation
When all menu items are disabled, `links` is an empty array. When `this.focusedOptionIndex.set(links[order].getAttribute('id'));` is invoked, this caused a typeError of `Cannot read properties of undefined (reading 'getAttribute')` when a click occurs anywhere on the document.

This PR adds a short-circuit to prevent the invoking of `getAttribute` if there are no enabled menu items.
