### PR TITLE
docs(toolbar): Improve import documentation

### DIFF
--- a/src/app/showcase/doc/toolbar/importdoc.ts
+++ b/src/app/showcase/doc/toolbar/importdoc.ts
@@ -7,6 +7,7 @@ import { Code } from '@domain/code';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ToolbarModule } from 'primeng/toolbar';`
+        typescript: `import { ToolbarModule } from 'primeng/toolbar';
+import { SharedModule } from 'primeng/api'; // Required if you will use Template`
     };
 }


### PR DESCRIPTION
Closes #15608

When you are using `pTemplate` in `Toolbar`, the `SharedModule` is required and this can be confused for some users.
I added a new line with a comment to be clear.

![image](https://github.com/primefaces/primeng/assets/19764334/e07beb1e-10bb-4c03-b179-78d378058579)
