### PR TITLE
feat: Paginator & Table - Add option to customize dropdown icon #9605

### DIFF
--- a/src/app/components/paginator/paginator.interface.ts
+++ b/src/app/components/paginator/paginator.interface.ts
@@ -17,6 +17,10 @@ export interface PaginatorState {
  */
 export interface PaginatorTemplates {
     /**
+     * Custom dropdown trigger icon template.
+     */
+    dropdownicon(): TemplateRef<any>
+    /**
      * Custom first page link icon template.
      */
     firstpagelinkicon(): TemplateRef<any>;

--- a/src/app/components/paginator/paginator.interface.ts
+++ b/src/app/components/paginator/paginator.interface.ts
@@ -19,7 +19,7 @@ export interface PaginatorTemplates {
     /**
      * Custom dropdown trigger icon template.
      */
-    dropdownicon(): TemplateRef<any>
+    dropdownicon(): TemplateRef<any>;
     /**
      * Custom first page link icon template.
      */

--- a/src/app/components/paginator/paginator.ts
+++ b/src/app/components/paginator/paginator.ts
@@ -78,6 +78,9 @@ import { PaginatorState } from './paginator.interface';
                 [scrollHeight]="dropdownScrollHeight"
             >
                 <ng-template pTemplate="selectedItem">{{ currentPageReport }}</ng-template>
+                <ng-template pTemplate="dropdownicon" *ngIf="dropdownIconTemplate">
+                    <ng-container *ngTemplateOutlet="dropdownIconTemplate"></ng-container>
+                </ng-template>
             </p-dropdown>
             <button
                 type="button"
@@ -125,6 +128,9 @@ import { PaginatorState } from './paginator.interface';
                         <ng-container *ngTemplateOutlet="dropdownItemTemplate; context: { $implicit: item }"> </ng-container>
                     </ng-template>
                 </ng-container>
+                <ng-template pTemplate="dropdownicon" *ngIf="dropdownIconTemplate">
+                    <ng-container *ngTemplateOutlet="dropdownIconTemplate"></ng-container>
+                </ng-template>
             </p-dropdown>
             <div class="p-paginator-right-content" *ngIf="templateRight" [attr.data-pc-section]="'end'">
                 <ng-container *ngTemplateOutlet="templateRight; context: { $implicit: paginatorState }"></ng-container>
@@ -261,6 +267,8 @@ export class Paginator implements OnInit, AfterContentInit, OnChanges {
 
     @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<any>>;
 
+    dropdownIconTemplate: Nullable<TemplateRef<any>>;
+
     firstPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
     previousPageLinkIconTemplate: Nullable<TemplateRef<any>>;
@@ -309,6 +317,10 @@ export class Paginator implements OnInit, AfterContentInit, OnChanges {
     ngAfterContentInit(): void {
         (this.templates as QueryList<PrimeTemplate>).forEach((item) => {
             switch (item.getType()) {
+                case 'dropdownicon':
+                    this.dropdownIconTemplate = item.template;
+                    break;
+
                 case 'firstpagelinkicon':
                     this.firstPageLinkIconTemplate = item.template;
                     break;

--- a/src/app/components/table/table.interface.ts
+++ b/src/app/components/table/table.interface.ts
@@ -527,7 +527,7 @@ export interface TableTemplates {
     /**
      * Custom paginator dropdown trigger icon template.
      */
-    paginatordropdownicon(): TemplateRef<any>
+    paginatordropdownicon(): TemplateRef<any>;
     /**
      * Custom paginator dropdown item template.
      */

--- a/src/app/components/table/table.interface.ts
+++ b/src/app/components/table/table.interface.ts
@@ -525,6 +525,10 @@ export interface TableTemplates {
      */
     paginatorright(): TemplateRef<any>;
     /**
+     * Custom paginator dropdown trigger icon template.
+     */
+    paginatordropdownicon(): TemplateRef<any>
+    /**
      * Custom paginator dropdown item template.
      */
     paginatordropdownitem(): TemplateRef<any>;

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -163,6 +163,10 @@ export class TableService {
                 [styleClass]="paginatorStyleClass"
                 [locale]="paginatorLocale"
             >
+                <ng-template pTemplate="dropdownicon" *ngIf="paginatorDropdownIconTemplate">
+                    <ng-container *ngTemplateOutlet="paginatorDropdownIconTemplate"></ng-container>
+                </ng-template>
+
                 <ng-template pTemplate="firstpagelinkicon" *ngIf="paginatorFirstPageLinkIconTemplate">
                     <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate"></ng-container>
                 </ng-template>
@@ -278,6 +282,10 @@ export class TableService {
                 [styleClass]="paginatorStyleClass"
                 [locale]="paginatorLocale"
             >
+                <ng-template pTemplate="dropdownicon" *ngIf="paginatorDropdownIconTemplate">
+                    <ng-container *ngTemplateOutlet="paginatorDropdownIconTemplate"></ng-container>
+                </ng-template>
+
                 <ng-template pTemplate="firstpagelinkicon" *ngIf="paginatorFirstPageLinkIconTemplate">
                     <ng-container *ngTemplateOutlet="paginatorFirstPageLinkIconTemplate"></ng-container>
                 </ng-template>
@@ -1043,6 +1051,8 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
     headerCheckboxIconTemplate: Nullable<TemplateRef<any>>;
 
+    paginatorDropdownIconTemplate: Nullable<TemplateRef<any>>;
+
     paginatorFirstPageLinkIconTemplate: Nullable<TemplateRef<any>>;
 
     paginatorLastPageLinkIconTemplate: Nullable<TemplateRef<any>>;
@@ -1245,6 +1255,10 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
 
                 case 'paginatorright':
                     this.paginatorRightTemplate = item.template;
+                    break;
+
+                case 'paginatordropdownicon':
+                    this.paginatorDropdownIconTemplate = item.template;
                     break;
 
                 case 'paginatordropdownitem':


### PR DESCRIPTION
### Defect Fixes
#9605

Hello, I've noticed that it is not possible to customize dropdown trigger icon in `page size selector` dropdown that is used inside Paginator and Table component.
The issue has been closed over 1 year ago without a fix.

Please let me know if my changes are sufficent. If not, please let me know what to change or just prioritize implementing this internally as it impacts custom theming.