### PR TITLE
Fix Issue with frozen columns #12408

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3305,9 +3305,20 @@ export class FrozenColumn implements AfterViewInit {
     ngAfterViewInit() {
         this.zone.runOutsideAngular(() => {
             setTimeout(() => {
-                this.updateStickyPosition();
+                this.recalculateColumns();
             }, 1000);
         });
+    }
+
+    @HostListener('window:resize', ['$event'])
+    recalculateColumns() {
+        const siblings = DomHandler.siblings(this.el.nativeElement);
+        const index = DomHandler.index(this.el.nativeElement);
+        const time = (siblings.length - index + 1) * 50;
+
+        setTimeout(() => {
+            this.updateStickyPosition();
+        }, time);
     }
 
     _frozen: boolean = true;


### PR DESCRIPTION
### Defect Fixes
Fixes #15303 

### Describe the bug

### Video with the actual issue attached

https://user-images.githubusercontent.com/11733376/208727545-67866f60-7db8-4256-ae2b-43a0a178753d.mov

### Environment

Frozen Columns

### Reproducer

Lolibai

### Angular version

17.3.1

### PrimeNG version

17.13.0

### Build / Runtime

Angular CLI App

### Language

TypeScript

### Node version (for AoT issues node --version)

20.12.2

### Browser(s)

Chrome 123.0.6312.123

### Steps to reproduce the behavior

1. Freeze columns to the right
2. Have at least 10 rows of data
3. See the "stairs" of columns that should be freezed

https://user-images.githubusercontent.com/11733376/208727545-67866f60-7db8-4256-ae2b-43a0a178753d.mov

### Expected behavior

All columns should be freezed as per attribute and directive assignment.

### Stackblitz

[Reproduction](https://stackblitz.com/edit/qnmajp?file=package.json)