### PR TITLE
Fixed #15818 - Fix calendar range selection shown date

### DIFF
--- a/src/app/components/calendar/calendar.spec.ts
+++ b/src/app/components/calendar/calendar.spec.ts
@@ -2018,4 +2018,43 @@ describe('Calendar', () => {
         expect(selectdateSpy).toHaveBeenCalled();
         expect(calendar.value).toEqual(minDate);
     });
+
+    it('should display end date instead of start date in range selection', () => {
+        calendar.selectionMode = 'range';
+        calendar.value = [new Date('2024-03-01'), new Date('2024-04-01')];
+
+        calendar.updateUI();
+        expect(calendar.currentMonth).toBe(3);
+        expect(calendar.currentYear).toBe(2024);
+    });
+
+    it('should display start date instead of default date in range selection', () => {
+        calendar.selectionMode = 'range';
+        calendar.value = [new Date('2024-03-01'), null];
+
+        calendar.updateUI();
+        expect(calendar.currentMonth).toBe(2);
+        expect(calendar.currentYear).toBe(2024);
+    });
+
+    it('should use default date when no range is selected in range selection', () => {
+        calendar.selectionMode = 'range';
+        calendar.defaultDate = new Date('2024-01-01');
+
+        calendar.updateUI();
+        expect(calendar.currentMonth).toBe(0);
+        expect(calendar.currentYear).toBe(2024);
+    });
+
+    it('should use current date when no default date and no range is selected in range selection', () => {
+        jasmine.clock().install();
+        jasmine.clock().mockDate(new Date('2024-06-11'));
+        calendar.selectionMode = 'range';
+
+        calendar.updateUI();
+        expect(calendar.currentMonth).toBe(5);
+        expect(calendar.currentYear).toBe(2024);
+
+        jasmine.clock().uninstall();
+    });
 });

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -2958,7 +2958,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     updateUI() {
         let propValue = this.value;
         if (Array.isArray(propValue)) {
-            propValue = propValue.length === 2 ? propValue[1] : propValue[0];
+            propValue = propValue[1] || propValue[0];
         }
 
         let val = this.defaultDate && this.isValidDate(this.defaultDate) && !this.value ? this.defaultDate : propValue && this.isValidDate(propValue) ? propValue : new Date();


### PR DESCRIPTION
Fixes #15818

It ensures the following order for shown date:
1. End date when it has one
2. Start date when it has one
3. Default date when provided
4. Use 'now' as fallback

Perhaps we could also consider an input to control whether start date should take precedence over end date (e.g., `showStartDate: boolean`)
