### PR TITLE
feat(chips): added onChipContextMenu output analog to onChipClick

### DIFF
--- a/src/app/components/chips/chips.interface.ts
+++ b/src/app/components/chips/chips.interface.ts
@@ -30,6 +30,13 @@ export interface ChipsRemoveEvent extends ChipsAddEvent {}
  */
 export interface ChipsClickEvent extends ChipsAddEvent {}
 /**
+ * Custom contextmenu event.
+ * @see {@link Chips.onChipContextMenu}
+ * @extends {ChipsAddEvent}
+ * @group Events
+ */
+export interface ChipsContextMenuEvent extends ChipsAddEvent {}
+/**
  * Defines valid templates in Chips.
  * @group Templates
  */

--- a/src/app/components/chips/chips.ts
+++ b/src/app/components/chips/chips.ts
@@ -27,7 +27,7 @@ import { TimesCircleIcon } from 'primeng/icons/timescircle';
 import { InputTextModule } from 'primeng/inputtext';
 import { Nullable } from 'primeng/ts-helpers';
 import { UniqueComponentId } from 'primeng/utils';
-import { ChipsAddEvent, ChipsClickEvent, ChipsRemoveEvent } from './chips.interface';
+import { ChipsAddEvent, ChipsClickEvent, ChipsContextMenuEvent, ChipsRemoveEvent } from './chips.interface';
 
 export const CHIPS_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
@@ -81,6 +81,7 @@ export const CHIPS_VALUE_ACCESSOR: any = {
                     [attr.data-p-focused]="focusedIndex === i"
                     [ngClass]="{ 'p-chips-token': true, 'p-focus': focusedIndex === i }"
                     (click)="onItemClick($event, item)"
+                    (contextmenu)="onItemContextMenu($event, item)"
                     [attr.data-pc-section]="'token'"
                 >
                     <ng-container *ngTemplateOutlet="itemTemplate; context: { $implicit: item }"></ng-container>
@@ -269,6 +270,12 @@ export class Chips implements AfterContentInit, ControlValueAccessor {
      */
     @Output() onChipClick: EventEmitter<ChipsClickEvent> = new EventEmitter<ChipsClickEvent>();
     /**
+     * Callback to invoke on chip contextmenu.
+     * @param {ChipsClickEvent} event - Custom chip contextmenu event.
+     * @group Emits
+     */
+    @Output() onChipContextMenu: EventEmitter<ChipsContextMenuEvent> = new EventEmitter<ChipsContextMenuEvent>();
+    /**
      * Callback to invoke on clear token clicked.
      * @group Emits
      */
@@ -432,6 +439,13 @@ export class Chips implements AfterContentInit, ControlValueAccessor {
 
     onItemClick(event: Event, item: any) {
         this.onChipClick.emit({
+            originalEvent: event,
+            value: item
+        });
+    }
+
+    onItemContextMenu(event: Event, item: any) {
+        this.onChipContextMenu.emit({
             originalEvent: event,
             value: item
         });

--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -7659,6 +7659,16 @@
                             "description": "Callback to invoke on chip clicked."
                         },
                         {
+                            "name": "onChipContextMenu",
+                            "parameters": [
+                                {
+                                    "name": "event",
+                                    "type": "ChipsContextMenuEvent"
+                                }
+                            ],
+                            "description": "Callback to invoke on chip contextmenu."
+                        },
+                        {
                             "name": "onClear",
                             "parameters": [
                                 {
@@ -7743,7 +7753,27 @@
                                 "optional": false,
                                 "readonly": false,
                                 "type": "any",
-                                "description": "Added/Removed item value."
+                                "description": "Clicked item value."
+                            }
+                        ]
+                    },
+                    {
+                        "name": "ChipsContextMenuEvent",
+                        "description": "Custom contextmenu event.",
+                        "props": [
+                            {
+                                "name": "originalEvent",
+                                "optional": false,
+                                "readonly": false,
+                                "type": "Event",
+                                "description": "Browser event."
+                            },
+                            {
+                                "name": "value",
+                                "optional": false,
+                                "readonly": false,
+                                "type": "any",
+                                "description": "Contextmenu requested item value."
                             }
                         ]
                     }


### PR DESCRIPTION
This PR exposes contextmenu events on chips analog to existing click events. 
This is a small non-breaking change and completes the existing api for usages of the contextmenu on single chip items.

Closes [2791](https://github.com/primefaces/primeng/issues/16769)