### PR TITLE
Add support dateFormat for buddhist calendar

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -2965,6 +2965,10 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
                         case 'y':
                             output += lookAhead('y') ? date.getFullYear() : (date.getFullYear() % 100 < 10 ? '0' : '') + (date.getFullYear() % 100);
                             break;
+                        case 'B':
+                            let buddhistYear = date.getFullYear() + 543;
+                            output += lookAhead('B') ? buddhistYear : (buddhistYear % 100 < 10 ? '0' : '') + (buddhistYear % 100);
+                            break;
                         case '@':
                             output += date.getTime();
                             break;

--- a/src/app/showcase/doc/calendar/formatdoc.ts
+++ b/src/app/showcase/doc/calendar/formatdoc.ts
@@ -17,8 +17,8 @@ import { Code } from '../../domain/code';
                 <li><i>mm</i> - month of year (two digit)</li>
                 <li><i>M</i> - month name short</li>
                 <li><i>MM</i> - month name long</li>
-                <li><i>B</i> - Full B.E. Year (four digit)</li>
-                <li><i>BB</i> - B.E. Year (two digit)</li>
+                <li><i>B</i> - B.E. Year (two digit)</li>
+                <li><i>BB</i> - Full B.E. Year (four digit)</li>
                 <li><i>y</i> - year (two digit)</li>
                 <li><i>yy</i> - year (four digit)</li>
                 <li><i>@</i> - Unix timestamp (ms since 01/01/1970)</li>

--- a/src/app/showcase/doc/calendar/formatdoc.ts
+++ b/src/app/showcase/doc/calendar/formatdoc.ts
@@ -17,6 +17,8 @@ import { Code } from '../../domain/code';
                 <li><i>mm</i> - month of year (two digit)</li>
                 <li><i>M</i> - month name short</li>
                 <li><i>MM</i> - month name long</li>
+                <li><i>B</i> - Full B.E. Year (four digit)</li>
+                <li><i>BB</i> - B.E. Year (two digit)</li>
                 <li><i>y</i> - year (two digit)</li>
                 <li><i>yy</i> - year (four digit)</li>
                 <li><i>@</i> - Unix timestamp (ms since 01/01/1970)</li>


### PR DESCRIPTION
Add buddhist calendar support

`
<p-calendar dateFormat="dd/mm/BB"></p-calendar>
`

**Output:**
01/11/2566 (Buddhist Era +543)

**Reference:**
- https://day.js.org/docs/en/plugin/buddhist-era
- https://en.wikipedia.org/wiki/Buddhist_calendar