### PR TITLE
 Component: KeyFilter #14639 limit input length

### DIFF
--- a/src/app/components/keyfilter/keyfilter.ts
+++ b/src/app/components/keyfilter/keyfilter.ts
@@ -1,7 +1,7 @@
-import { NgModule, Directive, ElementRef, HostListener, Input, forwardRef, Output, EventEmitter, Inject, PLATFORM_ID, Provider, booleanAttribute } from '@angular/core';
 import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { Directive, ElementRef, EventEmitter, HostListener, Inject, Input, NgModule, Output, PLATFORM_ID, Provider, booleanAttribute, forwardRef } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, Validator } from '@angular/forms';
 import { DomHandler } from 'primeng/dom';
-import { Validator, AbstractControl, NG_VALIDATORS } from '@angular/forms';
 import { KeyFilterPattern } from './keyfilter.interface';
 
 export const KEYFILTER_VALIDATOR: Provider = {
@@ -31,15 +31,15 @@ type Keys = {
 };
 
 const DEFAULT_MASKS: Record<KeyFilterPattern, RegExp> = {
-    pint: /[\d]/,
-    int: /[\d\-]/,
-    pnum: /[\d\.]/,
-    money: /[\d\.\s,]/,
-    num: /[\d\-\.]/,
-    hex: /[0-9a-f]/i,
-    email: /[a-z0-9_\.\-@]/i,
-    alpha: /[a-z_]/i,
-    alphanum: /[a-z0-9_]/i
+    pint: /^[\d]*$/,
+    int: /^[-]?[\d]*$/,
+    pnum: /^[\d\.]*$/,
+    money: /^[\d\.\s,]*$/,
+    num: /^[-]?[\d\.]*$/,
+    hex: /^[0-9a-f]*$/i,
+    email: /^[a-z0-9_\.\-@]*$/i,
+    alpha: /^[a-z_]*$/i,
+    alphanum: /^[a-z0-9_]*$/i
 };
 
 const KEYS: Keys = {
@@ -225,8 +225,8 @@ export class KeyFilter implements Validator {
         if (!browser.mozilla && (this.isSpecialKey(e) || !cc)) {
             return;
         }
-
-        ok = (<RegExp>this.regex).test(cc);
+        let val = this.el.nativeElement.value + cc;
+        ok = (<RegExp>this.regex).test(val);
 
         if (!ok) {
             e.preventDefault();

--- a/src/app/showcase/doc/keyfilter/regexdoc.ts
+++ b/src/app/showcase/doc/keyfilter/regexdoc.ts
@@ -21,8 +21,7 @@ import { Code } from '../../domain/code';
     `
 })
 export class RegexDoc {
-    blockSpace: RegExp = /[^\s]/;
-
+    blockSpace: RegExp = /^[^\s]+$/;
     blockChars: RegExp = /^[^<>*!]+$/;
 
     code: Code = {
@@ -49,8 +48,8 @@ import { Component } from '@angular/core';
     templateUrl: './key-filter-reg-exp-demo.html'
 })
 export class KeyFilterRegExpDemo {
-    blockSpace: RegExp = /[^\s]/; 
-    
+    blockSpace: RegExp = /[^\s]/;
+
     blockChars: RegExp = /^[^<>*!]+$/;
 }`
     };


### PR DESCRIPTION
FIXED #14639 

This bug was happening because the keyFilter would check each inputted character against the regex meaning you could never check for length of the whole input. Rectifying this meant that the preset Regex's in the keyfilter component had to be adjusted so that they would work again which I have done.