### PR TITLE
Fixed #16114 - Editor | hide primeng toolbar when insert quill modules.

### DIFF
--- a/src/app/components/editor/editor.ts
+++ b/src/app/components/editor/editor.ts
@@ -41,7 +41,7 @@ export const EDITOR_VALUE_ACCESSOR: any = {
                 <ng-content select="p-header"></ng-content>
                 <ng-container *ngTemplateOutlet="headerTemplate"></ng-container>
             </div>
-            <div class="p-editor-toolbar" *ngIf="!toolbar && !headerTemplate">
+            <div class="p-editor-toolbar" *ngIf="!modules && !toolbar && !headerTemplate">
                 <span class="ql-formats">
                     <select class="ql-header">
                         <option value="1">Heading</option>
@@ -194,7 +194,10 @@ export class Editor implements AfterContentInit, ControlValueAccessor {
 
     private quillElements!: { editorElement: HTMLElement; toolbarElement: HTMLElement };
 
-    constructor(public el: ElementRef, @Inject(PLATFORM_ID) private platformId: object) {
+    constructor(
+        public el: ElementRef,
+        @Inject(PLATFORM_ID) private platformId: object
+    ) {
         /**
          * Read or write the DOM once, when initializing non-Angular (Quill) library.
          */


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/16114