### PR TITLE
fix(calendar): added checking for each month when checking the disabled year

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1660,17 +1660,19 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         return false;
     }
 
-    isMonthDisabled(month: number) {
-        for (let day = 1; day < this.getDaysCountInMonth(month, this.currentYear) + 1; day++) {
-            if (this.isSelectable(day, month, this.currentYear, false)) {
+    isMonthDisabled(month: number, year?: number) {
+        const yearToCheck = year ?? this.currentYear;
+
+        for (let day = 1; day < this.getDaysCountInMonth(month, yearToCheck) + 1; day++) {
+            if (this.isSelectable(day, month, yearToCheck, false)) {
                 return false;
             }
         }
         return true;
     }
 
-    isYearDisabled(year) {
-        return !this.isSelectable(1, this.currentMonth, year, false);
+    isYearDisabled(year: number) {
+        return Array(12).fill(0).every((v, month) => this.isMonthDisabled(month, year));
     }
 
     isYearSelected(year: number) {

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1672,7 +1672,9 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     }
 
     isYearDisabled(year: number) {
-        return Array(12).fill(0).every((v, month) => this.isMonthDisabled(month, year));
+        return Array(12)
+            .fill(0)
+            .every((v, month) => this.isMonthDisabled(month, year));
     }
 
     isYearSelected(year: number) {


### PR DESCRIPTION
Fixes #13919 

When checking the year for disabled status, now each month is checked for disability. 
An optional year parameter has been added to the isMonthDisabled method
