### PR TITLE
fix: issue-12718 in tree with virtual scroll  parent node always undefined

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -765,6 +765,7 @@ export class UITreeNode implements OnInit {
                             [level]="rowNode.level"
                             [rowNode]="rowNode"
                             [node]="rowNode.node"
+                            [parentNode]="rowNode.parent"
                             [firstChild]="firstChild"
                             [lastChild]="lastChild"
                             [index]="getIndex(scrollerOptions, index)"


### PR DESCRIPTION
fix: issue-12718 in tree with virtual scroll  parent node always undefined

https://github.com/primefaces/primeng/issues/12718