### PR TITLE
Fix #14596 - fixes p-dropdown logic for selectedOption and label

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -924,8 +924,12 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     });
 
     label = computed(() => {
-        const selectedOptionIndex = this.findSelectedOptionIndex();
-        return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
+        // because of timining issues with virtual scroll lazy load  PrimeNG demo, keep original logic for virtual scroll
+        if (this.virtualScroll) {
+            const selectedOptionIndex = this.findSelectedOptionIndex();
+            return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
+        }
+        return this.modelValue() ? this.getOptionLabel(this.selectedOption) : this.placeholder || 'p-emptylabel';
     });
 
     selectedOption: any;
@@ -938,8 +942,11 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             const visibleOptions = this.visibleOptions();
 
             if (visibleOptions && ObjectUtils.isNotEmpty(visibleOptions)) {
-                this.selectedOption = visibleOptions[this.findSelectedOptionIndex()];
-                this.cd.markForCheck();
+                const selectedOptionIndex = this.findSelectedOptionIndex();
+                if (selectedOptionIndex !== -1 || !modelValue || this.editable) {
+                    this.selectedOption = visibleOptions[selectedOptionIndex];
+                    this.cd.markForCheck();
+                }
             }
 
             if (modelValue !== undefined && this.editable) {


### PR DESCRIPTION
Fix #14596

1) fixes logic for the dropdown's selectedOption
2) uses dropdown's selectedOption for computing label
-- note: issue with virtual scrolling with lazy loading (PrimeNG Demo) as a result keeping original logic for computing label when virtual load (no harm)

The following  video demonstrates  the fix working for the reproducer in  issue #The following video demonstrates the fix.

https://github.com/primefaces/primeng/assets/45439491/2bacb0a7-ff42-480c-82d2-bef95157e6da

