### PR TITLE
tabmenu: fix emitting change event twice when clicking on item

### DIFF
--- a/src/app/components/tabmenu/tabmenu.ts
+++ b/src/app/components/tabmenu/tabmenu.ts
@@ -344,7 +344,6 @@ export class TabMenu implements AfterContentInit, AfterViewInit, AfterViewChecke
         }
 
         this.activeItem = item;
-        this.activeItemChange.emit(item);
         this.tabChanged = true;
         this.cd.markForCheck();
     }


### PR DESCRIPTION
this is a fix for tabmenu component which emits change event twice when an item is clicked. 
issue #16123 