### PR TITLE
Fixes Content-security-Policies bug #14846

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -2655,7 +2655,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
                 }
             `;
         });
-        this.renderer.setProperty(this.styleElement, 'innerHTML', innerHTML);
+        this.styleElement.textContent = innerHTML;
     }
 
     onRowDragStart(event: any, index: number) {
@@ -2905,7 +2905,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
                     `;
                 });
 
-                this.styleElement.innerHTML = innerHTML;
+                this.styleElement.textContent = innerHTML;
             }
         }
     }
@@ -2999,7 +2999,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
         }
     }
     `;
-                this.renderer.setProperty(this.responsiveStyleElement, 'innerHTML', innerHTML);
+                this.responsiveStyleElement.textContent = innerHTML;
             }
         }
     }


### PR DESCRIPTION
Changed innerHTML injection to textContent. innerHTML is not parsed as HTML, so it does not violate the CSP.

Fixes bug for issue: #14846 
Suggested fix from: primefaces#12855