### PR TITLE
Fix #15192: Row grouping breaks after first page

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -3084,7 +3084,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
     template: `
         <ng-container *ngIf="!dt.expandedRowTemplate">
             <ng-template ngFor let-rowData let-rowIndex="index" [ngForOf]="value" [ngForTrackBy]="dt.rowTrackBy">
-                <ng-container *ngIf="dt.groupHeaderTemplate && !dt.virtualScroll && dt.rowGroupMode === 'subheader' && shouldRenderRowGroupHeader(value, rowData, rowIndex)" role="row">
+                <ng-container *ngIf="dt.groupHeaderTemplate && !dt.virtualScroll && dt.rowGroupMode === 'subheader' && shouldRenderRowGroupHeader(value, rowData, getRowIndex(rowIndex))" role="row">
                     <ng-container
                         *ngTemplateOutlet="dt.groupHeaderTemplate; context: { $implicit: rowData, rowIndex: getRowIndex(rowIndex), columns: columns, editing: dt.editMode === 'row' && dt.isRowEditing(rowData), frozen: frozen }"
                     ></ng-container>


### PR DESCRIPTION
Fixes #15192

### What was the problem
`shouldRenderRowGroupHeader` expects the `rowIndex` to be the absolute index (i.e. `first + rowIndex`)  when paginated.
The problem was that the `rowIndex` passed starts from `0` for every page, and the index calculation in the method then resulted in a negative number.

### How was the problem solved
For expanded rows,  the method `getRowIndex` is used, which adds the starting offset (`first`) to the `rowIndex`.
This method is used here now as well.