### PR TITLE
fix(autocomplete): not opening on second click

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -880,7 +880,14 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         return typeof this.modelValue() === 'string' && this.optionValue;
     }
 
-    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone) {
+    constructor(
+        public el: ElementRef,
+        public renderer: Renderer2,
+        public cd: ChangeDetectorRef,
+        public config: PrimeNGConfig,
+        public overlayService: OverlayService,
+        private zone: NgZone
+    ) {
         effect(() => {
             this.filled = ObjectUtils.isNotEmpty(this.modelValue());
         });
@@ -1100,12 +1107,12 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
             this.updateModel(query);
         }
 
-        if (query.length === 0 && !this.multiple) {
+        if (query.length === 0 && !this.multiple && !this.completeOnFocus) {
             this.onClear.emit();
 
             setTimeout(() => {
                 this.hide();
-            }, this.delay / 2);
+            });
         } else {
             if (query.length >= this.minLength) {
                 this.focusedOptionIndex.set(-1);
@@ -1147,6 +1154,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
         if (!this.dirty && this.completeOnFocus) {
             this.search(event, event.target.value, 'focus');
+            this.show();
         }
         this.dirty = true;
         this.focused = true;
@@ -1458,8 +1466,8 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
             return;
         }
 
-        //do not search blank values on input change
-        if (source === 'input' && query.trim().length === 0) {
+        //do not search on input change if minLength is not met
+        if (source === 'input' && query.trim().length < this.minLength) {
             return;
         }
         this.loading = true;

--- a/src/app/components/overlay/overlay.ts
+++ b/src/app/components/overlay/overlay.ts
@@ -524,16 +524,15 @@ export class Overlay implements AfterContentInit, OnDestroy {
             case 'void':
                 if (!this.visible) {
                     this.hide(container, true);
+                    this.modalVisible = false;
+                    this.unbindListeners();
+
+                    DomHandler.appendOverlay(this.overlayEl, this.targetEl, this.appendTo);
+                    ZIndexUtils.clear(container);
+                    this.cd.markForCheck();
+
+                    break;
                 }
-
-                this.unbindListeners();
-
-                DomHandler.appendOverlay(this.overlayEl, this.targetEl, this.appendTo);
-                ZIndexUtils.clear(container);
-                this.modalVisible = false;
-                this.cd.markForCheck();
-
-                break;
         }
 
         this.handleEvents('onAnimationDone', event);
@@ -546,6 +545,7 @@ export class Overlay implements AfterContentInit, OnDestroy {
     }
 
     bindListeners() {
+        this.unbindListeners();
         this.bindScrollListener();
         this.bindDocumentClickListener();
         this.bindDocumentResizeListener();


### PR DESCRIPTION
Fixes #15281

This PR fixes the mentioned issue & additionally a bug in the overlay which would close the panel & never open it again (when opening & closing before the animation finishes) as the internal state of the overlay was half opened / half closed.

Details:
`modalVisible` was `false` while `visible` was true. This basically "deadlocks" the overlay.

Also fixes the minlength behavior for when "0" is used as a value.