### PR TITLE
fix(autocomplete): Stop event propagations on remove option

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -718,9 +718,9 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
     _suggestions = signal<any>(null);
 
-    onModelChange: Function = () => { };
+    onModelChange: Function = () => {};
 
-    onModelTouched: Function = () => { };
+    onModelTouched: Function = () => {};
 
     timeout: Nullable<any>;
 
@@ -844,7 +844,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         return !this.virtualScroll;
     }
 
-    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone) { }
+    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone) {}
 
     ngOnInit() {
         this.id = this.id || UniqueComponentId();
@@ -974,8 +974,8 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         const matchedOptionIndex =
             index < this.visibleOptions().length - 1
                 ? this.visibleOptions()
-                    .slice(index + 1)
-                    .findIndex((option) => this.isValidOption(option))
+                      .slice(index + 1)
+                      .findIndex((option) => this.isValidOption(option))
                 : -1;
 
         return matchedOptionIndex > -1 ? matchedOptionIndex + index + 1 : index;
@@ -1531,9 +1531,9 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         return (
             (this.optionGroupLabel
                 ? index -
-                this.visibleOptions()
-                    .slice(0, index)
-                    .filter((option) => this.isOptionGroup(option)).length
+                  this.visibleOptions()
+                      .slice(0, index)
+                      .filter((option) => this.isOptionGroup(option)).length
                 : index) + 1
         );
     }
@@ -1610,4 +1610,4 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
     exports: [AutoComplete, OverlayModule, SharedModule, ScrollerModule, AutoFocusModule],
     declarations: [AutoComplete]
 })
-export class AutoCompleteModule { }
+export class AutoCompleteModule {}

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -718,9 +718,9 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
     _suggestions = signal<any>(null);
 
-    onModelChange: Function = () => {};
+    onModelChange: Function = () => { };
 
-    onModelTouched: Function = () => {};
+    onModelTouched: Function = () => { };
 
     timeout: Nullable<any>;
 
@@ -844,7 +844,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         return !this.virtualScroll;
     }
 
-    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone) {}
+    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone) { }
 
     ngOnInit() {
         this.id = this.id || UniqueComponentId();
@@ -974,8 +974,8 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         const matchedOptionIndex =
             index < this.visibleOptions().length - 1
                 ? this.visibleOptions()
-                      .slice(index + 1)
-                      .findIndex((option) => this.isValidOption(option))
+                    .slice(index + 1)
+                    .findIndex((option) => this.isValidOption(option))
                 : -1;
 
         return matchedOptionIndex > -1 ? matchedOptionIndex + index + 1 : index;
@@ -1418,6 +1418,8 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
     }
 
     removeOption(event, index) {
+        event.stopPropagation();
+
         const removedOption = this.modelValue()[index];
         const value = this.modelValue()
             .filter((_, i) => i !== index)
@@ -1529,9 +1531,9 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         return (
             (this.optionGroupLabel
                 ? index -
-                  this.visibleOptions()
-                      .slice(0, index)
-                      .filter((option) => this.isOptionGroup(option)).length
+                this.visibleOptions()
+                    .slice(0, index)
+                    .filter((option) => this.isOptionGroup(option)).length
                 : index) + 1
         );
     }
@@ -1608,4 +1610,4 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
     exports: [AutoComplete, OverlayModule, SharedModule, ScrollerModule, AutoFocusModule],
     declarations: [AutoComplete]
 })
-export class AutoCompleteModule {}
+export class AutoCompleteModule { }


### PR DESCRIPTION
Fix #14300

If you are using `AutoComplete` inside a `overlayPanel`, when removes the autocomplete option, it close the overlayPanel because is propaganding events.

## CURRENTLY
![overlay problem](https://github.com/primefaces/primeng/assets/19764334/ac90af52-e8a9-408d-a8a6-83f52773f272)

## AFTER SOLUTION
![overlaypanel fixed](https://github.com/primefaces/primeng/assets/19764334/d3c37278-d92b-4c12-9166-3481d98fcd5e)