### PR TITLE
Fixed #14634 - Table | Built-in Ctrl+A errors when rows parameter is …

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3576,7 +3576,7 @@ export class SelectableRow implements OnInit, OnDestroy {
 
             default:
                 if (event.code === 'KeyA' && (event.metaKey || event.ctrlKey)) {
-                    const data = this.dt.dataToRender(this.dt.rows);
+                    const data = this.dt.dataToRender(this.dt.processedData);
                     this.dt.selection = [...data];
                     this.dt.selectRange(event, data.length - 1);
 


### PR DESCRIPTION
Fixes #14634 
