### PR TITLE
Fix documentation typo

### DIFF
--- a/src/app/showcase/doc/dataview/sortingdoc.ts
+++ b/src/app/showcase/doc/dataview/sortingdoc.ts
@@ -8,7 +8,7 @@ import { ProductService } from '../../service/productservice';
     selector: 'data-view-sorting-demo',
     template: `
         <app-docsectiontext>
-            <p>Built-in sorting is controlled by bindings <i>sortField</i> and <i>sortField</i> properties from a custom UI.</p>
+            <p>Built-in sorting is controlled by bindings <i>sortField</i> and <i>sortOrder</i> properties from a custom UI.</p>
         </app-docsectiontext>
         <div class="card">
             <p-dataView #dv [value]="products" [sortField]="sortField" [sortOrder]="sortOrder">
@@ -228,7 +228,7 @@ export class DataViewSortingDemo {
 }`,
 
         data: `
-/* ProductService */        
+/* ProductService */
 {
     id: '1000',
     code: 'f230fh0g3',


### PR DESCRIPTION
sortField was noted twice. If you want me to make an issue for this, I will. Seemed a bit excessive since it doesn't touch any features.

Edit: created issue: https://github.com/primefaces/primeng/issues/14391