### PR TITLE
Fix closabledoc.ts typo for messages component

### DIFF
--- a/src/app/showcase/doc/messages/closabledoc.ts
+++ b/src/app/showcase/doc/messages/closabledoc.ts
@@ -34,7 +34,7 @@ export class ClosableDoc implements OnInit {
         ];
 
         this.messages2 = [
-            { severity: 'warn', summary: 'Waning', detail: 'Closable Message Content' },
+            { severity: 'warn', summary: 'Warning', detail: 'Closable Message Content' },
             { severity: 'error', summary: 'Error', detail: 'Closable Message Content' }
         ];
     }


### PR DESCRIPTION
This is a very simple fix as there is no error/defect. This is just something I noticed when searching for "warning" in the files, but not being able to find the string. 


edit: Forgot to create an issue first. 
Fix https://github.com/primefaces/primeng/issues/14009

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
