### PR TITLE
chore(tieredmenu): remove aria level attribute from list item

### DIFF
--- a/src/app/components/tieredmenu/tieredmenu.ts
+++ b/src/app/components/tieredmenu/tieredmenu.ts
@@ -77,7 +77,6 @@ import { ObjectUtils, UniqueComponentId, ZIndexUtils } from 'primeng/utils';
                     [attr.aria-disabled]="isItemDisabled(processedItem) || undefined"
                     [attr.aria-haspopup]="isItemGroup(processedItem) && !getItemProp(processedItem, 'to') ? 'menu' : undefined"
                     [attr.aria-expanded]="isItemGroup(processedItem) ? isItemActive(processedItem) : undefined"
-                    [attr.aria-level]="level + 1"
                     [attr.aria-setsize]="getAriaSetSize()"
                     [attr.aria-posinset]="getAriaPosInset(index)"
                     [ngStyle]="getItemProp(processedItem, 'style')"


### PR DESCRIPTION
Resolves #15130 

This is my first contribution. Forgive me if I have failed to follow S.O.P.

### Defect Fixes
This PR removes the `aria-level` attribute from the `<li>` items in the tiered menu component. The reason being that this attribute was flagged as incorrect by axe devtools (presumably due to the role attribute being incompatible with aria-level?)
