### PR TITLE
Fix dateAfter filter changing date object hours

### DIFF
--- a/src/app/components/api/filterservice.ts
+++ b/src/app/components/api/filterservice.ts
@@ -250,9 +250,11 @@ export class FilterService {
             if (value === undefined || value === null) {
                 return false;
             }
-            value.setHours(0, 0, 0, 0);
 
-            return value.getTime() > filter.getTime();
+            const valueCopy = new Date(value);
+            valueCopy.setHours(0, 0, 0, 0);
+
+            return valueCopy.getTime() > filter.getTime();
         }
     };
 


### PR DESCRIPTION
This fixes issue #15684 

I fixed it by making a copy of the value and setting the hours to 00:00 on that, then use that copy for comparison.