### PR TITLE
Fix #14691 DomHandler.getFocusableElements should return only visible els

### DIFF
--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -630,7 +630,8 @@ export class DomHandler {
         let visibleFocusableElements = [];
 
         for (let focusableElement of focusableElements) {
-            if (getComputedStyle(focusableElement).display != 'none' && getComputedStyle(focusableElement).visibility != 'hidden') visibleFocusableElements.push(focusableElement);
+            const computedStyle = getComputedStyle(focusableElement);
+            if (this.isVisible(focusableElement) && computedStyle.display != 'none' && computedStyle.visibility != 'hidden') visibleFocusableElements.push(focusableElement);
         }
 
         return visibleFocusableElements;


### PR DESCRIPTION
Fix for #14691  

Improved previous fix by by using the global `getComputedStyle`.

Also consolidated `getComputedStyle` calls, so now there's only one instead of two.