### PR TITLE
Fixed #15367 - Non-linear menu items are misaligned

### DIFF
--- a/src/app/components/speeddial/speeddial.css
+++ b/src/app/components/speeddial/speeddial.css
@@ -5,6 +5,14 @@
         z-index: 1;
     }
 
+    .p-speeddial:not(.p-speeddial-opened) {
+        pointer-events: none;
+    }
+
+    .p-speeddial:not(.p-speeddial-opened) .p-speeddial-button {
+        pointer-events: auto;
+    }
+
     .p-speeddial-list {
         margin: 0;
         padding: 0;

--- a/src/app/components/speeddial/speeddial.ts
+++ b/src/app/components/speeddial/speeddial.ts
@@ -92,7 +92,7 @@ import { asapScheduler } from 'rxjs';
                     </ng-container>
                     <ng-container *ngIf="!itemTemplate">
                         <a
-                            *ngIf="_visible && isClickableRouterLink(item); else elseBlock"
+                            *ngIf="isClickableRouterLink(item); else elseBlock"
                             pRipple
                             [routerLink]="item.routerLink"
                             [queryParams]="item.queryParams"
@@ -117,7 +117,6 @@ import { asapScheduler } from 'rxjs';
                         </a>
                         <ng-template #elseBlock>
                             <a
-                                *ngIf="_visible"
                                 [attr.href]="item.url || null"
                                 class="p-speeddial-action"
                                 role="menuitem"
@@ -499,7 +498,7 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
 
     onEnterKey(event: any) {
         const items = DomHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
-        const itemIndex = [...items].findIndex((item) => item.id === this.focusedOptionIndex);
+        const itemIndex = [...items].findIndex((item) => item.id === this.focusedOptionIndex());
 
         this.onItemClick(event, this.model[itemIndex]);
         this.onBlur(event);


### PR DESCRIPTION
### Background
In a previous PR (#13726), a change was made so that menu item actions would not be added to the DOM unless the speed dial menu was visible. This was done to prevent those menu items from interfering with clicks on elements below the items while the menu was closed.
However, the size of the menu item actions is used to position the items and the calculation is performed while the actions aren't in the DOM resulting in the items being misaligned. Additionally, the removal of the menu item actions causes the closing animation of the Speed Dial to not be displayed.

### Changes

1. Removes the changes from #13726 and uses CSS to achieve the desired effect.
2. Fixes a bug with accessing the value of the `focusedOptionIndex` signal which was causing an exception when pressing the enter key on a focused menu item.