### PR TITLE
Fixed curser position for negative numbers with suffix

### DIFF
--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -1289,7 +1289,7 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
             this._decimal.lastIndex = 0;
 
             if (this.suffixChar) {
-                return val1.replace(this.suffixChar, '').split(this._decimal)[0] + val2.replace(this.suffixChar, '').slice(decimalCharIndex) + this.suffixChar;
+                return decimalCharIndex !== -1 ? val1 : val1.replace(this.suffixChar, '').split(this._decimal)[0] + val2.replace(this.suffixChar, '').slice(decimalCharIndex) + this.suffixChar;
             } else {
                 return decimalCharIndex !== -1 ? val1.split(this._decimal)[0] + val2.slice(decimalCharIndex) : val1;
             }


### PR DESCRIPTION
When a negative number is entered with a suffix and minimum fraction digits, the format was incorrect.

For example:
-suffix " %"
-minFractionDigits 2
-0 resulted in a -00 concat value. (correct would be 0.00 %)

This results in a new call of formatValue() in handleOnInput(). The format is then correct, but the cursorposition is put to the end of the input: "0.00 %|" instead of "0|.00 %"

Fix #13651
