### PR TITLE
fix: Toggle only valid options for all select button in MultiSelect c…

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1832,9 +1832,11 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
             });
         } else {
             const value = this.allSelected()
-                ? []
+                ? this.visibleOptions()
+                      .filter((option) => !this.isValidOption(option) && this.isSelected(option))
+                      .map((option) => this.getOptionValue(option))
                 : this.visibleOptions()
-                      .filter((option) => this.isValidOption(option))
+                      .filter((option) => this.isSelected(option) || this.isValidOption(option))
                       .map((option) => this.getOptionValue(option));
 
             this.updateModel(value, event);


### PR DESCRIPTION
This pull request addresses issue #14617.

Summary of Correction:
In the MultiSelect component, this correction ensures that only valid options are toggled for all select buttons. The previous code did not handle the scenario where only valid options should be toggled when all options are selected.

Changes Made:
Modified the logic to correctly toggle only valid options when all options are selected.

Please review and merge accordingly. Thank you!
