### PR TITLE
fix: remove duplicate @Component annotation from table filter basic demo

### DIFF
--- a/src/app/showcase/doc/table/filterbasic.ts
+++ b/src/app/showcase/doc/table/filterbasic.ts
@@ -474,10 +474,6 @@ import { CommonModule } from '@angular/common';
     imports: [TableModule, TagModule, IconFieldModule, InputTextModule, InputIconModule, MultiSelectModule, DropdownModule, HttpClientModule, CommonModule],
     providers: [CustomerService]
 })
-@Component({
-    selector: 'table-filter-basic-demo',
-    templateUrl: 'table-filter-basic-demo.html'
-})
 export class TableFilterBasicDemo implements OnInit {
     customers!: Customer[];
 


### PR DESCRIPTION
Fixes [issue](https://github.com/primefaces/primeng/issues/15626) around table basic filtering demo not loading.

Issue was with a duplicate @Component annotation.