### PR TITLE
FIX: Multiple selection with SHIFT/click

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1849,6 +1849,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
         if (this.lazy && this.paginator) {
             (rangeStart as number) -= <number>this.first;
+            (rangeEnd as number) -= <number>this.first;
         }
 
         let rangeRowsData = [];


### PR DESCRIPTION
### Issue
#14140

### Solution
`rangeEnd` was missing while the table is lazily loaded and hence was selecting the whole page while using `shift` key
