### PR TITLE
Fixed #13993 - Performance update for virtualScroll selection

### DIFF
--- a/src/app/components/listbox/listbox.interface.ts
+++ b/src/app/components/listbox/listbox.interface.ts
@@ -44,10 +44,6 @@ export interface ListboxSelectAllChangeEvent {
      * Boolean value indicates whether all data is selected.
      */
     checked: boolean;
-    /**
-     * Method to invoke on model value change.
-     */
-    updateModel?: (value?: any, event?: Event) => void;
 }
 /**
  * Custom filter event.

--- a/src/app/components/listbox/listbox.interface.ts
+++ b/src/app/components/listbox/listbox.interface.ts
@@ -31,6 +31,25 @@ export interface ListboxChangeEvent {
     value: any;
 }
 /**
+ * Custom change event.
+ * @see {@link Listbox.onSelectAllChange}
+ * @group Events
+ */
+export interface ListboxSelectAllChangeEvent {
+    /**
+     * Browser event.
+     */
+    originalEvent: Event;
+    /**
+     * Boolean value indicates whether all data is selected.
+     */
+    checked: boolean;
+    /**
+     * Method to invoke on model value change.
+     */
+    updateModel?: (value?: any, event?: Event) => void;
+}
+/**
  * Custom filter event.
  * @see {@link Listbox.onFilter}
  * @group Events

--- a/src/app/components/listbox/listbox.ts
+++ b/src/app/components/listbox/listbox.ts
@@ -865,8 +865,7 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
         if(this.selectAll !== null) {
             this.onSelectAllChange.emit({
                 originalEvent: event,
-                checked: !this.allSelected(),
-                updateModel: this.updateModel.bind(this)
+                checked: !this.allSelected()
             })
         } else {
             const value = this.allSelected()

--- a/src/app/components/listbox/listbox.ts
+++ b/src/app/components/listbox/listbox.ts
@@ -31,7 +31,7 @@ import { Subscription } from 'rxjs';
 import { SearchIcon } from 'primeng/icons/search';
 import { CheckIcon } from 'primeng/icons/check';
 import { Nullable } from 'primeng/ts-helpers';
-import { ListboxChangeEvent, ListboxClickEvent, ListboxDoubleClickEvent, ListboxFilterEvent, ListboxFilterOptions } from './listbox.interface';
+import { ListboxChangeEvent, ListboxClickEvent, ListboxDoubleClickEvent, ListboxFilterEvent, ListboxFilterOptions, ListboxSelectAllChangeEvent } from './listbox.interface';
 import { Scroller, ScrollerModule } from 'primeng/scroller';
 
 export const LISTBOX_VALUE_ACCESSOR: any = {
@@ -474,6 +474,16 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
         this._filterValue.set(val);
     }
     /**
+     * Whether all data is selected.
+     * @group Props
+     */
+    @Input() get selectAll(): boolean | undefined | null {
+        return this._selectAll;
+    }
+    set selectAll(value: boolean | undefined | null) {
+        this._selectAll = value;
+    }
+    /**
      * Callback to invoke on value change.
      * @param {ListboxChangeEvent} event - Custom change event.
      * @group Emits
@@ -509,6 +519,12 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
      * @group Emits
      */
     @Output() onBlur: EventEmitter<FocusEvent> = new EventEmitter<FocusEvent>();
+    /**
+     * Callback to invoke when all data is selected.
+     * @param {ListboxSelectAllChangeEvent} event - Custom select event.
+     * @group Emits
+     */
+    @Output() onSelectAllChange: EventEmitter<ListboxSelectAllChangeEvent> = new EventEmitter<ListboxSelectAllChangeEvent>();
 
     @ViewChild('headerchkbox') headerCheckboxViewChild: Nullable<ElementRef>;
 
@@ -630,6 +646,8 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
 
     searchTimeout: any;
 
+    _selectAll: boolean | undefined | null = null;
+
     _options = signal<any>(null);
 
     startRangeIndex = signal<number>(-1);
@@ -744,8 +762,11 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
             this.onOptionSelect(null, this.visibleOptions()[this.focusedOptionIndex()]);
         }
     }
-
-    updateModel(value, event?) {
+    /**
+     * Updates the model value.
+     * @group Method
+     */
+    public updateModel(value, event?) {
         this.value = value;
         this.modelValue.set(value);
         this.onModelChange(value);
@@ -836,21 +857,29 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
         }
         DomHandler.focus(this.headerCheckboxViewChild.nativeElement);
 
-        const value = this.allSelected()
-            ? []
-            : this.visibleOptions()
-                  .filter((option) => this.isValidOption(option))
-                  .map((option) => this.getOptionValue(option));
-        this.updateModel(value, event);
-        this.onChange.emit({ originalEvent: event, value: this.value });
+        if(this.selectAll !== null) {
+            this.onSelectAllChange.emit({
+                originalEvent: event,
+                checked: !this.allSelected(),
+                updateModel: this.updateModel.bind(this)
+            })
+        } else {
+            const value = this.allSelected()
+                ? []
+                : this.visibleOptions()
+                      .filter((option) => this.isValidOption(option))
+                      .map((option) => this.getOptionValue(option));
+            
+            this.updateModel(value, event);
+            this.onChange.emit({ originalEvent: event, value: this.value });
+        }
 
         event.preventDefault();
-        event.stopPropagation();
+        // event.stopPropagation();
     }
 
     allSelected() {
-        const allSelected = this.visibleOptions().length > 0 && this.visibleOptions().every((option) => this.isOptionGroup(option) || this.isOptionDisabled(option) || this.isSelected(option));
-        return ObjectUtils.isNotEmpty(this.visibleOptions()) && allSelected;
+        return this.selectAll !== null ? this.selectAll : ObjectUtils.isNotEmpty(this.visibleOptions()) && this.visibleOptions().every((option) => this.isOptionGroup(option) || this.isOptionDisabled(option) || this.isSelected(option));
     }
 
     onOptionTouchEnd() {

--- a/src/app/components/multiselect/multiselect.interface.ts
+++ b/src/app/components/multiselect/multiselect.interface.ts
@@ -29,6 +29,25 @@ export interface MultiSelectChangeEvent {
     itemValue?: any;
 }
 /**
+ * Custom change event.
+ * @see {@link MultiSelect.onSelectAllChange}
+ * @group Events
+ */
+export interface MultiSelectSelectAllChangeEvent {
+    /**
+     * Browser event.
+     */
+    originalEvent: Event;
+    /**
+     * Boolean value indicates whether all data is selected.
+     */
+    checked: boolean;
+    /**
+     * Method to invoke on model value change.
+     */
+    updateModel?: (value?: any, event?: Event) => void;
+}
+/**
  * Custom filter event.
  * @see {@link MultiSelect.onFilter}
  * @group Events

--- a/src/app/components/multiselect/multiselect.interface.ts
+++ b/src/app/components/multiselect/multiselect.interface.ts
@@ -42,10 +42,6 @@ export interface MultiSelectSelectAllChangeEvent {
      * Boolean value indicates whether all data is selected.
      */
     checked: boolean;
-    /**
-     * Method to invoke on model value change.
-     */
-    updateModel?: (value?: any, event?: Event) => void;
 }
 /**
  * Custom filter event.

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1770,8 +1770,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         if(this.selectAll !== null) {
             this.onSelectAllChange.emit({
                 originalEvent: event,
-                checked: !this.allSelected(),
-                updateModel: this.updateModel.bind(this)
+                checked: !this.allSelected()
             })
         } else {
             const value = this.allSelected()

--- a/src/app/showcase/doc/listbox/virtualscrolldoc.ts
+++ b/src/app/showcase/doc/listbox/virtualscrolldoc.ts
@@ -47,7 +47,6 @@ export class VirtualScrollDoc {
     onSelectAllChange(event) {
         this.selectedItems = event.checked ? [...this.items] : [];
         this.selectAll = event.checked;
-        event.updateModel(this.selectedItems, event.originalEvent);
     }
 
     onChange(event) {

--- a/src/app/showcase/doc/listbox/virtualscrolldoc.ts
+++ b/src/app/showcase/doc/listbox/virtualscrolldoc.ts
@@ -12,9 +12,10 @@ import { Code } from '../../domain/code';
         </app-docsectiontext>
         <div class="card flex justify-content-center">
             <p-listbox
-                [options]="virtualItems"
+                [options]="items"
                 [(ngModel)]="selectedItems"
-                optionLabel="name"
+                [selectAll]="selectAll"
+                optionLabel="label"
                 [style]="{ width: '15rem' }"
                 [virtualScroll]="true"
                 [filter]="true"
@@ -23,35 +24,78 @@ import { Code } from '../../domain/code';
                 [checkbox]="true"
                 [showToggleAll]="false"
                 [metaKeySelection]="false"
+                [showToggleAll]="true"
+                (onSelectAllChange)="onSelectAllChange($event)"
+                (onChange)="onChange($event)"
                 [listStyle]="{ 'max-height': '220px' }"
             ></p-listbox>
         </div>
         <app-code [code]="code" selector="listbox-virtual-scroll-demo"></app-code>
     </section>`
 })
-export class VirtualScrollDoc implements OnInit {
+export class VirtualScrollDoc {
     @Input() id: string;
 
     @Input() title: string;
 
-    virtualItems!: any[];
+    items = Array.from({ length: 100000 }, (_, i) => ({ label: `Item #${i}`, value: i }))
 
     selectedItems!: any[];
 
-    ngOnInit() {
-        this.virtualItems = [];
-        for (let i = 0; i < 10000; i++) {
-            this.virtualItems.push({ name: 'Item ' + i, code: 'Item ' + i });
-        }
+    selectAll: boolean = false;
+
+    onSelectAllChange(event) {
+        this.selectedItems = event.checked ? [...this.items] : [];
+        this.selectAll = event.checked;
+        event.updateModel(this.selectedItems, event.originalEvent);
+    }
+
+    onChange(event) {
+        const { value } = event
+        if(value) this.selectAll = value.length === this.items.length;
     }
 
     code: Code = {
         basic: `
-<p-listbox [options]="virtualItems" [(ngModel)]="selectedItems" optionLabel="name" [style]="{ width: '15rem' }" [virtualScroll]="true" [filter]="true" [virtualScrollItemSize]="43" [multiple]="true" [checkbox]="true" [showToggleAll]="false" [metaKeySelection]="false" [listStyle]="{'max-height': '220px'}"></p-listbox>`,
+<p-listbox
+    [options]="items"
+    [(ngModel)]="selectedItems"
+    [selectAll]="selectAll"
+    optionLabel="label"
+    [style]="{ width: '15rem' }"
+    [virtualScroll]="true"
+    [filter]="true"
+    [virtualScrollItemSize]="43"
+    [multiple]="true"
+    [checkbox]="true"
+    [showToggleAll]="false"
+    [metaKeySelection]="false"
+    [showToggleAll]="true"
+    (onSelectAllChange)="onSelectAllChange($event)"
+    (onChange)="onChange($event)"
+    [listStyle]="{ 'max-height': '220px' }"
+></p-listbox>`,
 
         html: `
 <div class="card flex justify-content-center">
-    <p-listbox [options]="virtualItems" [(ngModel)]="selectedItems" optionLabel="name" [style]="{ width: '15rem' }" [virtualScroll]="true" [filter]="true" [virtualScrollItemSize]="43" [multiple]="true" [checkbox]="true" [showToggleAll]="false" [metaKeySelection]="false" [listStyle]="{'max-height': '220px'}"></p-listbox>
+    <p-listbox
+        [options]="items"
+        [(ngModel)]="selectedItems"
+        [selectAll]="selectAll"
+        optionLabel="label"
+        [style]="{ width: '15rem' }"
+        [virtualScroll]="true"
+        [filter]="true"
+        [virtualScrollItemSize]="43"
+        [multiple]="true"
+        [checkbox]="true"
+        [showToggleAll]="false"
+        [metaKeySelection]="false"
+        [showToggleAll]="true"
+        (onSelectAllChange)="onSelectAllChange($event)"
+        (onChange)="onChange($event)"
+        [listStyle]="{ 'max-height': '220px' }"
+    ></p-listbox>
 </div>`,
 
         typescript: `
@@ -61,16 +105,22 @@ import { Component, OnInit } from '@angular/core';
     selector: 'listbox-virtual-scroll-demo',
     templateUrl: './listbox-virtual-scroll-demo.html'
 })
-export class ListboxVirtualScrollDemo implements OnInit {
-    virtualItems!: any[];
+export class ListboxVirtualScrollDemo {
+    items = Array.from({ length: 100000 }, (_, i) => ({ label: \`Item #\${i}\`, value: i }))
 
-    selectedItems!: any;
+    selectedItems!: any[];
 
-    ngOnInit() {
-        this.virtualItems = [];
-        for (let i = 0; i < 10000; i++) {
-            this.virtualItems.push({ name: 'Item ' + i, code: 'Item ' + i });
-        }
+    selectAll = false;
+
+    onSelectAllChange(event) {
+        this.selectedItems = event.checked ? [...this.items] : [];
+        this.selectAll = event.checked;
+        event.updateModel(this.selectedItems, event.originalEvent)
+    }
+
+    onChange(event) {
+        const { originalEvent, value } = event
+        if(value) this.selectAll = value.length === this.items.length;
     }
 
 }`

--- a/src/app/showcase/doc/multiselect/virtualscrolldoc.ts
+++ b/src/app/showcase/doc/multiselect/virtualscrolldoc.ts
@@ -43,7 +43,6 @@ export class VirtualScrollDoc {
     onSelectAllChange(event) {
         this.selectedItems = event.checked ? [...this.items] : [];
         this.selectAll = event.checked;
-        event.updateModel(this.selectedItems, event.originalEvent);
     }
 
     onChange(event) {

--- a/src/app/showcase/doc/multiselect/virtualscrolldoc.ts
+++ b/src/app/showcase/doc/multiselect/virtualscrolldoc.ts
@@ -12,15 +12,18 @@ import { Code } from '../../domain/code';
         </app-docsectiontext>
         <div class="card flex justify-content-center">
             <p-multiSelect
-                [options]="virtualItems"
-                [showToggleAll]="false"
+                [options]="items"
+                [showToggleAll]="true"
+                [selectAll]="selectAll"
                 [(ngModel)]="selectedItems"
-                optionLabel="name"
+                optionLabel="label"
                 [virtualScroll]="true"
                 [filter]="true"
                 [virtualScrollItemSize]="43"
                 class="multiselect-custom-virtual-scroll"
                 placeholder="Select Cities"
+                (onSelectAllChange)="onSelectAllChange($event)"
+                (onChange)="onChange($event)"
             ></p-multiSelect>
         </div>
         <app-code [code]="code" selector="multi-select-virtual-scroll-demo"></app-code>
@@ -31,24 +34,56 @@ export class VirtualScrollDoc {
 
     @Input() title: string;
 
-    virtualItems!: any[];
+    items = Array.from({ length: 100000 }, (_, i) => ({ label: `Item #${i}`, value: i }))
 
     selectedItems!: any[];
 
-    constructor() {
-        this.virtualItems = [];
-        for (let i = 0; i < 10000; i++) {
-            this.virtualItems.push({ name: 'Item ' + i, code: 'Item ' + i });
-        }
+    selectAll: boolean = false;
+
+    onSelectAllChange(event) {
+        this.selectedItems = event.checked ? [...this.items] : [];
+        this.selectAll = event.checked;
+        event.updateModel(this.selectedItems, event.originalEvent);
+    }
+
+    onChange(event) {
+        const { value } = event
+        if(value) this.selectAll = value.length === this.items.length;
     }
 
     code: Code = {
         basic: `
-<p-multiSelect [options]="virtualItems" [showToggleAll]="false" [(ngModel)]="selectedItems" optionLabel="name" [virtualScroll]="true" [filter]="true" [virtualScrollItemSize]="43" class="multiselect-custom-virtual-scroll" placeholder="Select Cities"></p-multiSelect>`,
+<p-multiSelect
+    [options]="items"
+    [showToggleAll]="true"
+    [selectAll]="selectAll"
+    [(ngModel)]="selectedItems"
+    optionLabel="label"
+    [virtualScroll]="true"
+    [filter]="true"
+    [virtualScrollItemSize]="43"
+    class="multiselect-custom-virtual-scroll"
+    placeholder="Select Cities"
+    (onSelectAllChange)="onSelectAllChange($event)"
+    (onChange)="onChange($event)"
+></p-multiSelect>`,
 
         html: `
 <div class="card flex justify-content-center">
-    <p-multiSelect [options]="virtualItems" [showToggleAll]="false" [(ngModel)]="selectedItems" optionLabel="name" [virtualScroll]="true" [filter]="true" [virtualScrollItemSize]="43" class="multiselect-custom-virtual-scroll" placeholder="Select Cities"></p-multiSelect>
+    <p-multiSelect
+        [options]="items"
+        [showToggleAll]="true"
+        [selectAll]="selectAll"
+        [(ngModel)]="selectedItems"
+        optionLabel="label"
+        [virtualScroll]="true"
+        [filter]="true"
+        [virtualScrollItemSize]="43"
+        class="multiselect-custom-virtual-scroll"
+        placeholder="Select Cities"
+        (onSelectAllChange)="onSelectAllChange($event)"
+        (onChange)="onChange($event)"
+    ></p-multiSelect>
 </div>`,
 
         typescript: `
@@ -59,17 +94,23 @@ import { Component } from '@angular/core';
     templateUrl: './multi-select-virtual-scroll-demo.html'
 })
 export class MultiSelectVirtualScrollDemo {
-
-    virtualItems!: any[];
+    items = Array.from({ length: 100000 }, (_, i) => ({ label: \`Item #\${i}\`, value: i }))
 
     selectedItems!: any[];
 
-    constructor() {
-        this.virtualItems = [];
-        for (let i = 0; i < 10000; i++) {
-            this.virtualItems.push({ name: 'Item ' + i, code: 'Item ' + i });
-        }
+    selectAll = false;
+
+    onSelectAllChange(event) {
+        this.selectedItems = event.checked ? [...this.items] : [];
+        this.selectAll = event.checked;
+        event.updateModel(this.selectedItems, event.originalEvent)
     }
+
+    onChange(event) {
+        const { originalEvent, value } = event
+        if(value) this.selectAll = value.length === this.items.length;
+    }
+
 }`
     };
 }


### PR DESCRIPTION
Fixes #13993 

- `SelectAllChange` event added,
- `selectAll` boolean input added

Users can manage the selection state of all items from outside of the component without looping through options array and update selection state which causes browser freeze on select/deselect actions.