### PR TITLE
Feature #13789 Add icon template for Menu components

### DIFF
--- a/src/app/components/megamenu/megamenu.interface.ts
+++ b/src/app/components/megamenu/megamenu.interface.ts
@@ -10,6 +10,16 @@ export interface MegaMenuTemplates {
      */
     start(): TemplateRef<any>;
     /**
+     * Custom template of icon.
+     * @param {Object} context - item data.
+     */
+    icon(context: {
+        /**
+         * Item icon.
+         */
+        $implicit: any;
+    }): TemplateRef<{ $implicit: any }>;
+    /**
      * Custom template of submenuicon.
      */
     submenuicon(): TemplateRef<any>;

--- a/src/app/components/megamenu/megamenu.ts
+++ b/src/app/components/megamenu/megamenu.ts
@@ -93,16 +93,19 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                             [attr.tabindex]="-1"
                             pRipple
                         >
-                            <span
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                class="p-menuitem-icon"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            >
-                            </span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!megaMenu.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                >
+                                </span>
+                                <ng-template *ngTemplateOutlet="megaMenu.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span *ngIf="getItemProp(processedItem, 'escape'); else htmlLabel" class="p-menuitem-text" [attr.data-pc-section]="'label'">
                                 {{ getItemLabel(processedItem) }}
                             </span>
@@ -139,15 +142,18 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                             [state]="getItemProp(processedItem, 'state')"
                             pRipple
                         >
-                            <span
-                                class="p-menuitem-icon"
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            ></span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!megaMenu.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                ></span>
+                                <ng-template *ngTemplateOutlet="megaMenu.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span class="p-menuitem-text" *ngIf="getItemProp(processedItem, 'escape'); else htmlRouteLabel">{{ getItemLabel(processedItem) }}</span>
                             <ng-template #htmlRouteLabel><span class="p-menuitem-text" [innerHTML]="getItemLabel(processedItem)" [attr.data-pc-section]="'label'"></span></ng-template>
                             <span class="p-menuitem-badge" *ngIf="getItemProp(processedItem, 'badge')" [ngClass]="getItemProp(processedItem, 'badgeStyleClass')">{{ getItemProp(processedItem, 'badge') }}</span>
@@ -455,6 +461,8 @@ export class MegaMenu implements AfterContentInit, OnDestroy, OnInit {
 
     endTemplate: TemplateRef<any> | undefined;
 
+    iconTemplate: TemplateRef<any> | undefined;
+
     menuIconTemplate: TemplateRef<any> | undefined;
 
     submenuIconTemplate: TemplateRef<any> | undefined;
@@ -533,6 +541,10 @@ export class MegaMenu implements AfterContentInit, OnDestroy, OnInit {
 
                 case 'end':
                     this.endTemplate = item.template;
+                    break;
+
+                case 'icon':
+                    this.iconTemplate = item.template;
                     break;
 
                 case 'menuicon':

--- a/src/app/components/menu/menu.interface.ts
+++ b/src/app/components/menu/menu.interface.ts
@@ -1,10 +1,10 @@
 import { TemplateRef } from '@angular/core';
 
 /**
- * Defines valid templates in PanelMenu.
+ * Defines valid templates in Menu.
  * @group Templates
  */
-export interface PanelMenuTemplates {
+export interface MenuTemplates {
     /**
      * Custom template of icon.
      * @param {Object} context - item data.
@@ -15,8 +15,4 @@ export interface PanelMenuTemplates {
          */
         $implicit: any;
     }): TemplateRef<{ $implicit: any }>;
-    /**
-     * Custom template of submenuicon.
-     */
-    submenuicon(): TemplateRef<any>;
 }

--- a/src/app/components/menu/public_api.ts
+++ b/src/app/components/menu/public_api.ts
@@ -1,1 +1,2 @@
 export * from './menu';
+export * from './menu.interface';

--- a/src/app/components/menubar/menubar.interface.ts
+++ b/src/app/components/menubar/menubar.interface.ts
@@ -14,6 +14,16 @@ export interface MenubarTemplates {
      */
     end(): TemplateRef<any>;
     /**
+     * Custom template of icon.
+     * @param {Object} context - item data.
+     */
+    icon(context: {
+        /**
+         * Item icon.
+         */
+        $implicit: any;
+    }): TemplateRef<{ $implicit: any }>;
+    /**
      * Custom template of menuicon.
      */
     menuicon(): TemplateRef<any>;

--- a/src/app/components/menubar/menubar.ts
+++ b/src/app/components/menubar/menubar.ts
@@ -21,6 +21,7 @@ import {
     ViewChild,
     ViewEncapsulation,
     effect,
+    forwardRef,
     signal
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
@@ -54,7 +55,7 @@ export class MenubarService {
     selector: 'p-menubarSub',
     template: `
         <ul
-            #menubar
+            #sublist
             [ngClass]="{ 'p-submenu-list': !root, 'p-menubar-root-list': root }"
             [attr.data-pc-section]="'menu'"
             role="menu"
@@ -110,16 +111,19 @@ export class MenubarService {
                             [attr.tabindex]="-1"
                             pRipple
                         >
-                            <span
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                class="p-menuitem-icon"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            >
-                            </span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!menubar.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                >
+                                </span>
+                                <ng-template *ngTemplateOutlet="menubar.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span *ngIf="getItemProp(processedItem, 'escape'); else htmlLabel" class="p-menuitem-text" [attr.data-pc-section]="'label'">
                                 {{ getItemLabel(processedItem) }}
                             </span>
@@ -156,15 +160,19 @@ export class MenubarService {
                             [state]="getItemProp(processedItem, 'state')"
                             pRipple
                         >
-                            <span
-                                class="p-menuitem-icon"
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            ></span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!menubar.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                >
+                                </span>
+                                <ng-template *ngTemplateOutlet="menubar.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span class="p-menuitem-text" *ngIf="getItemProp(processedItem, 'escape'); else htmlRouteLabel">{{ getItemLabel(processedItem) }}</span>
                             <ng-template #htmlRouteLabel><span class="p-menuitem-text" [innerHTML]="getItemLabel(processedItem)" [attr.data-pc-section]="'label'"></span></ng-template>
                             <span class="p-menuitem-badge" *ngIf="getItemProp(processedItem, 'badge')" [ngClass]="getItemProp(processedItem, 'badgeStyleClass')">{{ getItemProp(processedItem, 'badge') }}</span>
@@ -234,11 +242,11 @@ export class MenubarSub implements OnInit, OnDestroy {
 
     @Output() menuKeydown: EventEmitter<any> = new EventEmitter();
 
-    @ViewChild('menubar', { static: true }) menubarViewChild: ElementRef;
+    @ViewChild('sublist', { static: true }) menubarViewChild: ElementRef;
 
     mouseLeaveSubscriber: Subscription | undefined;
 
-    constructor(public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, private menubarService: MenubarService) {}
+    constructor(public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, private menubarService: MenubarService, @Inject(forwardRef(() => Menubar)) public menubar: Menubar) {}
 
     ngOnInit() {
         this.mouseLeaveSubscriber = this.menubarService.mouseLeft$.subscribe(() => {
@@ -482,6 +490,8 @@ export class Menubar implements AfterContentInit, OnDestroy, OnInit {
 
     endTemplate: TemplateRef<any> | undefined;
 
+    iconTemplate: TemplateRef<any> | undefined;
+
     menuIconTemplate: TemplateRef<any> | undefined;
 
     submenuIconTemplate: TemplateRef<any> | undefined;
@@ -568,6 +578,10 @@ export class Menubar implements AfterContentInit, OnDestroy, OnInit {
 
                 case 'end':
                     this.endTemplate = item.template;
+                    break;
+
+                case 'icon':
+                    this.iconTemplate = item.template;
                     break;
 
                 case 'menuicon':

--- a/src/app/components/panelmenu/panelmenu.ts
+++ b/src/app/components/panelmenu/panelmenu.ts
@@ -83,7 +83,10 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                                 </ng-container>
                                 <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate"></ng-template>
                             </ng-container>
-                            <span class="p-menuitem-icon" [ngClass]="processedItem.icon" *ngIf="processedItem.icon" [ngStyle]="getItemProp(processedItem, 'iconStyle')"></span>
+                            <ng-container *ngIf="processedItem.icon">
+                                <span *ngIf="!panelMenu.iconTemplate" class="p-menuitem-icon" [ngClass]="processedItem.icon" [ngStyle]="getItemProp(processedItem, 'iconStyle')"></span>
+                                <ng-template *ngTemplateOutlet="panelMenu.iconTemplate; context: { $implicit: processedItem.icon }"></ng-template>
+                            </ng-container>
                             <span class="p-menuitem-text" *ngIf="processedItem.item?.escape !== false; else htmlLabel">{{ getItemProp(processedItem, 'label') }}</span>
                             <ng-template #htmlLabel><span class="p-menuitem-text" [innerHTML]="getItemProp(processedItem, 'label')"></span></ng-template>
                             <span class="p-menuitem-badge" *ngIf="processedItem.badge" [ngClass]="processedItem.badgeStyleClass">{{ processedItem.badge }}</span>
@@ -114,7 +117,10 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                                 </ng-container>
                                 <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate"></ng-template>
                             </ng-container>
-                            <span class="p-menuitem-icon" [ngClass]="processedItem.icon" *ngIf="processedItem.icon" [ngStyle]="getItemProp(processedItem, 'iconStyle')"></span>
+                            <ng-container *ngIf="processedItem.icon">
+                                <span *ngIf="!panelMenu.iconTemplate" class="p-menuitem-icon" [ngClass]="processedItem.icon" [ngStyle]="getItemProp(processedItem, 'iconStyle')"></span>
+                                <ng-template *ngTemplateOutlet="panelMenu.iconTemplate; context: { $implicit: processedItem.icon }"></ng-template>
+                            </ng-container>
                             <span class="p-menuitem-text" *ngIf="getItemProp(processedItem, 'escape') !== false; else htmlRouteLabel">{{ getItemProp(processedItem, 'label') }}</span>
                             <ng-template #htmlRouteLabel><span class="p-menuitem-text" [innerHTML]="getItemProp(processedItem, 'label')"></span></ng-template>
                             <span class="p-menuitem-badge" *ngIf="processedItem.badge" [ngClass]="getItemProp(processedItem, 'badgeStyleClass')">{{ getItemProp(processedItem, 'badge') }}</span>
@@ -719,7 +725,10 @@ export class PanelMenuList implements OnChanges {
                                     </ng-container>
                                     <ng-template *ngTemplateOutlet="submenuIconTemplate"></ng-template>
                                 </ng-container>
-                                <span class="p-menuitem-icon" [ngClass]="item.icon" *ngIf="item.icon" [ngStyle]="getItemProp(item, 'iconStyle')"></span>
+                                <ng-container *ngIf="item.icon">
+                                    <span *ngIf="!iconTemplate" class="p-menuitem-icon" [ngClass]="item.icon" [ngStyle]="getItemProp(item, 'iconStyle')"></span>
+                                    <ng-template *ngTemplateOutlet="iconTemplate; context: { $implicit: item.icon }"></ng-template>
+                                </ng-container>
                                 <span class="p-menuitem-text" *ngIf="getItemProp(item, 'escape') !== false; else htmlLabel">{{ getItemProp(item, 'label') }}</span>
                                 <ng-template #htmlLabel><span class="p-menuitem-text" [innerHTML]="getItemProp(item, 'label')"></span></ng-template>
                                 <span class="p-menuitem-badge" *ngIf="getItemProp(item, 'badge')" [ngClass]="getItemProp(item, 'badgeStyleClass')">{{ getItemProp(item, 'badge') }}</span>
@@ -748,7 +757,10 @@ export class PanelMenuList implements OnChanges {
                                     </ng-container>
                                     <ng-template *ngTemplateOutlet="submenuIconTemplate"></ng-template>
                                 </ng-container>
-                                <span class="p-menuitem-icon" [ngClass]="item.icon" *ngIf="item.icon" [ngStyle]="getItemProp(item, 'iconStyle')"></span>
+                                <ng-container *ngIf="item.icon">
+                                    <span *ngIf="!iconTemplate" class="p-menuitem-icon" [ngClass]="item.icon" [ngStyle]="getItemProp(item, 'iconStyle')"></span>
+                                    <ng-template *ngTemplateOutlet="iconTemplate; context: { $implicit: item.icon }"></ng-template>
+                                </ng-container>
                                 <span class="p-menuitem-text" *ngIf="getItemProp(item, 'escape') !== false; else htmlRouteLabel">{{ getItemProp(item, 'label') }}</span>
                                 <ng-template #htmlRouteLabel><span class="p-menuitem-text" [innerHTML]="getItemProp(item, 'label')"></span></ng-template>
                                 <span class="p-menuitem-badge" *ngIf="getItemProp(item, 'badge')" [ngClass]="getItemProp(item, 'badgeStyleClass')">{{ getItemProp(item, 'badge') }}</span>
@@ -848,7 +860,9 @@ export class PanelMenu implements AfterContentInit {
     @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
 
     @ViewChild('container') containerViewChild: ElementRef | undefined;
-
+    
+    iconTemplate: TemplateRef<any> | undefined;
+    
     submenuIconTemplate: TemplateRef<any> | undefined;
 
     public animating: boolean | undefined;
@@ -862,6 +876,10 @@ export class PanelMenu implements AfterContentInit {
     ngAfterContentInit() {
         this.templates?.forEach((item) => {
             switch (item.getType()) {
+                case 'icon':
+                    this.iconTemplate = item.template;
+                    break;
+                
                 case 'submenuicon':
                     this.submenuIconTemplate = item.template;
                     break;

--- a/src/app/components/slidemenu/slidemenu.interface.ts
+++ b/src/app/components/slidemenu/slidemenu.interface.ts
@@ -6,6 +6,16 @@ import { TemplateRef } from '@angular/core';
  */
 export interface SlideMenuTemplates {
     /**
+     * Custom template of icon.
+     * @param {Object} context - item data.
+     */
+    icon(context: {
+        /**
+         * Item icon.
+         */
+        $implicit: any;
+    }): TemplateRef<{ $implicit: any }>;
+    /**
      * Custom template of backicon.
      */
     backicon(): TemplateRef<any>;

--- a/src/app/components/slidemenu/slidemenu.ts
+++ b/src/app/components/slidemenu/slidemenu.ts
@@ -101,16 +101,19 @@ import { CaretLeftIcon } from 'primeng/icons/caretleft';
                             [attr.tabindex]="-1"
                             pRipple
                         >
-                            <span
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                class="p-menuitem-icon"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            >
-                            </span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!slideMenu.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                >
+                                </span>
+                                <ng-template *ngTemplateOutlet="slideMenu.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span *ngIf="getItemProp(processedItem, 'escape'); else htmlLabel" class="p-menuitem-text" [attr.data-pc-section]="'label'">
                                 {{ getItemLabel(processedItem) }}
                             </span>
@@ -144,16 +147,19 @@ import { CaretLeftIcon } from 'primeng/icons/caretleft';
                             [state]="getItemProp(processedItem, 'state')"
                             pRipple
                         >
-                            <span
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                class="p-menuitem-icon"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            >
-                            </span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!slideMenu.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                >
+                                </span>
+                                <ng-template *ngTemplateOutlet="slideMenu.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span *ngIf="getItemProp(processedItem, 'escape'); else htmlLabel" class="p-menuitem-text" [attr.data-pc-section]="'label'">
                                 {{ getItemLabel(processedItem) }}
                             </span>
@@ -509,6 +515,8 @@ export class SlideMenu implements OnInit, AfterContentInit, OnDestroy {
 
     @ViewChild('slideMenuContent') slideMenuContentViewChild: ElementRef<any> | undefined;
 
+    iconTemplate: Nullable<TemplateRef<any>>;
+
     submenuIconTemplate: Nullable<TemplateRef<any>>;
 
     backIconTemplate: TemplateRef<any>;
@@ -606,6 +614,10 @@ export class SlideMenu implements OnInit, AfterContentInit, OnDestroy {
     ngAfterContentInit() {
         this.templates.forEach((item) => {
             switch (item.getType()) {
+                case 'icon':
+                    this.iconTemplate = item.template;
+                    break;
+
                 case 'backicon':
                     this.backIconTemplate = item.template;
                     break;

--- a/src/app/components/tieredmenu/tieredmenu.interface.ts
+++ b/src/app/components/tieredmenu/tieredmenu.interface.ts
@@ -6,6 +6,16 @@ import { TemplateRef } from '@angular/core';
  */
 export interface TieredMenuTemplates {
     /**
+     * Custom template of icon.
+     * @param {Object} context - item data.
+     */
+    icon(context: {
+        /**
+         * Item icon.
+         */
+        $implicit: any;
+    }): TemplateRef<{ $implicit: any }>;
+    /**
      * Custom template of submenuicon.
      */
     submenuicon(): TemplateRef<any>;

--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -95,16 +95,19 @@ import { ObjectUtils, UniqueComponentId, ZIndexUtils } from 'primeng/utils';
                             [attr.tabindex]="-1"
                             pRipple
                         >
-                            <span
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                class="p-menuitem-icon"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            >
-                            </span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!tieredMenu.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                >
+                                </span>
+                                <ng-template *ngTemplateOutlet="tieredMenu.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span *ngIf="getItemProp(processedItem, 'escape'); else htmlLabel" class="p-menuitem-text" [attr.data-pc-section]="'label'">
                                 {{ getItemLabel(processedItem) }}
                             </span>
@@ -138,16 +141,19 @@ import { ObjectUtils, UniqueComponentId, ZIndexUtils } from 'primeng/utils';
                             [state]="getItemProp(processedItem, 'state')"
                             pRipple
                         >
-                            <span
-                                *ngIf="getItemProp(processedItem, 'icon')"
-                                class="p-menuitem-icon"
-                                [ngClass]="getItemProp(processedItem, 'icon')"
-                                [ngStyle]="getItemProp(processedItem, 'iconStyle')"
-                                [attr.data-pc-section]="'icon'"
-                                [attr.aria-hidden]="true"
-                                [attr.tabindex]="-1"
-                            >
-                            </span>
+                            <ng-container *ngIf="getItemProp(processedItem, 'icon')">
+                                <span
+                                    *ngIf="!tieredMenu.iconTemplate"
+                                    class="p-menuitem-icon"
+                                    [ngClass]="getItemProp(processedItem, 'icon')"
+                                    [ngStyle]="getItemProp(processedItem, 'iconStyle')"
+                                    [attr.data-pc-section]="'icon'"
+                                    [attr.aria-hidden]="true"
+                                    [attr.tabindex]="-1"
+                                >
+                                </span>
+                                <ng-template *ngTemplateOutlet="tieredMenu.iconTemplate; context: { $implicit: getItemProp(processedItem, 'icon') }" [attr.data-pc-section]="'icon'" [attr.aria-hidden]="true" [attr.tabindex]="-1"></ng-template>
+                            </ng-container>
                             <span *ngIf="getItemProp(processedItem, 'escape'); else htmlLabel" class="p-menuitem-text" [attr.data-pc-section]="'label'">
                                 {{ getItemLabel(processedItem) }}
                             </span>
@@ -312,6 +318,7 @@ export class TieredMenuSub {
     }
 
     onItemClick(event: any, processedItem: any) {
+        console.log(this.tieredMenu.iconTemplate);
         this.getItemProp(processedItem, 'command', { originalEvent: event, item: processedItem.item });
         this.itemClick.emit({ originalEvent: event, processedItem, isFocus: true });
     }
@@ -468,6 +475,8 @@ export class TieredMenu implements OnInit, AfterContentInit, OnDestroy {
 
     @ViewChild('container') containerViewChild: ElementRef<any> | undefined;
 
+    iconTemplate: Nullable<TemplateRef<any>>;
+    
     submenuIconTemplate: Nullable<TemplateRef<any>>;
 
     container: HTMLDivElement | undefined;
@@ -553,6 +562,10 @@ export class TieredMenu implements OnInit, AfterContentInit, OnDestroy {
     ngAfterContentInit() {
         this.templates?.forEach((item) => {
             switch (item.getType()) {
+                case 'icon':
+                    this.iconTemplate = item.template;
+                    break;
+                
                 case 'submenuicon':
                     this.submenuIconTemplate = item.template;
                     break;

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -13489,6 +13489,18 @@
                     },
                     {
                         "parent": "megamenu",
+                        "name": "icon",
+                        "parameters": [
+                            {
+                                "name": "context",
+                                "type": "{\n  \t $implicit: any, // Item icon.\n  }",
+                                "description": "item data."
+                            }
+                        ],
+                        "description": "Custom template of icon."
+                    },
+                    {
+                        "parent": "megamenu",
                         "name": "submenuicon",
                         "parameters": [],
                         "description": "Custom template of submenuicon."
@@ -13687,6 +13699,26 @@
                     ]
                 }
             }
+        },
+        "interfaces": {
+            "components": {},
+            "templates": {
+                "description": "Defines the templates used by the component.",
+                "values": [
+                    {
+                        "parent": "menu",
+                        "name": "icon",
+                        "parameters": [
+                            {
+                                "name": "context",
+                                "type": "{\n  \t $implicit: any, // Item icon.\n  }",
+                                "description": "item data."
+                            }
+                        ],
+                        "description": "Custom template of icon."
+                    }
+                ]
+            }
         }
     },
     "menubar": {
@@ -13822,6 +13854,18 @@
                         "name": "end",
                         "parameters": [],
                         "description": "Custom template of end."
+                    },
+                    {
+                        "parent": "menubar",
+                        "name": "icon",
+                        "parameters": [
+                            {
+                                "name": "context",
+                                "type": "{\n  \t $implicit: any, // Item icon.\n  }",
+                                "description": "item data."
+                            }
+                        ],
+                        "description": "Custom template of icon."
                     },
                     {
                         "parent": "menubar",
@@ -16281,6 +16325,18 @@
             "templates": {
                 "description": "Defines the templates used by the component.",
                 "values": [
+                    {
+                        "parent": "panelmenu",
+                        "name": "icon",
+                        "parameters": [
+                            {
+                                "name": "context",
+                                "type": "{\n  \t $implicit: any, // Item icon.\n  }",
+                                "description": "item data."
+                            }
+                        ],
+                        "description": "Custom template of icon."
+                    },
                     {
                         "parent": "panelmenu",
                         "name": "submenuicon",
@@ -19181,6 +19237,18 @@
             "templates": {
                 "description": "Defines the templates used by the component.",
                 "values": [
+                    {
+                        "parent": "slidemenu",
+                        "name": "icon",
+                        "parameters": [
+                            {
+                                "name": "context",
+                                "type": "{\n  \t $implicit: any, // Item icon.\n  }",
+                                "description": "item data."
+                            }
+                        ],
+                        "description": "Custom template of icon."
+                    },
                     {
                         "parent": "slidemenu",
                         "name": "backicon",
@@ -22550,6 +22618,18 @@
             "templates": {
                 "description": "Defines the templates used by the component.",
                 "values": [
+                    {
+                        "parent": "tieredmenu",
+                        "name": "icon",
+                        "parameters": [
+                            {
+                                "name": "context",
+                                "type": "{\n  \t $implicit: any, // Item icon.\n  }",
+                                "description": "item data."
+                            }
+                        ],
+                        "description": "Custom template of icon."
+                    },
                     {
                         "parent": "tieredmenu",
                         "name": "submenuicon",


### PR DESCRIPTION
Feature #13789 

This PR adds a template to customize the icons in menu components (Menu, Menubar, MegaMenu, PanelMenu, SlideMenu and TieredMenu) so they can be used with icon libraries that require to render a custom component instead of using classes.

E.g: [FontAwesome Angular](https://fontawesome.com/docs/web/use-with/angular) where icons are used like `<fa-icon [icon]="faCoffee"></fa-icon>`


I've added a working example of each component under "Basic" section in docs in https://github.com/ianvaernet/primeng/tree/menu-icon-template-examples but I haven't included those examples in this PR given that their use may not be that frequent and they require an external library.

![image](https://github.com/primefaces/primeng/assets/38286974/63bdd0ba-332c-4e0b-8060-ac9aca7fd0f6)
