### PR TITLE
Fix Carousel touch events on iOS devices

### DIFF
--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -62,8 +62,8 @@ import { DomHandler } from 'primeng/dom';
                             <ng-template *ngTemplateOutlet="previousIconTemplate"></ng-template>
                         </span>
                     </button>
-                    <div class="p-carousel-items-content" [ngStyle]="{ height: isVertical() ? verticalViewPortHeight : 'auto' }">
-                        <div #itemsContainer class="p-carousel-items-container" (transitionend)="onTransitionEnd()" (touchend)="onTouchEnd($event)" (touchstart)="onTouchStart($event)" (touchmove)="onTouchMove($event)">
+                    <div class="p-carousel-items-content" [ngStyle]="{ height: isVertical() ? verticalViewPortHeight : 'auto' }" (touchend)="onTouchEnd($event)" (touchstart)="onTouchStart($event)" (touchmove)="onTouchMove($event)">
+                        <div #itemsContainer class="p-carousel-items-container" (transitionend)="onTransitionEnd()">
                             <div
                                 *ngFor="let item of clonedItemsForStarting; let index = index"
                                 [ngClass]="{


### PR DESCRIPTION
Fixes swiping on carousel on iOS devices (Issues #12942 & #9786) by moving the existing touch event listeners to the parent div (.p-carousel-items-content), similar to the [implementation of the PrimeVue carousel](https://github.com/primefaces/primevue/blob/c8609171c29c702da09054d901fc76a671248ef8/components/lib/carousel/Carousel.vue#L24).
