### PR TITLE
13828 fix autohide tooltip

### DIFF
--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -358,7 +358,7 @@ export class Carousel implements AfterContentInit {
     }
 
     ngOnChanges(simpleChange: SimpleChanges) {
-        if(isPlatformBrowser(this.platformId)) {
+        if (isPlatformBrowser(this.platformId)) {
             if (simpleChange.value) {
                 if (this.circular && this._value) {
                     this.setCloneItems();
@@ -370,42 +370,41 @@ export class Carousel implements AfterContentInit {
                     if (this.responsiveOptions) {
                         this.defaultNumVisible = this.numVisible;
                     }
-    
+
                     if (this.isCircular()) {
                         this.setCloneItems();
                     }
-    
+
                     this.createStyle();
                     this.calculatePosition();
                 }
-    
+
                 if (simpleChange.numScroll) {
                     if (this.responsiveOptions) {
                         this.defaultNumScroll = this.numScroll;
                     }
                 }
             }
-
         }
     }
 
     ngAfterContentInit() {
         this.id = UniqueComponentId();
-        if(isPlatformBrowser(this.platformId)) {
+        if (isPlatformBrowser(this.platformId)) {
             this.allowAutoplay = !!this.autoplayInterval;
 
             if (this.circular) {
                 this.setCloneItems();
             }
-    
+
             if (this.responsiveOptions) {
                 this.defaultNumScroll = this._numScroll;
                 this.defaultNumVisible = this._numVisible;
             }
-    
+
             this.createStyle();
             this.calculatePosition();
-    
+
             if (this.responsiveOptions) {
                 this.bindDocumentListeners();
             }
@@ -441,17 +440,17 @@ export class Carousel implements AfterContentInit {
     }
 
     ngAfterContentChecked() {
-        if(isPlatformBrowser(this.platformId)) {
+        if (isPlatformBrowser(this.platformId)) {
             const isCircular = this.isCircular();
             let totalShiftedItems = this.totalShiftedItems;
-    
+
             if (this.value && this.itemsContainer && (this.prevState.numScroll !== this._numScroll || this.prevState.numVisible !== this._numVisible || this.prevState.value.length !== this.value.length)) {
                 if (this.autoplayInterval) {
                     this.stopAutoplay(false);
                 }
-    
+
                 this.remainingItems = (this.value.length - this._numVisible) % this._numScroll;
-    
+
                 let page = this._page;
                 if (this.totalDots() !== 0 && page >= this.totalDots()) {
                     page = this.totalDots() - 1;
@@ -460,39 +459,39 @@ export class Carousel implements AfterContentInit {
                         page: this.page
                     });
                 }
-    
+
                 totalShiftedItems = page * this._numScroll * -1;
                 if (isCircular) {
                     totalShiftedItems -= this._numVisible;
                 }
-    
+
                 if (page === this.totalDots() - 1 && this.remainingItems > 0) {
                     totalShiftedItems += -1 * this.remainingItems + this._numScroll;
                     this.isRemainingItemsAdded = true;
                 } else {
                     this.isRemainingItemsAdded = false;
                 }
-    
+
                 if (totalShiftedItems !== this.totalShiftedItems) {
                     this.totalShiftedItems = totalShiftedItems;
                 }
-    
+
                 this._oldNumScroll = this._numScroll;
                 this.prevState.numScroll = this._numScroll;
                 this.prevState.numVisible = this._numVisible;
                 this.prevState.value = [...(this._value as any[])];
-    
+
                 if (this.totalDots() > 0 && this.itemsContainer.nativeElement) {
                     this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
                 }
-    
+
                 this.isCreated = true;
-    
+
                 if (this.autoplayInterval && this.isAutoplay()) {
                     this.startAutoplay();
                 }
             }
-    
+
             if (isCircular) {
                 if (this.page === 0) {
                     totalShiftedItems = -1 * this._numVisible;
@@ -502,7 +501,7 @@ export class Carousel implements AfterContentInit {
                         this.isRemainingItemsAdded = true;
                     }
                 }
-    
+
                 if (totalShiftedItems !== this.totalShiftedItems) {
                     this.totalShiftedItems = totalShiftedItems;
                 }

--- a/src/app/components/galleria/galleria.ts
+++ b/src/app/components/galleria/galleria.ts
@@ -280,7 +280,7 @@ export class Galleria implements OnChanges, OnDestroy {
 
     maskVisible: boolean = false;
 
-    constructor(@Inject(DOCUMENT) private document: Document,  @Inject(PLATFORM_ID) public platformId: any, public element: ElementRef, public cd: ChangeDetectorRef, public config: PrimeNGConfig) {}
+    constructor(@Inject(DOCUMENT) private document: Document, @Inject(PLATFORM_ID) public platformId: any, public element: ElementRef, public cd: ChangeDetectorRef, public config: PrimeNGConfig) {}
 
     ngAfterContentInit() {
         this.templates?.forEach((item) => {
@@ -518,13 +518,13 @@ export class GalleriaContent implements DoCheck {
     }
 
     startSlideShow() {
-        if(isPlatformBrowser(this.galleria.platformId)) {
+        if (isPlatformBrowser(this.galleria.platformId)) {
             this.interval = setInterval(() => {
                 let activeIndex = this.galleria.circular && this.value.length - 1 === this.activeIndex ? 0 : this.activeIndex + 1;
                 this.onActiveIndexChange(activeIndex);
                 this.activeIndex = activeIndex;
             }, this.galleria.transitionInterval);
-    
+
             this.slideShowActive = true;
         }
     }

--- a/src/app/components/image/image.ts
+++ b/src/app/components/image/image.ts
@@ -23,7 +23,7 @@ import { FocusTrapModule } from 'primeng/focustrap';
     template: `
         <span [ngClass]="containerClass()" [class]="styleClass" [ngStyle]="style">
             <img [attr.src]="src" [attr.srcset]="srcSet" [attr.sizes]="sizes" [attr.alt]="alt" [attr.width]="width" [attr.height]="height" [ngStyle]="imageStyle" [class]="imageClass" (error)="imageError($event)" />
-            <button type="button" class="p-image-preview-indicator" (click)="onImageClick()" #previewButton [ngStyle]="{'height': height + 'px', 'width': width + 'px'}" style="border: 'none';">
+            <button type="button" class="p-image-preview-indicator" (click)="onImageClick()" #previewButton [ngStyle]="{ height: height + 'px', width: width + 'px' }" style="border: 'none';">
                 <ng-container *ngIf="indicatorTemplate; else defaultTemplate">
                     <ng-container *ngTemplateOutlet="indicatorTemplate"></ng-container>
                 </ng-container>

--- a/src/app/components/tooltip/tooltip.css
+++ b/src/app/components/tooltip/tooltip.css
@@ -4,7 +4,6 @@
         display: none;
         padding: 0.25em 0.5rem;
         max-width: 12.5rem;
-        pointer-events: none;
     }
 
     .p-tooltip.p-tooltip-right,

--- a/src/app/components/tooltip/tooltip.css
+++ b/src/app/components/tooltip/tooltip.css
@@ -4,6 +4,7 @@
         display: none;
         padding: 0.25em 0.5rem;
         max-width: 12.5rem;
+        pointer-events: none;
     }
 
     .p-tooltip.p-tooltip-right,

--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -163,7 +163,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     resizeListener: any;
 
-    constructor(@Inject(PLATFORM_ID) private platformId: any, public el: ElementRef, public zone: NgZone, public config: PrimeNGConfig, private renderer: Renderer2, private viewContainer: ViewContainerRef) { }
+    constructor(@Inject(PLATFORM_ID) private platformId: any, public el: ElementRef, public zone: NgZone, public config: PrimeNGConfig, private renderer: Renderer2, private viewContainer: ViewContainerRef) {}
 
     ngAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
@@ -701,4 +701,4 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     exports: [Tooltip],
     declarations: [Tooltip]
 })
-export class TooltipModule { }
+export class TooltipModule {}

--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -163,7 +163,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     resizeListener: any;
 
-    constructor(@Inject(PLATFORM_ID) private platformId: any, public el: ElementRef, public zone: NgZone, public config: PrimeNGConfig, private renderer: Renderer2, private viewContainer: ViewContainerRef) {}
+    constructor(@Inject(PLATFORM_ID) private platformId: any, public el: ElementRef, public zone: NgZone, public config: PrimeNGConfig, private renderer: Renderer2, private viewContainer: ViewContainerRef) { }
 
     ngAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
@@ -389,7 +389,10 @@ export class Tooltip implements AfterViewInit, OnDestroy {
             this.container.style.width = 'fit-content';
         }
 
-        if (!this.isAutoHide()) {
+        if (this.isAutoHide()) {
+            this.container.style.pointerEvents = 'none';
+        } else {
+            this.container.style.pointerEvents = 'unset';
             this.bindContainerMouseleaveListener();
         }
     }
@@ -698,4 +701,4 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     exports: [Tooltip],
     declarations: [Tooltip]
 })
-export class TooltipModule {}
+export class TooltipModule { }


### PR DESCRIPTION
Fix #13828

I have reverted the problem caused by this commit: https://github.com/primefaces/primeng/commit/bc98f435587562e234b36d035e0a544884232813.
[This was the issue](https://github.com/primefaces/primeng/issues/13680) before but I have not be able to reproduce the flickering in the tooltip and for that I think the best solution was remove the `pointer-events`.

# EDIT ⚠️ 
Finally I added a conditional to avoid the flickering. I cannot reproduce it but just in case now I added `pointer-events: none` when is `autoHide=true` and `pointer-events: unset` when `autoHide=false`. All works perfectly.

## PROBLEM
![problem autohide tooltip](https://github.com/primefaces/primeng/assets/19764334/ab185c85-444f-428f-899e-60f9f2273eea)

## AFTER SOLUTION
![fix autohide tooltip](https://github.com/primefaces/primeng/assets/19764334/25eaa562-40fd-49e3-af44-2df7154af303)

