### PR TITLE
fixed #15648 - fixed tooltip for custom component 

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -560,7 +560,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     }
 
     private get activeElement(): HTMLElement {
-        return this.el.nativeElement.nodeName.includes('P-') ? DomHandler.findSingle(this.el.nativeElement, '.p-component') : this.el.nativeElement;
+        return this.el.nativeElement.nodeName.includes('P-') ? DomHandler.findSingle(this.el.nativeElement, '.p-component') || this.el.nativeElement : this.el.nativeElement;
     }
 
     alignLeft() {


### PR DESCRIPTION
Updated logic of tooltip activeElement method to handle case of a non PrimeNG component.

The following Video shows the issue #15648 reproducer is fixed with this Pull Request:


https://github.com/primefaces/primeng/assets/45439491/080ab680-71da-4e52-8414-6f9730b64251


I also verified this fix against all the tooltip documentation examples