### PR TITLE
Fix #14323: Dropdown fix regression - options overlay is closed before it handles the click event

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1057,7 +1057,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         const value = this.getOptionValue(option);
         this.updateModel(value, event);
         this.focusedOptionIndex.set(this.findSelectedOptionIndex());
-        isHide && this.hide(true);
+        isHide && setTimeout(() => this.hide(true), 1);
         preventChange === false && this.onChange.emit({ originalEvent: event, value: value });
     }
 


### PR DESCRIPTION
Fixes #14323 created with  https://github.com/primefaces/primeng/pull/13991/commits/f52340b9daf5ea2ee921fc0906838b98007cd6ed

When selecting a dropdown option inside an `OverlayPanel` the click event also has to be processed by the options overlay and the `OverlayService`. Otherwise the `OverlayPanel` is not aware that the click on the option is a click on its content => `OverlayPanel` is closed. Unfortunately when improving the accessability an older "workaround" which handels the issue was removed and has now been added again.

Before:
![Dropdown inside overlay panel (Before)](https://github.com/primefaces/primeng/assets/70583111/91e0559d-28af-4c1f-b6b1-8a7d09783104)

After:
![Dropdown inside overlay panel (After)](https://github.com/primefaces/primeng/assets/70583111/68ef7d97-9a13-4823-a3f7-a764dbb7474c)

@cetincakiroglu would be great if you could have a look! 😄 