### PR TITLE
Fixed #14783 two validations simultaneously on fileupload (File limit and max file size)

### DIFF
--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -762,7 +762,8 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
 
     checkFileLimit(files: File[]) {
         this.msgs ??= [];
-        if (this.isFileLimitExceeded() || (this.msgs.length>0 && this.fileLimit < files.length)) {
+        const hasExistingValidationMessages = this.msgs.length > 0 && this.fileLimit < files.length;
+        if (this.isFileLimitExceeded() || hasExistingValidationMessages) {
             this.msgs.push({
                 severity: 'error',
                 summary: this.invalidFileLimitMessageSummary.replace('{0}', (this.fileLimit as number).toString()),


### PR DESCRIPTION
fixed [#14783](https://github.com/primefaces/primeng/issues/14789)

Describe the bug(issue)
In FileUpload control,

Two validations does not work simultaneously.
Tried validations as maxFileSize="1000" and fileLimit="2"
After selecting files, nothing is displayed on the control

Solution:
The issue was caused by not adding a file whose size exceeds maxFileSize when no files are in the main files array due to a filesize check. Consequently, the fileLimit check failed. Now, this code checks both maxFileSize and fileLimit.