### PR TITLE
fixed #14807 #14252 #14603 - updated onToggleAll method to call onChange and onSelectAllChange

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1042,8 +1042,12 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         return this.config.getTranslation(TranslationKeys.ARIA)['listLabel'];
     }
 
+    private getAllVisibleAndNonVisibleOptions() {
+        return this.group ? this.flatOptions(this.options) : this.options || [];
+    }
+
     visibleOptions = computed(() => {
-        const options = this.group ? this.flatOptions(this.options) : this.options || [];
+        const options = this.getAllVisibleAndNonVisibleOptions();
         const isArrayOfObjects = ObjectUtils.isArray(options) && ObjectUtils.isObject(options[0]);
 
         if (this._filterValue()) {
@@ -1834,8 +1838,17 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
                       .map((option) => this.getOptionValue(option));
 
             this.updateModel(value, event);
+
+            // because onToggleAll could have been called during filtering,  this additional test needs to be performed before calling onSelectAllChange.emit
+            if(!value.length || (value.length === this.getAllVisibleAndNonVisibleOptions().length)) {
+                this.onSelectAllChange.emit({
+                    originalEvent: event,
+                    checked: !!value.length
+                });
+            }
         }
 
+        this.onChange.emit({ originalEvent: event, value: this.value });
         DomHandler.focus(this.headerCheckboxViewChild?.nativeElement);
         this.headerCheckboxFocus = true;
 

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1840,7 +1840,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
             this.updateModel(value, event);
 
             // because onToggleAll could have been called during filtering,  this additional test needs to be performed before calling onSelectAllChange.emit
-            if(!value.length || (value.length === this.getAllVisibleAndNonVisibleOptions().length)) {
+            if (!value.length || value.length === this.getAllVisibleAndNonVisibleOptions().length) {
                 this.onSelectAllChange.emit({
                     originalEvent: event,
                     checked: !!value.length


### PR DESCRIPTION
Fix  #14807 
Fix #14252
Fix #14603

I  updated the onToggleAll method to call onChange.emit and onSelectAllChange.emit.  Special logic was add to determine whether or not onSelectAllChange.emit should be called since a user could be filtering.

The first video shows the issue #14807 reproducer (which I created based on the steps provided in the issue)  working after the fix.  Note:  the end of the video shows  how the changes work when the user filters  before toggling on and off

https://github.com/primefaces/primeng/assets/45439491/8cb5feb5-81d1-4365-b306-62250ee9f5d3

The second video shows the  issue #14252 reproducer working after the fix.  Note:  the end of the video also shows  how the changes work when the user filters  before toggling on and off

https://github.com/primefaces/primeng/assets/45439491/9bedc69d-9038-4ffd-97a3-0f4d35259d00

The third video shows issue #14603  fixed,  the PimeNG table filter-menu demo is fixed with this pull request

https://github.com/primefaces/primeng/assets/45439491/d250bc8d-9f44-49bf-87d7-65ce1cd7c869

This PR supersedes PR #14604
