### PR TITLE
Fix sidebar website on click Steps (collapse all the menu)

### DIFF
--- a/src/app/showcase/layout/menu/app.menuitem.component.html
+++ b/src/app/showcase/layout/menu/app.menuitem.component.html
@@ -11,7 +11,7 @@
     </div>
     {{item.name}}
 </a>
-<a *ngIf="item.routerLink" [routerLink]="item.routerLink" routerLinkActive="router-link-active" [routerLinkActiveOptions]="{ paths: 'exact', queryParams: 'ignored', matrixParams: 'ignored', fragment: 'ignored' }">
+<a *ngIf="item.routerLink" [routerLink]="item.routerLink" routerLinkActive="router-link-active" [routerLinkActiveOptions]="{ paths: '', queryParams: 'ignored', matrixParams: 'ignored', fragment: 'ignored' }">
     <div *ngIf="item.icon && root" class="menu-icon">
         <i [ngClass]="item.icon"></i>
     </div>

--- a/src/app/showcase/layout/menu/app.menuitem.component.ts
+++ b/src/app/showcase/layout/menu/app.menuitem.component.ts
@@ -11,10 +11,11 @@ export class AppMenuItemComponent {
 
     @Input() root: boolean = true;
 
-    constructor(private router: Router) {}
+    constructor(private router: Router) { }
 
     isActiveRootMenuItem(menuitem: MenuItem): boolean {
         const url = this.router.url.split('#')[0];
-        return menuitem.children && !menuitem.children.some((item) => item.routerLink === `${url}` || (item.children && item.children.some((it) => it.routerLink === `${url}`)));
+        const rootMenuItemRoute = menuitem.routerLink || '';
+        return url.includes(rootMenuItemRoute);
     }
 }

--- a/src/app/showcase/layout/menu/app.menuitem.component.ts
+++ b/src/app/showcase/layout/menu/app.menuitem.component.ts
@@ -11,7 +11,7 @@ export class AppMenuItemComponent {
 
     @Input() root: boolean = true;
 
-    constructor(private router: Router) { }
+    constructor(private router: Router) {}
 
     isActiveRootMenuItem(menuitem: MenuItem): boolean {
         const url = this.router.url.split('#')[0];


### PR DESCRIPTION
Fix #13885

- Refactor function `isActiveRootMenuItem`. This solved the problem that close all the sidebar on click `steps`.
- Remove `exact` to `"`. Now the class `router-link-active` is added correctly when you click on `steps`.

## PROBLEM
![problem steps](https://github.com/primefaces/primeng/assets/19764334/3134737d-03b0-42d0-a143-2e904e8ba26e)

## AFTER SOLUTION
![steps working](https://github.com/primefaces/primeng/assets/19764334/967045fe-db85-4aca-aa61-064fd631269c)
