### PR TITLE
closes #16209 Table: Cannot set autoSize from ScrollerOptions

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -200,13 +200,13 @@ export class TableService {
                     [step]="rows"
                     [delay]="lazy ? virtualScrollDelay : 0"
                     [inline]="true"
+                    [autoSize]="true"
                     [lazy]="lazy"
                     (onLazyLoad)="onLazyItemLoad($event)"
                     [loaderDisabled]="true"
                     [showSpacer]="false"
                     [showLoader]="loadingBodyTemplate"
                     [options]="virtualScrollOptions"
-                    [autoSize]="true"
                 >
                     <ng-template pTemplate="content" let-items let-scrollerOptions="options">
                         <ng-container *ngTemplateOutlet="buildInTable; context: { $implicit: items, options: scrollerOptions }"></ng-container>


### PR DESCRIPTION
closes #16209 Table: Cannot set autoSize from ScrollerOptions,
I have checked that options is the latest p-scroller parameter in all other components, they are all correct except for the table component.
I moved the autoSize before lazy to keep in sync with other components but moving it anywhere before options will fix this issue.
By and large, in all components [options]="virtualScrollOptions" should be latest binding since angular write them by order from top.
![image](https://github.com/user-attachments/assets/847cf5d3-f386-4249-be6b-522865736084)