### PR TITLE
TreeSelect Disabled State Not Updating Properly

### DIFF
--- a/src/app/components/treeselect/treeselect.ts
+++ b/src/app/components/treeselect/treeselect.ts
@@ -937,8 +937,8 @@ export class TreeSelect implements AfterContentInit {
     setDisabledState(val: boolean): void {
         setTimeout(() => {
             this.disabled = val;
+            this.cd.markForCheck();
         });
-        this.cd.markForCheck();
     }
 
     containerClass() {


### PR DESCRIPTION
Fixes #15378 The same problem occurs with the TreeSelect component, and it can be fixed in the same way as it was done in the Checkbox component.

https://github.com/primefaces/primeng/issues/14819
