### PR TITLE
feat(Chip): Add alt attribute

### DIFF
--- a/src/app/components/chip/chip.ts
+++ b/src/app/components/chip/chip.ts
@@ -11,7 +11,7 @@ import { TimesCircleIcon } from 'primeng/icons/timescircle';
     template: `
         <div [ngClass]="containerClass()" [class]="styleClass" [ngStyle]="style" *ngIf="visible" [attr.data-pc-name]="'chip'" [attr.aria-label]="label" [attr.data-pc-section]="'root'">
             <ng-content></ng-content>
-            <img [src]="image" *ngIf="image; else iconTemplate" (error)="imageError($event)" />
+            <img [src]="image" *ngIf="image; else iconTemplate" (error)="imageError($event)" [alt]="alt" />
             <ng-template #iconTemplate><span *ngIf="icon" [class]="icon" [ngClass]="'p-chip-icon'" [attr.data-pc-section]="'icon'"></span></ng-template>
             <div class="p-chip-text" *ngIf="label" [attr.data-pc-section]="'label'">{{ label }}</div>
             <ng-container *ngIf="removable">
@@ -48,6 +48,11 @@ export class Chip implements AfterContentInit {
      * @group Props
      */
     @Input() image: string | undefined;
+    /**
+     * Alt attribute of the image.
+     * @group Props
+     */
+    @Input() alt: string | undefined;
     /**
      * Inline style of the element.
      * @group Props

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -7077,6 +7077,13 @@
                             "description": "Defines the image to display."
                         },
                         {
+                            "name": "alt",
+                            "optional": false,
+                            "readonly": false,
+                            "type": "string",
+                            "description": "Alt attribute of the image."
+                        },
+                        {
                             "name": "style",
                             "optional": false,
                             "readonly": false,

--- a/src/app/showcase/doc/chip/imagedoc.ts
+++ b/src/app/showcase/doc/chip/imagedoc.ts
@@ -8,23 +8,23 @@ import { Code } from '../../domain/code';
             <p>The <i>image</i> property is used to display an image like an avatar.</p>
         </app-docsectiontext>
         <div class="card flex align-items-center gap-2 flex-wrap">
-            <p-chip label="Amy Elsner" image="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png"></p-chip>
-            <p-chip label="Asiya Javayant" image="https://primefaces.org/cdn/primeng/images/demo/avatar/asiyajavayant.png"></p-chip>
-            <p-chip label="Onyama Limba" image="https://primefaces.org/cdn/primeng/images/demo/avatar/onyamalimba.png"></p-chip>
-            <p-chip label="Xuxue Feng" image="https://primefaces.org/cdn/primeng/images/demo/avatar/xuxuefeng.png" [removable]="true"></p-chip>
+            <p-chip label="Amy Elsner" image="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png" alt="Avatar image"></p-chip>
+            <p-chip label="Asiya Javayant" image="https://primefaces.org/cdn/primeng/images/demo/avatar/asiyajavayant.png" alt="Avatar image"></p-chip>
+            <p-chip label="Onyama Limba" image="https://primefaces.org/cdn/primeng/images/demo/avatar/onyamalimba.png" alt="Avatar image"></p-chip>
+            <p-chip label="Xuxue Feng" image="https://primefaces.org/cdn/primeng/images/demo/avatar/xuxuefeng.png" alt="Avatar image" [removable]="true"></p-chip>
         </div>
         <app-code [code]="code" selector="chip-image-demo"></app-code>
     `
 })
 export class ImageDoc {
     code: Code = {
-        basic: `<p-chip label="Amy Elsner" image="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png"></p-chip>`,
+        basic: `<p-chip label="Amy Elsner" image="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png" alt="Avatar image"></p-chip>`,
         html: `
 <div class="card flex align-items-center gap-2 flex-wrap">
-    <p-chip label="Amy Elsner" image="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png"></p-chip>
-    <p-chip label="Asiya Javayant" image="https://primefaces.org/cdn/primeng/images/demo/avatar/asiyajavayant.png"></p-chip>
-    <p-chip label="Onyama Limba" image="https://primefaces.org/cdn/primeng/images/demo/avatar/onyamalimba.png"></p-chip>
-    <p-chip label="Xuxue Feng" image="https://primefaces.org/cdn/primeng/images/demo/avatar/xuxuefeng.png" [removable]="true"></p-chip>
+    <p-chip label="Amy Elsner" image="https://primefaces.org/cdn/primeng/images/demo/avatar/amyelsner.png" alt="Avatar image"></p-chip>
+    <p-chip label="Asiya Javayant" image="https://primefaces.org/cdn/primeng/images/demo/avatar/asiyajavayant.png" alt="Avatar image"></p-chip>
+    <p-chip label="Onyama Limba" image="https://primefaces.org/cdn/primeng/images/demo/avatar/onyamalimba.png" alt="Avatar image"></p-chip>
+    <p-chip label="Xuxue Feng" image="https://primefaces.org/cdn/primeng/images/demo/avatar/xuxuefeng.png" alt="Avatar image" [removable]="true"></p-chip>
 </div>`,
         typescript: `
 import { Component } from '@angular/core';


### PR DESCRIPTION
Fix https://github.com/primefaces/primeng/issues/15000

- Added alt attribute when `Chip` component has image.

## Currently

![image](https://github.com/primefaces/primeng/assets/19764334/eb2f43c0-616a-4c85-954c-6703232166fa)

## After implementation

![image](https://github.com/primefaces/primeng/assets/19764334/43f4ac91-9cfc-4cff-aea1-c69d7ebb77df)

