### PR TITLE
13714 - fix dismissableMask on confirmPopup component

### DIFF
--- a/src/app/components/confirmpopup/confirmpopup.ts
+++ b/src/app/components/confirmpopup/confirmpopup.ts
@@ -340,7 +340,7 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
             const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : this.document;
 
             this.documentClickListener = this.renderer.listen(documentTarget, documentEvent, (event) => {
-                if (this.confirmation) {
+                if (this.confirmation && this.confirmation.dismissableMask !== false) {
                     let targetElement = <HTMLElement>this.confirmation.target;
                     if (this.container !== event.target && !this.container?.contains(event.target) && targetElement !== event.target && !targetElement.contains(event.target)) {
                         this.hide();


### PR DESCRIPTION
Fix #13714

Now when you add `dismissableMask: false` in your `confirmationService` the `confirmPopup` will not close.
By default continue working as always, if you don't add the property, if you click outside, will close.

## AFTER SOLUTION

**Note:** In the following gif, I am clicking many times and it does not close after have applied `dismissableMask: false` 

![image](https://github.com/primefaces/primeng/assets/19764334/7fec450a-623c-4499-811e-2626a20c52cb)

![fix confirmPopup](https://github.com/primefaces/primeng/assets/19764334/be46223a-7c1d-4956-bd0b-1029dc8f6db5)
