### PR TITLE
Fixed #14815 - improved logic when modelValue is null and selected option value  is null

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -948,7 +948,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         // this will find the selected option whether or not the user is currently filtering  because the filtered (i.e. visible) options, are a subset of all the options
         const options = this.getAllVisibleAndNonVisibleOptions();
         // use isOptionEqualsModelValue for the use case where the dropdown is initalized with a disabled option
-        const selectedOptionIndex = options.findIndex((option) => this.isOptionEqualsModelValue(option));
+        const selectedOptionIndex = options.findIndex((option) => this.isOptionValueEqualsModelValue(option));
 
         return selectedOptionIndex !== -1 ? this.getOptionLabel(options[selectedOptionIndex]) : this.placeholder() || 'p-emptylabel';
     });
@@ -969,12 +969,12 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
             if (visibleOptions && ObjectUtils.isNotEmpty(visibleOptions)) {
                 const selectedOptionIndex = this.findSelectedOptionIndex();
-                if (selectedOptionIndex !== -1 || modelValue === undefined || modelValue === null || this.editable) {
+                if (selectedOptionIndex !== -1 || modelValue === undefined || this.isModelValueNotSet() || this.editable) {
                     this.selectedOption = visibleOptions[selectedOptionIndex];
                 }
             }
 
-            if (ObjectUtils.isEmpty(visibleOptions) && (modelValue === undefined || modelValue === null) && ObjectUtils.isNotEmpty(this.selectedOption)) {
+            if (ObjectUtils.isEmpty(visibleOptions) && (modelValue === undefined || this.isModelValueNotSet()) && ObjectUtils.isNotEmpty(this.selectedOption)) {
                 this.selectedOption = null;
             }
 
@@ -983,6 +983,12 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             }
             this.cd.markForCheck();
         });
+    }
+
+    // modelValue  equal to null would usually mean that modelValue was not set
+    // this method includes a test for the special case where modelValue is set because (modelValue is null and the selected option has a value of null) 
+    private isModelValueNotSet(): boolean {
+        return (this.modelValue() === null) && !this.isOptionValueEqualsModelValue(this.selectedOption);
     }
 
     private getAllVisibleAndNonVisibleOptions() {
@@ -1146,10 +1152,10 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     isSelected(option) {
-        return this.isValidOption(option) && this.isOptionEqualsModelValue(option);
+        return this.isValidOption(option) && this.isOptionValueEqualsModelValue(option);
     }
 
-    private isOptionEqualsModelValue(option: any) {
+    private isOptionValueEqualsModelValue(option: any) {
         return ObjectUtils.equals(this.modelValue(), this.getOptionValue(option), this.equalityKey());
     }
 

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -986,9 +986,9 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     // modelValue  equal to null would usually mean that modelValue was not set
-    // this method includes a test for the special case where modelValue is set because (modelValue is null and the selected option has a value of null) 
+    // this method includes a test for the special case where modelValue is set because (modelValue is null and the selected option has a value of null)
     private isModelValueNotSet(): boolean {
-        return (this.modelValue() === null) && !this.isOptionValueEqualsModelValue(this.selectedOption);
+        return this.modelValue() === null && !this.isOptionValueEqualsModelValue(this.selectedOption);
     }
 
     private getAllVisibleAndNonVisibleOptions() {


### PR DESCRIPTION
Fixed #14815

The video listed below shows the issue #14815 reducer working after the fix (Note "All" option corresponds to  

`{name: 'All',code: null})`

https://github.com/primefaces/primeng/assets/45439491/0c9c6130-6252-4aa5-b1d7-7c570345bac6


Note:  I verified the fix did not break any of the PrimeNG demo dropdown examples

The issue was caused by a special case where the modelValue is null but the selected option's value is also null.

As part of the PR,  I also renamed the method **isOptionEqualsModelValue** to **isOptionEqualsModelValue** which is a more descriptive name.  Note:  in a previous PR #14768 that was accepted I refactored the code that resulted  in the original **isOptionEqualsModelValue** method