### PR TITLE
Fix (Select v18): overlap between outline and border with invalid state

### DIFF
--- a/src/app/components/select/style/selectstyle.ts
+++ b/src/app/components/select/style/selectstyle.ts
@@ -197,8 +197,7 @@ input.p-select-label {
 
 .p-dropdown.ng-invalid.ng-dirty,
 .p-select.ng-invalid.ng-dirty {
-    outline: 1px solid ${dt('selectbutton.invalid.border.color')};
-    outline-offset: 0;
+    border-color: ${dt('selectbutton.invalid.border.color')};
 }
 
 `;


### PR DESCRIPTION
Fix Select component
Before
![image](https://github.com/user-attachments/assets/d3257e91-a242-454f-8b86-09cea75a1722)
After
![image](https://github.com/user-attachments/assets/a0e92691-00ca-408b-ab4d-8aca0b0cb8bc)
