### PR TITLE
Fix duplicate icon issue in button directive with loading state

### DIFF
--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -311,6 +311,7 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
             }
         } else if (this.icon && iconElement) {
             iconElement.className = `p-button-icon ${this.icon}`;
+            iconElement.innerHTML = '';
         } else if (iconElement) {
             iconElement.innerHTML = '';
             this.createIcon();


### PR DESCRIPTION
This pull request fixes a bug that caused a duplicate icon to appear in the button directive when the loading property was set to true. Previously, both the original icon and the loading indicator were displayed simultaneously.

#13716 
