### PR TITLE
Bug #14886: p-calendar "Date After" filters do not exclude date inclusive

### DIFF
--- a/src/app/components/api/filterservice.ts
+++ b/src/app/components/api/filterservice.ts
@@ -236,6 +236,7 @@ export class FilterService {
             if (value === undefined || value === null) {
                 return false;
             }
+            
             return value.getTime() < filter.getTime();
         },
 
@@ -248,6 +249,7 @@ export class FilterService {
                 return false;
             }
             value.setHours(0,0,0,0);
+            
             return value.getTime() > filter.getTime();
         }
     };

--- a/src/app/components/api/filterservice.ts
+++ b/src/app/components/api/filterservice.ts
@@ -236,7 +236,6 @@ export class FilterService {
             if (value === undefined || value === null) {
                 return false;
             }
-
             return value.getTime() < filter.getTime();
         },
 
@@ -248,7 +247,7 @@ export class FilterService {
             if (value === undefined || value === null) {
                 return false;
             }
-
+            value.setHours(0,0,0,0);
             return value.getTime() > filter.getTime();
         }
     };


### PR DESCRIPTION
FIXED #14886 

This bug seemed to be happening with entries that were the same date as the selected filter date but had a later time, there by making them after but on the same day. I have fixed this by changing the time for the entry to (0,0,0,0) during the filter comparison.