### PR TITLE
When scrollHeight is '100%' setSpacerSize() should not set static height to the scroller

### DIFF
--- a/src/app/components/scroller/scroller.ts
+++ b/src/app/components/scroller/scroller.ts
@@ -866,7 +866,7 @@ export class Scroller implements OnInit, AfterContentInit, AfterViewChecked, OnD
     }
 
     setSpacerSize() {
-        if (this._items) {
+        if (this._scrollHeight !== '100%' && this._items) {
             const contentPos = this.getContentPosition();
             const setProp = (_name: string, _value: any, _size: number, _cpos: number = 0) => (this.spacerStyle = { ...this.spacerStyle, ...{ [`${_name}`]: (_value || []).length * _size + _cpos + 'px' } });
 


### PR DESCRIPTION
Fixes #16165 
no need to set fixed height when scrollHeight === '100%' (setSpacerSize()) which is coming from scrollHeight = flex of all other components.
This causes on first load to set height to static values instead of '100%'.