### PR TITLE
Add missing expanded property to groupheader template interface for Table

### DIFF
--- a/src/app/components/table/table.interface.ts
+++ b/src/app/components/table/table.interface.ts
@@ -420,7 +420,7 @@ export interface TableTemplates {
         /**
          * Expanded state.
          */
-        expanded: boolean;
+        expanded?: boolean;
     }): TemplateRef<any>;
     /**
      * Custom group footer template.

--- a/src/app/components/table/table.interface.ts
+++ b/src/app/components/table/table.interface.ts
@@ -417,6 +417,10 @@ export interface TableTemplates {
          * Frozen state.
          */
         frozen?: boolean;
+        /**
+         * Expanded state.
+         */
+        expanded: boolean;
     }): TemplateRef<any>;
     /**
      * Custom group footer template.


### PR DESCRIPTION
`expanded` property is missing on the interface for the groupheader template in the Table component.

https://github.com/primefaces/primeng/blob/512f03d001eeb1479786425931ab14be759e0f97/src/app/components/table/table.ts#L3124-L3131
Here it's provided to the groupheader template. Also it's shown to be used the the docs ( https://primeng.org/table#expand )