### PR TITLE
Fixed #14987 - Table | Date Filter Closing Unexpectedly

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -5617,7 +5617,10 @@ export class ColumnFilter implements AfterContentInit {
             const documentTarget: any = this.el ? this.el.nativeElement.ownerDocument : 'document';
 
             this.documentClickListener = this.renderer.listen(documentTarget, 'mousedown', (event) => {
-                if (this.overlayVisible && this.isOutsideClicked(event)) {
+                const dialogElements = document.querySelectorAll('[role="dialog"]');
+                const targetIsColumnFilterMenuButton = event.target.closest('.p-column-filter-menu-button');
+
+                if (this.overlayVisible && this.isOutsideClicked(event) && (targetIsColumnFilterMenuButton || dialogElements?.length <= 1)) {
                     this.hide();
                 }
 


### PR DESCRIPTION
Fixes #14987 

The root of this issue stems from having two distinct dialog overlays appended to the body of the DOM. In the document event listener, the check for whether or not the user has clicked outside of the overlay only applies to the singular column-filter-menu overlay. In the specific case of the datepicker, this second overlay is not considered when this check occurs, thereby rendering any event target as invalid, closing the dialog.

This fix handles the following:

- Checks for the presence of multiple divs with the "role" attribute having a value of "dialog". If the number is greater than 1, disable the default behavior of closing the column filter dialog, prioritizing the behavior of the other dialogs. This was written to handle other cases beyond just the datepicker, though this issue seems to currently only occur for the datepicker specifically.
- When the event target is a column filter menu button, then all dialogs will close. If the target is the column filter menu button for the currently active dialog, the dialogs will simply close. If it is a different column filter menu button, the currently active dialogs will close, and the new one will appear in its place.