### PR TITLE
FileUpload - remove useless HttpClientModule import to fix standalone context issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "primeng",
-    "version": "17.13.0",
+    "version": "17.14.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "primeng",
-            "version": "17.13.0",
+            "version": "17.14.1",
             "license": "SEE LICENSE IN LICENSE.md",
             "devDependencies": {
                 "@angular-devkit/build-angular": "^17.3.1",

--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -1,5 +1,5 @@
 import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { HttpClient, HttpClientModule, HttpEvent, HttpEventType, HttpHeaders } from '@angular/common/http';
+import { HttpClient, HttpEvent, HttpEventType, HttpHeaders } from '@angular/common/http';
 import {
     AfterContentInit,
     AfterViewInit,
@@ -932,7 +932,7 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
 }
 
 @NgModule({
-    imports: [CommonModule, HttpClientModule, SharedModule, ButtonModule, ProgressBarModule, MessagesModule, RippleModule, PlusIcon, UploadIcon, TimesIcon],
+    imports: [CommonModule, SharedModule, ButtonModule, ProgressBarModule, MessagesModule, RippleModule, PlusIcon, UploadIcon, TimesIcon],
     exports: [FileUpload, SharedModule, ButtonModule, ProgressBarModule, MessagesModule],
     declarations: [FileUpload]
 })


### PR DESCRIPTION
fix suggestion for that [issue](https://github.com/primefaces/primeng/issues/15360)

Fileupload breaks http requests interceptor cycle when imported in a standalone context.
The correction simply consists in removing the import declaration, which is useless anyway.