### PR TITLE
Dataview / Tooltip: Fix wrong documentation

### DIFF
--- a/src/app/components/api/tooltipoptions.ts
+++ b/src/app/components/api/tooltipoptions.ts
@@ -14,7 +14,7 @@ export interface TooltipOptions {
      */
     tooltipPosition?: 'right' | 'left' | 'top' | 'bottom';
     /**
-     * Position of tooltip.
+     * Event to show the tooltip.
      */
     tooltipEvent?: 'hover' | 'focus';
     /**

--- a/src/app/showcase/doc/dataview/importdoc.ts
+++ b/src/app/showcase/doc/dataview/importdoc.ts
@@ -14,6 +14,6 @@ export class ImportDoc {
     @Input() title: string;
 
     code: Code = {
-        typescript: `import { DataViewModule, DataViewLayoutOptions } from 'primeng/dataview';`
+        typescript: `import { DataViewModule } from 'primeng/dataview';`
     };
 }


### PR DESCRIPTION
Fix #13794

## CURRENTLY

![image](https://github.com/primefaces/primeng/assets/19764334/5ced1a28-6877-4ef2-9342-c284e5f76c76)

This import is not necessary

![image](https://github.com/primefaces/primeng/assets/19764334/6247acc5-115d-42fd-ba8b-12df6d9377b2)

## AFTER SOLUTION

![image](https://github.com/primefaces/primeng/assets/19764334/77a90112-5b9f-4a5e-9195-601b8e627065)

![image](https://github.com/primefaces/primeng/assets/19764334/43d527cf-b59e-451c-9c3a-4aae21a7af43)
