### PR TITLE
Fix #14744: Autocomplete: Empty list showed, when no item fit condition

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -219,7 +219,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                     </ng-container>
 
                     <ng-template #buildInItems let-items let-scrollerOptions="options">
-                        <ul #items class="p-autocomplete-items" [ngClass]="scrollerOptions.contentStyleClass" [style]="scrollerOptions.contentStyle" role="listbox" [attr.id]="id + '_list'">
+                        <ul #resultItems *ngIf="items.length !== 0" class="p-autocomplete-items" [ngClass]="scrollerOptions.contentStyleClass" [style]="scrollerOptions.contentStyle" role="listbox" [attr.id]="id + '_list'">
                             <ng-template ngFor let-option [ngForOf]="items" let-i="index">
                                 <ng-container *ngIf="isOptionGroup(option)">
                                     <li [attr.id]="id + '_' + getOptionIndex(i, scrollerOptions)" class="p-autocomplete-item-group" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option">
@@ -681,7 +681,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
     @ViewChild('ddBtn') dropdownButton: Nullable<ElementRef>;
 
-    @ViewChild('items') itemsViewChild: Nullable<ElementRef>;
+    @ViewChild('resultItems') itemsViewChild: Nullable<ElementRef>;
 
     @ViewChild('scroller') scroller: Nullable<Scroller>;
 


### PR DESCRIPTION
Fix: #14744

Added condition to actually have items to show in list to ngif on mentioned list.
I'm a bit unsure about the name of list, cause needed to change it.

**Before:**
![emptydropdown-without-fix](https://github.com/primefaces/primeng/assets/37674650/afe1f600-e6ca-40bc-a01d-2d770d44163e)

**After:**
![emptydropdown-with-fix](https://github.com/primefaces/primeng/assets/37674650/0464087c-451d-413a-b40a-7b88d0d884c0)
