### PR TITLE
Feat: calendar - enable minDate & maxDate to be nullable

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -732,10 +732,10 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
      * The minimum selectable date.
      * @group Props
      */
-    @Input() get minDate(): Date {
+    @Input() get minDate(): Date | undefined | null {
         return this._minDate;
     }
-    set minDate(date: Date) {
+    set minDate(date: Date | undefined | null) {
         this._minDate = date;
 
         if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
@@ -746,10 +746,10 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
      * The maximum selectable date.
      * @group Props
      */
-    @Input() get maxDate(): Date {
+    @Input() get maxDate(): Date | undefined | null {
         return this._maxDate;
     }
-    set maxDate(date: Date) {
+    set maxDate(date: Date | undefined | null) {
         this._maxDate = date;
 
         if (this.currentMonth != undefined && this.currentMonth != null && this.currentYear) {
@@ -1039,9 +1039,9 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
 
     inputFieldValue: Nullable<string> = null;
 
-    _minDate!: Date;
+    _minDate?: Date | null;
 
-    _maxDate!: Date;
+    _maxDate?: Date | null;
 
     _showTime!: boolean;
 


### PR DESCRIPTION
See discussion #1136 https://github.com/orgs/primefaces/discussions/1136

For context : actually minDate & maxDate are 2 inputs of calendar that only accept non-nullable Date value. What it means is that you can have no value for any of them at startup but once you set any value (for example for search purpose) you can't reset it programmatically, i.e. providing undefined or null value. The only way to perform such reset is by using clear option (with [showClear]=true) or emptying the field manually (such leading in false value).

This change is all about enabling minDate & maxDate value to accept undefined value allowing free programmatical change, all checks about its truthyness being already handled. Let me know if null should be accepted instead/aswell.
