### PR TITLE
Wrong Api Description on Primeng Doc

### DIFF
--- a/src/app/showcase/doc/apidoc/index.json
+++ b/src/app/showcase/doc/apidoc/index.json
@@ -11830,7 +11830,7 @@
                                     "type": "RemoveUploadedFileEvent"
                                 }
                             ],
-                            "description": "This event is triggered if an error occurs while loading an image file."
+                            "description": "This event is triggered if an error occurs while removing an uploaded file."
                         }
                     ]
                 },


### PR DESCRIPTION
Error On https://primeng.org/fileupload#template:

Wrong Api Description for FileUpload->onRemoveUploadedFile Event.
Probably accidentally copied the description of onImageError.

