### PR TITLE
properly fix issue #13361

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3338,7 +3338,7 @@ export class SortableColumn implements OnInit, OnDestroy {
 
     @HostListener('click', ['$event'])
     onClick(event: MouseEvent) {
-        if (this.isEnabled()) {
+        if (this.isEnabled() && !this.isFilterElement(<HTMLElement>event.target)) {
             this.updateSortState();
             this.dt.sort({
                 originalEvent: event,
@@ -3356,6 +3356,13 @@ export class SortableColumn implements OnInit, OnDestroy {
 
     isEnabled() {
         return this.pSortableColumnDisabled !== true;
+    }
+
+    isFilterElement(element: HTMLElement) {
+        return this.isFilterElementIconOrButton(element) || this.isFilterElementIconOrButton(element?.parentElement?.parentElement);
+    }
+    private isFilterElementIconOrButton(element: HTMLElement) {
+        return DomHandler.hasClass(element, 'pi-filter-icon') || DomHandler.hasClass(element, 'p-column-filter-menu-button');
     }
 
     ngOnDestroy() {
@@ -4777,7 +4784,7 @@ export class ReorderableRow implements AfterViewInit {
                 aria-haspopup="true"
                 [attr.aria-expanded]="overlayVisible"
                 [ngClass]="{ 'p-column-filter-menu-button-open': overlayVisible, 'p-column-filter-menu-button-active': hasFilter() }"
-                (click)="toggleMenu($event)"
+                (click)="toggleMenu()"
                 (keydown)="onToggleButtonKeyDown($event)"
             >
                 <FilterIcon [styleClass]="'pi-filter-icon'" *ngIf="!filterIconTemplate" />
@@ -5108,9 +5115,8 @@ export class ColumnFilter implements AfterContentInit {
         }
     }
 
-    toggleMenu(event: any) {
+    toggleMenu() {
         this.overlayVisible = !this.overlayVisible;
-        event.stopPropagation();
     }
 
     onToggleButtonKeyDown(event: KeyboardEvent) {


### PR DESCRIPTION
Fixes #13392 

Merge pull request #13392 fixed issue #13361 but caused filters not to automatically close when clicking different filter icon buttons.

This pull request fixes "properly" issue #13361 and as a result fixes the bug that was induced by the original attempted fix.

This pull request reverts the original changes to fix issue #13361.  Instead of stopping the click event propagation,   the original isFilterElement method is reinstated and is improved by calling a new  isFilterElementIconOrButton method.

**The following demonstrates step by step the original issue, the incorrect fix, and the improved fix.**

Movie 1) shows the original issue #13361  in v16.0.2

https://github.com/primefaces/primeng/assets/45439491/80014fc3-d7ef-4bdf-9a53-49bd75bf0d81


Movie 2) shows proper filter clicking behavior in v16.0.2 before merge request #13392 breaks the funcitonality

https://github.com/primefaces/primeng/assets/45439491/a6eaead1-b043-43d8-a231-cc1909d42b83


Movie 3) shows that issue #13361 in v16.3.1  is fixed by merge request #13392 

https://github.com/primefaces/primeng/assets/45439491/38cb46fe-25e4-4648-af62-d4e4f66aa4c5


Movie 4) shows that v16.3.1  merge request #13392 breaks filter click icon functionality

https://github.com/primefaces/primeng/assets/45439491/29c9bfd0-6242-49af-889d-6218d1856699


Movie 5) shows that the changes in this pull request also fixes the issue #13361

https://github.com/primefaces/primeng/assets/45439491/4845ed6f-0a0e-43d8-9473-15c5528b4bc3


Movie 6) shows that the changes in this pull request also fixes the filter click icon functionality that was broken by merge request #13392


https://github.com/primefaces/primeng/assets/45439491/438d6ac6-b08b-47ac-9fb5-624b1ded3ccc

