### PR TITLE
#10358: fix date restriction within the hour issue

### DIFF
--- a/src/app/components/calendar/calendar.spec.ts
+++ b/src/app/components/calendar/calendar.spec.ts
@@ -7,7 +7,7 @@ import { SharedModule } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Calendar } from './calendar';
 
-describe('Calendar', () => {
+fdescribe('Calendar', () => {
     let calendar: Calendar;
     let fixture: ComponentFixture<Calendar>;
 
@@ -1901,4 +1901,44 @@ describe('Calendar', () => {
         expect(calendar.currentMinute).toEqual(10);
         expect(calendar.pm).toEqual(false);
     });
+
+    it('should allow changing time when min and max date times are within the hour', () => {
+        const event = { preventDefault: () => { } };
+        const now = new Date('2023-01-01T12:14:00.000Z'); // 1 minute before max date
+        const minDate = new Date('2023-01-01T11:45:00.000Z'); // quarter to now date hour
+        const maxDate = new Date('2023-01-01T12:15:01.000Z'); // quarter past now date hour, 1 minute and 1 second after now date
+        const maxDateISO = maxDate.toISOString();
+        const minDateISO = minDate.toISOString();
+        calendar.defaultDate = now;
+        calendar.value = now;
+        calendar.showTime = true;
+        calendar.showSeconds = true;
+        calendar.minDate = minDate;
+        calendar.maxDate = maxDate;
+        fixture.detectChanges();
+
+        calendar.incrementMinute(event);
+        // increment 2 seconds, should clamp to max date
+        calendar.incrementSecond(event);
+        calendar.incrementSecond(event);
+        calendar.updateTime();
+        expect((calendar.value as Date).toISOString()).toBe(maxDateISO);
+        // decrement back 1  minute and 1 second
+        calendar.decrementMinute(event);
+        calendar.decrementSecond(event);
+        calendar.updateTime();
+        // try increment 2 minutes, should clamp to max date
+        calendar.incrementMinute(event);
+        calendar.incrementMinute(event);
+        calendar.updateTime();
+        expect((calendar.value as Date).toISOString()).toBe(maxDateISO);
+        // now time should be 12:15, min time should be 11:45, decrementing hour should clamp to min date
+        calendar.decrementHour(event);
+        calendar.updateTime();
+        expect((calendar.value as Date).toISOString()).toBe(minDateISO);
+        // increment hour should clamp to max date
+        calendar.incrementHour(event);
+        calendar.updateTime();
+        expect((calendar.value as Date).toISOString()).toBe(maxDateISO);
+    })
 });

--- a/src/app/components/calendar/calendar.spec.ts
+++ b/src/app/components/calendar/calendar.spec.ts
@@ -7,7 +7,7 @@ import { SharedModule } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { Calendar } from './calendar';
 
-fdescribe('Calendar', () => {
+describe('Calendar', () => {
     let calendar: Calendar;
     let fixture: ComponentFixture<Calendar>;
 

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -2441,7 +2441,8 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         return hours;
     };
 
-    validateTime(hour: number, minute: number, second: number, pm: boolean) {
+    constrainTime(hour: number, minute: number, second: number, pm: boolean) {
+        let returnTimeTriple: number[] = [ hour, minute, second ]
         let value = this.value;
         const convertedHour = this.convertTo24Hour(hour, pm);
         if (this.isRangeSelection()) {
@@ -2451,58 +2452,42 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
             value = this.value[this.value.length - 1];
         }
         const valueDateString = value ? value.toDateString() : null;
-        if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {
-            if (this.minDate.getHours() > convertedHour) {
-                return false;
-            }
-            if (this.minDate.getHours() === convertedHour) {
-                if (this.minDate.getMinutes() > minute) {
-                    return false;
-                }
-                if (this.minDate.getMinutes() === minute) {
-                    if (this.minDate.getSeconds() > second) {
-                        return false;
-                    }
-                }
-            }
+        let isMinDate = this.minDate && valueDateString && this.minDate.toDateString() === valueDateString;
+        let isMaxDate = this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString;
+        switch (true) { // intentional fall through
+            case isMinDate && this.minDate.getHours() > convertedHour:
+                returnTimeTriple[0] = this.minDate.getHours();
+            case isMinDate && this.minDate.getHours() === convertedHour && this.minDate.getMinutes() > minute:
+                returnTimeTriple[1] = this.minDate.getMinutes();
+            case isMinDate && this.minDate.getHours() === convertedHour && this.minDate.getMinutes() === minute && this.minDate.getSeconds() > second:
+                returnTimeTriple[2] = this.minDate.getSeconds();
+                break;
+            case isMaxDate && this.maxDate.getHours() < convertedHour:
+                returnTimeTriple[0] = this.maxDate.getHours();
+            case isMaxDate && this.maxDate.getHours() === convertedHour && this.maxDate.getMinutes() < minute:
+                returnTimeTriple[1] = this.maxDate.getMinutes();
+            case isMaxDate && this.maxDate.getHours() === convertedHour && this.maxDate.getMinutes() === minute && this.maxDate.getSeconds() < second:
+                returnTimeTriple[2] = this.maxDate.getSeconds();
+                break;
         }
-
-        if (this.maxDate && valueDateString && this.maxDate.toDateString() === valueDateString) {
-            if (this.maxDate.getHours() < convertedHour) {
-                return false;
-            }
-            if (this.maxDate.getHours() === convertedHour) {
-                if (this.maxDate.getMinutes() < minute) {
-                    return false;
-                }
-                if (this.maxDate.getMinutes() === minute) {
-                    if (this.maxDate.getSeconds() < second) {
-                        return false;
-                    }
-                }
-            }
-        }
-        return true;
+        return returnTimeTriple;
     }
 
     incrementHour(event: any) {
-        const prevHour = this.currentHour;
-        let newHour = <number>this.currentHour + this.stepHour;
+        const prevHour = this.currentHour ?? 0;
+        let newHour = (this.currentHour ?? 0) + this.stepHour;
         let newPM = this.pm;
-
-        if (this.hourFormat == '24') newHour = newHour >= 24 ? newHour - 24 : newHour;
+        if (this.hourFormat == '24')
+            newHour = newHour >= 24 ? newHour - 24 : newHour;
         else if (this.hourFormat == '12') {
             // Before the AM/PM break, now after
-            if (<number>prevHour < 12 && newHour > 11) {
+            if (prevHour < 12 && newHour > 11) {
                 newPM = !this.pm;
             }
             newHour = newHour >= 13 ? newHour - 12 : newHour;
         }
-
-        if (this.validateTime(newHour, <any>this.currentMinute, <any>this.currentSecond, <any>newPM)) {
-            this.currentHour = newHour;
-            this.pm = newPM;
-        }
+        [ this.currentHour, this.currentMinute, this.currentSecond ] = this.constrainTime(newHour, this.currentMinute!, this.currentSecond!, newPM!);
+        this.pm = newPM;
         event.preventDefault();
     }
 
@@ -2564,10 +2549,10 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     }
 
     decrementHour(event: any) {
-        let newHour = <number>this.currentHour - this.stepHour;
+        let newHour = ( this.currentHour ?? 0 ) - this.stepHour;
         let newPM = this.pm;
-
-        if (this.hourFormat == '24') newHour = newHour < 0 ? 24 + newHour : newHour;
+        if (this.hourFormat == '24')
+            newHour = newHour < 0 ? 24 + newHour : newHour;
         else if (this.hourFormat == '12') {
             // If we were at noon/midnight, then switch
             if (this.currentHour === 12) {
@@ -2575,52 +2560,36 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
             }
             newHour = newHour <= 0 ? 12 + newHour : newHour;
         }
-
-        if (this.validateTime(newHour, <any>this.currentMinute, <any>this.currentSecond, <any>newPM)) {
-            this.currentHour = newHour;
-            this.pm = newPM;
-        }
-
+        [ this.currentHour, this.currentMinute, this.currentSecond ] = this.constrainTime(newHour, this.currentMinute!, this.currentSecond!, newPM!);
+        this.pm = newPM;
         event.preventDefault();
     }
 
     incrementMinute(event: any) {
-        let newMinute = <number>this.currentMinute + this.stepMinute;
+        let newMinute = ( this.currentMinute ?? 0 ) + this.stepMinute;
         newMinute = newMinute > 59 ? newMinute - 60 : newMinute;
-        if (this.validateTime(<any>this.currentHour, newMinute, <any>this.currentSecond, <any>this.pm)) {
-            this.currentMinute = newMinute;
-        }
-
+        [ this.currentHour, this.currentMinute, this.currentSecond ] = this.constrainTime(this.currentHour, newMinute, this.currentSecond!, this.pm!);
         event.preventDefault();
     }
 
     decrementMinute(event: any) {
-        let newMinute = <any>this.currentMinute - this.stepMinute;
+        let newMinute = ( this.currentMinute ?? 0 ) - this.stepMinute;
         newMinute = newMinute < 0 ? 60 + newMinute : newMinute;
-        if (this.validateTime(<any>this.currentHour, newMinute, <any>this.currentSecond, <any>this.pm)) {
-            this.currentMinute = newMinute;
-        }
-
+        [ this.currentHour, this.currentMinute, this.currentSecond ] = this.constrainTime(this.currentHour, newMinute, this.currentSecond, this.pm);
         event.preventDefault();
     }
 
     incrementSecond(event: any) {
         let newSecond = <any>this.currentSecond + this.stepSecond;
         newSecond = newSecond > 59 ? newSecond - 60 : newSecond;
-        if (this.validateTime(<any>this.currentHour, <any>this.currentMinute, newSecond, <any>this.pm)) {
-            this.currentSecond = newSecond;
-        }
-
+        [ this.currentHour, this.currentMinute, this.currentSecond ] = this.constrainTime(this.currentHour, this.currentMinute, newSecond, this.pm);
         event.preventDefault();
     }
 
     decrementSecond(event: any) {
         let newSecond = <any>this.currentSecond - this.stepSecond;
         newSecond = newSecond < 0 ? 60 + newSecond : newSecond;
-        if (this.validateTime(<any>this.currentHour, <any>this.currentMinute, newSecond, <any>this.pm)) {
-            this.currentSecond = newSecond;
-        }
-
+        [ this.currentHour, this.currentMinute, this.currentSecond ] = this.constrainTime(this.currentHour, this.currentMinute, newSecond, this.pm);
         event.preventDefault();
     }
 
@@ -2659,10 +2628,9 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
     toggleAMPM(event: any) {
         const newPM = !this.pm;
-        if (this.validateTime(<any>this.currentHour, <any>this.currentMinute, <any>this.currentSecond, newPM)) {
-            this.pm = newPM;
-            this.updateTime();
-        }
+        [ this.currentHour, this.currentMinute, this.currentSecond ] = this.constrainTime(this.currentHour, this.currentMinute, this.currentSecond, newPM);
+        this.pm = newPM;
+        this.updateTime();
         event.preventDefault();
     }
 

--- a/src/app/showcase/doc/calendar/minmaxdox.ts
+++ b/src/app/showcase/doc/calendar/minmaxdox.ts
@@ -8,7 +8,7 @@ import { Code } from '../../domain/code';
             <p>Boundaries for the permitted dates that can be entered are defined with <i>minDate</i> and <i>maxDate</i> properties.</p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">
-            <p-calendar [(ngModel)]="date" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true"></p-calendar>
+            <p-calendar [(ngModel)]="date" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true" [showTime]="true"></p-calendar>
         </div>
         <app-code [code]="code" selector="calendar-minmax-demo"></app-code>
     </section>`
@@ -44,7 +44,7 @@ export class MinMaxDoc {
         basic: `
 <p-calendar [(ngModel)]="date" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true"></p-calendar>`,
 
-        html: ` 
+        html: `
 <div class="card flex justify-content-center">
     <p-calendar [(ngModel)]="date" [minDate]="minDate" [maxDate]="maxDate" [readonlyInput]="true"></p-calendar>
 </div>`,
@@ -56,9 +56,9 @@ import { Component, OnInit } from '@angular/core';
     selector: 'calendar-minmax-demo',
     templateUrl: './calendar-minmax-demo.html'
 })
-export class CalendarMinmaxDemo implements OnInit {        
+export class CalendarMinmaxDemo implements OnInit {
     date: Date | undefined;
-    
+
     minDate: Date | undefined;
 
     maxDate: Date | undefined;


### PR DESCRIPTION
This PR fixes this issue #10358 
i.e. it now allows the user to use the time selector but it changes the actual time value to be clamped within min/max date inputs 