### PR TITLE
fix: #13687 || panelmenu: panelMenuSub unknown function and duplicate…

### DIFF
--- a/src/app/components/panelmenu/panelmenu.ts
+++ b/src/app/components/panelmenu/panelmenu.ts
@@ -267,7 +267,6 @@ export class PanelMenuSub {
             [activeItemPath]="activeItemPath()"
             [transitionOptions]="transitionOptions"
             [items]="processedItems()"
-            [activeItemPath]="activeItemPath()"
             [parentExpanded]="parentExpanded"
             (itemToggle)="onItemToggle($event)"
             (keydown)="onKeyDown($event)"
@@ -776,7 +775,6 @@ export class PanelMenuList implements OnChanges {
                                 [activeItem]="activeItem()"
                                 [tabindex]="tabindex"
                                 [parentExpanded]="isItemActive(item)"
-                                (itemToggle)="changeExpandedKeys($event)"
                                 (headerFocus)="updateFocusedHeader($event)"
                             ></p-panelMenuList>
                         </div>


### PR DESCRIPTION
Fix: #13687 

I just remove undefined function and duplicate call.

1. Remove duplicate call `[activeItemPath]="activeItemPath()"`
2. Removed undefined function call  `(itemToggle)="changeExpandedKeys($event)"`