### PR TITLE
Enabled splitter to support zero width panels #16425

### DIFF
--- a/src/app/components/splitter/splitter.ts
+++ b/src/app/components/splitter/splitter.ts
@@ -117,7 +117,7 @@ export class Splitter {
 
             this.panels.map((panel, i) => {
                 let panelInitialSize = this.panelSizes.length - 1 >= i ? this.panelSizes[i] : null;
-                let panelSize = panelInitialSize || 100 / this.panels.length;
+                let panelSize = panelInitialSize ?? 100 / this.panels.length;
                 _panelSizes[i] = panelSize;
                 children[i].style.flexBasis = 'calc(' + panelSize + '% - ' + (this.panels.length - 1) * this.gutterSize + 'px)';
             });


### PR DESCRIPTION
Fixes #16425

zero width panels are incorrectly parsed as null, and therefore incorrectly set to the default size. Switching over to the null coalescing operator will accept 0 as a valid size, and default only if the size was null.
