### PR TITLE
fix: #13571 | Multiselect not repositioned

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1471,6 +1471,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     onFilterInputChange(event: KeyboardEvent) {
         this._filterValue = (<HTMLInputElement>event.target).value;
         this.activateFilter();
+        this.filtered = true;
         this.onFilter.emit({ originalEvent: event, filter: this._filterValue });
         this.cd.detectChanges();
     }


### PR DESCRIPTION
fix: #13571 

## Explanation

The code for MultiSelect and Dropdown components closely resembles each other. However, I observed that the bug was occurring exclusively in the MultiSelect component. Upon comparing their respective code, I identified that a particular section of the MultiSelect code was never executed due to the constant state of the `filtered` variable being set to `false`. To address this issue, I introduced a code modification that ensures `filtered` is set to 'true' whenever the `onFilterInputChange` method is invoked.

## In code
```ts
onFilterInputChange(event: KeyboardEvent) {
    this._filterValue = (<HTMLInputElement>event.target).value;
    this.activateFilter();
    this.filtered = true; // I add this line
    this.onFilter.emit({ originalEvent: event, filter: this._filterValue });
    this.cd.detectChanges();
}
```
`this.cd.detectChanges()` refresh the view and call ngAfterViewChecked but `filtered` attribut is on false, so the `alignOverlay` is never call.
```ts
ngAfterViewChecked() {
    if (this.filtered) {
        this.zone.runOutsideAngular(() => {
            setTimeout(() => {
                this.overlayViewChild?.alignOverlay();
            }, 1);
        });
        this.filtered = false;
    }
}
```

I hope my explanations are clear, and I haven't made any mistakes when reading the code.