### PR TITLE
Carousel: Typo documentation autoPlayInterval

### DIFF
--- a/src/app/showcase/doc/carousel/circulardoc.ts
+++ b/src/app/showcase/doc/carousel/circulardoc.ts
@@ -10,7 +10,7 @@ import { ProductService } from '../../service/productservice';
             <p>When <i>autoplayInterval</i> is defined in milliseconds, items are scrolled automatically. In addition, for infinite scrolling <i>circular</i> property needs to be added which is enabled automatically in auto play mode.</p>
         </app-docsectiontext>
         <div class="card">
-            <p-carousel [value]="products" [numVisible]="3" [numScroll]="3" [circular]="true" [responsiveOptions]="responsiveOptions" autoPlayInterval="3000">
+            <p-carousel [value]="products" [numVisible]="3" [numScroll]="3" [circular]="true" [responsiveOptions]="responsiveOptions" autoplayInterval="3000">
                 <ng-template let-product pTemplate="item">
                     <div class="border-1 surface-border border-round m-2 text-center py-5 px-3">
                         <div class="mb-3">
@@ -81,7 +81,7 @@ export class CircularDoc implements OnInit {
 
     code: Code = {
         basic: `
-<p-carousel [value]="products" [numVisible]="3" [numScroll]="3" [circular]="true" [responsiveOptions]="responsiveOptions" autoPlayInterval="3000">
+<p-carousel [value]="products" [numVisible]="3" [numScroll]="3" [circular]="true" [responsiveOptions]="responsiveOptions" autoplayInterval="3000">
     <ng-template let-product pTemplate="item">
         <div class="border-1 surface-border border-round m-2 text-center py-5 px-3">
             <div class="mb-3">
@@ -101,7 +101,7 @@ export class CircularDoc implements OnInit {
 </p-carousel>`,
         html: `
 <div class="card">
-    <p-carousel [value]="products" [numVisible]="3" [numScroll]="3" [circular]="true" [responsiveOptions]="responsiveOptions" autoPlayInterval="3000">
+    <p-carousel [value]="products" [numVisible]="3" [numScroll]="3" [circular]="true" [responsiveOptions]="responsiveOptions" autoplayInterval="3000">
         <ng-template let-product pTemplate="item">
             <div class="border-1 surface-border border-round m-2 text-center py-5 px-3">
                 <div class="mb-3">


### PR DESCRIPTION
Fix #13728

Changed `autoPlayInterval` to `autoplayInterval` in docs and now is animated again too.

![carousel working](https://github.com/primefaces/primeng/assets/19764334/5affe452-c9d3-44e4-adbb-564fd7de1db4)

