### PR TITLE
fix(#16410): Autocomplete Clear Icon correctly shown when value set programmatically

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -94,7 +94,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                 (paste)="onInputPaste($event)"
                 (keyup)="onInputKeyUp($event)"
             />
-            <ng-container *ngIf="filled && !disabled && showClear && !loading">
+            <ng-container *ngIf="isVisibleClearIcon">
                 <TimesIcon *ngIf="!clearIconTemplate" [styleClass]="'p-autocomplete-clear-icon'" (click)="clear()" [attr.aria-hidden]="true" />
                 <span *ngIf="clearIconTemplate" class="p-autocomplete-clear-icon" (click)="clear()" [attr.aria-hidden]="true">
                     <ng-template *ngTemplateOutlet="clearIconTemplate"></ng-template>
@@ -878,6 +878,10 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
     get optionValueSelected() {
         return typeof this.modelValue() === 'string' && this.optionValue;
+    }
+
+    get isVisibleClearIcon(): boolean | undefined {
+        return this.modelValue() != null && this.hasSelectedOption() && this.showClear && !this.disabled && !this.loading;
     }
 
     constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone) {

--- a/src/app/showcase/doc/autocomplete/autocompletedoc.module.ts
+++ b/src/app/showcase/doc/autocomplete/autocompletedoc.module.ts
@@ -22,10 +22,11 @@ import { DisabledDoc } from './disableddoc';
 import { InvalidDoc } from './invaliddoc';
 import { FilledDoc } from './filleddoc';
 import { FloatLabelModule } from 'primeng/floatlabel';
+import { ShowClearDoc } from '@doc/autocomplete/showclear-doc.component';
 
 @NgModule({
     imports: [CommonModule, RouterModule, AppCodeModule, FormsModule, AppDocModule, AutoCompleteModule, ReactiveFormsModule, RouterModule, FloatLabelModule],
     exports: [AppDocModule],
-    declarations: [ImportDoc, BasicDoc, TemplateDoc, GroupDoc, VirtualScrollDoc, MultipleDoc, StyleDoc, AccessibilityDoc, DropdownDoc, ForceSelectionDoc, ObjectsDoc, ReactiveFormsDoc, FloatLabelDoc, DisabledDoc, InvalidDoc, FilledDoc]
+    declarations: [ImportDoc, BasicDoc, TemplateDoc, GroupDoc, VirtualScrollDoc, MultipleDoc, StyleDoc, AccessibilityDoc, DropdownDoc, ForceSelectionDoc, ObjectsDoc, ReactiveFormsDoc, FloatLabelDoc, DisabledDoc, InvalidDoc, FilledDoc, ShowClearDoc]
 })
 export class AutoCompleteDocModule {}

--- a/src/app/showcase/doc/autocomplete/dropdowndoc.ts
+++ b/src/app/showcase/doc/autocomplete/dropdowndoc.ts
@@ -17,7 +17,7 @@ interface AutoCompleteCompleteEvent {
             </p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">
-            <p-autoComplete [(ngModel)]="selectedCountry" [dropdown]="true" placeholder="Search" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" />
+            <p-autoComplete [(ngModel)]="selectedCountry" [dropdown]="true" placeholder="Search" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" optionLabel="name" />
         </div>
         <app-code [code]="code" selector="autocomplete-dropdown-demo"></app-code>`
 })
@@ -53,20 +53,20 @@ export class DropdownDoc implements OnInit {
     }
 
     code: Code = {
-        basic: `<p-autoComplete 
-    [(ngModel)]="selectedCountry" 
-    [dropdown]="true" 
-    [suggestions]="filteredCountries" 
-    (completeMethod)="filterCountry($event)" 
-    field="name" />`,
+        basic: `<p-autoComplete
+    [(ngModel)]="selectedCountry"
+    [dropdown]="true"
+    [suggestions]="filteredCountries"
+    (completeMethod)="filterCountry($event)"
+    optionLabel="name" />`,
 
         html: `<div class="card flex justify-content-center">
-    <p-autoComplete 
-        [(ngModel)]="selectedCountry" 
-        [dropdown]="true" 
-        [suggestions]="filteredCountries" 
-        (completeMethod)="filterCountry($event)" 
-        field="name" />
+    <p-autoComplete
+        [(ngModel)]="selectedCountry"
+        [dropdown]="true"
+        [suggestions]="filteredCountries"
+        (completeMethod)="filterCountry($event)"
+        optionLabel="name" />
 </div>`,
 
         typescript: `import { Component, OnInit } from '@angular/core';

--- a/src/app/showcase/doc/autocomplete/forceselectiondoc.ts
+++ b/src/app/showcase/doc/autocomplete/forceselectiondoc.ts
@@ -13,7 +13,7 @@ interface AutoCompleteCompleteEvent {
             <p>ForceSelection mode validates the manual input to check whether it also exists in the suggestions list, if not the input value is cleared to make sure the value passed to the model is always one of the suggestions.</p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">
-            <p-autoComplete [(ngModel)]="selectedCountry" [forceSelection]="true" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" />
+            <p-autoComplete [(ngModel)]="selectedCountry" [forceSelection]="true" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" optionLabel="name" />
         </div>
         <app-code [code]="code" selector="autocomplete-force-selection-demo"></app-code>`
 })
@@ -51,20 +51,20 @@ export class ForceSelectionDoc implements OnInit {
     }
 
     code: Code = {
-        basic: `<p-autoComplete 
-    [(ngModel)]="selectedCountry" 
-    [forceSelection]="true" 
-    [suggestions]="filteredCountries" 
+        basic: `<p-autoComplete
+    [(ngModel)]="selectedCountry"
+    [forceSelection]="true"
+    [suggestions]="filteredCountries"
     (completeMethod)="filterCountry($event)"
-    field="name" />`,
+    optionLabel="name" />`,
 
         html: `<div class="card flex justify-content-center">
-    <p-autoComplete 
-        [(ngModel)]="selectedCountry" 
-        [forceSelection]="true" 
-        [suggestions]="filteredCountries" 
-        (completeMethod)="filterCountry($event)" 
-        field="name" />
+    <p-autoComplete
+        [(ngModel)]="selectedCountry"
+        [forceSelection]="true"
+        [suggestions]="filteredCountries"
+        (completeMethod)="filterCountry($event)"
+        optionLabel="name" />
 </div>`,
 
         typescript: `import { Component, OnInit } from '@angular/core';

--- a/src/app/showcase/doc/autocomplete/objectsdoc.ts
+++ b/src/app/showcase/doc/autocomplete/objectsdoc.ts
@@ -11,12 +11,12 @@ interface AutoCompleteCompleteEvent {
     selector: 'autocomplete-objects-demo',
     template: ` <app-docsectiontext>
             <p>
-                AutoComplete can also work with objects using the <i>field</i> property that defines the label to display as a suggestion. The value passed to the model would still be the object instance of a suggestion. Here is an example with a
+                AutoComplete can also work with objects using the <i>optionLabel</i> property that defines the label to display as a suggestion. The value passed to the model would still be the object instance of a suggestion. Here is an example with a
                 Country object that has name and code fields such as <i>&#123;name: "United States", code:"USA"&#125;</i>.
             </p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">
-            <p-autoComplete [(ngModel)]="selectedCountry" placeholder="Search" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" />
+            <p-autoComplete [(ngModel)]="selectedCountry" placeholder="Search" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" optionLabel="name" />
         </div>
         <app-code [code]="code" selector="autocomplete-objects-demo"></app-code>`
 })
@@ -50,18 +50,18 @@ export class ObjectsDoc implements OnInit {
     }
 
     code: Code = {
-        basic: `<p-autoComplete 
-    [(ngModel)]="selectedCountry" 
-    [suggestions]="filteredCountries" 
-    (completeMethod)="filterCountry($event)" 
-    field="name" />`,
+        basic: `<p-autoComplete
+    [(ngModel)]="selectedCountry"
+    [suggestions]="filteredCountries"
+    (completeMethod)="filterCountry($event)"
+    optionLabel="name" />`,
 
         html: `<div class="card flex justify-content-center">
-    <p-autoComplete 
-        [(ngModel)]="selectedCountry" 
-        [suggestions]="filteredCountries" 
-        (completeMethod)="filterCountry($event)" 
-        field="name" />
+    <p-autoComplete
+        [(ngModel)]="selectedCountry"
+        [suggestions]="filteredCountries"
+        (completeMethod)="filterCountry($event)"
+        optionLabel="name" />
 </div>`,
 
         typescript: `import { Component, OnInit } from '@angular/core';

--- a/src/app/showcase/doc/autocomplete/reactiveformsdoc.ts
+++ b/src/app/showcase/doc/autocomplete/reactiveformsdoc.ts
@@ -15,7 +15,7 @@ interface AutoCompleteCompleteEvent {
         </app-docsectiontext>
         <div class="card flex justify-content-center">
             <form [formGroup]="formGroup">
-                <p-autoComplete formControlName="selectedCountry" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" placeholder="Search" />
+                <p-autoComplete formControlName="selectedCountry" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" optionLabel="name" placeholder="Search" />
             </form>
         </div>
         <app-code [code]="code" selector="autocomplete-reactive-forms-demo"></app-code>`
@@ -55,20 +55,20 @@ export class ReactiveFormsDoc implements OnInit {
 
     code: Code = {
         basic: `<form [formGroup]="formGroup">
-    <p-autoComplete 
+    <p-autoComplete
         formControlName="selectedCountry"
-        [suggestions]="filteredCountries" 
-        (completeMethod)="filterCountry($event)" 
-        field="name" />
+        [suggestions]="filteredCountries"
+        (completeMethod)="filterCountry($event)"
+        optionLabel="name" />
 </form>`,
 
         html: `<div class="card flex justify-content-center">
     <form [formGroup]="formGroup">
-        <p-autoComplete 
+        <p-autoComplete
             formControlName="selectedCountry"
-            [suggestions]="filteredCountries" 
-            (completeMethod)="filterCountry($event)" 
-            field="name" />
+            [suggestions]="filteredCountries"
+            (completeMethod)="filterCountry($event)"
+            optionLabel="name" />
     </form>
 </div>`,
 

--- a/src/app/showcase/doc/autocomplete/showclear-doc.component.ts
+++ b/src/app/showcase/doc/autocomplete/showclear-doc.component.ts
@@ -1,0 +1,135 @@
+import { Component, OnInit } from '@angular/core';
+import { Code } from '@domain/code';
+import { CountryService } from '@service/countryservice';
+import { PlatformService } from '@service/platformservice';
+import { FormBuilder, FormGroup } from '@angular/forms';
+
+interface AutoCompleteCompleteEvent {
+    originalEvent: Event;
+    query: string;
+}
+
+@Component({
+    selector: 'dropdown-clear-icon-demo',
+    template: `
+        <app-docsectiontext>
+            <p>When <i>showClear</i> is enabled, a clear icon is added to reset the Autocomplete.</p>
+        </app-docsectiontext>
+        <div class="card flex justify-content-center" [formGroup]="countryFormGroup">
+            <p-autoComplete formControlName="country" [dropdown]="true" [showClear]="true" placeholder="Search" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" optionLabel="name" />
+        </div>
+        <app-code [code]="code" selector="dropdown-clear-icon-demo"></app-code>
+    `
+})
+export class ShowClearDoc implements OnInit {
+    countries: any[] | undefined;
+
+    countryFormGroup: FormGroup = this.formBuilder.group({
+        'country': [{ name: 'Switzerland', code: 'CH' }]
+    });
+
+    filteredCountries: any[] | undefined;
+
+    constructor(private countryService: CountryService, private PlatformService: PlatformService, private formBuilder: FormBuilder) {}
+
+    ngOnInit() {
+        if (this.PlatformService.isBrowser()) {
+            this.countryService.getCountries().then((countries) => {
+                this.countries = countries;
+            });
+        }
+    }
+
+    filterCountry(event: AutoCompleteCompleteEvent) {
+        let filtered: any[] = [];
+        let query = event.query;
+
+        for (let i = 0; i < (this.countries as any[]).length; i++) {
+            let country = (this.countries as any[])[i];
+            if (country.name.toLowerCase().indexOf(query.toLowerCase()) == 0) {
+                filtered.push(country);
+            }
+        }
+
+        this.filteredCountries = filtered;
+    }
+
+    code: Code = {
+        basic: `<p-autoComplete
+    formControlName="country"
+    [dropdown]="true"
+    [showClear]="true"
+    [suggestions]="filteredCountries"
+    (completeMethod)="filterCountry($event)"
+    optionLabel="name" />`,
+
+        html: `<div class="card flex justify-content-center" [formGroup]="countryFormGroup">
+    <p-autoComplete
+        formControlName="country"
+        [dropdown]="true"
+        [showClear]="true"
+        [suggestions]="filteredCountries"
+        (completeMethod)="filterCountry($event)"
+        optionLabel="name" />
+</div>`,
+
+        typescript: `import { Component, OnInit } from '@angular/core';
+import { CountryService } from '@service/countryservice';
+import { FormsModule } from '@angular/forms';
+import { AutoCompleteModule } from 'primeng/autocomplete';
+import { FormBuilder, FormGroup } from '@angular/forms';
+
+interface AutoCompleteCompleteEvent {
+    originalEvent: Event;
+    query: string;
+}
+
+@Component({
+    selector: 'autocomplete-dropdown-demo',
+    templateUrl: './autocomplete-dropdown-demo.html',
+    standalone:true,
+    imports: [FormsModule, AutoCompleteModule],
+    providers:[CountryService]
+})
+export class AutocompleteShowClearDemo implements OnInit {
+    countries: any[] | undefined;
+
+    countryFormGroup: FormGroup = this.formBuilder.group({
+        'country': [{ name: 'Switzerland', code: 'CH' }]
+    });
+
+    filteredCountries: any[] | undefined;
+
+    constructor(private countryService: CountryService, private formBuilder: FormBuilder) {}
+
+    ngOnInit() {
+        this.countryService.getCountries().then((countries) => {
+            this.countries = countries;
+        });
+    }
+
+    filterCountry(event: AutoCompleteCompleteEvent) {
+        let filtered: any[] = [];
+        let query = event.query;
+
+        for (let i = 0; i < (this.countries as any[]).length; i++) {
+            let country = (this.countries as any[])[i];
+            if (country.name.toLowerCase().indexOf(query.toLowerCase()) == 0) {
+                filtered.push(country);
+            }
+        }
+
+        this.filteredCountries = filtered;
+    }
+}`,
+        service: ['CountryService'],
+
+        data: `
+//CountryService
+{
+    "name": "Afghanistan",
+    "code": "AF"
+}
+...`
+    };
+}

--- a/src/app/showcase/doc/autocomplete/templatedoc.ts
+++ b/src/app/showcase/doc/autocomplete/templatedoc.ts
@@ -13,7 +13,7 @@ interface AutoCompleteCompleteEvent {
             <p><i>item</i> template allows displaying custom content inside the suggestions panel. The local ng-template variable passed to the ng-template is an object in the suggestions array.</p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">
-            <p-autoComplete [(ngModel)]="selectedCountryAdvanced" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" field="name" placeholder="Search">
+            <p-autoComplete [(ngModel)]="selectedCountryAdvanced" [suggestions]="filteredCountries" (completeMethod)="filterCountry($event)" optionLabel="name" placeholder="Search">
                 <ng-template let-country pTemplate="item">
                     <div class="flex align-items-center gap-2">
                         <img src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" [class]="'flag flag-' + country.code.toLowerCase()" style="width: 18px" />
@@ -53,16 +53,16 @@ export class TemplateDoc {
     }
 
     code: Code = {
-        basic: `<p-autoComplete 
-    [(ngModel)]="selectedCountryAdvanced" 
-    [suggestions]="filteredCountries" 
-    (completeMethod)="filterCountry($event)" 
-    field="name">
+        basic: `<p-autoComplete
+    [(ngModel)]="selectedCountryAdvanced"
+    [suggestions]="filteredCountries"
+    (completeMethod)="filterCountry($event)"
+    optionLabel="name">
         <ng-template let-country pTemplate="item">
             <div class="flex align-items-center gap-2">
-                <img 
-                    src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" 
-                    [class]="'flag flag-' + country.code.toLowerCase()" 
+                <img
+                    src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png"
+                    [class]="'flag flag-' + country.code.toLowerCase()"
                     style="width: 18px" />
                 <div>{{ country.name }}</div>
             </div>
@@ -70,16 +70,16 @@ export class TemplateDoc {
 </p-autoComplete>`,
 
         html: `<div class="card flex justify-content-center">
-    <p-autoComplete 
-    [(ngModel)]="selectedCountryAdvanced" 
-    [suggestions]="filteredCountries" 
-    (completeMethod)="filterCountry($event)" 
-    field="name">
+    <p-autoComplete
+    [(ngModel)]="selectedCountryAdvanced"
+    [suggestions]="filteredCountries"
+    (completeMethod)="filterCountry($event)"
+    optionLabel="name">
         <ng-template let-country pTemplate="item">
             <div class="flex align-items-center gap-2">
-                <img 
-                    src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png" 
-                    [class]="'flag flag-' + country.code.toLowerCase()" 
+                <img
+                    src="https://primefaces.org/cdn/primeng/images/demo/flag/flag_placeholder.png"
+                    [class]="'flag flag-' + country.code.toLowerCase()"
                     style="width: 18px" />
                 <div>{{ country.name }}</div>
             </div>
@@ -110,7 +110,7 @@ export class AutocompleteTemplateDemo {
 
     selectedCountryAdvanced: any[] | undefined;
 
-    filteredCountries: any[] | undefined; 
+    filteredCountries: any[] | undefined;
 
     constructor(private countryService: CountryService) {}
 

--- a/src/app/showcase/doc/autocomplete/virtualscrolldoc.ts
+++ b/src/app/showcase/doc/autocomplete/virtualscrolldoc.ts
@@ -15,7 +15,7 @@ interface AutoCompleteCompleteEvent {
             </p>
         </app-docsectiontext>
         <div class="card flex justify-content-center">
-            <p-autoComplete [(ngModel)]="selectedItem" [virtualScroll]="true" [suggestions]="filteredItems" [virtualScrollItemSize]="34" (completeMethod)="filterItems($event)" field="label" [dropdown]="true" />
+            <p-autoComplete [(ngModel)]="selectedItem" [virtualScroll]="true" [suggestions]="filteredItems" [virtualScrollItemSize]="34" (completeMethod)="filterItems($event)" optionLabel="label" [dropdown]="true" />
         </div>
         <app-code [code]="code" selector="autocomplete-virtual-scroll-demo"></app-code>`
 })
@@ -49,23 +49,23 @@ export class VirtualScrollDoc {
     }
 
     code: Code = {
-        basic: `<p-autoComplete 
-    [(ngModel)]="selectedItem" 
-    [virtualScroll]="true" 
-    [suggestions]="filteredItems" 
-    [virtualScrollItemSize]="34" 
-    (completeMethod)="filterItems($event)" 
-    field="label" 
+        basic: `<p-autoComplete
+    [(ngModel)]="selectedItem"
+    [virtualScroll]="true"
+    [suggestions]="filteredItems"
+    [virtualScrollItemSize]="34"
+    (completeMethod)="filterItems($event)"
+    optionLabel="label"
     [dropdown]="true" />`,
 
         html: `<div class="card flex justify-content-center">
-    <p-autoComplete 
-        [(ngModel)]="selectedItem" 
-        [virtualScroll]="true" 
-        [suggestions]="filteredItems" 
-        [virtualScrollItemSize]="34" 
-        (completeMethod)="filterItems($event)" 
-        field="label" 
+    <p-autoComplete
+        [(ngModel)]="selectedItem"
+        [virtualScroll]="true"
+        [suggestions]="filteredItems"
+        [virtualScrollItemSize]="34"
+        (completeMethod)="filterItems($event)"
+        optionLabel="label"
         [dropdown]="true" />
 </div>`,
 

--- a/src/app/showcase/pages/autocomplete/index.ts
+++ b/src/app/showcase/pages/autocomplete/index.ts
@@ -16,6 +16,7 @@ import { DisabledDoc } from '@doc/autocomplete/disableddoc';
 import { InvalidDoc } from '@doc/autocomplete/invaliddoc';
 import { AutoCompleteDocModule } from '@doc/autocomplete/autocompletedoc.module';
 import { FilledDoc } from '@doc/autocomplete/filleddoc';
+import { ShowClearDoc } from '@doc/autocomplete/showclear-doc.component';
 
 @Component({
     template: `<app-doc docTitle="Angular AutoComplete Component" header="AutoComplete" description="AutoComplete is an input component that provides real-time suggestions when being typed." [docs]="docs" [apiDocs]="['AutoComplete']"></app-doc>`,
@@ -89,6 +90,11 @@ export class AutoCompleteDemo {
             id: 'disabled',
             label: 'Disabled',
             component: DisabledDoc
+        },
+        {
+            id: 'showclear',
+            label: 'Show Clear',
+            component: ShowClearDoc
         },
         {
             id: 'invalid',


### PR DESCRIPTION
Fixes #16410 and adds new Autocomplete ShowClear documentation