### PR TITLE
feat (v18): Modernize Badge and expand test

### DIFF
--- a/src/app/components/badge/badge.spec.ts
+++ b/src/app/components/badge/badge.spec.ts
@@ -1,3 +1,4 @@
+import { Component, ComponentRef } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Badge, BadgeModule } from './badge';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -6,6 +7,7 @@ import { By } from '@angular/platform-browser';
 describe('Badge', () => {
     let badge: Badge;
     let fixture: ComponentFixture<Badge>;
+    let badgeRef: ComponentRef<Badge>;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -14,6 +16,7 @@ describe('Badge', () => {
 
         fixture = TestBed.createComponent(Badge);
         badge = fixture.componentInstance;
+        badgeRef = fixture.componentRef;
     });
 
     it('should display by default', () => {
@@ -21,5 +24,192 @@ describe('Badge', () => {
 
         const badgeEl = fixture.debugElement.query(By.css('.p-badge'));
         expect(badgeEl.nativeElement).toBeTruthy();
+    });
+
+    it('should render the badge with a value', () => {
+        badgeRef.setInput('value', '5');
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.textContent).toBe('5');
+    });
+
+    it('should apply p-badge-no-gutter class for single character values', () => {
+        badgeRef.setInput('value', 'A');
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.classList).toContain('p-badge-no-gutter');
+    });
+
+    it('should not apply p-badge-no-gutter class for multiple character values', () => {
+        badgeRef.setInput('value', 'AB');
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.classList).not.toContain('p-badge-no-gutter');
+    });
+
+    it('should apply the large size class', () => {
+        badgeRef.setInput('badgeSize', 'large');
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.classList).toContain('p-badge-lg');
+    });
+
+    it('should apply the xlarge size class', () => {
+        badgeRef.setInput('badgeSize', 'xlarge');
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.classList).toContain('p-badge-xl');
+    });
+
+    it('should apply the correct severity class', () => {
+        badgeRef.setInput('severity', 'danger');
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.classList).toContain('p-badge-danger');
+    });
+
+    it('should not render when badge is disabled', () => {
+        badgeRef.setInput('badgeDisabled', true);
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement).toBeNull();
+    });
+
+    it('should apply inline styles', () => {
+        badgeRef.setInput('style', { color: 'red' });
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.style.color).toBe('red');
+    });
+
+    it('should apply the custom class', () => {
+        badgeRef.setInput('styleClass', 'custom-class');
+        fixture.detectChanges();
+
+        const spanElement = fixture.nativeElement.querySelector('span');
+        expect(spanElement.classList).toContain('custom-class');
+    });
+});
+
+@Component({
+    template: `<div
+        pBadge
+        [value]="value"
+        [badgeDisabled]="disabled"
+        [badgeSize]="badgeSize"
+        [severity]="severity"
+    ></div> `,
+    imports: [BadgeModule],
+    standalone: true,
+})
+export class TestHostComponent {
+    value: string | number | null = '5';
+    disabled = false;
+    badgeSize: 'large' | 'xlarge' | undefined;
+    severity: 'success' | 'info' | 'warning' | 'danger' | null | undefined;
+}
+
+describe('BadgeDirective', () => {
+    let fixture: ComponentFixture<TestHostComponent>;
+    let component: TestHostComponent;
+
+    beforeEach(async () => {
+        await TestBed.configureTestingModule({ imports: [TestHostComponent] }).compileComponents();
+
+        fixture = TestBed.createComponent(TestHostComponent);
+        component = fixture.componentInstance;
+    });
+
+    it('should render badge with value', () => {
+        component.value = '10';
+        fixture.detectChanges();
+
+        const badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.textContent).toBe('10');
+    });
+
+    it('should not render the badge when disabled is true', () => {
+        component.disabled = true;
+        fixture.detectChanges();
+
+        const badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement).toBeNull();
+    });
+
+    it('should update the badge value when value changes', () => {
+        component.value = '5';
+        fixture.detectChanges();
+
+        let badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.textContent).toBe('5');
+
+        component.value = '10';
+        fixture.detectChanges();
+
+        badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.textContent).toBe('10');
+    });
+
+    it('should apply the correct severity class', () => {
+        component.severity = 'danger';
+        fixture.detectChanges();
+
+        const badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.classList).toContain('p-badge-danger');
+    });
+
+    it('should apply large size class', () => {
+        component.badgeSize = 'large';
+        fixture.detectChanges();
+
+        const badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.classList).toContain('p-badge-lg');
+    });
+
+    it('should apply xlarge size class', () => {
+        component.badgeSize = 'xlarge';
+        fixture.detectChanges();
+
+        const badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.classList).toContain('p-badge-xl');
+    });
+
+    it('should apply dot class when value is undefined', () => {
+        component.value = null;
+        fixture.detectChanges();
+
+        const badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.classList).toContain('p-badge-dot');
+    });
+
+    it('should apply no gutter class for single character value', () => {
+        component.value = 'A';
+        fixture.detectChanges();
+
+        const badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement.classList).toContain('p-badge-no-gutter');
+    });
+
+    it('should remove the badge when disabled is set to true', () => {
+        component.value = '5';
+        component.disabled = false;
+        fixture.detectChanges();
+
+        let badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement).not.toBeNull();
+
+        component.disabled = true;
+        fixture.detectChanges();
+
+        badgeElement = fixture.nativeElement.querySelector('span.p-badge');
+        expect(badgeElement).toBeNull();
     });
 });

--- a/src/app/components/badge/badge.ts
+++ b/src/app/components/badge/badge.ts
@@ -14,6 +14,8 @@ import {
     ViewEncapsulation,
     booleanAttribute,
     inject,
+    input,
+    computed,
 } from '@angular/core';
 import { SharedModule } from 'primeng/api';
 import { DomHandler } from 'primeng/dom';

--- a/src/app/components/badge/badge.ts
+++ b/src/app/components/badge/badge.ts
@@ -1,14 +1,11 @@
-import { CommonModule, DOCUMENT } from '@angular/common';
+import { NgClass, NgStyle } from '@angular/common';
 import {
     AfterViewInit,
     ChangeDetectionStrategy,
     Component,
     Directive,
-    ElementRef,
-    Inject,
     Input,
     NgModule,
-    Renderer2,
     OnChanges,
     SimpleChanges,
     ViewEncapsulation,
@@ -289,7 +286,7 @@ export class Badge extends BaseComponent {
 }
 
 @NgModule({
-    imports: [CommonModule],
+    imports: [NgClass, NgStyle],
     exports: [Badge, BadgeDirective, SharedModule],
     declarations: [Badge, BadgeDirective],
 })

--- a/src/app/components/badge/badge.ts
+++ b/src/app/components/badge/badge.ts
@@ -226,7 +226,11 @@ export class BadgeDirective extends BaseComponent implements OnChanges, AfterVie
  */
 @Component({
     selector: 'p-badge',
-    template: ` <span *ngIf="!badgeDisabled" [ngClass]="containerClass()" [class]="styleClass" [ngStyle]="style">{{ value }}</span> `,
+    template: `
+        @if (!badgeDisabled()) {
+            <span [ngClass]="containerClass()" [class]="styleClass()" [ngStyle]="style()">{{ value() }}</span>
+        }
+    `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     providers: [BadgeStyle],
@@ -236,59 +240,50 @@ export class Badge extends BaseComponent {
      * Class of the element.
      * @group Props
      */
-    @Input() styleClass: string | undefined;
+    styleClass = input<string>();
     /**
      * Inline style of the element.
      * @group Props
      */
-    @Input() style: { [klass: string]: any } | null | undefined;
+    style = input<{ [klass: string]: any } | null>();
     /**
      * Size of the badge, valid options are "large" and "xlarge".
      * @group Props
      */
-    @Input() badgeSize: 'small' | 'large' | 'xlarge' | null | undefined;
+    badgeSize = input<'small' | 'large' | 'xlarge' | null>();
     /**
      * Severity type of the badge.
      * @group Props
      */
-    @Input() severity: 'success' | 'info' | 'warn' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null | undefined;
+    severity = input<'success' | 'info' | 'warn' | 'danger' | 'help' | 'primary' | 'secondary' | 'contrast' | null>();
     /**
      * Value to display inside the badge.
      * @group Props
      */
-    @Input() value: string | number | null | undefined;
+    value = input<string | number | null>();
     /**
      * When specified, disables the component.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) badgeDisabled: boolean = false;
-    /**
-     * Size of the badge, valid options are "large" and "xlarge".
-     * @group Props
-     * @deprecated use badgeSize instead.
-     */
-    @Input() public set size(value: 'large' | 'xlarge' | 'small' | undefined | null) {
-        this._size = value;
-        !this.badgeSize && this.size && console.log('size property is deprecated and will removed in v18, use badgeSize instead.');
-    }
-    get size() {
-        return this._size;
-    }
-    _size: 'large' | 'xlarge' | 'small' | undefined | null;
+    badgeDisabled = input<boolean, boolean>(false, { transform: booleanAttribute });
 
     _componentStyle = inject(BadgeStyle);
 
-    containerClass() {
+    /**
+     * Computes the container class for the badge element based on its properties.
+     * @returns An object representing the CSS classes to be applied to the badge container.
+     */
+    containerClass = computed<{ [klass: string]: any }>(() => {
         return {
             'p-badge p-component': true,
-            'p-badge-circle': ObjectUtils.isNotEmpty(this.value) && String(this.value).length === 1,
-            'p-badge-lg': this.badgeSize === 'large' || this.size === 'large',
-            'p-badge-xl': this.badgeSize === 'xlarge' || this.size === 'xlarge',
-            'p-badge-sm': this.badgeSize === 'small' || this.size === 'small',
-            'p-badge-dot': ObjectUtils.isEmpty(this.value),
-            [`p-badge-${this.severity}`]: this.severity,
+            'p-badge-circle': ObjectUtils.isNotEmpty(this.value()) && String(this.value()).length === 1,
+            'p-badge-lg': this.badgeSize() === 'large',
+            'p-badge-xl': this.badgeSize() === 'xlarge',
+            'p-badge-sm': this.badgeSize() === 'small',
+            'p-badge-dot': ObjectUtils.isEmpty(this.value()),
+            [`p-badge-${this.severity()}`]: this.severity(),
         };
-    }
+    });
 }
 
 @NgModule({


### PR DESCRIPTION
Refactored Badge component to use Angular's new signal-based inputs for better reactivity.

Added comprehensive test cases for both the Badge component and BadgeDirective, covering dynamic input handling, styles, sizes, severity, and disabled states.

remove deprecated feature in v18