### PR TITLE
fix: primefaces #14839, Calendar: The lowest year in the Year navigator dropdown remains disabled when we are applying minDate in date selector

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1835,7 +1835,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
         if (this.minDate) {
             if (this.minDate.getFullYear() > year) {
                 validMin = false;
-            } else if (this.minDate.getFullYear() === year) {
+            } else if (this.minDate.getFullYear() === year && this.currentView != 'year') {
                 if (this.minDate.getMonth() > month) {
                     validMin = false;
                 } else if (this.minDate.getMonth() === month) {


### PR DESCRIPTION
### Defect Fixes
fix: primefaces #14839, Calendar: The lowest year in the Year navigator dropdown remains disabled when we are applying minDate in date selector.

