### PR TITLE
#15512 Table: Numeric Filter - issue fixed

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -5243,7 +5243,7 @@ export class ColumnFilter implements AfterContentInit {
      * Enables currency input.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) currency: boolean | undefined;
+    @Input({ transform: booleanAttribute }) currency: string;
     /**
      * Defines the display of the currency input.
      * @group Props


### PR DESCRIPTION
#15512 Table: Numeric Filter issue fixed based on the discussion with @ethanolre by converting the currency value in table.ts into string from boolean | undefined. The reasoning behind it is that it is the form that it is in the inputnumber.ts file and it works flawlessly there.