### PR TITLE
fix 13929 tieredMenuSub not posititioning itself within viewport

### DIFF
--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -192,7 +192,7 @@ import { ObjectUtils, UniqueComponentId, ZIndexUtils } from 'primeng/utils';
         class: 'p-element'
     }
 })
-export class TieredMenuSub {
+export class TieredMenuSub implements AfterContentInit {
     @Input() items: any[];
 
     @Input() itemTemplate: HTMLElement | undefined;
@@ -234,6 +234,10 @@ export class TieredMenuSub {
     @ViewChild('sublist', { static: true }) sublistViewChild: ElementRef;
 
     constructor(public el: ElementRef, public renderer: Renderer2, @Inject(forwardRef(() => TieredMenu)) public tieredMenu: TieredMenu) {}
+
+    ngAfterContentInit(): void {
+        this.positionSubmenu();
+    }
 
     positionSubmenu() {
         const sublist = this.sublistViewChild && this.sublistViewChild.nativeElement;


### PR DESCRIPTION
Fixes #13929 

[13929](https://github.com/primefaces/primeng/issues/13929)

`positionSubmenu()` is never called because of this codeBlock beeing deleted in the commit 
https://github.com/primefaces/primeng/commit/28989fd4cafe4ee5b7d805f5b059618f5fc1128b#diff-0f78da967be578fe31289e62b917434f52f9902618913c827f6388d7de7fc3c0L147 

```
@Input() get parentActive(): boolean {
        return this._parentActive as boolean;
    }
    set parentActive(value) {
        if (!this.root) {
            this._parentActive = value;

            if (!value) this.activeItem = null;
            else this.positionSubmenu();
        }
    }
```