### PR TITLE
Fixes #13761. Breaking out early in the align() method when the confirmation is null.

### DIFF
--- a/src/app/components/confirmpopup/confirmpopup.ts
+++ b/src/app/components/confirmpopup/confirmpopup.ts
@@ -272,6 +272,9 @@ export class ConfirmPopup implements AfterContentInit, OnDestroy {
             ZIndexUtils.set('overlay', this.container, this.config.zIndex.overlay);
         }
 
+        if (!this.confirmation) {
+            return;
+        }
         DomHandler.absolutePosition(this.container, this.confirmation?.target);
 
         const containerOffset = DomHandler.getOffset(this.container);


### PR DESCRIPTION
Fixes #13761. The changes I made in #13035 worked for me locally, but when I updated our application to use the 16.0.1 release, there was a different error with the same cause. This pull request fixes that error and should properly fix #13034. 
Added a new bug report #13761 so it can have its own milestone, although the underlying issue is the same.
