### PR TITLE
Fix #14525 reading properties of undefined during EditableColumn changes

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -4063,8 +4063,8 @@ export class EditableColumn implements OnChanges, AfterViewInit, OnDestroy {
 
     constructor(public dt: Table, public el: ElementRef, public zone: NgZone) {}
 
-    public ngOnChanges({ data }: SimpleChanges): void {
-        if (this.el.nativeElement && !data.firstChange) {
+    public ngOnChanges(changes: SimpleChanges): void {
+        if (this.el.nativeElement && (!changes.data || !changes.data.firstChange)) {
             this.dt.updateEditingCell(this.el.nativeElement, this.data, this.field, <number>this.rowIndex);
         }
     }

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -4064,7 +4064,7 @@ export class EditableColumn implements OnChanges, AfterViewInit, OnDestroy {
     constructor(public dt: Table, public el: ElementRef, public zone: NgZone) {}
 
     public ngOnChanges(changes: SimpleChanges): void {
-        if (this.el.nativeElement && (!changes.data || !changes.data.firstChange)) {
+        if (this.el.nativeElement && (!changes.data?.firstChange)) {
             this.dt.updateEditingCell(this.el.nativeElement, this.data, this.field, <number>this.rowIndex);
         }
     }


### PR DESCRIPTION
SimpleChanges might not have `data` defined when only other input than `data` changes.

For details see reporting issue: https://github.com/primefaces/primeng/issues/14525
