### PR TITLE
Fixed #15876 - TreeTable: Resizing one column resizes other columns a…

### DIFF
--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -1439,11 +1439,6 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
                     let scrollableBodyTable = DomHandler.findSingle(scrollableView, '.p-treetable-scrollable-body table') || DomHandler.findSingle(scrollableView, '.p-scroller-viewport table');
                     let scrollableHeaderTable = DomHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-header-table');
                     let scrollableFooterTable = DomHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-footer-table');
-                    scrollableBodyTable.style.width = scrollableBodyTable.offsetWidth + delta + 'px';
-                    scrollableHeaderTable.style.width = scrollableHeaderTable.offsetWidth + delta + 'px';
-                    if (scrollableFooterTable) {
-                        scrollableFooterTable.style.width = scrollableFooterTable.offsetWidth + delta + 'px';
-                    }
                     let resizeColumnIndex = DomHandler.index(column);
 
                     const scrollableBodyTableWidth = column ? scrollableBodyTable.offsetWidth + delta : newColumnWidth;


### PR DESCRIPTION
…s well

the resizing is already done within the method "setWidth" so it doesn't need to be done before that.
Doing it twice resulted in adding the delta twice.

fixes #15876

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar) or mention it in the description using #<issue_id>.

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
