### PR TITLE
Fixed #14867 - Tab change inkbar for material design theme

### DIFF
--- a/src/app/components/tabmenu/tabmenu.spec.ts
+++ b/src/app/components/tabmenu/tabmenu.spec.ts
@@ -117,6 +117,28 @@ describe('TabMenu', () => {
         expect(itemClickSpy).toHaveBeenCalled();
     });
 
+    it('should select item when activeItem controlled', () => {
+        tabmenu.model = [
+            { label: 'Stats', icon: 'pi pi-fw pi-bar-chart' },
+            { label: 'Calendar', icon: 'pi pi-fw pi-calendar' },
+            { label: 'Documentation', icon: 'pi pi-fw pi-book' },
+            { label: 'Support', icon: 'pi pi-fw pi-support' },
+            { label: 'Social', icon: 'pi pi-fw pi-twitter' }
+        ];
+
+        const updateInkBarSpy = spyOn(tabmenu, 'updateInkBar').and.callThrough();
+
+        tabmenu.activeItem = tabmenu.model[1];
+        fixture.detectChanges();
+
+        const itemList = fixture.debugElement.query(By.css('ul'));
+
+        expect(itemList.children[1].nativeElement.className).toContain('p-highlight');
+        expect(tabmenu.activeItem.label).toEqual('Calendar');
+        expect(tabmenu.activeItem.icon).toContain('pi-calendar');
+        expect(updateInkBarSpy).toHaveBeenCalled();
+    });
+
     it("shouldn't show content", () => {
         tabmenu.model = [
             { label: 'Stats', icon: 'pi pi-fw pi-bar-chart', disabled: true },

--- a/src/app/components/tabmenu/tabmenu.ts
+++ b/src/app/components/tabmenu/tabmenu.ts
@@ -150,7 +150,15 @@ export class TabMenu implements AfterContentInit, AfterViewInit, AfterViewChecke
      * Defines the default active menuitem
      * @group Props
      */
-    @Input() activeItem: MenuItem | undefined;
+    @Input() set activeItem(value: MenuItem | undefined) {
+        this._activeItem = value;
+        this.activeItemChange.emit(value);
+        this.tabChanged = true;
+    }
+
+    get activeItem(): MenuItem | undefined {
+        return this._activeItem;
+    }
     /**
      * When enabled displays buttons at each side of the tab headers to scroll the tab list.
      * @group Props
@@ -221,6 +229,8 @@ export class TabMenu implements AfterContentInit, AfterViewInit, AfterViewChecke
 
     _model: MenuItem[] | undefined;
 
+    _activeItem: MenuItem | undefined;
+
     focusedItemInfo = signal<any>(null);
 
     get focusableItems() {
@@ -267,7 +277,7 @@ export class TabMenu implements AfterContentInit, AfterViewInit, AfterViewChecke
     }
 
     ngAfterViewChecked() {
-        if (this.tabChanged) {
+        if (isPlatformBrowser(this.platformId) && this.tabChanged) {
             this.updateInkBar();
             this.tabChanged = false;
         }


### PR DESCRIPTION
Fixes #14867 

When the TabMenu is controlled by updating the activeItem property, the updateInkBar() method isn't called hence the reason the inkbar doesn't get updated in the UI.

![image](https://github.com/primefaces/primeng/assets/104988100/c5a240fa-4bda-48af-87c7-a320b5478ae0)

After the fix
![image](https://github.com/primefaces/primeng/assets/104988100/302d8a11-9269-4f4c-a0ed-674a979e24fd)


