### PR TITLE
Issues#13845/Accordion Component Allows Tab Navigation Into Closed Accordion Tabs

### DIFF
--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -281,9 +281,29 @@ export class AccordionTab implements AfterContentInit, OnDestroy {
 
         this.selectedChange.emit(this.selected);
         this.accordion.updateActiveIndex();
+        this.fixKeyboardNavigation();
         this.changeDetector.markForCheck();
 
         event.preventDefault();
+    }
+
+    fixKeyboardNavigation() {
+        const accordionTabs = this.accordion.el.nativeElement.querySelectorAll('.p-accordion-tab');
+        accordionTabs.forEach((tab) => {
+            const content = tab.querySelector('.p-accordion-content');
+            const focusableElements = DomHandler.getFocusableElements(content);
+            if (tab.classList.contains('p-accordion-tab-active')) {
+                focusableElements.forEach((element) => {
+                    if (!element.classList.contains('p-accordion-header-link')) {
+                        element.tabIndex = -2;
+                    }
+                });
+            } else {
+                focusableElements.forEach((element) => {
+                    element.tabIndex = 0;
+                });
+            }
+        });
     }
 
     findTabIndex() {

--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -292,17 +292,9 @@ export class AccordionTab implements AfterContentInit, OnDestroy {
         accordionTabs.forEach((tab) => {
             const content = tab.querySelector('.p-accordion-content');
             const focusableElements = DomHandler.getFocusableElements(content);
-            if (tab.classList.contains('p-accordion-tab-active')) {
-                focusableElements.forEach((element) => {
-                    if (!element.classList.contains('p-accordion-header-link')) {
-                        element.tabIndex = -2;
-                    }
-                });
-            } else {
-                focusableElements.forEach((element) => {
-                    element.tabIndex = 0;
-                });
-            }
+            focusableElements.forEach((element) => {
+                element.tabIndex = tab.classList.contains('p-accordion-tab-active') && !element.classList.contains('p-accordion-header-link') ? -2 : 0;
+            });
         });
     }
 


### PR DESCRIPTION
When any tab is toggled, run fixKeyboardNavigation method to set tabIndex of focusable elements inside of tabs, both open and closed. When a tab is open, focusable elements inside of that open tab have tabIndex of 0, when it's closed, set them to -2 to avoid accessing.

Using -2 instead of -1, as DomHandler.getFocusableElements ignores elements with tabIndex of -2

Issue can be found [here](https://github.com/primefaces/primeng/issues/13845)
Fix #13845

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
