### PR TITLE
Fix: Issue #14163 - AutoComplete: ArrowDown key no longer opens up the dropdown

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -1245,7 +1245,16 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
     onArrowDownKey(event) {
         if (!this.overlayVisible) {
-            return;
+            if(this.focused) {
+                const el = this.inputEL.nativeElement as HTMLInputElement | undefined;
+                if(el){
+                    // Put cursor at the end as the preventDefault blocks this behaviour
+                    el.selectionStart = el.selectionEnd = el.value.length;
+                }
+                this.overlayVisible = true;
+            } else {
+                return;
+            }
         }
 
         const optionIndex = this.focusedOptionIndex() !== -1 ? this.findNextOptionIndex(this.focusedOptionIndex()) : this.findFirstFocusedOptionIndex();


### PR DESCRIPTION
This should fix #14163 

**Notes**

There is already a pull request to fix the issue - https://github.com/primefaces/primeng/pull/14176

However, that PR has not been approved, due to it containing fixes for other files, and the author has not responded for about a month now. As the original issue is blocking the company I work from upgrading to v17, I decided to do my own PR for it, taking only the fix for Auto-Complete.
