### PR TITLE
Fixed #15903 - Table | Multiple Selection with dataKey shows wrong selected row count upon CTRL+A

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1877,9 +1877,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
                 }
 
                 rangeRowsData.push(rangeRowData);
-                setTimeout(() => {
-                    this._selection = [...this.selection, rangeRowData];
-                });
+
                 let dataKeyValue = this.dataKey ? String(ObjectUtils.resolveFieldData(rangeRowData, this.dataKey)) : null;
                 if (dataKeyValue) {
                     this.selectionKeys[dataKeyValue] = 1;


### PR DESCRIPTION
Fixes #15903 