### PR TITLE
docs: remove entryComponents from DynamicDialogs

### DIFF
--- a/src/app/showcase/doc/dynamicdialog/basicdoc.ts
+++ b/src/app/showcase/doc/dynamicdialog/basicdoc.ts
@@ -10,8 +10,7 @@ import { ProductListDemo } from './productlistdemo';
     template: ` <section class="py-3">
         <app-docsectiontext [title]="title" [id]="id">
             <p>
-                Dynamic dialogs require an instance of a <i>DialogService</i> that is responsible for displaying a dialog with a component as its content. Since the dynamically loaded content is not defined at build time, a configuration is necessary
-                using the <i>entryComponents</i> of your parent module. Calling <i>open</i> method of <i>DialogService</i> will display dynamic dialog. First parameter of <i>open</i> method is the type of component to load and the second parameter is
+                Dynamic dialogs require an instance of a <i>DialogService</i> that is responsible for displaying a dialog with a component as its content. Calling <i>open</i> method of <i>DialogService</i> will display dynamic dialog. First parameter of <i>open</i> method is the type of component to load and the second parameter is
                 the configuration of the Dialog such as <i>header</i>, <i>width</i> and more.
             </p>
         </app-docsectiontext>


### PR DESCRIPTION
According to the current documentation for Dynamic Dialogs, it is stated that entryComponents are required for dynamic dialogs. However, with Angular 9 and above, using the Ivy rendering engine, entryComponents are generally no longer necessary. This could lead to confusion for developers using newer versions of Angular.

### Defect Fixes
Fix #13679

