### PR TITLE
SplitButton | Flag for hiding menu on default button click.

### DIFF
--- a/src/app/components/splitbutton/splitbutton.ts
+++ b/src/app/components/splitbutton/splitbutton.ts
@@ -166,6 +166,10 @@ export class SplitButton {
      */
     @Input() menuButtonProps: MenuButtonProps | undefined;
     /**
+     * When true menu is hidden on default button click, otherwise just event is handled
+     */
+    @Input() hideMenuOnDefaultButtonClick = true;
+    /**
      * Callback to invoke when default command button is clicked.
      * @param {MouseEvent} event - Mouse event.
      * @group Emits
@@ -217,8 +221,10 @@ export class SplitButton {
     }
 
     onDefaultButtonClick(event: MouseEvent) {
+        if (this.hideMenuOnDefaultButtonClick) {
+            this.menu.hide();
+        }
         this.onClick.emit(event);
-        this.menu.hide();
     }
 
     onDropdownButtonClick(event?: MouseEvent) {


### PR DESCRIPTION
Continue on fix #13962 from #13983.

So right now, when someone would like to have same behaviour on default button as it was for the menu button, it was impossible due to hiding menu after event handling. 

One can see that here: https://stackblitz.com/edit/8tkckf?file=src%2Fapp%2Fdemo%2Fsplit-button-basic-demo.html

After the change, with setting the new flag to true, the same behaviour on default and menu button will be possible.
Probably there can be a flag to have same behaviour for both buttons, but... with onClick still possible to be set, both setups would be against each other.

**BEFORE:**
![default-behaviour-without-fix](https://github.com/primefaces/primeng/assets/37674650/55ca459a-7df1-468d-bc34-a11c41943284)

**AFTER:**
![default-behaviour-fix](https://github.com/primefaces/primeng/assets/37674650/1da47d81-be9a-47d6-8629-38580329e6e7)