### PR TITLE
Fix the tree checkbox css issue and make it clearer when it is disabled

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -103,7 +103,7 @@ import {
                             <ng-template *ngTemplateOutlet="tree.togglerIconTemplate; context: { $implicit: node.expanded }"></ng-template>
                         </span>
                     </button>
-                    <div class="p-checkbox p-component" [ngClass]="{ 'p-checkbox-disabled': node.selectable === false }" *ngIf="tree.selectionMode == 'checkbox'" aria-hidden="true">
+                    <div class="p-checkbox p-component" [ngClass]="{ 'p-checkbox-disabled p-disabled': node.selectable === false }" *ngIf="tree.selectionMode == 'checkbox'" aria-hidden="true">
                         <div class="p-checkbox-box" [ngClass]="{ 'p-highlight': isSelected(), 'p-indeterminate': node.partialSelected }" role="checkbox">
                             <ng-container *ngIf="!tree.checkboxIconTemplate">
                                 <CheckIcon *ngIf="!node.partialSelected && isSelected()" [styleClass]="'p-checkbox-icon'" />


### PR DESCRIPTION
Resolves #14251 

# Description

When a tree node attribute `selectable` is set to `false`, we want to indicate this visually by making the checkbox 

# Implementation Details

- Added `p-disabled`; I think we should also reduce the entire row `opacity`, not only the checkbox.

# Steps to verify
- [ ] Create a dummy tree and set one node attribute `selectable` to `false` and the other to `true`, note that the differences are like this: 

![image](https://github.com/primefaces/primeng/assets/36598060/19ca6c6b-f87a-4f28-aefb-f1b2b31f7dd1)
