### PR TITLE
fix(14706): restore addOnTab behavior - allow user to add chip on tab…

### DIFF
--- a/src/app/components/chips/chips.ts
+++ b/src/app/components/chips/chips.ts
@@ -514,6 +514,13 @@ export class Chips implements AfterContentInit, ControlValueAccessor {
 
                 break;
 
+            case 'Tab':
+                if (this.addOnTab && inputValue && inputValue.trim().length && !this.isMaxedOut) {
+                    this.addItem(event, inputValue, true);
+                }
+
+                break;
+
             case 'ArrowLeft':
                 if (inputValue.length === 0 && this.value && this.value.length > 0) {
                     this.containerViewChild?.nativeElement.focus();


### PR DESCRIPTION
Fixes #14706 

Kept the initial behavior which tabbed the user out of the field if addOnTab is not enabled, add new chip otherwise
