### PR TITLE
Fix #14691 DomHandler.getFocusableElements returns visible elements

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -630,7 +630,7 @@ export class DomHandler {
         let visibleFocusableElements = [];
 
         for (let focusableElement of focusableElements) {
-            if (getComputedStyle(focusableElement).display != 'none' && getComputedStyle(focusableElement).visibility != 'hidden') visibleFocusableElements.push(focusableElement);
+            if (this.isVisible(focusableElement) && focusableElement.getComputedStyle(focusableElement).display != 'none' && getComputedStyle(focusableElement).visibility != 'hidden') visibleFocusableElements.push(focusableElement);
         }
 
         return visibleFocusableElements;


### PR DESCRIPTION
Fixes [#14691](https://github.com/primefaces/primeng/issues/14691) by checking if each element is visible.
