### PR TITLE
Fixed inputNumber with numeric prefix is not working as expected 

### DIFF
--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -616,16 +616,13 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
     }
 
     getPrefixExpression(): RegExp {
-        console.log("prefix", this.prefix);
 
         if (this.prefix) {
             this.prefixChar = this.prefix;
-            console.log("prefix char", this.prefixChar);
 
         } else {
             const formatter = new Intl.NumberFormat(this.locale, { style: this.mode, currency: this.currency, currencyDisplay: this.currencyDisplay });
             this.prefixChar = formatter.format(1).split('1')[0];
-            console.log("prefix char", this.prefixChar);
 
         }
 
@@ -656,9 +653,6 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
                 console.log(value);
 
                 if (this.prefix) {
-                    console.log("prefix ", this.prefix);
-                    console.log("formattedValue ", formattedValue);
-
                     formattedValue = this.prefix + formattedValue;
                 }
 
@@ -882,8 +876,20 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
             case 'Backspace': {
                 event.preventDefault();
 
+
                 if (selectionStart === selectionEnd) {
-                    const deleteChar = inputValue.charAt(selectionStart - 1);
+                    console.log("SekectionStart ", selectionStart);
+                    console.log("inputValue.length ", inputValue.length);
+
+                    const deleteIndex = selectionStart - 1;
+                    console.log("deleteIndex ", deleteIndex);
+
+                    if(selectionStart == 1 || selectionStart == inputValue.length){
+                        break;
+                    }
+                    const deleteChar = inputValue.charAt(deleteIndex);
+                    console.log("deleteChar ", deleteChar);
+
                     const { decimalCharIndex, decimalCharIndexWithoutPrefix } = this.getDecimalCharIndexes(inputValue);
 
                     if (this.isNumeralChar(deleteChar)) {
@@ -926,7 +932,15 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
                 event.preventDefault();
 
                 if (selectionStart === selectionEnd) {
+                    console.log("SekectionStart ", selectionStart);
+                    console.log("inputValue.length ", inputValue.length);
+
+                    if(selectionStart == 0 || selectionStart == inputValue.length-1){
+                        break;
+                    }
                     const deleteChar = inputValue.charAt(selectionStart);
+                    console.log("deleteChar ", deleteChar);
+
                     const { decimalCharIndex, decimalCharIndexWithoutPrefix } = this.getDecimalCharIndexes(inputValue);
 
                     if (this.isNumeralChar(deleteChar)) {

--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -25,6 +25,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, NgControl } from '@angular/forms';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
+import { AutoFocusModule } from 'primeng/autofocus';
 import { ButtonModule } from 'primeng/button';
 import { DomHandler } from 'primeng/dom';
 import { AngleDownIcon } from 'primeng/icons/angledown';
@@ -32,7 +33,6 @@ import { AngleUpIcon } from 'primeng/icons/angleup';
 import { TimesIcon } from 'primeng/icons/times';
 import { InputTextModule } from 'primeng/inputtext';
 import { Nullable } from 'primeng/ts-helpers';
-import { AutoFocusModule } from 'primeng/autofocus';
 import { InputNumberInputEvent } from './inputnumber.interface';
 
 export const INPUTNUMBER_VALUE_ACCESSOR: any = {
@@ -616,11 +616,17 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
     }
 
     getPrefixExpression(): RegExp {
+        console.log("prefix", this.prefix);
+
         if (this.prefix) {
             this.prefixChar = this.prefix;
+            console.log("prefix char", this.prefixChar);
+
         } else {
             const formatter = new Intl.NumberFormat(this.locale, { style: this.mode, currency: this.currency, currencyDisplay: this.currencyDisplay });
             this.prefixChar = formatter.format(1).split('1')[0];
+            console.log("prefix char", this.prefixChar);
+
         }
 
         return new RegExp(`${this.escapeRegExp(this.prefixChar || '')}`, 'g');
@@ -647,7 +653,12 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
             if (this.format) {
                 let formatter = new Intl.NumberFormat(this.locale, this.getOptions());
                 let formattedValue = formatter.format(value);
+                console.log(value);
+
                 if (this.prefix) {
+                    console.log("prefix ", this.prefix);
+                    console.log("formattedValue ", formattedValue);
+
                     formattedValue = this.prefix + formattedValue;
                 }
 
@@ -665,12 +676,16 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
     }
 
     parseValue(text: any) {
+        const suffixRegex = new RegExp(this._suffix, '');
+        const prefixRegex = new RegExp(this._prefix, '');
+        const currencyRegex = new RegExp(this._currency, '');
+
         let filteredText = text
-            .replace(this._suffix as RegExp, '')
-            .replace(this._prefix as RegExp, '')
+            .replace(suffixRegex, '')
+            .replace(prefixRegex, '')
             .trim()
             .replace(/\s/g, '')
-            .replace(this._currency as RegExp, '')
+            .replace(currencyRegex, '')
             .replace(this._group, '')
             .replace(this._minusSign, '-')
             .replace(this._decimal, '.')
@@ -985,7 +1000,6 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
             char = this._decimalChar;
             code = char.charCodeAt(0);
         }
-
         const newValue = this.parseValue(this.input.nativeElement.value + char);
         const newValueStr = newValue != null ? newValue.toString() : '';
 

--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -651,11 +651,11 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
                 let formatter = new Intl.NumberFormat(this.locale, this.getOptions());
                 let formattedValue = formatter.format(value);
 
-                if (this.prefix) {
+                if (this.prefix && value != this.prefix) {
                     formattedValue = this.prefix + formattedValue;
                 }
 
-                if (this.suffix) {
+                if (this.suffix && value != this.suffix) {
                     formattedValue = formattedValue + this.suffix;
                 }
 

--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -650,7 +650,6 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
             if (this.format) {
                 let formatter = new Intl.NumberFormat(this.locale, this.getOptions());
                 let formattedValue = formatter.format(value);
-                console.log(value);
 
                 if (this.prefix) {
                     formattedValue = this.prefix + formattedValue;
@@ -878,18 +877,13 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
 
 
                 if (selectionStart === selectionEnd) {
-                    console.log("SekectionStart ", selectionStart);
-                    console.log("inputValue.length ", inputValue.length);
 
-                    const deleteIndex = selectionStart - 1;
-                    console.log("deleteIndex ", deleteIndex);
+                    if((selectionStart == 1 && this.prefix)|| (selectionStart == inputValue.length && this.suffix)){
 
-                    if(selectionStart == 1 || selectionStart == inputValue.length){
                         break;
                     }
-                    const deleteChar = inputValue.charAt(deleteIndex);
-                    console.log("deleteChar ", deleteChar);
 
+                    const deleteChar = inputValue.charAt(selectionStart - 1);
                     const { decimalCharIndex, decimalCharIndexWithoutPrefix } = this.getDecimalCharIndexes(inputValue);
 
                     if (this.isNumeralChar(deleteChar)) {
@@ -932,15 +926,11 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
                 event.preventDefault();
 
                 if (selectionStart === selectionEnd) {
-                    console.log("SekectionStart ", selectionStart);
-                    console.log("inputValue.length ", inputValue.length);
 
-                    if(selectionStart == 0 || selectionStart == inputValue.length-1){
+                    if((selectionStart == 0 && this.prefix)|| (selectionStart == inputValue.length-1  && this.suffix)){
                         break;
                     }
                     const deleteChar = inputValue.charAt(selectionStart);
-                    console.log("deleteChar ", deleteChar);
-
                     const { decimalCharIndex, decimalCharIndexWithoutPrefix } = this.getDecimalCharIndexes(inputValue);
 
                     if (this.isNumeralChar(deleteChar)) {


### PR DESCRIPTION
FIXED  #15311 

The issue was essentially that each time a value was entered a RegExp would be used to replace the prefix and suffix with '' however the RegExp had the /g flag and as such would replace all occurances of the pre/suffix including any occurances entered by the user. I also fixed some issues around the use of backspace and delete keys when the selector was around the prefix and suffix