### PR TITLE
Fix #16246 TreeTable Spacer Size Calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
                 "@types/jest": "^29.5.1",
                 "@types/node": "^16.18.67",
                 "@types/react": "^18.2.41",
+                "@types/resize-observer-browser": "^0.1.11",
                 "@typescript-eslint/eslint-plugin": "^7.11.0",
                 "chart.js": "4.4.2",
                 "codelyzer": "^0.0.28",
@@ -7043,6 +7044,12 @@
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
+        },
+        "node_modules/@types/resize-observer-browser": {
+            "version": "0.1.11",
+            "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.11.tgz",
+            "integrity": "sha512-cNw5iH8JkMkb3QkCoe7DaZiawbDQEUX8t7iuQaRTyLOyQCR2h+ibBD4GJt7p5yhUHrlOeL7ZtbxNHeipqNsBzQ==",
+            "dev": true
         },
         "node_modules/@types/resolve": {
             "version": "1.20.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "@types/jest": "^29.5.1",
         "@types/node": "^16.18.67",
         "@types/react": "^18.2.41",
+        "@types/resize-observer-browser": "^0.1.11",
         "@typescript-eslint/eslint-plugin": "^7.11.0",
         "chart.js": "4.4.2",
         "codelyzer": "^0.0.28",

--- a/src/app/components/tsconfig.lib.json
+++ b/src/app/components/tsconfig.lib.json
@@ -15,7 +15,7 @@
             "dom"
         ],
         "skipLibCheck": true,
-        "types": [],
+        "types": ["resize-observer-browser"],
         "paths": {
             "primeng/*": ["src/app/components/*/public_api"]
         }


### PR DESCRIPTION
### Defect Fixes
Fixes #16246

Commit e7b611 introduced a regression in the size calculation for `TreeTable` component with a `"flex"` height configuration. The issue arises because the spacer size is no longer being updated correctly. As a result, the scrollbar resizes itself during scrolling, which causes jumping of the scrollbar.

I have replaced the window-size listener with a `ResizeObserver`, because the number of visible items in a `TreeTable` with virtual scrolling must get recalculated if the view size changes. The new observer should handle window size changes, important to the `TreeTable`, equally well.