### PR TITLE
fix(#13481): add id back to menu item content

### DIFF
--- a/src/app/components/menu/menu.ts
+++ b/src/app/components/menu/menu.ts
@@ -54,6 +54,7 @@ export class SafeHtmlPipe implements PipeTransform {
             <a
                 *ngIf="!item?.routerLink"
                 [attr.title]="item.title"
+                [attr.id]="item.id"
                 [attr.href]="item.url || null"
                 [attr.data-automationid]="item.automationId"
                 [attr.tabindex]="-1"
@@ -75,6 +76,7 @@ export class SafeHtmlPipe implements PipeTransform {
                 [attr.data-pc-section]="'action'"
                 [attr.aria-hidden]="true"
                 [attr.title]="item.title"
+                [attr.id]="item.id"
                 [queryParams]="item.queryParams"
                 routerLinkActive="p-menuitem-link-active"
                 [routerLinkActiveOptions]="item.routerLinkActiveOptions || { exact: false }"


### PR DESCRIPTION
### Defect Fixes
Fix #13481 

```
this.items = [
    {
        label: 'New',
        icon: 'pi pi-fw pi-plus'
    },
    {
        id: 'delete',
        label: 'Delete',
        icon: 'pi pi-fw pi-trash'
    }
];
```

The `id="delete"` is added correctly to the menu item content. 

<img width="929" alt="image" src="https://github.com/primefaces/primeng/assets/14116156/e0a0dda9-c637-44c7-b9f8-8955403bd8ce">
