### PR TITLE
Rename autocomplete methods in test

### DIFF
--- a/src/app/components/autocomplete/autocomplete.spec.ts
+++ b/src/app/components/autocomplete/autocomplete.spec.ts
@@ -163,8 +163,8 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const onKeydownSpy = spyOn(autocomplete, 'onKeydown').and.callThrough();
-        const onKeyupSpy = spyOn(autocomplete, 'onKeyup').and.callThrough();
+        const onKeydownSpy = spyOn(autocomplete, 'onKeyDown').and.callThrough();
+        const onKeyupSpy = spyOn(autocomplete, 'onKeyUp').and.callThrough();
         const onInputSpy = spyOn(autocomplete, 'onInput').and.callThrough();
         const handleSuggestionsChangeSpy = spyOn(autocomplete, 'handleSuggestionsChange').and.callThrough();
         const filterBrandsSpy = spyOn(testComponent, 'filterBrands').and.callThrough();
@@ -353,7 +353,6 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
         inputEl.nativeElement.value = 'vsa';
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         inputEl.nativeElement.dispatchEvent(new Event('input'));
@@ -376,7 +375,7 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         inputEl.nativeElement.value = 'v';
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         inputEl.nativeElement.dispatchEvent(new Event('input'));
@@ -389,7 +388,7 @@ describe('AutoComplete', () => {
         fixture.detectChanges();
 
         expect(autocomplete.value).toEqual('Volvo');
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(inputEl.nativeElement.value).toEqual(autocomplete.value);
         expect(testComponent.brand).toEqual(autocomplete.value);
         flush();
@@ -436,7 +435,7 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete2, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete2, 'onOptionSelect').and.callThrough();
         inputEl.nativeElement.value = 'v';
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         inputEl.nativeElement.dispatchEvent(new Event('input'));
@@ -448,7 +447,7 @@ describe('AutoComplete', () => {
         firstItemEl.click();
         fixture.detectChanges();
         expect(autocomplete2.value.brand).toEqual('Volvo');
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(inputEl.nativeElement.value).toEqual(autocomplete2.value.brand);
         expect(testComponent.car).toEqual(autocomplete2.value);
         flush();
@@ -505,7 +504,7 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         inputEl.nativeElement.value = 'v';
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         inputEl.nativeElement.dispatchEvent(new Event('input'));
@@ -519,7 +518,7 @@ describe('AutoComplete', () => {
         fixture.detectChanges();
         expect(autocomplete.value[0]).toEqual('Volvo');
         expect(autocomplete.value.length).toEqual(1);
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(testComponent.brand).toEqual(autocomplete.value);
         flush();
     }));
@@ -533,7 +532,7 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         inputEl.nativeElement.value = 'v';
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         inputEl.nativeElement.dispatchEvent(new Event('input'));
@@ -547,7 +546,7 @@ describe('AutoComplete', () => {
 
         expect(autocomplete.value[0]).toEqual('Volvo');
         expect(autocomplete.value.length).toEqual(1);
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(testComponent.brand).toEqual(autocomplete.value);
         flush();
     }));
@@ -561,7 +560,7 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         inputEl.nativeElement.value = 'v';
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         inputEl.nativeElement.dispatchEvent(new Event('input'));
@@ -574,12 +573,12 @@ describe('AutoComplete', () => {
         fixture.detectChanges();
         expect(autocomplete.value[0]).toEqual('Volvo');
         expect(autocomplete.value.length).toEqual(1);
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(testComponent.brand).toEqual(autocomplete.value);
         let backspaceEvent = new Event('keydown');
         Object.defineProperty(backspaceEvent, 'which', { value: 8 });
         Object.defineProperty(backspaceEvent, 'preventDefault', { value: () => {} });
-        autocomplete.onKeydown(backspaceEvent);
+        autocomplete.onKeyDown(backspaceEvent);
         fixture.detectChanges();
 
         expect(autocomplete.value[0]).toEqual(undefined);
@@ -596,7 +595,7 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         inputEl.nativeElement.value = 'v';
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         inputEl.nativeElement.dispatchEvent(new Event('input'));
@@ -609,7 +608,7 @@ describe('AutoComplete', () => {
         fixture.detectChanges();
         expect(autocomplete.value[0]).toEqual('Volvo');
         expect(autocomplete.value.length).toEqual(1);
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(testComponent.brand).toEqual(autocomplete.value);
         const iconEl = fixture.debugElement.query(By.css('.p-autocomplete-token-icon'));
         iconEl.nativeElement.click();
@@ -628,22 +627,22 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         autocomplete.suggestions = ['Volvo', 'VW'];
         autocomplete.overlayVisible = true;
         let navigateEvent = new Event('keydown');
         Object.defineProperty(navigateEvent, 'which', { value: 40 });
         Object.defineProperty(navigateEvent, 'preventDefault', { value: () => {} });
-        autocomplete.onKeydown(navigateEvent);
+        autocomplete.onKeyDown(navigateEvent);
 
         let event = new Event('keydown');
         Object.defineProperty(event, 'which', { value: 13 });
         Object.defineProperty(event, 'preventDefault', { value: () => {} });
-        autocomplete.onKeydown(event);
+        autocomplete.onKeyDown(event);
         fixture.detectChanges();
 
         expect(autocomplete.value).toEqual('Volvo');
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(testComponent.brand).toEqual(autocomplete.value);
     });
 
@@ -655,22 +654,22 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         autocomplete.suggestions = ['Volvo', 'VW'];
         autocomplete.overlayVisible = true;
 
         let navigateEvent = new Event('keydown');
         Object.defineProperty(navigateEvent, 'which', { value: 40 });
         Object.defineProperty(navigateEvent, 'preventDefault', { value: () => {} });
-        autocomplete.onKeydown(navigateEvent);
+        autocomplete.onKeyDown(navigateEvent);
 
         let event = new Event('keydown');
         Object.defineProperty(event, 'which', { value: 9 });
         Object.defineProperty(event, 'preventDefault', { value: () => {} });
-        autocomplete.onKeydown(event);
+        autocomplete.onKeyDown(event);
         fixture.detectChanges();
         expect(autocomplete.value).toEqual('Volvo');
-        expect(selectItemSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(testComponent.brand).toEqual(autocomplete.value);
     });
 
@@ -682,7 +681,7 @@ describe('AutoComplete', () => {
         inputEl.nativeElement.click();
         fixture.detectChanges();
 
-        const selectItemSpy = spyOn(autocomplete, 'selectItem').and.callThrough();
+        const onOptionSelectSpy = spyOn(autocomplete, 'onOptionSelect').and.callThrough();
         const hideSpy = spyOn(autocomplete, 'hide').and.callThrough();
         autocomplete.suggestions = ['Volvo', 'VW'];
         autocomplete.overlayVisible = true;
@@ -690,11 +689,11 @@ describe('AutoComplete', () => {
         Object.defineProperty(event, 'which', { value: 27 });
         Object.defineProperty(event, 'preventDefault', { value: () => {} });
 
-        autocomplete.onKeydown(event);
+        autocomplete.onKeyDown(event);
         fixture.detectChanges();
 
         expect(autocomplete.value).toEqual(null);
-        expect(selectItemSpy).not.toHaveBeenCalled();
+        expect(onOptionSelectSpy).not.toHaveBeenCalled();
         expect(hideSpy).toHaveBeenCalled();
         expect(autocomplete.overlayVisible).toEqual(false);
     });

--- a/src/app/components/checkbox/checkbox.spec.ts
+++ b/src/app/components/checkbox/checkbox.spec.ts
@@ -167,15 +167,4 @@ describe('Checkbox', () => {
         expect(iconEl.className).toContain('pi pi-new-check');
     });
 
-    it('should call handleChange', () => {
-        fixture.detectChanges();
-
-        checkbox.binary = true;
-        const handleChangeSpy = spyOn(checkbox, 'handleChange').and.callThrough();
-        const input = fixture.nativeElement.querySelector('input');
-        input.dispatchEvent(new Event('change'));
-        fixture.detectChanges();
-
-        expect(handleChangeSpy).toHaveBeenCalled();
-    });
 });

--- a/src/app/components/chips/chips.spec.ts
+++ b/src/app/components/chips/chips.spec.ts
@@ -79,13 +79,13 @@ describe('Chips', () => {
         fixture.detectChanges();
 
         expect(onInputFocusSpy).toHaveBeenCalled();
-        expect(chips.focus).toEqual(true);
+        expect(chips.focused).toEqual(true);
         expect(focusData).toBeTruthy();
         inputEl.nativeElement.dispatchEvent(new Event('blur'));
         fixture.detectChanges();
 
         expect(onInputBlurSpy).toHaveBeenCalled();
-        expect(chips.focus).toEqual(false);
+        expect(chips.focused).toEqual(false);
         expect(blurData).toBeTruthy();
     });
 
@@ -96,14 +96,14 @@ describe('Chips', () => {
         let data;
         chips.onAdd.subscribe((value) => (data = value));
         const addItemSpy = spyOn(chips, 'addItem').and.callThrough();
-        const onKeydownSpy = spyOn(chips, 'onKeydown').and.callThrough();
+        const onKeydownSpy = spyOn(chips, 'onKeyDown').and.callThrough();
         const updateMaxedOutSpy = spyOn(chips, 'updateMaxedOut').and.callThrough();
         const inputEl = fixture.debugElement.query(By.css('input'));
         inputEl.nativeElement.value = 'primeng';
         fixture.detectChanges();
 
         let event = { which: 13, preventDefault() {} };
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         chips.cd.detectChanges();
@@ -124,13 +124,13 @@ describe('Chips', () => {
         fixture.detectChanges();
 
         let event = { which: 13, preventDefault() {} };
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         inputEl.nativeElement.value = 'primeng';
         fixture.detectChanges();
 
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         expect(chips.value.length).toEqual(2);
@@ -147,13 +147,13 @@ describe('Chips', () => {
         fixture.detectChanges();
 
         let event = { which: 13, preventDefault() {} };
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         inputEl.nativeElement.value = 'primeng';
         fixture.detectChanges();
 
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         expect(chips.value.length).toEqual(1);
@@ -165,14 +165,14 @@ describe('Chips', () => {
         fixture.detectChanges();
 
         const addItemSpy = spyOn(chips, 'addItem').and.callThrough();
-        const onKeydownSpy = spyOn(chips, 'onKeydown').and.callThrough();
+        const onKeydownSpy = spyOn(chips, 'onKeyDown').and.callThrough();
         const updateMaxedOutSpy = spyOn(chips, 'updateMaxedOut').and.callThrough();
         const inputEl = fixture.debugElement.query(By.css('input'));
         inputEl.nativeElement.value = 'primeng';
         fixture.detectChanges();
 
         let event = { which: 9, preventDefault() {} };
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         expect(addItemSpy).toHaveBeenCalled();
@@ -210,17 +210,17 @@ describe('Chips', () => {
         fixture.detectChanges();
 
         let event = { which: 13, preventDefault() {} };
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         inputEl.nativeElement.value = 'primeng';
         fixture.detectChanges();
 
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         event.which = 81;
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         expect(chips.value.length).toEqual(2);
@@ -228,7 +228,7 @@ describe('Chips', () => {
         expect(chips.value[1]).toEqual('primeng');
         expect(inputEl.nativeElement.disabled).toEqual(true);
         event.which = 8;
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         chips.updateMaxedOut();
         fixture.detectChanges();
 
@@ -246,7 +246,7 @@ describe('Chips', () => {
         fixture.detectChanges();
 
         let event = { which: 8, preventDefault() {} };
-        chips.onKeydown(event as KeyboardEvent);
+        chips.onKeyDown(event as KeyboardEvent);
         fixture.detectChanges();
 
         expect(data).toBeTruthy();

--- a/src/app/components/inputswitch/inputswitch.spec.ts
+++ b/src/app/components/inputswitch/inputswitch.spec.ts
@@ -28,7 +28,7 @@ describe('InputSwitch', () => {
         inputswitch.disabled = true;
         fixture.detectChanges();
 
-        const updateModelSpy = spyOn(inputswitch, 'updateModel').and.callThrough();
+        const onClickSpy = spyOn(inputswitch, 'onClick').and.callThrough();
         const inputSwitchEl = fixture.debugElement.query(By.css('div')).nativeElement;
         const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
         inputSwitchEl.click();
@@ -36,7 +36,7 @@ describe('InputSwitch', () => {
 
         expect(inputSwitchEl.className).toContain('p-disabled');
         expect(inputEl.disabled).toEqual(true);
-        expect(updateModelSpy).not.toHaveBeenCalled();
+        expect(onClickSpy).not.toHaveBeenCalled();
     });
 
     it('should change style and styleClass', () => {
@@ -64,7 +64,7 @@ describe('InputSwitch', () => {
     it('should checked when click', () => {
         fixture.detectChanges();
 
-        const toggleSpy = spyOn(inputswitch, 'toggle').and.callThrough();
+        const onClickSpy = spyOn(inputswitch, 'onClick').and.callThrough();
         const inputSwitchEl = fixture.debugElement.query(By.css('div')).nativeElement;
         let data;
         inputswitch.onChange.subscribe((value) => (data = value));
@@ -73,7 +73,7 @@ describe('InputSwitch', () => {
 
         expect(inputswitch.checked()).toEqual(true);
         expect(data.checked).toEqual(true);
-        expect(toggleSpy).toHaveBeenCalled();
+        expect(onClickSpy).toHaveBeenCalled();
     });
 
     it('should listen event emitter', () => {
@@ -113,28 +113,13 @@ describe('InputSwitch', () => {
         expect(onModelTouchedSpy).toHaveBeenCalled();
     });
 
-    it('should call onInputChange', () => {
-        fixture.detectChanges();
-
-        const updateModelSpy = spyOn(inputswitch, 'updateModel').and.callThrough();
-        const onInputChangeSpy = spyOn(inputswitch, 'onInputChange').and.callThrough();
-        const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
-        inputEl.checked = true;
-        inputEl.dispatchEvent(new Event('change'));
-        fixture.detectChanges();
-
-        expect(updateModelSpy).toHaveBeenCalled();
-        expect(onInputChangeSpy).toHaveBeenCalled();
-        expect(inputswitch.checked()).toEqual(true);
-    });
-
     it('should change disabled', () => {
         fixture.detectChanges();
 
         inputswitch.setDisabledState(true);
         fixture.detectChanges();
 
-        const updateModelSpy = spyOn(inputswitch, 'updateModel').and.callThrough();
+        const onClickSpy = spyOn(inputswitch, 'onClick').and.callThrough();
         const inputSwitchEl = fixture.debugElement.query(By.css('div')).nativeElement;
         const inputEl = fixture.debugElement.query(By.css('input')).nativeElement;
         inputSwitchEl.click();
@@ -142,6 +127,35 @@ describe('InputSwitch', () => {
 
         expect(inputSwitchEl.className).toContain('p-disabled');
         expect(inputEl.disabled).toEqual(true);
-        expect(updateModelSpy).not.toHaveBeenCalled();
+        expect(onClickSpy).not.toHaveBeenCalled();
+    });
+
+    it('should toggle the modelValue and call necessary functions when not disabled and not readonly', () => {
+        spyOn(inputswitch, 'onClick');
+        const divElement: HTMLElement = fixture.debugElement.query(By.css('div')).nativeElement;
+        divElement.click();
+        expect(inputswitch.onClick).toHaveBeenCalledWith(jasmine.anything());
+
+        const initialModelValue = inputswitch.modelValue;
+        inputswitch.onClick(new Event('click'));
+        expect(inputswitch.modelValue).toEqual(initialModelValue ? inputswitch.falseValue : inputswitch.trueValue);
+        expect(inputswitch.onModelChange).toHaveBeenCalledWith(inputswitch.modelValue);
+        expect(inputswitch.onChange.emit).toHaveBeenCalledWith({
+            originalEvent: jasmine.anything(),
+            checked: inputswitch.modelValue
+        });
+    });
+
+    it('should not toggle the modelValue when disabled or readonly', () => {
+        inputswitch.disabled = true;
+        let initialModelValue = inputswitch.modelValue;
+        inputswitch.onClick(new Event('click'));
+        expect(inputswitch.modelValue).toEqual(initialModelValue);
+
+        inputswitch.disabled = false;
+        inputswitch.readonly = true;
+        initialModelValue = inputswitch.modelValue;
+        inputswitch.onClick(new Event('click'));
+        expect(inputswitch.modelValue).toEqual(initialModelValue);
     });
 });

--- a/src/app/components/listbox/listbox.spec.ts
+++ b/src/app/components/listbox/listbox.spec.ts
@@ -43,7 +43,7 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const clickSingleSpy = spyOn(listbox, 'onOptionClickCheckbox').and.callThrough();
+        const onOptionSelectSpy = spyOn(listbox, 'onOptionSelect').and.callThrough();
         fixture.detectChanges();
 
         const bmwEl = fixture.debugElement.query(By.css('ul')).children[1].nativeElement;
@@ -52,7 +52,7 @@ describe('Listbox', () => {
 
         const filterInputEl = fixture.debugElement.query(By.css('.p-listbox-filter-container')).query(By.css('input')).nativeElement;
         expect(filterInputEl.disabled).toEqual(true);
-        expect(clickSingleSpy).not.toHaveBeenCalled();
+        expect(onOptionSelectSpy).not.toHaveBeenCalled();
     });
 
     it('should call onOptionTouchEnd', () => {
@@ -129,14 +129,14 @@ describe('Listbox', () => {
         ];
         fixture.detectChanges();
 
-        const onOptionClick = spyOn(listbox, 'onOptionClick').and.callThrough();
+        const onOptionSelect = spyOn(listbox, 'onOptionSelect').and.callThrough();
         const bmwEl = fixture.debugElement.query(By.css('ul')).children[1].nativeElement;
         bmwEl.click();
         fixture.detectChanges();
 
         expect(listbox.value).toEqual('BMW');
         expect(bmwEl.className).toContain('p-highlight');
-        expect(onOptionClick).toHaveBeenCalled();
+        expect(onOptionSelect).toHaveBeenCalled();
         expect(listbox.optionTouched).toEqual(false);
     });
 
@@ -184,7 +184,7 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const clickMultipleSpy = spyOn(listbox, 'onOptionClickMultiple').and.callThrough();
+        const optionSelectMultipleSpy = spyOn(listbox, 'onOptionSelectMultiple').and.callThrough();
         fixture.detectChanges();
 
         const bmwEl = fixture.debugElement.query(By.css('ul')).children[1].nativeElement;
@@ -199,7 +199,7 @@ describe('Listbox', () => {
         expect(listbox.value[1]).toEqual('Audi');
         expect(bmwEl.className).toContain('p-highlight');
         expect(audiEl.className).toContain('p-highlight');
-        expect(clickMultipleSpy).toHaveBeenCalledTimes(2);
+        expect(optionSelectMultipleSpy).toHaveBeenCalledTimes(2);
     });
 
     it('should drop two item when double click', () => {
@@ -217,7 +217,7 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const clickMultipleSpy = spyOn(listbox, 'onOptionClickMultiple').and.callThrough();
+        const optionSelectMultipleSpy = spyOn(listbox, 'onOptionSelectMultiple').and.callThrough();
         fixture.detectChanges();
 
         const bmwEl = fixture.debugElement.query(By.css('ul')).children[1].nativeElement;
@@ -232,7 +232,7 @@ describe('Listbox', () => {
         expect(listbox.value[1]).not.toEqual('Audi');
         expect(bmwEl.className).not.toContain('p-highlight');
         expect(audiEl.className).not.toContain('p-highlight');
-        expect(clickMultipleSpy).toHaveBeenCalledTimes(4);
+        expect(optionSelectMultipleSpy).toHaveBeenCalledTimes(4);
     });
 
     it('should select all', () => {
@@ -250,7 +250,7 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const toggleAllSpy = spyOn(listbox, 'toggleAll').and.callThrough();
+        const onToggleAllSpy = spyOn(listbox, 'onToggleAll').and.callThrough();
         listbox.cd.detectChanges();
         fixture.detectChanges();
 
@@ -259,9 +259,9 @@ describe('Listbox', () => {
         fixture.detectChanges();
 
         expect(listbox.value.length).toEqual(10);
-        expect(listbox.allChecked).toEqual(true);
+        expect(listbox.selectAll).toEqual(true);
         expect(selectAllEl.className).toContain('p-highlight');
-        expect(toggleAllSpy).toHaveBeenCalled();
+        expect(onToggleAllSpy).toHaveBeenCalled();
     });
 
     it('should show filtered items', () => {
@@ -383,7 +383,7 @@ describe('Listbox', () => {
             { label: 'Volvo', value: 'Volvo' }
         ];
         listbox.metaKeySelection = true;
-        const onOptionClick = spyOn(listbox, 'onOptionClick').and.callThrough();
+        const onOptionSelect = spyOn(listbox, 'onOptionSelect').and.callThrough();
         fixture.detectChanges();
 
         let data;
@@ -395,13 +395,13 @@ describe('Listbox', () => {
         bmwEl.click();
         fixture.detectChanges();
 
-        listbox.onOptionClick(event, listbox.options[1]);
+        listbox.onOptionSelect(event, listbox.options[1]);
         fixture.detectChanges();
 
         listbox.cd.detectChanges();
         expect(listbox.value).toEqual(null);
         expect(bmwEl.className).not.toContain('p-highlight');
-        expect(onOptionClick).toHaveBeenCalled();
+        expect(onOptionSelect).toHaveBeenCalled();
         expect(data.value).toEqual(null);
     });
 
@@ -420,7 +420,7 @@ describe('Listbox', () => {
         ];
         listbox.metaKeySelection = true;
         listbox.multiple = true;
-        const onOptionClick = spyOn(listbox, 'onOptionClick').and.callThrough();
+        const onOptionSelect = spyOn(listbox, 'onOptionSelect').and.callThrough();
         fixture.detectChanges();
 
         let data;
@@ -432,13 +432,13 @@ describe('Listbox', () => {
         bmwEl.click();
         fixture.detectChanges();
 
-        listbox.onOptionClick(event, listbox.options[1]);
+        listbox.onOptionSelect(event, listbox.options[1]);
         fixture.detectChanges();
 
         listbox.cd.detectChanges();
         expect(listbox.value).toEqual([]);
         expect(bmwEl.className).not.toContain('p-highlight');
-        expect(onOptionClick).toHaveBeenCalled();
+        expect(onOptionSelect).toHaveBeenCalled();
         expect(data.value).toEqual([]);
     });
 
@@ -457,7 +457,7 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const clickCheckboxSpy = spyOn(listbox, 'onOptionClickCheckbox').and.callThrough();
+        const onOptionSelectSpy = spyOn(listbox, 'onOptionSelect').and.callThrough();
         fixture.detectChanges();
 
         const bmwEl = fixture.debugElement.query(By.css('ul')).children[1].nativeElement;
@@ -473,7 +473,7 @@ describe('Listbox', () => {
         expect(listbox.value.length).toEqual(1);
         expect(listbox.value[1]).not.toEqual('Audi');
         expect(bmwEl.className).toContain('p-highlight');
-        expect(clickCheckboxSpy).toHaveBeenCalledTimes(3);
+        expect(onOptionSelectSpy).toHaveBeenCalledTimes(3);
     });
 
     it('should unselect all', () => {
@@ -491,7 +491,7 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const toggleAllSpy = spyOn(listbox, 'toggleAll').and.callThrough();
+        const toggleAllSpy = spyOn(listbox, 'onToggleAll').and.callThrough();
         fixture.detectChanges();
 
         listbox.cd.detectChanges();
@@ -503,7 +503,7 @@ describe('Listbox', () => {
         fixture.detectChanges();
 
         expect(listbox.value.length).toEqual(0);
-        expect(listbox.allChecked).toEqual(false);
+        expect(listbox.selectAll).toEqual(false);
         expect(selectAllEl.className).not.toContain('p-highlight');
         expect(toggleAllSpy).toHaveBeenCalledTimes(2);
     });
@@ -524,7 +524,7 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const toggleAllSpy = spyOn(listbox, 'toggleAll').and.callThrough();
+        const toggleAllSpy = spyOn(listbox, 'onToggleAll').and.callThrough();
         fixture.detectChanges();
 
         listbox.cd.detectChanges();
@@ -533,7 +533,7 @@ describe('Listbox', () => {
         fixture.detectChanges();
 
         expect(listbox.value).toBeFalsy();
-        expect(listbox.allChecked).toBeFalsy();
+        expect(listbox.selectAll).toBeFalsy();
         expect(selectAllEl.className).not.toContain('p-highlight');
         expect(toggleAllSpy).toHaveBeenCalledTimes(1);
     });
@@ -609,8 +609,8 @@ describe('Listbox', () => {
             { label: 'VW', value: 'VW' },
             { label: 'Volvo', value: 'Volvo' }
         ];
-        const findNextItemSpy = spyOn(listbox, 'findNextItem').and.callThrough();
-        const findPrevItemSpy = spyOn(listbox, 'findPrevItem').and.callThrough();
+        const findNextOptionIndexSpy = spyOn(listbox, 'findNextOptionIndex').and.callThrough();
+        const findPrevOptionIndexSpy = spyOn(listbox, 'findPrevOptionIndex').and.callThrough();
         fixture.detectChanges();
 
         const bmwEl = fixture.debugElement.query(By.css('ul')).children[1].nativeElement;
@@ -628,8 +628,8 @@ describe('Listbox', () => {
         bmwEl.dispatchEvent(event);
         fixture.detectChanges();
 
-        expect(findNextItemSpy).toHaveBeenCalled();
-        expect(findPrevItemSpy).toHaveBeenCalled();
+        expect(findNextOptionIndexSpy).toHaveBeenCalled();
+        expect(findPrevOptionIndexSpy).toHaveBeenCalled();
         expect(listbox.value).toEqual('BMW');
     });
 });

--- a/src/app/components/multiselect/multiselect.spec.ts
+++ b/src/app/components/multiselect/multiselect.spec.ts
@@ -12,6 +12,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('MultiSelect', () => {
     let multiselect: MultiSelect;
+    let multiselectItem: MultiSelectItem;
     let fixture: ComponentFixture<MultiSelect>;
 
     beforeEach(() => {
@@ -27,7 +28,7 @@ describe('MultiSelect', () => {
 
     it('should disabled', () => {
         multiselect.disabled = true;
-        const showSpy = spyOn(multiselect, 'onMouseclick').and.callThrough();
+        const showSpy = spyOn(multiselect, 'onContainerClick').and.callThrough();
         fixture.detectChanges();
 
         const containerEl = fixture.debugElement.query(By.css('div')).nativeElement;
@@ -95,7 +96,7 @@ describe('MultiSelect', () => {
         fixture.detectChanges();
 
         const multiselectEl = fixture.debugElement.children[0].nativeElement;
-        const clickSpy = spyOn(multiselect, 'onMouseclick').and.callThrough();
+        const clickSpy = spyOn(multiselect, 'onContainerClick').and.callThrough();
         multiselectEl.click();
         fixture.detectChanges();
 
@@ -110,7 +111,7 @@ describe('MultiSelect', () => {
         fixture.detectChanges();
 
         const inputEl = fixture.debugElement.query(By.css('input'));
-        const onKeydownSpy = spyOn(multiselect, 'onKeydown').and.callThrough();
+        const onKeyDownSpy = spyOn(multiselect, 'onKeyDown').and.callThrough();
         const keydownEvent: any = document.createEvent('CustomEvent');
         keydownEvent.which = 40;
         keydownEvent.altKey = true;
@@ -122,12 +123,11 @@ describe('MultiSelect', () => {
         let multiselectPanelEl = fixture.debugElement.query(By.css('.p-multiselect-panel'));
         expect(multiselect.overlayVisible).toEqual(true);
         expect(multiselectPanelEl).toBeTruthy();
-        expect(onKeydownSpy).toHaveBeenCalled();
+        expect(onKeyDownSpy).toHaveBeenCalled();
         keydownEvent.which = 27;
         inputEl.nativeElement.dispatchEvent(keydownEvent);
         fixture.detectChanges();
 
-        multiselectPanelEl = fixture.debugElement.query(By.css('.p-multiselect-panel'));
         expect(hideSpy).toHaveBeenCalled();
         keydownEvent.which = 32;
         inputEl.nativeElement.dispatchEvent(keydownEvent);
@@ -142,7 +142,7 @@ describe('MultiSelect', () => {
         fixture.detectChanges();
 
         const multiselectEl = fixture.debugElement.children[0].nativeElement;
-        const clickSpy = spyOn(multiselect, 'onMouseclick').and.callThrough();
+        const clickSpy = spyOn(multiselect, 'onContainerClick').and.callThrough();
         const hideSpy = spyOn(multiselect, 'hide').and.callThrough();
         multiselectEl.click();
         fixture.detectChanges();
@@ -178,7 +178,7 @@ describe('MultiSelect', () => {
         const multiselectItemEl = fixture.debugElement.queryAll(By.css('.p-multiselect-item'));
         expect(multiselectItemEl.length).toEqual(10);
         const bmwEl = multiselectItemEl[1];
-        const onOptionClickSpy = spyOn(multiselect, 'onOptionClick').and.callThrough();
+        const onOptionClickSpy = spyOn(multiselectItem, 'onOptionClick').and.callThrough();
         bmwEl.nativeElement.click();
         fixture.detectChanges();
 
@@ -214,11 +214,11 @@ describe('MultiSelect', () => {
         expect(multiselectItemEl.length).toEqual(10);
         expect(multiselect.value[0]).toEqual('BMW');
         expect(multiselect.value.length).toEqual(1);
-        const onOptionKeydownSpy = spyOn(multiselect, 'onOptionKeydown').and.callThrough();
+        const onKeyDownSpy = spyOn(multiselect, 'onKeyDown').and.callThrough();
         bmwEl.nativeElement.dispatchEvent(keydownEvent);
         fixture.detectChanges();
 
-        expect(onOptionKeydownSpy).toBeTruthy();
+        expect(onKeyDownSpy).toBeTruthy();
         expect(multiselect.value.length).toEqual(0);
         keydownEvent.which = 40;
         bmwEl.nativeElement.dispatchEvent(keydownEvent);
@@ -257,7 +257,7 @@ describe('MultiSelect', () => {
         expect(multiselectItemEl.length).toEqual(10);
         const audiEl = multiselectItemEl[0];
         const bmwEl = multiselectItemEl[1];
-        const onOptionClickSpy = spyOn(multiselect, 'onOptionClick').and.callThrough();
+        const onOptionClickSpy = spyOn(multiselectItem, 'onOptionClick').and.callThrough();
         bmwEl.nativeElement.click();
         audiEl.nativeElement.click();
         fixture.detectChanges();
@@ -296,7 +296,7 @@ describe('MultiSelect', () => {
         const fiatEl = multiselectItemEl[1];
         const bmwEl = multiselectItemEl[2];
         const audiEl = multiselectItemEl[0];
-        const onOptionClickSpy = spyOn(multiselect, 'onOptionClick').and.callThrough();
+        const onOptionClickSpy = spyOn(multiselectItem, 'onOptionClick').and.callThrough();
         bmwEl.nativeElement.click();
         fixture.detectChanges();
 
@@ -332,7 +332,7 @@ describe('MultiSelect', () => {
         expect(multiselectItemEl.length).toEqual(10);
         const bmwEl = multiselectItemEl[1];
         const fordEl = multiselectItemEl[3];
-        const onOptionClickSpy = spyOn(multiselect, 'onOptionClick').and.callThrough();
+        const onOptionClickSpy = spyOn(multiselectItem, 'onOptionClick').and.callThrough();
         bmwEl.nativeElement.click();
         fordEl.nativeElement.click();
         fixture.detectChanges();
@@ -358,7 +358,7 @@ describe('MultiSelect', () => {
         multiselect.value = [];
         multiselect.selectionLimit = 2;
         const multiselectEl = fixture.debugElement.children[0].nativeElement;
-        const onOptionClickSpy = spyOn(multiselect, 'onOptionClick').and.callThrough();
+        const onOptionClickSpy = spyOn(multiselectItem, 'onOptionClick').and.callThrough();
         fixture.detectChanges();
 
         multiselectEl.click();
@@ -396,7 +396,7 @@ describe('MultiSelect', () => {
         fixture.detectChanges();
 
         const multiselectEl = fixture.debugElement.children[0].nativeElement;
-        const itemClickSpy = spyOn(multiselect, 'toggleAll').and.callThrough();
+        const itemClickSpy = spyOn(multiselect, 'onToggleAll').and.callThrough();
         multiselectEl.click();
         fixture.detectChanges();
 
@@ -460,7 +460,7 @@ describe('MultiSelect', () => {
         fixture.detectChanges();
 
         const multiselectEl = fixture.debugElement.children[0].nativeElement;
-        const toggleSpy = spyOn(multiselect, 'toggleAll').and.callThrough();
+        const toggleSpy = spyOn(multiselect, 'onToggleAll').and.callThrough();
         multiselectEl.click();
         fixture.detectChanges();
 
@@ -500,7 +500,7 @@ describe('MultiSelect', () => {
         filterInputEl.dispatchEvent(new Event('input'));
         fixture.detectChanges();
 
-        expect(multiselect.optionsToRender.length).toEqual(2);
+        expect(multiselect.visibleOptions().length).toEqual(2);
     });
 
     it('should close with close icon and reset filter input', () => {
@@ -529,7 +529,7 @@ describe('MultiSelect', () => {
         filterInputEl.dispatchEvent(new Event('input'));
         fixture.detectChanges();
 
-        expect(multiselect.optionsToRender.length).toEqual(2);
+        expect(multiselect.visibleOptions().length).toEqual(2);
         const closeEl = fixture.debugElement.query(By.css('.p-multiselect-close'));
         closeEl.nativeElement.click();
         fixture.detectChanges();

--- a/src/app/components/selectbutton/selectbutton.spec.ts
+++ b/src/app/components/selectbutton/selectbutton.spec.ts
@@ -71,13 +71,13 @@ describe('SelectButton', () => {
         ];
         fixture.detectChanges();
 
-        const onItemClickSpy = spyOn(selectButton, 'onItemClick').and.callThrough();
+        const onOptionSelectSpy = spyOn(selectButton, 'onOptionSelect').and.callThrough();
         const buttonEls = fixture.debugElement.queryAll(By.css('.p-button'));
         expect(buttonEls.length).toEqual(3);
         buttonEls[1].nativeElement.click();
         fixture.detectChanges();
 
-        expect(onItemClickSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(selectButton.value).toEqual(undefined);
     });
 
@@ -95,7 +95,7 @@ describe('SelectButton', () => {
         let valueChange;
         selectButton.onOptionClick.subscribe((data) => (valueOptionClick = data));
         selectButton.onChange.subscribe((data) => (valueChange = data));
-        const onItemClickSpy = spyOn(selectButton, 'onItemClick').and.callThrough();
+        const onOptionSelectSpy = spyOn(selectButton, 'onOptionSelect').and.callThrough();
         const buttonEls = fixture.debugElement.queryAll(By.css('.p-button'));
         expect(buttonEls.length).toEqual(3);
         buttonEls[0].nativeElement.click();
@@ -106,7 +106,7 @@ describe('SelectButton', () => {
         buttonEls[2].nativeElement.click();
         fixture.detectChanges();
 
-        expect(onItemClickSpy).toHaveBeenCalled();
+        expect(onOptionSelectSpy).toHaveBeenCalled();
         expect(selectButton.value.length).toEqual(2);
         expect(valueOptionClick.option).toBeTruthy();
         expect(valueChange.value).toBeTruthy();

--- a/src/app/components/tristatecheckbox/tristatecheckbox.spec.ts
+++ b/src/app/components/tristatecheckbox/tristatecheckbox.spec.ts
@@ -187,36 +187,19 @@ describe('TriStateCheckbox', () => {
         expect(checkBoxEl.nativeElement.className).not.toContain('p-focus');
     });
 
-    it('should call onKeydown', () => {
+    it('should call onKeyDown', () => {
         tristate.label = 'Primeng';
         fixture.detectChanges();
 
         let value;
         tristate.onChange.subscribe((data) => (value = data));
-        const onKeydownSpy = spyOn(tristate, 'onKeydown').and.callThrough();
+        const onKeyDownSpy = spyOn(tristate, 'onKeyDown').and.callThrough();
         const inputEl = fixture.debugElement.query(By.css('input'));
         inputEl.nativeElement.dispatchEvent(new Event('keydown'));
         fixture.detectChanges();
 
-        expect(onKeydownSpy).toHaveBeenCalled();
+        expect(onKeyDownSpy).toHaveBeenCalled();
         expect(tristate.value).toBeUndefined();
     });
 
-    it('should call onKeydown', () => {
-        tristate.label = 'Primeng';
-        fixture.detectChanges();
-
-        let value;
-        tristate.onChange.subscribe((data) => (value = data));
-        const onKeydownSpy = spyOn(tristate, 'onKeyup').and.callThrough();
-        const inputEl = fixture.debugElement.query(By.css('input'));
-        const openEvent: any = document.createEvent('CustomEvent');
-        openEvent.keyCode = 32;
-        openEvent.initEvent('keyup', true, true);
-        inputEl.nativeElement.dispatchEvent(openEvent);
-        fixture.detectChanges();
-
-        expect(onKeydownSpy).toHaveBeenCalled();
-        expect(tristate.value).toBeTruthy();
-    });
 });


### PR DESCRIPTION
Fix test case error for autocomplete 

The 'onKeydown', 'onKeyup' and 'selectItem' methods have been renamed to 'onKeyDown', 'onKeyUp', and 'onOptionSelect', respectively in the autocomplete test script. Changes made to maintain consistency with actual method naming, enhancing readability and maintainability of the tests.
