### PR TITLE
Fixed dropdown issue. When mouse out dropdown will be closed! (Issue number #16101)

### DIFF
--- a/src/app/components/menubar/menubar.ts
+++ b/src/app/components/menubar/menubar.ts
@@ -99,6 +99,7 @@ export class MenubarService {
                     [class]="getItemProp(processedItem, 'styleClass')"
                     pTooltip
                     [tooltipOptions]="getItemProp(processedItem, 'tooltipOptions')"
+                    (mouseleave)="onItemMouseLeave()"
                 >
                     <div class="p-menuitem-content" [attr.data-pc-section]="'content'" (click)="onItemClick($event, processedItem)" (mouseenter)="onItemMouseEnter({ $event, processedItem })">
                         <ng-container *ngIf="!itemTemplate">
@@ -251,7 +252,7 @@ export class MenubarSub implements OnInit, OnDestroy {
 
     mouseLeaveSubscriber: Subscription | undefined;
 
-    constructor(public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, private menubarService: MenubarService) {}
+    constructor(public el: ElementRef, public renderer: Renderer2, private cd: ChangeDetectorRef, private menubarService: MenubarService) { }
 
     ngOnInit() {
         this.mouseLeaveSubscriber = this.menubarService.mouseLeft$.subscribe(() => {
@@ -333,6 +334,7 @@ export class MenubarSub implements OnInit, OnDestroy {
     }
 
     onItemMouseLeave() {
+        this.activeItemPath = [];
         this.menubarService.mouseLeaves.next(true);
     }
 
@@ -1132,4 +1134,4 @@ export class Menubar implements AfterContentInit, OnDestroy, OnInit {
     exports: [Menubar, RouterModule, TooltipModule, SharedModule],
     declarations: [Menubar, MenubarSub]
 })
-export class MenubarModule {}
+export class MenubarModule { }

--- a/src/app/components/menubar/menubar.ts
+++ b/src/app/components/menubar/menubar.ts
@@ -224,6 +224,10 @@ export class MenubarSub implements OnInit, OnDestroy {
 
     @Input({ transform: booleanAttribute }) autoDisplay: boolean | undefined;
 
+    @Input({ transform: booleanAttribute }) autoHide: boolean | undefined;
+
+    @Input({ transform: numberAttribute }) autoHideDelay: number = 100;
+
     @Input() menuId: string | undefined;
 
     @Input() ariaLabel: string | undefined;
@@ -334,7 +338,12 @@ export class MenubarSub implements OnInit, OnDestroy {
     }
 
     onItemMouseLeave() {
-        this.activeItemPath = [];
+        if (this.autoHide) {
+            const timeout = setTimeout(() => {
+                this.activeItemPath = [];
+                clearTimeout(timeout);
+            }, this.autoHideDelay); // By default autoHideDelay is 100
+        }
         this.menubarService.mouseLeaves.next(true);
     }
 
@@ -388,6 +397,8 @@ export class MenubarSub implements OnInit, OnDestroy {
                 [autoZIndex]="autoZIndex"
                 [mobileActive]="mobileActive"
                 [autoDisplay]="autoDisplay"
+                [autoHide]="autoHide"
+                [autoHideDelay]="autoHideDelay"
                 [ariaLabel]="ariaLabel"
                 [ariaLabelledBy]="ariaLabelledBy"
                 [focusedItemId]="focused ? focusedItemId : undefined"
@@ -459,7 +470,7 @@ export class Menubar implements AfterContentInit, OnDestroy, OnInit {
      * Whether to hide a root submenu when mouse leaves.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) autoHide: boolean | undefined;
+    @Input({ transform: booleanAttribute }) autoHide: boolean | undefined = false;
     /**
      * Delay to hide the root submenu in milliseconds when mouse leaves.
      * @group Props


### PR DESCRIPTION
Fixes : #16101 
The submenu now closes on mouseout. Previously, the submenu remained open if the mouse exited from the top or bottom without hovering over another menu item, even if autoHide was set to true. Now, the submenu automatically hides when `autoHide` is enabled.