### PR TITLE
Fix #14508 Panel id generation

### DIFF
--- a/src/app/components/panel/panel.ts
+++ b/src/app/components/panel/panel.ts
@@ -205,9 +205,7 @@ export class Panel implements AfterContentInit, BlockableUI {
 
     headerIconTemplate: Nullable<TemplateRef<any>>;
 
-    get id() {
-        return UniqueComponentId();
-    }
+    readonly id = UniqueComponentId();
 
     get buttonAriaLabel() {
         return this.header;


### PR DESCRIPTION
Fixes #14508 by generating one unique id for the component rather than a new one each time the property is read.


