### PR TITLE
fixed #14716 and fixed #14757 - updated computed label logic to also handle disabled selected option

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -903,7 +903,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     visibleOptions = computed(() => {
-        const options = this.group ? this.flatOptions(this.options) : this.options || [];
+        const options = this.getAllVisibleAndNonVisibleOptions();
 
         if (this._filterValue()) {
             const _filterBy = this.filterBy || this.optionLabel;
@@ -938,9 +938,13 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     });
 
     label = computed(() => {
-        const selectedOptionIndex = this.findSelectedOptionIndex();
+        // use  getAllVisibleAndNonVisibleOptions verses just visible options
+        // this will find the selected option whether or not the user is currently filtering  because the filtered (i.e. visible) options, are a subset of all the options
+        const options = this.getAllVisibleAndNonVisibleOptions();
+        // use isOptionEqualsModelValue for the use case where the dropdown is initalized with a disabled option
+        const selectedOptionIndex = options.findIndex((option) => this.isOptionEqualsModelValue(option));
 
-        return selectedOptionIndex !== -1 ? this.getOptionLabel(this.visibleOptions()[selectedOptionIndex]) : this.placeholder() || 'p-emptylabel';
+        return selectedOptionIndex !== -1 ? this.getOptionLabel(options[selectedOptionIndex]) : this.placeholder() || 'p-emptylabel';
     });
 
     filled = computed(() => {
@@ -969,6 +973,10 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
                 this.updateEditableLabel();
             }
         });
+    }
+
+    private getAllVisibleAndNonVisibleOptions() {
+        return this.group ? this.flatOptions(this.options) : this.options || [];
     }
 
     ngOnInit() {
@@ -1126,7 +1134,11 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     isSelected(option) {
-        return this.isValidOption(option) && ObjectUtils.equals(this.modelValue(), this.getOptionValue(option), this.equalityKey());
+        return this.isValidOption(option) && this.isOptionEqualsModelValue(option);
+    }
+
+    private isOptionEqualsModelValue(option: any) {
+        return ObjectUtils.equals(this.modelValue(), this.getOptionValue(option), this.equalityKey());
     }
 
     ngAfterViewInit() {


### PR DESCRIPTION
Fixed #14716
Fixed #14757
re-fixed #14596 - v17.6.0 broke  changes that were made in v17.5.0 that were used to fix issue #14596

The changes:
1) when computing the label,  use  all options verses just visible options this new logic will find the selected option whether or not the user is currently filtering  because the filtered (i.e. visible) options, are a subset of all the options
2) When finding selected option,  consider all options even those that have been disabled

**Note: These changes supersedes PR #14759.  This PR contains all the changes of #14759 (change (1)) plus change (2)**

Please see the annotated screenshot and the  video listed below  which shows the fixed issue #14716

![Cursor_and_Angular_Dropdown_Component](https://github.com/primefaces/primeng/assets/45439491/9bb6b703-f1ec-49c1-9aaa-e977c870b468)

https://github.com/primefaces/primeng/assets/45439491/5c801d9f-0894-4f8c-af07-bb7d770af402
