### PR TITLE
Update table filter match mode behavior

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -5459,8 +5459,11 @@ export class ColumnFilter implements AfterContentInit {
     }
 
     onRowMatchModeChange(matchMode: string) {
-        (<FilterMetadata>this.dt.filters[<string>this.field]).matchMode = matchMode;
-        this.dt._filter();
+        const fieldFilter = <FilterMetadata>this.dt.filters[<string>this.field];
+        fieldFilter.matchMode = matchMode;
+        if (fieldFilter.value) {
+            this.dt._filter();
+        }
         this.hide();
     }
 


### PR DESCRIPTION
Fixes #15283
Refactored the `onRowMatchModeChange` method in the `Table` component. A check is now included to ensure `fieldFilter.value` is present before calling the filter function, preventing unnecessary filter function calls.