### PR TITLE
Fix #16248 - Removed aria-hidden attribute from MegaMenu

### DIFF
--- a/src/app/components/megamenu/megamenu.ts
+++ b/src/app/components/megamenu/megamenu.ts
@@ -89,7 +89,6 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                             <a
                                 *ngIf="!getItemProp(processedItem, 'routerLink')"
                                 [attr.href]="getItemProp(processedItem, 'url')"
-                                [attr.aria-hidden]="true"
                                 [attr.data-automationid]="getItemProp(processedItem, 'automationId')"
                                 [attr.data-pc-section]="'action'"
                                 [target]="getItemProp(processedItem, 'target')"
@@ -103,7 +102,6 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                                     [ngClass]="getItemProp(processedItem, 'icon')"
                                     [ngStyle]="getItemProp(processedItem, 'iconStyle')"
                                     [attr.data-pc-section]="'icon'"
-                                    [attr.aria-hidden]="true"
                                     [attr.tabindex]="-1"
                                 >
                                 </span>


### PR DESCRIPTION
This PR fixes issue #16248.

This Issue #16248 was similar to closed Issue #16241.  As a result I used merged PR #16241 as a reference.

The video below shows the fix working:


https://github.com/user-attachments/assets/3ed703af-d9a2-4f4c-8539-14d0e5e3d685


