### PR TITLE
Fix #15305: MeterGroup - Use signal query viewChild

### DIFF
--- a/src/app/components/metergroup/metergroup.ts
+++ b/src/app/components/metergroup/metergroup.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AfterContentInit, ChangeDetectionStrategy, Component, ContentChildren, ElementRef, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation, effect, forwardRef, inject, ViewChild } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component, ContentChildren, ElementRef, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation, effect, forwardRef, inject, viewChild } from '@angular/core';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { DomHandler } from 'primeng/dom';
 import { MeterItem } from './metergroup.interface';
@@ -142,7 +142,7 @@ export class MeterGroup implements AfterContentInit {
 
     iconTemplate: TemplateRef<any> | undefined;
 
-    container = ViewChild('container', { read: ElementRef });
+    container = viewChild('container', { read: ElementRef });
 
     containerEffect = effect(() => {
         const _container = this.container();


### PR DESCRIPTION
Use the new `viewChild` signal query instead of the presumably unintended decorator `ViewChild`. Fixes #15305
