### PR TITLE
docs: typo in chart and primeflex docs

### DIFF
--- a/src/app/showcase/doc/chart/combodoc.ts
+++ b/src/app/showcase/doc/chart/combodoc.ts
@@ -7,7 +7,7 @@ import { AppConfigService } from '../../service/appconfigservice';
     selector: 'chart-combo-demo',
     template: `
         <app-docsectiontext>
-            <p>Different chart types can be combined in the same graph usign the <i>type</i> option of a dataset.</p>
+            <p>Different chart types can be combined in the same graph using the <i>type</i> option of a dataset.</p>
         </app-docsectiontext>
         <div class="card">
             <p-chart type="line" [data]="data" [options]="options"></p-chart>

--- a/src/app/showcase/doc/theming/primeflexdoc.ts
+++ b/src/app/showcase/doc/theming/primeflexdoc.ts
@@ -7,7 +7,7 @@ import { Code } from '../../domain/code';
         <app-docsectiontext>
             <p>
                 <a href="https://primeflex.org/">PrimeFlex</a> is a lightweight responsive CSS utility library to accompany Prime UI libraries and static webpages as well. PrimeNG can be used with any CSS utility library like bootstrap and tailwind
-                however PrimeFlex has benefits like integration with PrimeNG themes usign CSS variables so that colors classes e.g. <i>bg-blue-500</i> receive the color code from the PrimeNG theme being used. PrimeNG follows the CSS utility approach
+                however PrimeFlex has benefits like integration with PrimeNG themes using CSS variables so that colors classes e.g. <i>bg-blue-500</i> receive the color code from the PrimeNG theme being used. PrimeNG follows the CSS utility approach
                 of PrimeFlex and currently does not provide an extended style property like <i>sx</i>. Same approach is also utilized in <a href="https://blocks.primeng.org">PrimeBlocks for PrimeNG</a> project as well.
             </p>
         </app-docsectiontext>


### PR DESCRIPTION
Fixed a couple spots in the docs from 'usign' to 'using'.

Let me know if I should open an issue for this, from looking at past PRs it looks like this might be small enough that might not be needed.

Thanks!