### PR TITLE
Fixed #16282 Loading icon does not show on child items

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -153,6 +153,7 @@ import {
                         [index]="index"
                         [itemSize]="itemSize"
                         [level]="level + 1"
+                        [loadingMode]="loadingMode"
                     ></p-treeNode>
                 </ul>
             </li>


### PR DESCRIPTION
Fixes #16282 - When using loadingMode="icon", the spinning loading icon only appears on root items, not on child items.

The bug occurred due to not including loadingMode="icon" to the nested TreeNode component.

The new line forwards the loadingMode veriable to the nested TreeNode component.
