### PR TITLE
Fix #14596 - fixed label logic

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -924,8 +924,14 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     });
 
     label = computed(() => {
-        const selectedOptionIndex = this.findSelectedOptionIndex();
-        return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
+        let holdValue: any;
+        if (this.virtualScroll) {
+            const selectedOptionIndex = this.findSelectedOptionIndex();
+            holdValue = selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : null;
+        } else {
+            holdValue = this.modelValue();
+        }
+        return holdValue ? this.getOptionLabel(holdValue) : this.placeholder || 'p-emptylabel';
     });
 
     selectedOption: any;

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -926,13 +926,13 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     private currentLabel: string = null;
 
     label = computed(() => {
-        if(this.itemsWrapper()) {
+        if (this.itemsWrapper()) {
             return this.currentLabel;
         }
         const selectedOptionIndex = this.findSelectedOptionIndex();
         // tricky logic
         // this if condition is only true when the selected option was filtered from the options list
-        if ((selectedOptionIndex === -1) && (this.currentLabel !== null)) {
+        if (selectedOptionIndex === -1 && this.currentLabel !== null) {
             return this.currentLabel;
         }
         this.currentLabel = selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';

--- a/test
+++ b/test
@@ -1,1 +1,0 @@
-this is a test

--- a/test
+++ b/test
@@ -1,0 +1,1 @@
+this is a test


### PR DESCRIPTION
Fix #14596 

The following video  demonstrates the fix.


https://github.com/primefaces/primeng/assets/45439491/22edab94-f1a2-4214-abc4-496e7c246341

To fix this issue, I updated the logic for computing the dropdown's label.

Note:  For "virtual scroll" configurations,  the original logic is unchanged

I manually tested my fix on all the PrimeNG dropdown demos

