### PR TITLE
fix: #12948 || Overlay: p-overlay div not removed from DOM on hiding …

### DIFF
--- a/src/app/components/overlay/overlay.ts
+++ b/src/app/components/overlay/overlay.ts
@@ -3,6 +3,7 @@ import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
     AfterContentInit,
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
     Component,
     ContentChildren,
     ElementRef,
@@ -65,7 +66,7 @@ const hideOverlayContentAnimation = animation([animate('{{hideTransitionParams}}
                 'p-overlay-right-start': modal && overlayResponsiveDirection === 'right-start',
                 'p-overlay-right-end': modal && overlayResponsiveDirection === 'right-end'
             }"
-            (click)="onOverlayClick($event)"
+            (click)="onOverlayClick()"
         >
             <div
                 *ngIf="visible"
@@ -422,6 +423,7 @@ export class Overlay implements AfterContentInit, OnDestroy {
         public renderer: Renderer2,
         private config: PrimeNGConfig,
         public overlayService: OverlayService,
+        public cd: ChangeDetectorRef,
         private zone: NgZone
     ) {
         this.window = this.document.defaultView;
@@ -524,6 +526,7 @@ export class Overlay implements AfterContentInit, OnDestroy {
                 DomHandler.appendOverlay(this.overlayEl, this.targetEl, this.appendTo);
                 ZIndexUtils.clear(container);
                 this.modalVisible = false;
+                this.cd.markForCheck();
 
                 break;
         }


### PR DESCRIPTION
Fix: #12948 

Previously I did try to solve it by `z-index` for CSS animation but now I re-check hole process and identified that dome should remove when overlay is hide. 

There issue was after complete animation `this.modalVisible = false;`  can not event fire angular change detection life cycle so dome was not removed properly so we fire it manually by `this.cd.markForCheck()` then dome gone and solve it issues.


## Extra code: 
I removed `event` from `(click)="onOverlayClick($event)"` because `onOverlayClick` function don't have any parameter. 