### PR TITLE
Fix #13722: FileUpload click instead of mouseup

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -121,7 +121,7 @@ import { FileBeforeUploadEvent, FileProgressEvent, FileRemoveEvent, FileSelectEv
                 [ngClass]="{ 'p-button p-component p-fileupload-choose': true, 'p-button-icon-only': !basicButtonLabel, 'p-fileupload-choose-selected': hasFiles(), 'p-focus': focus, 'p-disabled': disabled }"
                 [ngStyle]="style"
                 [class]="styleClass"
-                (mouseup)="onBasicUploaderClick()"
+                (click)="onBasicUploaderClick()"
                 (keydown)="onBasicKeydown($event)"
                 tabindex="0"
                 pRipple


### PR DESCRIPTION
Closes #13722

Here's a summary of the changes made

- Previously, we were using a generic mouseup event to detect the click event on the FileUpload component
- I've now refined it to specifically detect left mouse clicks, making our event handling more precise
- This change ensures that our component responds correctly to left mouse clicks without interfering with other mouse actions.

Please review the code changes, and if everything looks good, consider merging this update.  Kindly let me know if any changes required.