### PR TITLE
Fixed #15455 - DataView [rowsPerPageOption] not working

### DIFF
--- a/src/app/components/dataview/dataview.ts
+++ b/src/app/components/dataview/dataview.ts
@@ -147,7 +147,7 @@ export class DataView implements OnInit, AfterContentInit, OnDestroy, BlockableU
      * Array of integer/object values to display inside rows per page dropdown of paginator
      * @group Props
      */
-    @Input({ transform: numberAttribute }) rowsPerPageOptions: number[] | any[] | undefined;
+    @Input() rowsPerPageOptions: number[] | any[] | undefined;
     /**
      * Position of the paginator.
      * @group Props


### PR DESCRIPTION
Fixes [#15455](https://github.com/primefaces/primeng/issues/15455)

### Issue
When adding the [rowsPerPageOption] to the p-dataview attribute list it is not loading the dropwdown. As rowsPerPageOption is being transformed into NaN

### Change
Remove transform numberattribute as it is unable to parse an array of numbers 


