### PR TITLE
fix #14611 -- fixed  multiselect scrollIntoView to use 'nearest'

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1915,7 +1915,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
                         let selectedListItem = DomHandler.findSingle(this.itemsWrapper, '.p-multiselect-item.p-highlight');
 
                         if (selectedListItem) {
-                            selectedListItem.scrollIntoView({ block: 'nearest', inline: 'center' });
+                            selectedListItem.scrollIntoView({ block: 'nearest', inline: 'nearest' });
                         }
                     }
                 }


### PR DESCRIPTION
Fixed #14611

The first video demonstrates that after the pull request changes the scrolling issue with the PrimeNG table filter row demo is fixed.

https://github.com/primefaces/primeng/assets/45439491/32f9134f-f7de-4a43-aaa0-720e5b8b5b90

The second video demonstrates that after the pull request changes the reproducer is fixed.

https://github.com/primefaces/primeng/assets/45439491/1cbd49e3-7eab-45a8-abfb-7862e544c0f0