### PR TITLE
fix: Do not take into account non exportable fields for csv separators

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2263,43 +2263,32 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
             }
         }
 
-        //headers
-        for (let i = 0; i < (<any[]>columns).length; i++) {
-            let column = (<any[]>columns)[i];
-            if (column.exportable !== false && column.field) {
-                csv += '"' + this.getExportHeader(column) + '"';
+        const exportableColumns: any[] = (<any[]>columns).filter(column => column.exportable !== false && column.field);
 
-                if (i < (<any[]>columns).length - 1) {
-                    csv += this.csvSeparator;
-                }
-            }
-        }
+        //headers
+        csv += exportableColumns.map(column => '"' + this.getExportHeader(column) + '"').join(this.csvSeparator);
 
         //body
-        data.forEach((record: any, i: number) => {
-            csv += '\n';
-            for (let i = 0; i < (<any[]>columns).length; i++) {
-                let column = (<any[]>columns)[i];
-                if (column.exportable !== false && column.field) {
-                    let cellData = ObjectUtils.resolveFieldData(record, column.field);
+        const body = data.map((record: any) =>
+            exportableColumns.map(column => {
+                let cellData = ObjectUtils.resolveFieldData(record, column.field);
 
-                    if (cellData != null) {
-                        if (this.exportFunction) {
-                            cellData = this.exportFunction({
-                                data: cellData,
-                                field: column.field
-                            });
-                        } else cellData = String(cellData).replace(/"/g, '""');
-                    } else cellData = '';
+                if (cellData != null) {
+                    if (this.exportFunction) {
+                        cellData = this.exportFunction({
+                            data: cellData,
+                            field: column.field
+                        });
+                    } else cellData = String(cellData).replace(/"/g, '""');
+                } else cellData = '';
 
-                    csv += '"' + cellData + '"';
+                return '"' + cellData + '"';
+            }).join(this.csvSeparator)
+        ).join('\n');
 
-                    if (i < (<any[]>columns).length - 1) {
-                        csv += this.csvSeparator;
-                    }
-                }
-            }
-        });
+        if (body.length) {
+            csv += '\n' + body;
+        }
 
         let blob = new Blob([csv], {
             type: 'text/csv;charset=utf-8;'


### PR DESCRIPTION
Fixes #14248

### Current behavior

Exporting a table with 3 columns while the last one is not exportable will still print a csvSeparator after the 2nd column, leading into an empty column in most CSV viewers.

### New behavior

Only exportable columns will be taken into account while considering printing csvSeparator.
