### PR TITLE
Fix #14052: Update z-index to proper order when the table is scrollable

### DIFF
--- a/src/app/components/table/table.css
+++ b/src/app/components/table/table.css
@@ -45,7 +45,7 @@
     .p-datatable-scrollable-table > .p-datatable-thead {
         position: sticky;
         top: 0;
-        z-index: 1;
+        z-index: 3;
     }
 
     .p-datatable-scrollable-table > .p-datatable-frozen-tbody {
@@ -56,7 +56,7 @@
     .p-datatable-scrollable-table > .p-datatable-tfoot {
         position: sticky;
         bottom: 0;
-        z-index: 1;
+        z-index: 2;
     }
 
     .p-datatable-scrollable .p-frozen-column {


### PR DESCRIPTION
Fix [#14052](https://github.com/primefaces/primeng/issues/14052) Fix an issue where if a column is set as frozen, the table body overlaps with the table header because of the z-index.