### PR TITLE
fix: #14051 || applyFocus() method is working only when dropdown is editable.

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1711,7 +1711,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
     applyFocus(): void {
         if (this.editable) DomHandler.findSingle(this.el.nativeElement, '.p-dropdown-label.p-inputtext').focus();
-        else DomHandler.findSingle(this.el.nativeElement, 'input[readonly]').focus();
+        else DomHandler.focus(this.focusInputViewChild?.nativeElement);
     }
     /**
      * Applies focus.


### PR DESCRIPTION
Fix: #14051 