### PR TITLE
Fix: pFrozenColumn freeze on right breaks with many cols

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3322,6 +3322,7 @@ export class FrozenColumn implements AfterViewInit {
     updateStickyPosition() {
         if (this._frozen) {
             let currentElement = this.el.nativeElement;
+            let index = DomHandler.index(currentElement);
             if (this.alignFrozen === 'right') {
                 let right = 0;
                 if (currentElement.nodeName == 'TH') {
@@ -3330,7 +3331,7 @@ export class FrozenColumn implements AfterViewInit {
                         right += parseFloat(currentElement.style.minWidth);
                     }
                 } else {
-                    let currentElementHeader = currentElement?.parentElement?.parentElement?.previousElementSibling?.firstElementChild?.cells[DomHandler.index(this.el.nativeElement)];
+                    let currentElementHeader = currentElement?.parentElement?.parentElement?.previousElementSibling?.firstElementChild?.cells[index];
                     right = parseFloat(currentElementHeader.style.right);
                 }
                 this.el.nativeElement.style.right = right + 'px';
@@ -3342,7 +3343,7 @@ export class FrozenColumn implements AfterViewInit {
                         left += parseFloat(currentElement.style.minWidth);
                     }
                 } else {
-                    let currentElementHeader = currentElement?.parentElement?.parentElement?.previousElementSibling?.firstElementChild?.cells[DomHandler.index(this.el.nativeElement)];
+                    let currentElementHeader = currentElement?.parentElement?.parentElement?.previousElementSibling?.firstElementChild?.cells[index];
                     left = parseFloat(currentElementHeader.style.left);
                 }
                 this.el.nativeElement.style.left = left + 'px';
@@ -3351,7 +3352,6 @@ export class FrozenColumn implements AfterViewInit {
             const filterRow = this.el.nativeElement?.parentElement?.nextElementSibling;
 
             if (filterRow) {
-                let index = DomHandler.index(this.el.nativeElement);
                 if (filterRow.children && filterRow.children[index]) {
                     filterRow.children[index].style.left = this.el.nativeElement.style.left;
                     filterRow.children[index].style.right = this.el.nativeElement.style.right;

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3321,18 +3321,29 @@ export class FrozenColumn implements AfterViewInit {
 
     updateStickyPosition() {
         if (this._frozen) {
+            let currentElement = this.el.nativeElement;
             if (this.alignFrozen === 'right') {
                 let right = 0;
-                let next = this.el.nativeElement.nextElementSibling;
-                if (next) {
-                    right = DomHandler.getOuterWidth(next) + (parseFloat(next.style.right) || 0);
+                if (currentElement.nodeName == 'TH') {
+                    while (currentElement.nextElementSibling != null) {
+                        currentElement = currentElement.nextElementSibling;
+                        right += parseFloat(currentElement.style.minWidth);
+                    }
+                } else {
+                    let currentElementHeader = currentElement?.parentElement?.parentElement?.previousElementSibling?.firstElementChild?.cells[DomHandler.index(this.el.nativeElement)];
+                    right = parseFloat(currentElementHeader.style.right);
                 }
                 this.el.nativeElement.style.right = right + 'px';
             } else {
                 let left = 0;
-                let prev = this.el.nativeElement.previousElementSibling;
-                if (prev) {
-                    left = DomHandler.getOuterWidth(prev) + (parseFloat(prev.style.left) || 0);
+                if (currentElement.nodeName == 'TH') {
+                    while (currentElement.previousElementSibling != null) {
+                        currentElement = currentElement.previousElementSibling;
+                        left += parseFloat(currentElement.style.minWidth);
+                    }
+                } else {
+                    let currentElementHeader = currentElement?.parentElement?.parentElement?.previousElementSibling?.firstElementChild?.cells[DomHandler.index(this.el.nativeElement)];
+                    left = parseFloat(currentElementHeader.style.left);
                 }
                 this.el.nativeElement.style.left = left + 'px';
             }


### PR DESCRIPTION
Fixes #14955 

Previously the 'left' and 'right' style attributes were retrieved by checking the next or previous elements. However, the first element in each column didn't have a neighbouring element with these attributes so it was being set as 0 each time. Fixed it by getting the attributes by counting the width of each element on front or behind the current frozen column.
