### PR TITLE
SplitButton: Hide menu on click on default button.

### DIFF
--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -422,7 +422,7 @@ export class Accordion implements BlockableUI, AfterContentInit, OnDestroy {
      */
     @Output() activeIndexChange: EventEmitter<number | number[]> = new EventEmitter<number | number[]>();
 
-    @ContentChildren(AccordionTab, {descendants: true}) tabList: QueryList<AccordionTab> | undefined;
+    @ContentChildren(AccordionTab, { descendants: true }) tabList: QueryList<AccordionTab> | undefined;
 
     tabListSubscription: Subscription | null = null;
 

--- a/src/app/components/splitbutton/splitbutton.ts
+++ b/src/app/components/splitbutton/splitbutton.ts
@@ -218,6 +218,7 @@ export class SplitButton {
 
     onDefaultButtonClick(event: MouseEvent) {
         this.onClick.emit(event);
+        this.menu.hide();
     }
 
     onDropdownButtonClick(event?: MouseEvent) {


### PR DESCRIPTION
Fix #13962

## PROBLEM
![problem splitbutton](https://github.com/primefaces/primeng/assets/19764334/b0e81669-7d45-4e63-a965-729ef288d165)

## AFTER SOLUTION
![fix splitbutton](https://github.com/primefaces/primeng/assets/19764334/aca053dc-b7df-4b96-96cf-0a9233cc6780)
