### PR TITLE
columnFilter: hide on mousedown instead of click

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -5484,7 +5484,7 @@ export class ColumnFilter implements AfterContentInit {
         if (!this.documentClickListener) {
             const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
 
-            this.documentClickListener = this.renderer.listen(documentTarget, 'click', (event) => {
+            this.documentClickListener = this.renderer.listen(documentTarget, 'mousedown', (event) => {
                 if (this.overlayVisible && !this.selfClick && this.isOutsideClicked(event)) {
                     this.hide();
                 }


### PR DESCRIPTION
When you do a mouse selection that ends outside the filter frame, with "click"event it close the column filter. This change the event listener to mousedown to avoid this issue.

### Defect Fixes
#14410