### PR TITLE
fix: Dropdown Empty Filter Message not displayed

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1187,7 +1187,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     isEmpty() {
-        return !this._options() || (this._options() && this._options().length === 0);
+        return !this._options() || (this.visibleOptions() && this.visibleOptions().length === 0);
     }
 
     onEditableInput(event: KeyboardEvent) {


### PR DESCRIPTION
### Defect Fixes
This PR fix issue with displaying "No results found" / "Empty filter message template" for Dropdown component. The same issue was fix for Multiselect component under this PR: https://github.com/primefaces/primeng/pull/14096

right now `isEmpty` method checking filtered list, not the one provided in input.