### PR TITLE
Fix #16308: Flawed example in table paginator documentation

### DIFF
--- a/src/app/showcase/doc/table/paginatorprogrammaticdoc.ts
+++ b/src/app/showcase/doc/table/paginatorprogrammaticdoc.ts
@@ -84,7 +84,7 @@ export class PaginatorProgrammaticDoc {
     }
 
     isLastPage(): boolean {
-        return this.customers ? this.first === this.customers.length - this.rows : true;
+        return this.customers ? this.first + this.rows >= this.customers.length : true;
     }
 
     isFirstPage(): boolean {


### PR DESCRIPTION
Fixes #16308 _- The example code for programmatically paginating trough tables, in the `isLastPage()` function, is flawed because it only works correctly when the amount of items in the table is an exact multiple of the rows per page count._

The new line correctly identifies the last page by checking if the index after the current page's last item reaches or exceeds the total length of the customers list.

The old line incorrectly identifies the last page, only working correctly when the amount of items in the table is an exact multiple of the rows per page count.
