### PR TITLE
fix typo inputnumber

### DIFF
--- a/src/app/showcase/doc/inputnumber/buttonsdoc.ts
+++ b/src/app/showcase/doc/inputnumber/buttonsdoc.ts
@@ -6,7 +6,7 @@ import { Code } from '../../domain/code';
     template: ` <section class="py-3">
         <app-docsectiontext [title]="title" [id]="id">
             <p>
-                Spinner buttons is enabled using the <i>showButtons</i> options and layout is defined with the <i>buttonLayout</i>. Default value is "stacked" whereas "horizontal" and "stacked" are alternatives. Note that even there are no buttons,
+                Spinner buttons are enabled using the <i>showButtons</i> options and layout is defined with the <i>buttonLayout</i>. Default value is "stacked" whereas "horizontal" and "stacked" are alternatives. Note that even there are no buttons,
                 up and down arrow keys can be used to spin the values with keyboard.
             </p>
         </app-docsectiontext>


### PR DESCRIPTION
Fix #13752

Added `are` instead `is`

## CURRENTLY

![image](https://github.com/primefaces/primeng/assets/19764334/9d5bfdc7-dafe-46ec-877e-74c1a22c7c30)

## AFTER

![image](https://github.com/primefaces/primeng/assets/19764334/0927d55f-9537-4931-934d-e4422c29f7f7)
