### PR TITLE
feat: Dynamic dialog. Child component reference to be able to 

### DIFF
--- a/src/app/components/dynamicdialog/dialogservice.ts
+++ b/src/app/components/dynamicdialog/dialogservice.ts
@@ -12,7 +12,7 @@ import { ObjectUtils } from 'primeng/utils';
  */
 @Injectable()
 export class DialogService {
-    dialogComponentRefMap: Map<DynamicDialogRef, ComponentRef<DynamicDialogComponent>> = new Map();
+    dialogComponentRefMap: Map<DynamicDialogRef<any>, ComponentRef<DynamicDialogComponent>> = new Map();
 
     constructor(private appRef: ApplicationRef, private injector: Injector, @Inject(DOCUMENT) private document: Document) {}
     /**
@@ -22,12 +22,12 @@ export class DialogService {
      * @returns {DynamicDialogRef} DynamicDialog instance.
      * @group Method
      */
-    public open(componentType: Type<any>, config: DynamicDialogConfig): DynamicDialogRef {
+    public open<T>(componentType: Type<T>, config: DynamicDialogConfig): DynamicDialogRef<T> {
         if (!this.duplicationPermission(componentType, config)) {
             return null;
         }
 
-        const dialogRef = this.appendDialogComponentToBody(config);
+        const dialogRef = this.appendDialogComponentToBody<T>(config, componentType);
 
         this.dialogComponentRefMap.get(dialogRef).instance.childComponentType = componentType;
 
@@ -38,15 +38,15 @@ export class DialogService {
      * @param {ref} DynamicDialogRef - DynamicDialog instance.
      * @group Method
      */
-    public getInstance(ref: DynamicDialogRef) {
+    public getInstance(ref: DynamicDialogRef<any>) {
         return this.dialogComponentRefMap.get(ref).instance;
     }
 
-    private appendDialogComponentToBody(config: DynamicDialogConfig) {
+    private appendDialogComponentToBody<T>(config: DynamicDialogConfig, componentType: Type<T>): DynamicDialogRef<T> {
         const map = new WeakMap();
         map.set(DynamicDialogConfig, config);
 
-        const dialogRef = new DynamicDialogRef();
+        const dialogRef = new DynamicDialogRef<T>();
         map.set(DynamicDialogRef, dialogRef);
 
         const sub = dialogRef.onClose.subscribe(() => {
@@ -75,7 +75,7 @@ export class DialogService {
         return dialogRef;
     }
 
-    private removeDialogComponentFromBody(dialogRef: DynamicDialogRef) {
+    private removeDialogComponentFromBody(dialogRef: DynamicDialogRef<any>) {
         if (!dialogRef || !this.dialogComponentRefMap.has(dialogRef)) {
             return;
         }

--- a/src/app/components/dynamicdialog/dynamicdialog-ref.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog-ref.ts
@@ -1,9 +1,10 @@
 import { Observable, Subject } from 'rxjs';
+import { Output, EventEmitter, Type } from '@angular/core';
 /**
  * Dynamic Dialog instance.
  * @group Components
  */
-export class DynamicDialogRef {
+export class DynamicDialogRef<ComponentType = any> {
     constructor() {}
     /**
      * Closes dialog.
@@ -117,4 +118,11 @@ export class DynamicDialogRef {
      * @group Events
      */
     onMaximize: Observable<any> = this._onMaximize.asObservable();
+
+    /**
+     * Event triggered on child component load.
+     * @param {*} value - Chi.
+     * @group Events
+     */
+    readonly onChildComponentLoaded = new Subject<ComponentType>();
 }

--- a/src/app/components/dynamicdialog/dynamicdialog.ts
+++ b/src/app/components/dynamicdialog/dynamicdialog.ts
@@ -309,6 +309,7 @@ export class DynamicDialogComponent implements AfterViewInit, OnDestroy {
         viewContainerRef?.clear();
 
         this.componentRef = viewContainerRef?.createComponent(componentType);
+        this.dialogRef.onChildComponentLoaded.next(this.componentRef!.instance);
     }
 
     moveOnTop() {


### PR DESCRIPTION
Motivation:
With the current implementation is hard to do things like use the child component public API (i.e. to populate inputs) because the component is created asynchronously and trying to pass data using the angular lifecycle hooks to access the child component throws errors because often is undefined. Pass the data through the DynamicDialogConfig is a bit tricky.

So I made generic the open method of the DialogService and DynamicDialogRef. The open method of the DialogService now returns a typed DynamicDialogRef that has a new subject (onChildComponentLoaded) where the typed component instance is emitted when loaded.


