### PR TITLE
Menubar: Enter key moves focus at first menuitem 

### DIFF
--- a/src/app/components/menubar/menubar.ts
+++ b/src/app/components/menubar/menubar.ts
@@ -1050,10 +1050,6 @@ export class Menubar implements AfterContentInit, OnDestroy, OnInit {
 
             anchorElement ? anchorElement.click() : element && element.click();
 
-            const processedItem = this.visibleItems[this.focusedItemInfo().index];
-            const grouped = this.isProccessedItemGroup(processedItem);
-
-            !grouped && (this.focusedItemInfo().index = this.findFirstFocusedItemIndex());
         }
 
         event.preventDefault();


### PR DESCRIPTION
Solves issue [#15040 ](https://github.com/primefaces/primeng/issues/15040)
Fixed #15040 
menu items now keeps the focus the clicked/Enterkey one and no longer focuses back to first menuitem