### PR TITLE
fix: accordionTab.toggle() with no args

### DIFF
--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -283,7 +283,7 @@ export class AccordionTab implements AfterContentInit, OnDestroy {
         this.accordion.updateActiveIndex();
         this.changeDetector.markForCheck();
 
-        event.preventDefault();
+        event?.preventDefault();
     }
 
     findTabIndex() {


### PR DESCRIPTION
Fixes #13872 
