### PR TITLE
Issue-14420 

### DIFF
--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -673,7 +673,7 @@ export class PickList implements AfterViewChecked, AfterContentInit {
     }
 
     get moveToSourceAriaLabel() {
-        return this.allLeftButtonAriaLabel ? this.allLeftButtonAriaLabel : this.config.translation.aria ? this.config.translation.aria.moveToSource : undefined;
+        return this.leftButtonAriaLabel ? this.leftButtonAriaLabel : this.config.translation.aria ? this.config.translation.aria.moveToSource : undefined;
     }
 
     get moveAllToSourceAriaLabel() {


### PR DESCRIPTION
### Defect Fixes
Tested with MacOS voiceover. Aria label from the button to put a selected element on the left should not have the value given to 'allLeftButtonAriaLabel', it now will use the value from leftButtonAriaLabel.
https://github.com/primefaces/primeng/issues/14420

