### PR TITLE
#15535 - skeleton value changed from a shape to string for rem values

### DIFF
--- a/src/app/components/skeleton/skeleton.ts
+++ b/src/app/components/skeleton/skeleton.ts
@@ -44,7 +44,7 @@ export class Skeleton {
      * Size of the skeleton.
      * @group Props
      */
-    @Input() size: 'circle' | 'square' | undefined;
+    @Input() size: string | undefined;
     /**
      * Width of the element.
      * @group Props


### PR DESCRIPTION
### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.

### Description
#15535 issue has been close by this commit I've submitted. I've changed the type of the input parameter because I've seen that the skeleton file has already a shape input so it is not the right place for the strict size input to have a type of shapes. I've returned the size to accept string inputs so that a rem, em and other values can be set to it.