### PR TITLE
Fix #14281 - Autocomplete with long list of options make the whole page scrollable

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -257,11 +257,11 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                             </li>
                         </ul>
                         <ng-container *ngTemplateOutlet="footerTemplate; context: { $implicit: items }"></ng-container>
-                        <span role="status" aria-live="polite" class="p-hidden-accessible">
-                            {{ selectedMessageText }}
-                        </span>
                     </ng-template>
                 </div>
+                <span role="status" aria-live="polite" class="p-hidden-accessible">
+                    {{ selectedMessageText }}
+                </span>
             </p-overlay>
         </div>
     `,


### PR DESCRIPTION
Fix #14281 
When Autocomplete has a long list of options `p-hidden-accessible` element is rendered outside of the viewport, and because of that the whole page becomes scrollable. For additional info check out attached issue.

With this fix accessibility element now is rendered in the bottom-left corner of overlay, same as in Dropdown and MultiSelect components.