### PR TITLE
Fix #12506 | Chart Docs - Import instructions and tooltip customization

### DIFF
--- a/src/app/showcase/doc/chart/chartjsdoc.ts
+++ b/src/app/showcase/doc/chart/chartjsdoc.ts
@@ -18,10 +18,6 @@ export class ChartjsDoc {
     code: Code = {
         typescript: `
 npm install chart.js --save
-
-"scripts": [
-    "../node_modules/chart.js/dist/chart.js",
-    //..others
-],`
+`
     };
 }

--- a/src/app/showcase/doc/chart/stackedbardoc.ts
+++ b/src/app/showcase/doc/chart/stackedbardoc.ts
@@ -60,7 +60,7 @@ export class StackedBarDoc implements OnInit {
                 maintainAspectRatio: false,
                 aspectRatio: 0.8,
                 plugins: {
-                    tooltips: {
+                    tooltip: {
                         mode: 'index',
                         intersect: false
                     },
@@ -149,7 +149,7 @@ export class ChartStackedBarDemo implements OnInit {
             maintainAspectRatio: false,
             aspectRatio: 0.8,
             plugins: {
-                tooltips: {
+                tooltip: {
                     mode: 'index',
                     intersect: false
                 },


### PR DESCRIPTION
### Defect Fixes
Fixes #12506

### Summary
ChartJS no longer requires adding the script to angular.json because PrimeNG is using the ESM `chart.js/auto` import. Attempting to follow the PrimeNG docs results in an error.

The Stack Bar example also included a customization for tooltips which were improperly configured. 
The [configuration object](https://www.chartjs.org/docs/latest/configuration/tooltip.html#tooltip-configuration) is "tooltip", not "tooltips".

Please note that the StackBlitz and CodeSandbox examples do not include the script tag in angular.json, **but they do have the "tooltips" bug and should also be changed**.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
