### PR TITLE
Fixed primefaces#16074 - ButtonDirective changing severity does not update styles

### DIFF
--- a/src/app/components/api/constants.ts
+++ b/src/app/components/api/constants.ts
@@ -1,0 +1,1 @@
+export type ButtonSeverity = 'success' | 'info' | 'warn' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null | undefined

--- a/src/app/components/api/public_api.ts
+++ b/src/app/components/api/public_api.ts
@@ -31,3 +31,4 @@ export * from './lazyloadmeta';
 export * from './tooltipoptions';
 export * from './scrolleroptions';
 export * from './treetablenode';
+export * from './constants'

--- a/src/app/components/button/button.interface.ts
+++ b/src/app/components/button/button.interface.ts
@@ -29,5 +29,3 @@ export interface ButtonTemplates {
         class: NgClass;
     }): TemplateRef<NgClass>;
 }
-
-export type ButtonSeverity = 'success' | 'info' | 'warning' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null | undefined

--- a/src/app/components/button/button.interface.ts
+++ b/src/app/components/button/button.interface.ts
@@ -29,3 +29,5 @@ export interface ButtonTemplates {
         class: NgClass;
     }): TemplateRef<NgClass>;
 }
+
+export type ButtonSeverity = 'success' | 'info' | 'warning' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null | undefined

--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -19,13 +19,12 @@ import {
     booleanAttribute,
     numberAttribute
 } from '@angular/core';
-import { PrimeTemplate, SharedModule } from 'primeng/api';
+import { PrimeTemplate, SharedModule, ButtonSeverity } from 'primeng/api';
 import { AutoFocus } from 'primeng/autofocus';
 import { DomHandler } from 'primeng/dom';
 import { SpinnerIcon } from 'primeng/icons/spinner';
 import { Ripple } from 'primeng/ripple';
 import { ObjectUtils } from 'primeng/utils';
-import {ButtonSeverity} from "./button.interface";
 
 type ButtonIconPosition = 'left' | 'right' | 'top' | 'bottom';
 

--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -25,6 +25,7 @@ import { DomHandler } from 'primeng/dom';
 import { SpinnerIcon } from 'primeng/icons/spinner';
 import { Ripple } from 'primeng/ripple';
 import { ObjectUtils } from 'primeng/utils';
+import {ButtonSeverity} from "./button.interface";
 
 type ButtonIconPosition = 'left' | 'right' | 'top' | 'bottom';
 
@@ -109,7 +110,22 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
      * Defines the style of the button.
      * @group Props
      */
-    @Input() severity: 'success' | 'info' | 'warning' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null | undefined;
+    @Input() get severity(): ButtonSeverity{
+        return this._severity
+    }
+
+    set severity(val: ButtonSeverity){
+        // Remove existing severity styleclass first
+        if(this.initialized){
+            this.htmlElement.classList.remove(this.getSeverityStyleClass());
+        }
+        // Set new severity
+        this._severity = val;
+        // Adds new severity styleclass again
+        if(this.initialized){
+            this.setStyleClass();
+        }
+    }
     /**
      * Add a shadow to indicate elevation.
      * @group Props
@@ -143,6 +159,8 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
 
     public _label: string | undefined;
 
+    public _severity: ButtonSeverity;
+
     public _icon: string | undefined;
 
     public _loading: boolean = false;
@@ -164,6 +182,13 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
         this.createLabel();
 
         this.initialized = true;
+    }
+
+    getSeverityStyleClass(): string{
+        if (this._severity) {
+            return `p-button-${this._severity}`;
+        }
+        return ''
     }
 
     getStyleClass(): string[] {
@@ -189,8 +214,8 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
             styleClass.push('p-button-text');
         }
 
-        if (this.severity) {
-            styleClass.push(`p-button-${this.severity}`);
+        if (this._severity) {
+            styleClass.push(this.getSeverityStyleClass());
         }
 
         if (this.plain) {
@@ -415,7 +440,7 @@ export class Button implements AfterContentInit {
      * Defines the style of the button.
      * @group Props
      */
-    @Input() severity: 'success' | 'info' | 'warning' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null | undefined;
+    @Input() severity: ButtonSeverity;
     /**
      * Add a border class without a background initially.
      * @group Props

--- a/src/app/components/splitbutton/splitbutton.ts
+++ b/src/app/components/splitbutton/splitbutton.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ContentChildren, ElementRef, EventEmitter, Input, NgModule, Output, QueryList, TemplateRef, ViewChild, ViewEncapsulation, booleanAttribute, numberAttribute, signal } from '@angular/core';
-import { MenuItem, PrimeTemplate } from 'primeng/api';
+import {ButtonSeverity, MenuItem, PrimeTemplate} from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { ChevronDownIcon } from 'primeng/icons/chevrondown';
 import { TieredMenu, TieredMenuModule } from 'primeng/tieredmenu';
@@ -115,7 +115,7 @@ export class SplitButton {
      * Defines the style of the button.
      * @group Props
      */
-    @Input() severity: 'success' | 'info' | 'warning' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null | undefined;
+    @Input() severity: ButtonSeverity;
     /**
      * Add a shadow to indicate elevation.
      * @group Props


### PR DESCRIPTION
Fixed primefaces#16074 - ButtonDirective changing severity does not update styles

The issue was that the severity still has been there for all severities added to the button in the past. Even if the severity changed it has p-button-primary and p-button-secondary for example. The fix removes the severity class before appending the new severity class again:

https://github.com/user-attachments/assets/65fc29c3-ba63-47f3-9e21-3074f51f5845

