### PR TITLE
Issues#13859/Multiselect Component Close Button Accessibility Issues - Empty Button and Screen Reader reading 'Unlabeled Button'

### DIFF
--- a/src/app/components/multiselect/multiselect.css
+++ b/src/app/components/multiselect/multiselect.css
@@ -99,6 +99,10 @@
         position: relative;
     }
 
+    .p-multiselect-close-label {
+        display: none;
+    }
+
     .p-fluid .p-multiselect {
         display: flex;
     }

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -251,7 +251,8 @@ export class MultiSelectItem {
                                     </span>
                                 </div>
 
-                                <button class="p-multiselect-close p-link p-button-icon-only" type="button" (click)="close($event)" pRipple>
+                                <button aria-labelledBy="close-label" class="p-multiselect-close p-link p-button-icon-only" type="button" (click)="close($event)" pRipple>
+                                    <span id="close-label" class="p-multiselect-close-label">Close multiselect input</span>
                                     <TimesIcon [styleClass]="'p-multiselect-close-icon'" *ngIf="!closeIconTemplate" />
                                     <span *ngIf="closeIconTemplate" class="p-multiselect-close-icon">
                                         <ng-template *ngTemplateOutlet="closeIconTemplate"></ng-template>


### PR DESCRIPTION
Add a <span> tag with label text that is hidden. Does not show visually but fixes the empty button 508 error.

Set aria-labelledBy for the button to reference the <span> label, so  a screen reader will read 'close multiselect input' instead of unlabeled

Fix #13859

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
