### PR TITLE
fix(MultiSelect): Check for NaN values in isSelectionAllDisabled method

### DIFF
--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -571,7 +571,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
      * Decides how many selected item labels to show at most.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) selectionLimit: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) selectionLimit: number | null | undefined;
     /**
      * Label to display after exceeding max selected labels e.g. ({0} items selected), defaults "ellipsis" keyword to indicate a text-overflow.
      * @group Props
@@ -1471,10 +1471,6 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     }
 
     isSelectionAllDisabled() {
-        if (this.showToggleAll && isNaN(this.selectionLimit)) {
-            return true;
-        }
-
         return this.showToggleAll && ObjectUtils.isEmpty(this.selectionLimit);
     }
 

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1471,6 +1471,10 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     }
 
     isSelectionAllDisabled() {
+        if (this.showToggleAll && isNaN(this.selectionLimit)) {
+            return true;
+        }
+
         return this.showToggleAll && ObjectUtils.isEmpty(this.selectionLimit);
     }
 


### PR DESCRIPTION
Fixes #16039

Added a check for NaN values.

Note:

I couldn't add new tests because my unit tests were not working locally.

When running `npm test`, I've got a lot of errors with this message: `export 'async' (imported as 'async') was not found in '@angular/core/testing'`