### PR TITLE
fix(splitter): resize not working when iFrames are used in panels

### DIFF
--- a/src/app/components/splitter/splitter.css
+++ b/src/app/components/splitter/splitter.css
@@ -62,4 +62,8 @@
         width: 24px;
         height: 100%;
     }
+
+    .p-splitter-resizing .p-splitter-panel {
+        pointer-events: none;
+    }
 }


### PR DESCRIPTION
Setting `pointer-events` to none to the panels when resizing fixes this issue.

Closes: #15942