### PR TITLE
fix: #13781 || dataTable: frozenColumn header overlap with frozen body

### DIFF
--- a/src/app/components/table/table.css
+++ b/src/app/components/table/table.css
@@ -45,7 +45,7 @@
     .p-datatable-scrollable-table > .p-datatable-thead {
         position: sticky;
         top: 0;
-        z-index: 1;
+        z-index: 2;
     }
 
     .p-datatable-scrollable-table > .p-datatable-frozen-tbody {
@@ -84,7 +84,7 @@
 
     .p-datatable-scrollable-table > .p-datatable-tbody > .p-rowgroup-header {
         position: sticky;
-        z-index: 1;
+        z-index: 2;
     }
 
     /* Resizable */
@@ -163,7 +163,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        z-index: 2;
+        z-index: 3;
     }
 
     /* Filter */


### PR DESCRIPTION
### Defect Fixes

Fix: #13781 

## Explanation 

I apologize for any oversight in my previous pull request. In this new pull request, I've taken steps to ensure that the changes won't adversely affect any other parts of the codebase.

The primary change in this PR involves adjusting the z-index values for various elements. Specifically, I've set the z-index of datatable-thead and rowgroup-header to level 2, and the datatable-loading-overlay now has a z-index of 3.

I also considered raising the z-index of datatable-tfoot to level 2, but after thorough testing, I couldn't identify any issues with the current setup. I'm somewhat uncertain about whether this adjustment is necessary, so I'd appreciate any guidance or suggestions in this regard.

Please review the changes, and I'm open to any feedback or additional adjustments to ensure the code remains robust. Thank you for your time and consideration.