### PR TITLE
ConfirmPopup: Add hostListener to closeOnEscape

### DIFF
--- a/src/app/components/confirmpopup/confirmpopup.ts
+++ b/src/app/components/confirmpopup/confirmpopup.ts
@@ -1,6 +1,23 @@
 import { AnimationEvent, animate, state, style, transition, trigger } from '@angular/animations';
 import { CommonModule, DOCUMENT } from '@angular/common';
-import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ContentChildren, ElementRef, EventEmitter, Inject, Input, NgModule, OnDestroy, QueryList, Renderer2, TemplateRef, ViewEncapsulation } from '@angular/core';
+import {
+    AfterContentInit,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    Component,
+    ContentChildren,
+    ElementRef,
+    EventEmitter,
+    HostListener,
+    Inject,
+    Input,
+    NgModule,
+    OnDestroy,
+    QueryList,
+    Renderer2,
+    TemplateRef,
+    ViewEncapsulation
+} from '@angular/core';
 import { Confirmation, ConfirmationService, OverlayService, PrimeNGConfig, PrimeTemplate, SharedModule, TranslationKeys } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ConnectedOverlayScrollHandler, DomHandler } from 'primeng/dom';
@@ -206,6 +223,13 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
                     break;
             }
         });
+    }
+
+    @HostListener('document:keydown.escape', ['$event'])
+    onEscapeKeydown(event: KeyboardEvent) {
+        if (this.confirmation && this.confirmation.closeOnEscape) {
+            this.reject();
+        }
     }
 
     onAnimationStart(event: AnimationEvent) {


### PR DESCRIPTION
Fix #13652 

Now if you use `closeOnEscape: true` when you press `ESC` close the popup.
I added only the `hostlistener`. The rest of the code was formatted by Prettier.

# After Solution
![fixed confirmPopup](https://github.com/primefaces/primeng/assets/19764334/5b68d6e7-bfbd-443d-b79a-768f4fe263bc)
