### PR TITLE
Fix #13774 - Tab navigation broken on p-dropdown

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1308,7 +1308,6 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             case 27:
             case 9:
                 this.hide();
-                event.preventDefault();
                 break;
 
             //search item based on keyboard input


### PR DESCRIPTION
Fix #13774 

With that fix, keyboard navigation with "tab" key works on dropdown component
