### PR TITLE
#15260: Messages component uses `closable` and `id` from `Message`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
     "name": "primeng",
-    "version": "17.11.0",
-    "version": "17.12.0",
+    "version": "17.13.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "primeng",
-            "version": "17.12.0",
+            "version": "17.13.0",
             "license": "SEE LICENSE IN LICENSE.md",
             "devDependencies": {
                 "@angular-devkit/build-angular": "^17.3.1",

--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -42,7 +42,7 @@ import { Subscription, timer } from 'rxjs';
                     role="alert"
                     [@messageAnimation]="{ value: 'visible', params: { showTransitionParams: showTransitionOptions, hideTransitionParams: hideTransitionOptions } }"
                 >
-                    <div class="p-message-wrapper" [attr.data-pc-section]="'wrapper'">
+                    <div class="p-message-wrapper" [attr.data-pc-section]="'wrapper'" [attr.id]="msg.id || null">
                         <span *ngIf="msg.icon" [class]="'p-message-icon pi ' + msg.icon" [attr.data-pc-section]="'icon'"> </span>
                         <span class="p-message-icon" *ngIf="!msg.icon">
                             <ng-container>

--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -58,9 +58,9 @@ import { Subscription, timer } from 'rxjs';
                         </ng-container>
                         <ng-template #escapeOut>
                             <span *ngIf="msg.summary" class="p-message-summary" [attr.data-pc-section]="'summary'">{{ msg.summary }}</span>
-                            <span *ngIf="msg.detail" class="p-message-detail" [attr.data-pc-section]="'detail'">{{ msg.detail }} test</span>
+                            <span *ngIf="msg.detail" class="p-message-detail" [attr.data-pc-section]="'detail'">{{ msg.detail }}</span>
                         </ng-template>
-                        <button class="p-message-close p-link" (click)="removeMessage(i)" *ngIf="msg.closable || (closable && msg.closable)" type="button" pRipple [attr.aria-label]="closeAriaLabel" [attr.data-pc-section]="'closebutton'">
+                        <button class="p-message-close p-link" (click)="removeMessage(i)" *ngIf="closable && (msg.closable ?? true)" type="button" pRipple [attr.aria-label]="closeAriaLabel" [attr.data-pc-section]="'closebutton'">
                             <TimesIcon [styleClass]="'p-message-close-icon'" [attr.data-pc-section]="'closeicon'" />
                         </button>
                     </div>

--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -58,9 +58,9 @@ import { Subscription, timer } from 'rxjs';
                         </ng-container>
                         <ng-template #escapeOut>
                             <span *ngIf="msg.summary" class="p-message-summary" [attr.data-pc-section]="'summary'">{{ msg.summary }}</span>
-                            <span *ngIf="msg.detail" class="p-message-detail" [attr.data-pc-section]="'detail'">{{ msg.detail }}</span>
+                            <span *ngIf="msg.detail" class="p-message-detail" [attr.data-pc-section]="'detail'">{{ msg.detail }} test</span>
                         </ng-template>
-                        <button class="p-message-close p-link" (click)="removeMessage(i)" *ngIf="closable" type="button" pRipple [attr.aria-label]="closeAriaLabel" [attr.data-pc-section]="'closebutton'">
+                        <button class="p-message-close p-link" (click)="removeMessage(i)" *ngIf="msg.closable || (closable && msg.closable)" type="button" pRipple [attr.aria-label]="closeAriaLabel" [attr.data-pc-section]="'closebutton'">
                             <TimesIcon [styleClass]="'p-message-close-icon'" [attr.data-pc-section]="'closeicon'" />
                         </button>
                     </div>

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -1313,7 +1313,7 @@
             "values": [
                 {
                     "name": "Message",
-                    "description": "Deines valid options for the message.",
+                    "description": "Defines valid options for the message.",
                     "props": [
                         {
                             "name": "severity",

--- a/src/app/showcase/doc/messages/servicedoc.ts
+++ b/src/app/showcase/doc/messages/servicedoc.ts
@@ -32,8 +32,8 @@ export class ServiceDoc {
 
     addMultiple() {
         this.messageService.addAll([
-            { severity: 'success', summary: 'Service Message', detail: 'Via MessageService' },
-            { severity: 'info', summary: 'Info Message', detail: 'Via MessageService' }
+            { severity: 'success', summary: 'Service Message', detail: 'Via MessageService', closable: true },
+            { severity: 'info', summary: 'Info Message', detail: 'Via MessageService', closable: false }
         ]);
     }
 
@@ -75,8 +75,8 @@ export class MessagesServiceDemo {
 
     addMultiple() {
         this.messageService.addAll([
-            {severity:'success', summary:'Service Message', detail:'Via MessageService'},
-            {severity:'info', summary:'Info Message', detail:'Via MessageService'}
+            { severity: 'success', summary: 'Service Message', detail: 'Via MessageService', closable: true },
+            { severity: 'info', summary: 'Info Message', detail: 'Via MessageService', closable: false }
         ]);
     }
     

--- a/src/app/showcase/doc/messages/servicedoc.ts
+++ b/src/app/showcase/doc/messages/servicedoc.ts
@@ -32,8 +32,8 @@ export class ServiceDoc {
 
     addMultiple() {
         this.messageService.addAll([
-            { severity: 'success', summary: 'Service Message', detail: 'Via MessageService', closable: true },
-            { severity: 'info', summary: 'Info Message', detail: 'Via MessageService', closable: false }
+            { severity: 'success', summary: 'Service Message', detail: 'Via MessageService' },
+            { severity: 'info', summary: 'Info Message', detail: 'Via MessageService' }
         ]);
     }
 
@@ -75,8 +75,8 @@ export class MessagesServiceDemo {
 
     addMultiple() {
         this.messageService.addAll([
-            { severity: 'success', summary: 'Service Message', detail: 'Via MessageService', closable: true },
-            { severity: 'info', summary: 'Info Message', detail: 'Via MessageService', closable: false }
+            { severity: 'success', summary: 'Service Message', detail: 'Via MessageService' },
+            { severity: 'info', summary: 'Info Message', detail: 'Via MessageService' }
         ]);
     }
     


### PR DESCRIPTION
### Defect Fixes
#15260

`<p-messages>` element does not use `msg.closable` in the `*ngIf`. This means that when adding multiple messages to the service, you cannot have some closable and others not closable.

This PR adds the logic and updates the documentation to fix this and allow the ID attribute to be set from the `Message` object.