### PR TITLE
p-image: preview image execute ngSubmit #13611 fixed

### DIFF
--- a/src/app/components/image/image.ts
+++ b/src/app/components/image/image.ts
@@ -23,7 +23,7 @@ import { FocusTrapModule } from 'primeng/focustrap';
     template: `
         <span [ngClass]="containerClass()" [class]="styleClass" [ngStyle]="style">
             <img [attr.src]="src" [attr.alt]="alt" [attr.width]="width" [attr.height]="height" [ngStyle]="imageStyle" [class]="imageClass" (error)="imageError($event)" />
-            <button class="p-image-preview-indicator" *ngIf="preview" (click)="onImageClick()" #previewButton>
+            <button type="button" class="p-image-preview-indicator" *ngIf="preview" (click)="onImageClick()" #previewButton>
                 <ng-container *ngIf="indicatorTemplate; else defaultTemplate">
                     <ng-container *ngTemplateOutlet="indicatorTemplate"></ng-container>
                 </ng-container>


### PR DESCRIPTION
### Defect Fixes 
Issue Fixed:
#13611 p-image: preview image execute ngSubmit

### Describing the bug
I have a form

``` <form (ngSubmit)="onFormSubmit()">
<p-image [src]="imageURL" width="90" height="90" alt="image" [preview]="true"></p-image>
</form>
```
When I click to preview image, onFormSubmit method is executed it and It's wrong.

### Expected behavior
ngSubmit form must not be executed when I click on preview image.

<div class="p-image-preview-indicator"...>
was changed
<button class="p-image-preview-indicator" .... >

type="button" must be present

### Issue Fixed
![image](https://github.com/primefaces/primeng/assets/47118913/b67652cb-e711-45b8-93aa-598347e7f6e3)

type="button" added to button