### PR TITLE
Fixed OverlayPanel containing component

### DIFF
--- a/src/app/components/overlaypanel/overlaypanel.ts
+++ b/src/app/components/overlaypanel/overlaypanel.ts
@@ -229,7 +229,7 @@ export class OverlayPanel implements AfterContentInit, OnDestroy {
                 const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : this.document;
 
                 this.documentClickListener = this.renderer.listen(documentTarget, documentEvent, (event) => {
-                    if (!this.container?.contains(event.target) && !this.target.contains(event.target)) {
+                    if (!this.container?.contains(event.target) && this.target !== event.target && !this.target.contains(event.target)) {
                         this.hide();
                     }
 


### PR DESCRIPTION
Fixes #13601 #13605 

### Problem
Starting from version **16.2.0** the component OverlayPanel suffered a significant regression when it contains a component through the template directive.
It would close after a random number of clicks inside the contained component, making the component unusable. The problem is reproducible by inserting any PrimeNg component inside the OverlayPanel and rendering it through Template directive.

### Solved
Restored part of the check previously modified in PR #13480 to solve problem where OverlayPanel component would not close when user clicks outside the panel.
