### PR TITLE
fix #14606 restricted pointer events more

### DIFF
--- a/src/app/components/calendar/calendar.css
+++ b/src/app/components/calendar/calendar.css
@@ -166,7 +166,7 @@
         cursor: pointer;
     }
 
-    .p-icon-wrapper {
+    .p-datepicker-icon {
         pointer-events: none;
     }
 

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -120,7 +120,9 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
                     </ng-container>
                 </button>
                 <ng-container *ngIf="iconDisplay === 'input' && showIcon">
-                    <CalendarIcon *ngIf="!inputIconTemplate" (click)="onButtonClick($event)" class="p-datepicker-icon" />
+                    <CalendarIcon (click)="onButtonClick($event)" *ngIf="!inputIconTemplate" [ngClass]="{
+                        'p-datepicker-icon': showOnFocus
+                    }"/>
                     <ng-container *ngTemplateOutlet="inputIconTemplate; context: { clickCallBack: onButtonClick.bind(this) }"></ng-container>
                 </ng-container>
             </ng-template>

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -120,7 +120,7 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
                     </ng-container>
                 </button>
                 <ng-container *ngIf="iconDisplay === 'input' && showIcon">
-                    <CalendarIcon *ngIf="!inputIconTemplate" (click)="onButtonClick($event)" />
+                    <CalendarIcon *ngIf="!inputIconTemplate" (click)="onButtonClick($event)" class="p-datepicker-icon" />
                     <ng-container *ngTemplateOutlet="inputIconTemplate; context: { clickCallBack: onButtonClick.bind(this) }"></ng-container>
                 </ng-container>
             </ng-template>

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -120,9 +120,13 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
                     </ng-container>
                 </button>
                 <ng-container *ngIf="iconDisplay === 'input' && showIcon">
-                    <CalendarIcon (click)="onButtonClick($event)" *ngIf="!inputIconTemplate" [ngClass]="{
-                        'p-datepicker-icon': showOnFocus
-                    }"/>
+                    <CalendarIcon
+                        (click)="onButtonClick($event)"
+                        *ngIf="!inputIconTemplate"
+                        [ngClass]="{
+                            'p-datepicker-icon': showOnFocus
+                        }"
+                    />
                     <ng-container *ngTemplateOutlet="inputIconTemplate; context: { clickCallBack: onButtonClick.bind(this) }"></ng-container>
                 </ng-container>
             </ng-template>


### PR DESCRIPTION
Fix #14606

This fix was the root cause of the issue:
https://github.com/primefaces/primeng/issues/14501

I added a class to the inline icon in the input, to make it more restrictive and only disable pointer events for this specific icon

Update:

@k0sr mentioned another bug with this solution. The pointer events need to stay when the calendar does not open when focusing the input.
This partially reverts 14501. So we need another solution for that