### PR TITLE
Fixed #15804 - Advance Filtering is broken (revert PR #15594 changes)

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -5395,8 +5395,6 @@ export class ColumnFilter implements AfterContentInit {
 
     overlayId: any;
 
-    applyHasBeenClicked: boolean = false;
-
     get fieldConstraints(): FilterMetadata[] | undefined | null {
         return this.dt.filters ? <FilterMetadata[]>this.dt.filters[<string>this.field] : null;
     }
@@ -5651,11 +5649,6 @@ export class ColumnFilter implements AfterContentInit {
     }
 
     onEscape() {
-        if (this.hasFilterNotBeenApplied()) {
-            this.clearFilter();
-        }
-        this.applyHasBeenClicked = false;
-        this.overlayVisible = false;
         this.icon?.nativeElement.focus();
     }
 
@@ -5755,10 +5748,6 @@ export class ColumnFilter implements AfterContentInit {
         return false;
     }
 
-    hasFilterNotBeenApplied(): boolean {
-        return this.hasFilter() && !this.applyHasBeenClicked;
-    }
-
     isOutsideClicked(event: any): boolean {
         return !(
             DomHandler.hasClass(this.overlay?.nextElementSibling, 'p-overlay') ||
@@ -5833,10 +5822,6 @@ export class ColumnFilter implements AfterContentInit {
     }
 
     hide() {
-        if (this.hasFilterNotBeenApplied()) {
-            this.clearFilter();
-        }
-        this.applyHasBeenClicked = false;
         this.overlayVisible = false;
         this.cd.markForCheck();
     }
@@ -5849,14 +5834,12 @@ export class ColumnFilter implements AfterContentInit {
     }
 
     clearFilter() {
-        this.applyHasBeenClicked = false;
         this.initFieldFilterConstraint();
         this.dt._filter();
         if (this.hideOnClear) this.hide();
     }
 
     applyFilter() {
-        this.applyHasBeenClicked = true;
         this.dt._filter();
         this.hide();
     }


### PR DESCRIPTION
This PR reverts the changes made in PR #15594

This PR also fixes issue #15778

This PR fixes the functionality of the PrimeNG's Table Advance Filters which was  "Critically" broken when trying to fix issue #15557.   Note:  PR #15594 actually only partially fixed issue #15557.

This PR also breaks issue #15557.  Since the problem identified in issue #15557 has been in PrimeNG for multiple years without being fixed,  I believe it is better to fix the Advance Filter immediately and in the future develop a more holistic/complete fix for issue #15557 that doesn't "critically" break  Advance Table Filters