### PR TITLE
Fix #13646 dynamic dialog module same instances on top of each other/get rid of deprecated implementation

### DIFF
--- a/src/app/components/dynamicdialog/dialogservice.ts
+++ b/src/app/components/dynamicdialog/dialogservice.ts
@@ -22,6 +22,11 @@ export class DialogService {
      * @group Method
      */
     public open(componentType: Type<any>, config: DynamicDialogConfig): DynamicDialogRef {
+
+        if (!this.duplicationPermission(componentType, config)) {
+            return null;
+        }
+
         const dialogRef = this.appendDialogComponentToBody(config);
 
         this.dialogComponentRefMap.get(dialogRef).instance.childComponentType = componentType;
@@ -71,5 +76,19 @@ export class DialogService {
         this.appRef.detachView(dialogComponentRef.hostView);
         dialogComponentRef.destroy();
         this.dialogComponentRefMap.delete(dialogRef);
-      }
+    }
+
+    private duplicationPermission(componentType: Type<any>, config: DynamicDialogConfig): boolean {
+        if (config.duplicate) {
+            return true;
+        }
+        let permission = true;
+        for (const [key, value] of this.dialogComponentRefMap) {
+            if (value.instance.childComponentType === componentType) {
+                permission = false;
+                break;
+            }
+        }
+        return permission;
+    }
 }

--- a/src/app/components/dynamicdialog/dialogservice.ts
+++ b/src/app/components/dynamicdialog/dialogservice.ts
@@ -1,4 +1,4 @@
-import { Injectable, ComponentFactoryResolver, ApplicationRef, Injector, Type, EmbeddedViewRef, ComponentRef, Inject } from '@angular/core';
+import { Injectable, ApplicationRef, Injector, Type, EmbeddedViewRef, ComponentRef, Inject, createComponent } from '@angular/core';
 import { DomHandler } from 'primeng/dom';
 import { DynamicDialogComponent } from './dynamicdialog';
 import { DynamicDialogInjector } from './dynamicdialog-injector';
@@ -13,7 +13,7 @@ import { DOCUMENT } from '@angular/common';
 export class DialogService {
     dialogComponentRefMap: Map<DynamicDialogRef, ComponentRef<DynamicDialogComponent>> = new Map();
 
-    constructor(private componentFactoryResolver: ComponentFactoryResolver, private appRef: ApplicationRef, private injector: Injector, @Inject(DOCUMENT) private document: Document) {}
+    constructor(private appRef: ApplicationRef, private injector: Injector, @Inject(DOCUMENT) private document: Document) {}
     /**
      * Displays the dialog using the dynamic dialog object options.
      * @param {*} componentType - Dynamic component for content template.
@@ -46,8 +46,7 @@ export class DialogService {
             sub.unsubscribe();
         });
 
-        const componentFactory = this.componentFactoryResolver.resolveComponentFactory(DynamicDialogComponent);
-        const componentRef = componentFactory.create(new DynamicDialogInjector(this.injector, map));
+        const componentRef = createComponent(DynamicDialogComponent, { environmentInjector: this.appRef.injector, elementInjector: new DynamicDialogInjector(this.injector, map) });
 
         this.appRef.attachView(componentRef.hostView);
 
@@ -72,5 +71,5 @@ export class DialogService {
         this.appRef.detachView(dialogComponentRef.hostView);
         dialogComponentRef.destroy();
         this.dialogComponentRefMap.delete(dialogRef);
-    }
+      }
 }

--- a/src/app/components/dynamicdialog/dynamicdialog-config.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog-config.ts
@@ -4,6 +4,10 @@
  */
 export class DynamicDialogConfig<T = any> {
     /**
+     * A boolean to determine if it can be duplicate.
+     */
+    duplicate?: boolean;
+    /**
      * An object to pass to the component loaded inside the Dialog.
      */
     data?: T;

--- a/src/app/components/dynamicdialog/dynamicdialog-injector.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog-injector.ts
@@ -1,11 +1,9 @@
-import { Injector, Type, InjectionToken, InjectFlags } from '@angular/core';
+import { InjectOptions, Injector, ProviderToken, InjectFlags } from '@angular/core';
 
 export class DynamicDialogInjector implements Injector {
     constructor(private _parentInjector: Injector, private _additionalTokens: WeakMap<any, any>) {}
 
-    get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T, flags?: InjectFlags): T;
-    get(token: any, notFoundValue?: any);
-    get(token: any, notFoundValue?: any, flags?: any) {
+    get<T>(token: ProviderToken<T>, notFoundValue?: T, options?: InjectOptions | InjectFlags): T {
         const value = this._additionalTokens.get(token);
 
         if (value) return value;

--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -5,7 +5,6 @@ import {
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
-    ComponentFactoryResolver,
     ComponentRef,
     ElementRef,
     Inject,
@@ -207,7 +206,6 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
     constructor(
         @Inject(DOCUMENT) private document: Document,
         @Inject(PLATFORM_ID) private platformId: any,
-        private componentFactoryResolver: ComponentFactoryResolver,
         private cd: ChangeDetectorRef,
         public renderer: Renderer2,
         public config: DynamicDialogConfig,
@@ -228,12 +226,10 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
     }
 
     loadChildComponent(componentType: Type<any>) {
-        let componentFactory = this.componentFactoryResolver.resolveComponentFactory(componentType);
+      let viewContainerRef = this.insertionPoint?.viewContainerRef;
+      viewContainerRef?.clear();
 
-        let viewContainerRef = this.insertionPoint?.viewContainerRef;
-        viewContainerRef?.clear();
-
-        this.componentRef = viewContainerRef?.createComponent(componentFactory);
+      this.componentRef = viewContainerRef?.createComponent(componentType);
     }
 
     moveOnTop() {


### PR DESCRIPTION
Fix #13646
step_1: [ComponentFactoryResolver is DEPRECATED since v13]
step_2: [add a duplicate flag to DynamicDialogConfig]
step_3: [two overload method are deprecated]
----------
issue fixed:
dynamic dialog module (same instances on top of each other) #13646
https://github.com/primefaces/primeng/issues/13646
----------