### PR TITLE
Fixed #15762 p dropdown open style missing from dropdown

### DIFF
--- a/src/app/components/dropdown/dropdown.spec.ts
+++ b/src/app/components/dropdown/dropdown.spec.ts
@@ -160,6 +160,7 @@ describe('Dropdown', () => {
 
         const dropdownPanel = fixture.debugElement.query(By.css('.p-dropdown-panel'));
         expect(dropdownPanel).toBeTruthy();
+        expect(container.className).toContain('p-dropdown-open');
         expect(dropdown.overlayVisible).toBeTrue();
     });
 

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -932,7 +932,8 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
             'p-focus': this.focused,
             'p-inputwrapper-filled': this.modelValue() !== undefined && this.modelValue() !== null && !this.modelValue().length,
             'p-inputwrapper-focus': this.focused || this.overlayVisible,
-            'p-variant-filled': this.variant === 'filled' || this.config.inputStyle() === 'filled'
+            'p-variant-filled': this.variant === 'filled' || this.config.inputStyle() === 'filled',
+            'p-dropdown-open': this.overlayVisible
         };
     }
 


### PR DESCRIPTION
This fixes #15762 where when the dropdown panel is open, the p-dropdown-open class is not added to the container. Also added a unit test to ensure functionality continues working in the future