### PR TITLE
Fixed Domhandler tests

### DIFF
--- a/src/app/components/dom/domhandler.spec.ts
+++ b/src/app/components/dom/domhandler.spec.ts
@@ -74,7 +74,7 @@ describe('DomHandler', () => {
         element.appendChild(childEl3);
         element.appendChild(childEl4);
         document.body.appendChild(element);
-        expect(DomHandler.getFocusableElements(element).length).toEqual(2);
+        expect(DomHandler.getFocusableElements(element).length).toEqual(1);
     });
 
     it('should get the next focusable element', () => {


### PR DESCRIPTION
In a PR 16 months ago the expect for this test was altered from 1 to 2. I can't seem to find any reason why, only one button is added, the 'a' and 'p' tags are not focusable so shouldn't impact this, as such I've changed it back