### PR TITLE
fixed dropdown navigation (issue #13903)

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1307,8 +1307,10 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             //escape and tab
             case 27:
             case 9:
-                this.hide();
-                event.preventDefault();
+                if (this.overlayVisible) {
+                    this.hide();
+                    event.preventDefault();
+                }
                 break;
 
             //search item based on keyboard input

--- a/src/app/showcase/doc/dropdown/accessibilitydoc.ts
+++ b/src/app/showcase/doc/dropdown/accessibilitydoc.ts
@@ -34,12 +34,6 @@ import { Code } from '../../domain/code';
                     <tbody>
                         <tr>
                             <td>
-                                <i>tab</i>
-                            </td>
-                            <td>Moves focus to the dropdown element.</td>
-                        </tr>
-                        <tr>
-                            <td>
                                 <i>space</i>
                             </td>
                             <td>Opens the popup and moves visual focus to the selected option, if there is none then first option receives the focus.</td>
@@ -74,11 +68,11 @@ import { Code } from '../../domain/code';
                             <td>
                                 <i>tab</i>
                             </td>
-                            <td>Moves focus to the next focusable element in the popup, if there is none then first focusable element receives the focus.</td>
+                            <td>Selects the focused option and closes the popup.</td>
                         </tr>
                         <tr>
                             <td><i>shift</i> + <i>tab</i></td>
-                            <td>Moves focus to the previous focusable element in the popup, if there is none then last focusable element receives the focus.</td>
+                            <td>Selects the focused option and closes the popup.</td>
                         </tr>
                         <tr>
                             <td>


### PR DESCRIPTION
Fixes issue #13903

1. Implement "special" processing for escape and tab only if the overlay is visible 
2. Updated documentation

The following video shows the fix working.  After the fix, a user can navigate away from a dropdown

https://github.com/primefaces/primeng/assets/45439491/9c1ec1ce-c022-42fd-899c-5d15e44a0959