### PR TITLE
Discussion #1009 -- Enhancement: Update chips.ts to have a clearInput method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "primeng",
-    "version": "17.3.0",
+    "version": "17.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "primeng",
-            "version": "17.3.0",
+            "version": "17.3.3",
             "license": "SEE LICENSE IN LICENSE.md",
             "devDependencies": {
                 "@angular-devkit/build-angular": "^17.0.5",
@@ -5112,35 +5112,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/parser": {
-            "version": "6.13.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.13.1.tgz",
-            "integrity": "sha512-fs2XOhWCzRhqMmQf0eicLa/CWSaYss2feXsy7xBD/pLyWke/jCIVc2s1ikEAtSW7ina1HNhv7kONoEfVNEcdDQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "@typescript-eslint/scope-manager": "6.13.1",
-                "@typescript-eslint/types": "6.13.1",
-                "@typescript-eslint/typescript-estree": "6.13.1",
-                "@typescript-eslint/visitor-keys": "6.13.1",
-                "debug": "^4.3.4"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "6.13.1",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
@@ -7608,16 +7579,6 @@
             "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
-        },
-        "node_modules/colors": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.1.90"
-            }
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -16752,24 +16713,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/optimist": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-            "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "minimist": "~0.0.1",
-                "wordwrap": "~0.0.2"
-            }
-        },
-        "node_modules/optimist/node_modules/minimist": {
-            "version": "0.0.10",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-            "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/optionator": {
             "version": "0.9.3",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -18902,13 +18845,6 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
-        "node_modules/search-insights": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.11.0.tgz",
-            "integrity": "sha512-Uin2J8Bpm3xaZi9Y8QibSys6uJOFZ+REMrf42v20AA3FUDUrshKkMEP6liJbMAHCm71wO6ls4mwAf7a3gFVxLw==",
-            "dev": true,
-            "peer": true
-        },
         "node_modules/select-hose": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -20709,68 +20645,6 @@
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
             "dev": true
         },
-        "node_modules/tslint": {
-            "version": "3.15.1",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-3.15.1.tgz",
-            "integrity": "sha512-wkqXlDiU1qG31dMuxnCSNeNMdKmSaEMYgJ2RERgFkt1WvVEF/wYwUYR396DDDcJDDBYpq16a6XJodQh70IRtBQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "colors": "^1.1.2",
-                "diff": "^2.2.1",
-                "findup-sync": "~0.3.0",
-                "glob": "^7.0.3",
-                "optimist": "~0.6.0",
-                "resolve": "^1.1.7",
-                "underscore.string": "^3.3.4"
-            },
-            "bin": {
-                "tslint": "bin/tslint"
-            },
-            "peerDependencies": {
-                "typescript": ">=1.7.3"
-            }
-        },
-        "node_modules/tslint/node_modules/diff": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
-            "integrity": "sha512-9wfm3RLzMp/PyTFWuw9liEzdlxsdGixCW0ZTU1XDmtlAkvpVXTPGF8KnfSs0hm3BPbg19OrUPPsRkHXoREpP1g==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.3.1"
-            }
-        },
-        "node_modules/tslint/node_modules/findup-sync": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-            "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "glob": "~5.0.0"
-            },
-            "engines": {
-                "node": ">= 0.6.0"
-            }
-        },
-        "node_modules/tslint/node_modules/findup-sync/node_modules/glob": {
-            "version": "5.0.15",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-            "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "2 || 3",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/tuf-js": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-2.1.0.tgz",
@@ -21029,20 +20903,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/underscore.string": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
-            "integrity": "sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==",
-            "dev": true,
-            "peer": true,
-            "dependencies": {
-                "sprintf-js": "^1.1.1",
-                "util-deprecate": "^1.0.2"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/undertaker": {
@@ -22446,16 +22306,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.8"
-            }
-        },
-        "node_modules/wordwrap": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-            "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
-            "dev": true,
-            "peer": true,
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/src/app/components/chips/chips.ts
+++ b/src/app/components/chips/chips.ts
@@ -493,6 +493,10 @@ export class Chips implements AfterContentInit, ControlValueAccessor {
         this.onClear.emit();
     }
 
+    public clearInput(): void {
+        this.inputViewChild.nativeElement.value = '';
+    }
+
     onKeyDown(event) {
         const inputValue = event.target.value;
 


### PR DESCRIPTION
Discussion: https://github.com/orgs/primefaces/discussions/1009

### Feature Requests
I am creating a discussion and a pull request to enhance the Chips component. Currently, there is no way to clear the input field. This is problematic when you display the Chips component in a dialog, then you hide the dialog, and upon reopening the dialog any unsubmitted Chip will still linger in the input field.

Ideally, this would be tied into the hide event as it would be my expected behavior. However, that does align with how Primeng usually handles hiding components (does not hard-clear/edit fields).

You are currently required to access the input field through the element query selector:
`chipsRef.el.nativeElement.querySelector("input");`

I believe this enhancement would prevent others from manually targeting and clearing the input field and it could be done with a public method.

```
public clearInput(): void {
    this.inputViewChild.nativeElement.value = '';
}
```
