### PR TITLE
fix(primeNg-dropdown): mark the form as touched when we click the clear icon.

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1827,6 +1827,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     public clear(event?: Event) {
         this.updateModel(null, event);
         this.clearEditableLabel();
+        this.onModelTouched();
         this.onChange.emit({ originalEvent: event, value: this.value });
         this.onClear.emit(event);
         this.resetFilter();


### PR DESCRIPTION
This commit adds a logic to mark the form as touched, when the dropdown already has a pre-populated value in it and when the user tries to clear that value, the form currently is not marked as touched, the above change marks the form as touched.

### Defect Fixes
Issue ID: #14836