### PR TITLE
Fix #14389: ForceSelection does not force selection - formControl value is changed even without selection

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -1061,7 +1061,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
         let query = event.target.value;
 
-        if (!this.multiple) {
+        if (!this.multiple && !this.forceSelection) {
             this.updateModel(query);
         }
 


### PR DESCRIPTION
Fix #14389 
ForceSelection flag set to true at p-autocomplete waits for actual selection to change model value of associated form control.

**Before:**
![forceselection-without-fix](https://github.com/primefaces/primeng/assets/37674650/f5a1a214-2d7d-440e-b989-ace5958058b7)

**After:**
![forceselection-fix](https://github.com/primefaces/primeng/assets/37674650/d5f7d12f-7836-4cd5-91d5-f40ece2da567)

<note, on the element I've added the flag, at demo it isn't there>
Values seen in console are from subscription on form control associated with the element. 
