### PR TITLE
fix: #15005 Calendar time-picker errors when changing time before date

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -2484,11 +2484,20 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     validateTime(hour: number, minute: number, second: number, pm: boolean) {
         let value = this.value;
         const convertedHour = this.convertTo24Hour(hour, pm);
-        if (this.isRangeSelection()) {
-            value = this.value[1] || this.value[0];
-        }
-        if (this.isMultipleSelection()) {
-            value = this.value[this.value.length - 1];
+        const isRange = this.isRangeSelection(),
+            isMultiple = this.isMultipleSelection(),
+            isMultiValue = isRange || isMultiple;
+
+        if (isMultiValue) {
+            if (!this.value) {
+                this.value = [new Date(), new Date()];
+            }
+            if (isRange) {
+                value = this.value[1] || this.value[0];
+            }
+            if (isMultiple) {
+                value = this.value[this.value.length - 1];
+            }
         }
         const valueDateString = value ? value.toDateString() : null;
         if (this.minDate && valueDateString && this.minDate.toDateString() === valueDateString) {


### PR DESCRIPTION
This fixes issue #15005 using the current date when setting a time before picking a date.

### Objective
Fix #15005, allows users to pick a time before specifying a date in calendars with `showTime` enabled. 

### Solution
Modified the implementation of `calendar.validateTime()` to set the date value to the current date when validating a time without picking a date first. Previously, `Calendar.value` was `undefined` when trying to access it as an array [here](https://github.com/primefaces/primeng/blob/13fbaf38acba3ba3a5fb1f35832baf607bce4ef3/src/app/components/calendar/calendar.ts#L2488C5-L2488C16), causing the error mentioned in #15005.

### Discussion

- This is my first PR here, so please bear with me as I get used to this :)
- This currently works by defaulting to the current date... so it could be a band-aid/temp solution? 
    - What is the most intuitive way for the calendar to behave when the user selects a time without a date first? 
    - Is it acceptable that a user could open the calendar, page back a few months without selecting a date, then pick a time and have the active date value be set to the current date instead?