### PR TITLE
feat(toast): providing close callback to headless toast template

### DIFF
--- a/src/app/components/toast/toast.ts
+++ b/src/app/components/toast/toast.ts
@@ -50,37 +50,42 @@ import { ToastCloseEvent, ToastItemCloseEvent, ToastPositionType } from './toast
             [attr.data-pc-name]="'toast'"
             [attr.data-pc-section]="'root'"
         >
-            <div class="p-toast-message-content" [ngClass]="message?.contentStyleClass" [attr.data-pc-section]="'content'">
-                <ng-container *ngIf="!template">
-                    <span *ngIf="message.icon" [class]="'p-toast-message-icon pi ' + message.icon"></span>
-                    <span class="p-toast-message-icon" *ngIf="!message.icon" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'">
-                        <ng-container>
-                            <CheckIcon *ngIf="message.severity === 'success'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
-                            <InfoCircleIcon *ngIf="message.severity === 'info'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
-                            <TimesCircleIcon *ngIf="message.severity === 'error'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
-                            <ExclamationTriangleIcon *ngIf="message.severity === 'warn'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
-                        </ng-container>
-                    </span>
-                    <div class="p-toast-message-text" [attr.data-pc-section]="'text'">
-                        <div class="p-toast-summary" [attr.data-pc-section]="'summary'">{{ message.summary }}</div>
-                        <div class="p-toast-detail" [attr.data-pc-section]="'detail'">{{ message.detail }}</div>
-                    </div>
-                </ng-container>
-                <ng-container *ngTemplateOutlet="template; context: { $implicit: message }"></ng-container>
-                <button
-                    type="button"
-                    class="p-toast-icon-close p-link"
-                    (click)="onCloseIconClick($event)"
-                    (keydown.enter)="onCloseIconClick($event)"
-                    *ngIf="message?.closable !== false"
-                    pRipple
-                    [attr.aria-label]="'Close'"
-                    [attr.data-pc-section]="'closebutton'"
-                >
-                    <span *ngIf="message.closeIcon" [class]="'pt-1 text-base p-toast-message-icon pi ' + message.closeIcon"></span>
-                    <TimesIcon *ngIf="!message.closeIcon" [styleClass]="'p-toast-icon-close-icon'" [attr.aria-hidden]="true" [attr.data-pc-section]="'closeicon'" />
-                </button>
-            </div>
+            <ng-container *ngIf="headlessTemplate; else notHeadless">
+                <ng-container *ngTemplateOutlet="headlessTemplate; context: { $implicit: message, closeFn: onCloseIconClick }"></ng-container>
+            </ng-container>
+            <ng-template #notHeadless>
+                <div class="p-toast-message-content" [ngClass]="message?.contentStyleClass" [attr.data-pc-section]="'content'">
+                    <ng-container *ngIf="!template">
+                        <span *ngIf="message.icon" [class]="'p-toast-message-icon pi ' + message.icon"></span>
+                        <span class="p-toast-message-icon" *ngIf="!message.icon" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'">
+                            <ng-container>
+                                <CheckIcon *ngIf="message.severity === 'success'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
+                                <InfoCircleIcon *ngIf="message.severity === 'info'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
+                                <TimesCircleIcon *ngIf="message.severity === 'error'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
+                                <ExclamationTriangleIcon *ngIf="message.severity === 'warn'" [attr.aria-hidden]="true" [attr.data-pc-section]="'icon'" />
+                            </ng-container>
+                        </span>
+                        <div class="p-toast-message-text" [attr.data-pc-section]="'text'">
+                            <div class="p-toast-summary" [attr.data-pc-section]="'summary'">{{ message.summary }}</div>
+                            <div class="p-toast-detail" [attr.data-pc-section]="'detail'">{{ message.detail }}</div>
+                        </div>
+                    </ng-container>
+                    <ng-container *ngTemplateOutlet="template; context: { $implicit: message }"></ng-container>
+                    <button
+                        type="button"
+                        class="p-toast-icon-close p-link"
+                        (click)="onCloseIconClick($event)"
+                        (keydown.enter)="onCloseIconClick($event)"
+                        *ngIf="message?.closable !== false"
+                        pRipple
+                        [attr.aria-label]="closeAriaLabel"
+                        [attr.data-pc-section]="'closebutton'"
+                    >
+                        <span *ngIf="message.closeIcon" [class]="'pt-1 text-base p-toast-message-icon pi ' + message.closeIcon"></span>
+                        <TimesIcon *ngIf="!message.closeIcon" [styleClass]="'p-toast-icon-close-icon'" [attr.aria-hidden]="true" [attr.data-pc-section]="'closeicon'" />
+                    </button>
+                </div>
+            </ng-template>
         </div>
     `,
     animations: [
@@ -126,6 +131,8 @@ export class ToastItem implements AfterViewInit, OnDestroy {
 
     @Input() template: TemplateRef<any> | undefined;
 
+    @Input() headlessTemplate: TemplateRef<any> | undefined;
+
     @Input() showTransformOptions: string | undefined;
 
     @Input() hideTransformOptions: string | undefined;
@@ -140,7 +147,7 @@ export class ToastItem implements AfterViewInit, OnDestroy {
 
     timeout: any;
 
-    constructor(private zone: NgZone) {}
+    constructor(private zone: NgZone, private config: PrimeNGConfig) {}
 
     ngAfterViewInit() {
         this.initTimeout();
@@ -174,7 +181,7 @@ export class ToastItem implements AfterViewInit, OnDestroy {
         this.initTimeout();
     }
 
-    onCloseIconClick(event: Event) {
+    onCloseIconClick = (event: Event) => {
         this.clearTimeout();
 
         this.onClose.emit({
@@ -183,6 +190,10 @@ export class ToastItem implements AfterViewInit, OnDestroy {
         });
 
         event.preventDefault();
+    }
+
+    get closeAriaLabel() {
+        return this.config.translation.aria ? this.config.translation.aria.close : undefined;
     }
 
     ngOnDestroy() {
@@ -205,6 +216,7 @@ export class ToastItem implements AfterViewInit, OnDestroy {
                 [life]="life"
                 (onClose)="onMessageClose($event)"
                 [template]="template"
+                [headlessTemplate]="headlessTemplate"
                 @toastAnimation
                 (@toastAnimation.start)="onAnimationStart($event)"
                 (@toastAnimation.done)="onAnimationEnd($event)"
@@ -324,6 +336,8 @@ export class Toast implements OnInit, AfterContentInit, OnDestroy {
 
     template: TemplateRef<any> | undefined;
 
+    headlessTemplate: TemplateRef<any> | undefined;
+
     _position: ToastPositionType = 'top-right';
 
     constructor(@Inject(DOCUMENT) private document: Document, private renderer: Renderer2, public messageService: MessageService, private cd: ChangeDetectorRef, public config: PrimeNGConfig) {}
@@ -404,6 +418,9 @@ export class Toast implements OnInit, AfterContentInit, OnDestroy {
             switch (item.getType()) {
                 case 'message':
                     this.template = item.template;
+                    break;
+                case 'headless':
+                    this.headlessTemplate = item.template;
                     break;
 
                 default:

--- a/src/app/showcase/doc/toast/headlessdoc.ts
+++ b/src/app/showcase/doc/toast/headlessdoc.ts
@@ -1,0 +1,164 @@
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { MessageService } from 'primeng/api';
+import { Code } from '../../domain/code';
+
+@Component({
+    selector: 'headless-doc',
+    template: `
+        <app-docsectiontext>
+            <p><i>Headless</i> mode allows you to customize the entire user interface instead of the default elements.</p>
+        </app-docsectiontext>
+        <div class="card flex justify-content-center">
+            <p-toast position="top-center" key="confirm" (onClose)="onClose()" [baseZIndex]="5000">
+                <ng-template let-message pTemplate="headless" let-closeFn="closeFn">
+                    <section class="flex p-3 gap-3 w-full bg-black-alpha-90 shadow-2" style="border-radius: 10px">
+                        <i class="pi pi-cloud-upload text-primary-500 text-2xl"></i>
+                        <div class="flex flex-column gap-3 w-full">
+                            <p class="m-0 font-semibold text-base text-white">{{ message.summary }}</p>
+                            <p class="m-0 text-base text-700">{{ message.detail }}</p>
+                            <div class="flex flex-column gap-2">
+                                <p-progressBar [value]="progress" [showValue]="false" [style]="{ height: '4px' }"></p-progressBar>
+                                <label class="text-right text-xs text-white">{{ progress }}% uploaded...</label>
+                            </div>
+                            <div class="flex gap-3 mb-3">
+                                <p-button label="Another Upload?" text="true" styleClass="p-0" (click)="closeFn($event)"></p-button>
+                                <p-button label="Cancel" text="true" styleClass="text-white p-0" (click)="closeFn($event)"></p-button>
+                            </div>
+                        </div>
+                    </section>
+                </ng-template>
+            </p-toast>
+            <button type="button" pButton pRipple (click)="showConfirm()" label="Confirm"></button>
+        </div>
+        <app-code [code]="code" selector="toast-headless-demo"></app-code>
+    `,
+    providers: [MessageService]
+})
+export class HeadlessDoc {
+    constructor(private messageService: MessageService, private cdr: ChangeDetectorRef) {}
+
+    visible: boolean = false;
+
+    progress: number = 0;
+
+    interval = null;
+
+    showConfirm() {
+        if (!this.visible) {
+            this.messageService.add({ key: 'confirm', sticky: true, severity: 'custom', summary: 'Uploading your files.' });
+            this.visible = true;
+            this.progress = 0;
+
+            if (this.interval) {
+                clearInterval(this.interval);
+            }
+
+            this.interval = setInterval(() => {
+                if (this.progress <= 100) {
+                    this.progress = this.progress + 20;
+                }
+
+                if (this.progress >= 100) {
+                    this.progress = 100;
+                    clearInterval(this.interval);
+                }
+                this.cdr.markForCheck();
+            }, 1000);
+        }
+    }
+
+    onClose() {
+        this.visible = false;
+    }
+
+    code: Code = {
+        basic: `<p-toast position="top-center" key="confirm" (onClose)="onClose()" [baseZIndex]="5000">
+ <ng-template let-message pTemplate="headless" let-closeFn="closeFn">
+     <section class="flex p-3 gap-3 w-full bg-black-alpha-90 shadow-2" style="border-radius: 10px">
+         <i class="pi pi-cloud-upload text-primary-500 text-2xl"></i>
+         <div class="flex flex-column gap-3 w-full">
+             <p class="m-0 font-semibold text-base text-white">{{ message.summary }}</p>
+             <p class="m-0 text-base text-700">{{ message.detail }}</p>
+             <div class="flex flex-column gap-2">
+                 <p-progressBar [value]="progress" [showValue]="false" [style]="{ height: '4px' }"></p-progressBar>
+                 <label class="text-right text-xs text-white">{{ progress }}% uploaded...</label>
+             </div>
+             <div class="flex gap-3 mb-3">
+                 <p-button label="Another Upload?" text="true" styleClass="p-0" (click)="closeFn($event)"></p-button>
+                 <p-button label="Cancel" text="true" styleClass="text-white p-0" (click)="closeFn($event)"></p-button>
+             </div>
+         </div>
+     </section>
+ </ng-template>
+</p-toast>
+<button type="button" pButton pRipple (click)="showConfirm()" label="Confirm"></button>`,
+        html: `<div class="card flex justify-content-center">
+    <p-toast position="top-center" key="confirm" (onClose)="onClose()" [baseZIndex]="5000">
+    <ng-template let-message pTemplate="headless" let-closeFn="closeFn">
+        <section class="flex p-3 gap-3 w-full bg-black-alpha-90 shadow-2" style="border-radius: 10px">
+            <i class="pi pi-cloud-upload text-primary-500 text-2xl"></i>
+            <div class="flex flex-column gap-3 w-full">
+                <p class="m-0 font-semibold text-base text-white">{{ message.summary }}</p>
+                <p class="m-0 text-base text-700">{{ message.detail }}</p>
+                <div class="flex flex-column gap-2">
+                    <p-progressBar [value]="progress" [showValue]="false" [style]="{ height: '4px' }"></p-progressBar>
+                    <label class="text-right text-xs text-white">{{ progress }}% uploaded...</label>
+                </div>
+                <div class="flex gap-3 mb-3">
+                    <p-button label="Another Upload?" text="true" styleClass="p-0" (click)="closeFn($event)"></p-button>
+                    <p-button label="Cancel" text="true" styleClass="text-white p-0" (click)="closeFn($event)"></p-button>
+                </div>
+            </div>
+        </section>
+    </ng-template>
+    </p-toast>
+    <button type="button" pButton pRipple (click)="showConfirm()" label="Confirm"></button>
+</div>`,
+        typescript: `
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { MessageService } from 'primeng/api';
+
+@Component({
+    selector: 'toast-headless-demo',
+    templateUrl: './toast-headless-demo.html',
+    providers: [MessageService]
+})
+export class ToastHeadlessDemo {
+    constructor(private messageService: MessageService,private cdr:ChangeDetectorRef) {}
+
+    visible: boolean = false;
+
+    progress: number = 0;
+
+    interval = null;
+
+    showConfirm() {
+        if (!this.visible) {
+            this.messageService.add({ key: 'confirm', sticky: true, severity: 'custom', summary: 'Uploading your files.' });
+            this.visible = true;
+            this.progress = 0;
+
+            if (this.interval) {
+                clearInterval(this.interval);
+            }
+
+            this.interval = setInterval(() => {
+                if (this.progress <= 100) {
+                    this.progress = this.progress + 20;
+                }
+
+                if (this.progress >= 100) {
+                    this.progress = 100;
+                    clearInterval(this.interval);
+                }
+                this.cdr.detectChanges()
+            }, 1000);
+        }
+    }
+
+    onClose() {
+        this.visible = false;
+    }
+}`
+    };
+}


### PR DESCRIPTION
### Feat
Fixes https://github.com/orgs/primefaces/discussions/740

This feature provide the default toast close callback to any headless toast template so that it can be rejected/closed cleanly like any other closable toast  without clearing the whole service toast channel (see doc example for reference)
