### PR TITLE
Dropdown option fix

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -903,8 +903,8 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
     label = computed(() => {
         let selectedOptionIndex;
-        this.autoDisplayFirst ? (!this.modelValue() ? (selectedOptionIndex = -1) : (selectedOptionIndex = this.findFirstOptionIndex())) : (selectedOptionIndex = this.findSelectedOptionIndex());
-        return this.modelValue() ? this.getOptionLabel(this.modelValue()) : selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
+        this.autoDisplayFirst && !this.modelValue() ?  (selectedOptionIndex = this.findFirstOptionIndex()) : (selectedOptionIndex = this.findSelectedOptionIndex());
+        return  selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.modelValue() || this.placeholder || 'p-emptylabel';
     });
 
     constructor(public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public zone: NgZone, public filterService: FilterService, public config: PrimeNGConfig) {

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -903,7 +903,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
     label = computed(() => {
         let selectedOptionIndex;
-        this.autoDisplayFirst && !this.modelValue() ?  (selectedOptionIndex = this.findFirstOptionIndex()) : (selectedOptionIndex = this.findSelectedOptionIndex());
+        this.autoDisplayFirst && !this.modelValue() && !this.placeholder ?  (selectedOptionIndex = this.findFirstOptionIndex()) : (selectedOptionIndex = this.findSelectedOptionIndex());
         return  selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.modelValue() || this.placeholder || 'p-emptylabel';
     });
 

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -903,8 +903,8 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
     label = computed(() => {
         let selectedOptionIndex;
-        this.autoDisplayFirst && !this.modelValue() && !this.placeholder ?  (selectedOptionIndex = this.findFirstOptionIndex()) : (selectedOptionIndex = this.findSelectedOptionIndex());
-        return  selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.modelValue() || this.placeholder || 'p-emptylabel';
+        this.autoDisplayFirst && !this.modelValue() && !this.placeholder ? (selectedOptionIndex = this.findFirstOptionIndex()) : (selectedOptionIndex = this.findSelectedOptionIndex());
+        return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.modelValue() || this.placeholder || 'p-emptylabel';
     });
 
     constructor(public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public zone: NgZone, public filterService: FilterService, public config: PrimeNGConfig) {

--- a/src/app/showcase/doc/dropdown/floatlabeldoc.ts
+++ b/src/app/showcase/doc/dropdown/floatlabeldoc.ts
@@ -14,7 +14,7 @@ interface City {
         </app-docsectiontext>
         <div class="card flex justify-content-center">
             <span class="p-float-label">
-                <p-dropdown [options]="cities" [(ngModel)]="selectedCity" optionLabel="name" inputId="float-label"></p-dropdown>
+                <p-dropdown [options]="cities" [(ngModel)]="selectedCity" placeholder="Select a City" optionLabel="name" inputId="float-label"></p-dropdown>
                 <label for="float-label">Select a City</label>
             </span>
         </div>

--- a/src/app/showcase/doc/dropdown/reactiveformsdoc.ts
+++ b/src/app/showcase/doc/dropdown/reactiveformsdoc.ts
@@ -15,7 +15,7 @@ interface City {
         </app-docsectiontext>
         <div class="card flex justify-content-center">
             <form [formGroup]="formGroup">
-                <p-dropdown formControlName="selectedCity" [options]="cities" optionLabel="name"></p-dropdown>
+                <p-dropdown formControlName="selectedCity" [options]="cities" optionLabel="name" [autoDisplayFirst]="false"></p-dropdown>
             </form>
         </div>
         <app-code [code]="code" selector="dropdown-reactive-forms-demo"></app-code>
@@ -47,13 +47,13 @@ export class ReactiveFormsDoc implements OnInit {
     code: Code = {
         basic: `
 <form [formGroup]="formGroup">
-    <p-dropdown formControlName="city" [options]="cities" optionLabel="name"></p-dropdown>
+    <p-dropdown formControlName="city" [options]="cities" optionLabel="name" [autoDisplayFirst]="false"></p-dropdown>
 </form>`,
 
         html: `
 <div class="card flex justify-content-center">
     <form [formGroup]="formGroup">
-        <p-dropdown formControlName="city" [options]="cities" optionLabel="name"></p-dropdown>
+        <p-dropdown formControlName="city" [options]="cities" optionLabel="name" [autoDisplayFirst]="false"></p-dropdown>
     </form>
 </div>`,
 


### PR DESCRIPTION
Fixes #14055
Fixes #14054

The pull request changes to dropdown.ts are slightly different then the changes I proposed in issue,  I added logic for placeHolder:

 **&& !this.placeholder** 


The first video shows this pull request fixes the reproducer provided for issue #14055


https://github.com/primefaces/primeng/assets/45439491/0e57c16e-d2e3-4997-b611-cb84bb903d2d



The second video shows this pull request fixes the reproducer provided for issue #14054.  Note to be consistent with the "demo" reactive form example,  I added '[autoDisplayFirst]="false"' to the reproducer html




https://github.com/primefaces/primeng/assets/45439491/13b44e19-e4ac-482b-8f34-8c4ab1052f32




I have also tested the code changes with the PrimeNG dropdown demos.  They appear to work properly.   Note:  I had to update two demo files because of missing attributes?

