### PR TITLE
BlockUI: Removed wrong paragraph in demo

### DIFF
--- a/src/app/showcase/doc/blockui/importdoc.ts
+++ b/src/app/showcase/doc/blockui/importdoc.ts
@@ -4,9 +4,7 @@ import { Code } from '../../domain/code';
 @Component({
     selector: 'import-doc',
     template: ` <section class="py-3">
-        <app-docsectiontext [title]="title" [id]="id">
-            <p>Content of the badge is specified using the <i>value</i> property.</p>
-        </app-docsectiontext>
+        <app-docsectiontext [title]="title" [id]="id"/>
         <app-code [code]="code" [hideToggleCode]="true"></app-code>
     </section>`
 })

--- a/src/app/showcase/doc/blockui/importdoc.ts
+++ b/src/app/showcase/doc/blockui/importdoc.ts
@@ -4,7 +4,7 @@ import { Code } from '../../domain/code';
 @Component({
     selector: 'import-doc',
     template: ` <section class="py-3">
-        <app-docsectiontext [title]="title" [id]="id"/>
+        <app-docsectiontext [title]="title" [id]="id" />
         <app-code [code]="code" [hideToggleCode]="true"></app-code>
     </section>`
 })

--- a/src/app/showcase/doc/dynamicdialog/basicdoc.ts
+++ b/src/app/showcase/doc/dynamicdialog/basicdoc.ts
@@ -10,8 +10,8 @@ import { ProductListDemo } from './productlistdemo';
     template: ` <section class="py-3">
         <app-docsectiontext [title]="title" [id]="id">
             <p>
-                Dynamic dialogs require an instance of a <i>DialogService</i> that is responsible for displaying a dialog with a component as its content. Calling <i>open</i> method of <i>DialogService</i> will display dynamic dialog. First parameter of <i>open</i> method is the type of component to load and the second parameter is
-                the configuration of the Dialog such as <i>header</i>, <i>width</i> and more.
+                Dynamic dialogs require an instance of a <i>DialogService</i> that is responsible for displaying a dialog with a component as its content. Calling <i>open</i> method of <i>DialogService</i> will display dynamic dialog. First parameter
+                of <i>open</i> method is the type of component to load and the second parameter is the configuration of the Dialog such as <i>header</i>, <i>width</i> and more.
             </p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">

--- a/src/app/showcase/doc/megamenu/basicdoc.ts
+++ b/src/app/showcase/doc/megamenu/basicdoc.ts
@@ -12,7 +12,7 @@ import { Code } from '../../domain/code';
             <p-megaMenu [model]="items"></p-megaMenu>
         </div>
         <app-code [code]="code" selector="mega-menu-basic-demo"></app-code>
-    </section>`,
+    </section>`
 })
 export class BasicDoc implements OnInit {
     @Input() id: string;

--- a/src/app/showcase/doc/treetable/columnresizefitdoc.ts
+++ b/src/app/showcase/doc/treetable/columnresizefitdoc.ts
@@ -16,7 +16,7 @@ interface Column {
             <p>Columns can be resized with drag and drop when <i>resizableColumns</i> is enabled. Default resize mode is <i>fit</i> that does not change the overall table width.</p>
         </app-docsectiontext>
         <div class="card">
-            <p-treeTable [value]="files" [columns]="cols" [resizableColumns]="true" [tableStyle]="{'min-width': '50rem'}">
+            <p-treeTable [value]="files" [columns]="cols" [resizableColumns]="true" [tableStyle]="{ 'min-width': '50rem' }">
                 <ng-template pTemplate="header" let-columns>
                     <tr>
                         <th *ngFor="let col of columns" ttResizableColumn>

--- a/src/app/showcase/doc/treetable/columnresizescrollabledoc.ts
+++ b/src/app/showcase/doc/treetable/columnresizescrollabledoc.ts
@@ -15,10 +15,10 @@ interface Column {
             <p>To utilize the column resize modes with a <i>scrollable</i> TreeTable, a <i>colgroup</i> template must be defined. The default value of scrollHeight is "flex," it can also be set as a string value.</p>
         </app-docsectiontext>
         <div class="card">
-            <p-treeTable [value]="files" [columns]="cols" [resizableColumns]="true" [scrollable]="true" scrollHeight="200px" [tableStyle]="{'min-width': '50rem'}">
+            <p-treeTable [value]="files" [columns]="cols" [resizableColumns]="true" [scrollable]="true" scrollHeight="200px" [tableStyle]="{ 'min-width': '50rem' }">
                 <ng-template pTemplate="colgroup" let-columns>
                     <colgroup>
-                        <col *ngFor="let col of columns">
+                        <col *ngFor="let col of columns" />
                     </colgroup>
                 </ng-template>
                 <ng-template pTemplate="header" let-columns>

--- a/src/app/showcase/layout/app.component.ts
+++ b/src/app/showcase/layout/app.component.ts
@@ -11,7 +11,7 @@ import Announcement from '../data/news.json';
 })
 export class AppComponent implements OnInit, OnDestroy {
     constructor(@Inject(DOCUMENT) private document: Document, @Inject(PLATFORM_ID) private platformId: any, private renderer: Renderer2, private configService: AppConfigService, private router: Router) {
-        if(isPlatformBrowser(platformId) && window && process.env.NODE_ENV === 'production'){
+        if (isPlatformBrowser(platformId) && window && process.env.NODE_ENV === 'production') {
             this.injectScripts();
         }
         this.handleRouteEvents();

--- a/src/app/showcase/pages/megamenu/megamenudemo.ts
+++ b/src/app/showcase/pages/megamenu/megamenudemo.ts
@@ -8,13 +8,15 @@ import { AccessibilityDoc } from '../../doc/megamenu/accessibilitydoc';
 
 @Component({
     templateUrl: './megamenudemo.html',
-    styles: [`
-        :host ::ng-deep{
-            .p-megamenu-panel {
-                z-index: 3;
+    styles: [
+        `
+            :host ::ng-deep {
+                .p-megamenu-panel {
+                    z-index: 3;
+                }
             }
-        }
-    `]
+        `
+    ]
 })
 export class MegaMenuDemo {
     docs = [


### PR DESCRIPTION
Removed wrong paragraph.

**Note:** I modified only `src\app\showcase\doc\blockui\importdoc.ts`. 
The rest of the files were formatted.

## CURRENTLY

![image](https://github.com/primefaces/primeng/assets/19764334/a355c472-0db9-4ce6-b043-a49648c8beda)

## AFTER SOLUTION

![image](https://github.com/primefaces/primeng/assets/19764334/174dd52a-8c15-4f3e-bf7e-0381643e7e16)