### PR TITLE
Fixes #15487 - Calendar component: invalid date value is removed even though KeepInvalid is true

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -3427,6 +3427,9 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     }
 
     isValidDateForTimeConstraints(selectedDate: Date) {
+        if (this.keepInvalid) {
+            return true; // If we are keeping invalid dates, we don't need to check for time constraints
+        }
         return (!this.minDate || selectedDate >= this.minDate) && (!this.maxDate || selectedDate <= this.maxDate);
     }
 


### PR DESCRIPTION
Fixes [#15487](https://github.com/primefaces/primeng/issues/15487)

### Issue
Calendar component: date input value is removed when a date before min Date is entered when KeepInvalid has been set to true

