### PR TITLE
fix Dropdown: Tab key not navigating between fields #13664

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1304,11 +1304,14 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
                 event.preventDefault();
                 break;
 
-            //escape and tab
+            //escape
             case 27:
-            case 9:
                 this.hide();
                 event.preventDefault();
+                break;
+            // tab
+            case 9:
+                this.hide();
                 break;
 
             //search item based on keyboard input


### PR DESCRIPTION
Call preventDefault only for Escape key

### Defect Fixes
Fix #13664 Dropdown: Tab key not navigating between fields
