### PR TITLE
FEAT: Implement @types/quill for the correct typing for QuillJS in the Editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "@types/jasmine": "~4.3.1",
                 "@types/jest": "^29.5.1",
                 "@types/node": "^12.20.55",
+                "@types/quill": "^1.3.7",
                 "chart.js": "3.3.2",
                 "codelyzer": "^0.0.28",
                 "del": "^7.0.0",
@@ -4488,6 +4489,15 @@
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
             "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
             "dev": true
+        },
+        "node_modules/@types/quill": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.7.tgz",
+            "integrity": "sha512-OLCF0e+ZaknLCF+1Bmw0FXXJQtVv7iNbPrTOlBLEOSocu6EWo+7Zr7SuovFcHOgr5YPaYvjiXy0pOmCYyZBfww==",
+            "dev": true,
+            "dependencies": {
+                "parchment": "^1.1.2"
+            }
         },
         "node_modules/@types/raf": {
             "version": "3.4.0",
@@ -26014,6 +26024,15 @@
             "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
             "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
             "dev": true
+        },
+        "@types/quill": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.7.tgz",
+            "integrity": "sha512-OLCF0e+ZaknLCF+1Bmw0FXXJQtVv7iNbPrTOlBLEOSocu6EWo+7Zr7SuovFcHOgr5YPaYvjiXy0pOmCYyZBfww==",
+            "dev": true,
+            "requires": {
+                "parchment": "^1.1.2"
+            }
         },
         "@types/raf": {
             "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
         "@types/jasmine": "~4.3.1",
         "@types/jest": "^29.5.1",
         "@types/node": "^12.20.55",
+        "@types/quill": "^1.3.7",
         "chart.js": "3.3.2",
         "codelyzer": "^0.0.28",
         "del": "^7.0.0",

--- a/src/app/components/editor/editor.interface.ts
+++ b/src/app/components/editor/editor.interface.ts
@@ -1,5 +1,6 @@
 import { TemplateRef } from '@angular/core';
 import { Editor } from './editor';
+import Quill, { RangeStatic } from 'quill';
 
 /**
  * Custom text change event.
@@ -33,11 +34,11 @@ export interface EditorSelectionChangeEvent {
     /**
      * Representation of the selection boundaries.
      */
-    range: string;
+    range: RangeStatic;
     /**
      * Representation of the previous selection boundaries.
      */
-    oldRange: string;
+    oldRange: RangeStatic;
     /**
      * Source of change. Will be either 'user' or 'api'.
      */
@@ -52,7 +53,7 @@ export interface EditorInitEvent {
     /**
      * Text editor instance.
      */
-    editor: any;
+    editor: Quill;
 }
 /**
  * Defines valid templates in Editor.

--- a/src/app/components/editor/editor.spec.ts
+++ b/src/app/components/editor/editor.spec.ts
@@ -70,6 +70,6 @@ describe('Editor', () => {
         fixture.detectChanges();
 
         const quill = editor.getQuill();
-        expect(quill.container.className).toContain('p-editor-content');
+        expect(quill.root.className).toContain('ql-editor');
     });
 });


### PR DESCRIPTION
Implementing proper type handling for [QuillJS](https://github.com/quilljs/quill/tree/1.3.7) that is leveraged within the `Editor` component. 

This is due to the quill implementation currently using the `any` type.

__NOTE:__ Types are provided from `@types\quill@1.3.7` ([@types/quill](https://www.npmjs.com/package/@types/quill/v/1.3.7)) 