### PR TITLE
fix: #14724, Password: Hand/Pointer icon not displayed while hovering over the eye icon in password ToggleMask mode

### DIFF
--- a/src/app/components/common/common.css
+++ b/src/app/components/common/common.css
@@ -149,6 +149,7 @@
 
     .p-icon {
         display: inline-block;
+        cursor: pointer;
     }
 
     .p-icon-spin {


### PR DESCRIPTION

### Defect Fixes
fix: #14724, Password: Hand/Pointer icon not displayed while hovering over the eye icon in password ToggleMask mode

