### PR TITLE
Fixes #15022:  dialog not closing

### DIFF
--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -706,7 +706,7 @@ export class Dialog implements AfterContentInit, OnInit, OnDestroy {
     }
 
     initDrag(event: MouseEvent) {
-        if (DomHandler.hasClass(event.target, 'p-dialog-header-icon') || DomHandler.hasClass((<HTMLElement>event.target).parentElement, 'p-dialog-header-icon')) {
+        if (DomHandler.hasClass(event.target, 'p-dialog-header-icon') || DomHandler.hasClass(event.target, "p-dialog-header-close-icon") || DomHandler.hasClass((<HTMLElement>event.target).parentElement, 'p-dialog-header-icon')) {
             return;
         }
 

--- a/src/app/components/dialog/dialog.ts
+++ b/src/app/components/dialog/dialog.ts
@@ -706,7 +706,7 @@ export class Dialog implements AfterContentInit, OnInit, OnDestroy {
     }
 
     initDrag(event: MouseEvent) {
-        if (DomHandler.hasClass(event.target, 'p-dialog-header-icon') || DomHandler.hasClass(event.target, "p-dialog-header-close-icon") || DomHandler.hasClass((<HTMLElement>event.target).parentElement, 'p-dialog-header-icon')) {
+        if (DomHandler.hasClass(event.target, 'p-dialog-header-icon') || DomHandler.hasClass(event.target, 'p-dialog-header-close-icon') || DomHandler.hasClass((<HTMLElement>event.target).parentElement, 'p-dialog-header-icon')) {
             return;
         }
 


### PR DESCRIPTION
Fixes #15022
The bug happens because there's a onMouseDown event on the dialog header that does nothing if the element has class 'p-dialog-header-icon' else it does the drag logic. However when a user clicks on the TimeIcon instead of the button (that has the p-dialog-header-icon css class) , the implements the drag logic instead of closing. I have added the css class of the TimesIcon to fix the bug. 
