### PR TITLE
fix(14715): selecting a falsy value (such as '0' or 0) should not show placeholder

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -931,7 +931,8 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             const selectedOptionIndex = this.findSelectedOptionIndex();
             return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.placeholder || 'p-emptylabel';
         }
-        return this.modelValue() ? this.getOptionLabel(this.selectedOption) : this.placeholder || 'p-emptylabel';
+        const modelValue = this.modelValue();
+        return modelValue !== undefined && modelValue !== null ? this.getOptionLabel(this.selectedOption) : this.placeholder || 'p-emptylabel';
     });
 
     selectedOption: any;

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -861,7 +861,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     get filled(): boolean {
         if (typeof this.modelValue() === 'string') return !!this.modelValue();
 
-        return this.modelValue() || this.modelValue() != null || this.modelValue() != undefined;
+        return this.modelValue() || this.modelValue() !== null || this.modelValue() !== undefined;
     }
 
     get isVisibleClearIcon(): boolean | undefined {
@@ -946,7 +946,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
             if (visibleOptions && ObjectUtils.isNotEmpty(visibleOptions)) {
                 const selectedOptionIndex = this.findSelectedOptionIndex();
-                if (selectedOptionIndex !== -1 || !modelValue || this.editable) {
+                if (selectedOptionIndex !== -1 || modelValue === undefined || modelValue === null || this.editable) {
                     this.selectedOption = visibleOptions[selectedOptionIndex];
                     this.cd.markForCheck();
                 }
@@ -1067,7 +1067,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             this.focusedOptionIndex.set(this.findFirstFocusedOptionIndex());
             this.onOptionSelect(null, this.visibleOptions()[this.focusedOptionIndex()], false);
         }
-        if (this.autoDisplayFirst && !this.modelValue()) {
+        if (this.autoDisplayFirst && (this.modelValue() === null || this.modelValue() === undefined)) {
             const ind = this.findFirstOptionIndex();
             this.onOptionSelect(null, this.visibleOptions()[ind], false, true);
         }
@@ -1107,7 +1107,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     allowModelChange() {
-        return this.autoDisplayFirst && !this.placeholder && !this.modelValue() && !this.editable && this.options && this.options.length;
+        return this.autoDisplayFirst && !this.placeholder && (this.modelValue() === undefined || this.modelValue() === null) && !this.editable && this.options && this.options.length;
     }
 
     isSelected(option) {

--- a/src/app/showcase/doc/dropdown/filterdoc.ts
+++ b/src/app/showcase/doc/dropdown/filterdoc.ts
@@ -9,15 +9,13 @@ import { Code } from '../../domain/code';
         </app-docsectiontext>
         <div class="card flex justify-content-center">
             <p-dropdown [options]="countries" [(ngModel)]="selectedCountry" optionLabel="name" [filter]="true" filterBy="name" [showClear]="true" placeholder="Select a Country">
-                <ng-template pTemplate="selectedItem">
-                    <div class="flex align-items-center gap-2" *ngIf="selectedCountry">
-                        <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + selectedCountry.code.toLowerCase()" style="width: 18px" />
-                        <div>{{ selectedCountry.name }}</div>
+                <ng-template pTemplate="selectedItem" let-selectedOption>
+                    <div class="flex align-items-center gap-2">
+                        <div>{{ selectedOption.name }}</div>
                     </div>
                 </ng-template>
                 <ng-template let-country pTemplate="item">
                     <div class="flex align-items-center gap-2">
-                        <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + country.code.toLowerCase()" style="width: 18px" />
                         <div>{{ country.name }}</div>
                     </div>
                 </ng-template>
@@ -48,10 +46,10 @@ export class FilterDoc implements OnInit {
 
     code: Code = {
         basic: `<p-dropdown [options]="countries" [(ngModel)]="selectedCountry" optionLabel="name" [filter]="true" filterBy="name" [showClear]="true" placeholder="Select a Country">
-    <ng-template pTemplate="selectedItem">
-        <div class="flex align-items-center gap-2" *ngIf="selectedCountry">
+    <ng-template pTemplate="selectedItem" let-selectedOption>
+        <div class="flex align-items-center gap-2">
             <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + selectedCountry.code.toLowerCase()" style="width: 18px"/>
-            <div>{{ selectedCountry.name }}</div>
+            <div>{{ selectedOption.name }}</div>
         </div>
     </ng-template>
     <ng-template let-country pTemplate="item">
@@ -65,10 +63,10 @@ export class FilterDoc implements OnInit {
         html: `
 <div class="card flex justify-content-center">
     <p-dropdown [options]="countries" [(ngModel)]="selectedCountry" optionLabel="name" [filter]="true" filterBy="name" [showClear]="true" placeholder="Select a Country">
-        <ng-template pTemplate="selectedItem">
-            <div class="flex align-items-center gap-2" *ngIf="selectedCountry">
+        <ng-template pTemplate="selectedItem" let-selectedOption>
+            <div class="flex align-items-center gap-2">
                 <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + selectedCountry.code.toLowerCase()" style="width: 18px"/>
-                <div>{{ selectedCountry.name }}</div>
+                <div>{{ selectedOption.name }}</div>
             </div>
         </ng-template>
         <ng-template let-country pTemplate="item">


### PR DESCRIPTION
See #14715

Not sure if this is by design or if a larger set of value should or should not be accepted (such as true/false), feel free to reject this PR. I did hesitate to use ObjectUtils.isNotEmpty but since it excludes an empty string as being an authorized option, I thought it may be too much.