### PR TITLE
Fix typo in Scaling docs

### DIFF
--- a/src/app/showcase/doc/theming/scalingdoc.ts
+++ b/src/app/showcase/doc/theming/scalingdoc.ts
@@ -7,7 +7,7 @@ import { Code } from '../../domain/code';
         <app-docsectiontext>
             <p>
                 PrimeNG utilizes rem units to make sure the components blend in with the rest of your UI perfectly. This also enables scaling, for example changing the size of the components is easy as configuring the font size of your document. Code
-                below sets the scale of the components based on 16px. If you reqire bigger or smaller components, just change this variable and components will scale accordingly.
+                below sets the scale of the components based on 16px. If you require bigger or smaller components, just change this variable and components will scale accordingly.
             </p>
         </app-docsectiontext>
         <app-code [code]="code" [hideToggleCode]="true"></app-code>


### PR DESCRIPTION
Pointed out in PrimeLand discord; there is a typo in the Scaling docs. "reqire" should be "require".

