### PR TITLE
Fixed #13974 - Fixed carousel circular not working on init in some cases

### DIFF
--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -422,7 +422,7 @@ export class Accordion implements BlockableUI, AfterContentInit, OnDestroy {
      */
     @Output() activeIndexChange: EventEmitter<number | number[]> = new EventEmitter<number | number[]>();
 
-    @ContentChildren(AccordionTab, {descendants: true}) tabList: QueryList<AccordionTab> | undefined;
+    @ContentChildren(AccordionTab, { descendants: true }) tabList: QueryList<AccordionTab> | undefined;
 
     tabListSubscription: Subscription | null = null;
 

--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -386,6 +386,7 @@ export class Carousel implements AfterContentInit {
                 }
             }
         }
+        this.cd.markForCheck();
     }
 
     ngAfterContentInit() {
@@ -437,6 +438,7 @@ export class Carousel implements AfterContentInit {
                     break;
             }
         });
+        this.cd.detectChanges();
     }
 
     ngAfterContentChecked() {
@@ -812,6 +814,7 @@ export class Carousel implements AfterContentInit {
             }
         }, this.autoplayInterval);
         this.allowAutoplay = true;
+        this.cd.markForCheck();
     }
 
     stopAutoplay(changeAllow: boolean = true) {
@@ -822,6 +825,7 @@ export class Carousel implements AfterContentInit {
                 this.allowAutoplay = false;
             }
         }
+        this.cd.markForCheck();
     }
 
     isPlaying(): boolean {


### PR DESCRIPTION
Fixed #13974 - Fixed carousel circular not working on init in some cases

Added more change detection so initial state is working correctly.

(Also contains prettier fix)