### PR TITLE
Autocomplete: Fixed alignment token icon

### DIFF
--- a/src/app/components/autocomplete/autocomplete.css
+++ b/src/app/components/autocomplete/autocomplete.css
@@ -62,6 +62,7 @@
 }
 
 .p-autocomplete-token-icon {
+    display: flex;
     cursor: pointer;
 }
 

--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -467,7 +467,7 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
         private http: HttpClient,
         public cd: ChangeDetectorRef,
         public config: PrimeNGConfig
-    ) { }
+    ) {}
 
     ngAfterContentInit() {
         this.templates?.forEach((item) => {
@@ -901,4 +901,4 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
     exports: [FileUpload, SharedModule, ButtonModule, ProgressBarModule, MessagesModule],
     declarations: [FileUpload]
 })
-export class FileUploadModule { }
+export class FileUploadModule {}

--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -607,7 +607,7 @@ export class Menu implements OnDestroy {
     changeFocusedOptionIndex(index) {
         const links = DomHandler.find(this.containerViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
 
-        if(links.length > 0) {
+        if (links.length > 0) {
             let order = index >= links.length ? links.length - 1 : index < 0 ? 0 : index;
             order > -1 && this.focusedOptionIndex.set(links[order].getAttribute('id'));
         }

--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -222,7 +222,7 @@ export class TieredMenuSub {
 
     @ViewChild('sublist', { static: true }) sublistViewChild: ElementRef;
 
-    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef,@Inject(forwardRef(() => TieredMenu)) public tieredMenu: TieredMenu) {}
+    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, @Inject(forwardRef(() => TieredMenu)) public tieredMenu: TieredMenu) {}
 
     positionSubmenu() {
         let sublist = this.sublistViewChild && this.sublistViewChild.nativeElement;


### PR DESCRIPTION
Fix #13532 

I added only the line: `display: flex;`. The rest of files and lines was the `npm run format`.

![image](https://github.com/primefaces/primeng/assets/19764334/c6dd305f-f578-4068-8784-dfa010d99be1)

### CURRENTLY
![image](https://github.com/primefaces/primeng/assets/19764334/46ab6b6e-442c-4816-a957-9d6242515426)


### AFTER SOLUTION
![image](https://github.com/primefaces/primeng/assets/19764334/8ca4e728-6302-4dc0-9c69-ab94a593f6b3)