### PR TITLE
fix: move all columns with CTRL+A in picklist

### DIFF
--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -1130,11 +1130,14 @@ export class PickList implements AfterViewChecked, AfterContentInit {
 
     moveRight() {
         if (this.selectedItemsSource && this.selectedItemsSource.length) {
-            for (let i = 0; i < this.selectedItemsSource.length; i++) {
-                let selectedItem = this.selectedItemsSource[i];
+            const selectedItemsCopy = [...this.selectedItemsSource];
+            for (let i = 0; i < selectedItemsCopy.length; i++) {
+                let selectedItem = selectedItemsCopy[i];
                 if (ObjectUtils.findIndexInList(selectedItem, this.target) == -1) {
-                    this.target?.push(this.source?.splice(ObjectUtils.findIndexInList(selectedItem, this.source), 1)[0]);
-
+                    let indexInSource = ObjectUtils.findIndexInList(selectedItem, this.source);
+                    if (indexInSource !== -1) {
+                        this.target?.push(this.source?.splice(indexInSource, 1)[0]);
+                    }
                     if (this.visibleOptionsSource?.includes(selectedItem)) {
                         this.visibleOptionsSource.splice(ObjectUtils.findIndexInList(selectedItem, this.visibleOptionsSource), 1);
                     }
@@ -1190,11 +1193,14 @@ export class PickList implements AfterViewChecked, AfterContentInit {
 
     moveLeft() {
         if (this.selectedItemsTarget && this.selectedItemsTarget.length) {
-            for (let i = 0; i < this.selectedItemsTarget.length; i++) {
-                let selectedItem = this.selectedItemsTarget[i];
+            const selectedItemsCopy = [...this.selectedItemsTarget];
+            for (let i = 0; i < selectedItemsCopy.length; i++) {
+                let selectedItem = selectedItemsCopy[i];
                 if (ObjectUtils.findIndexInList(selectedItem, this.source) == -1) {
-                    this.source?.push(this.target?.splice(ObjectUtils.findIndexInList(selectedItem, this.target), 1)[0]);
-
+                    let indexInTarget = ObjectUtils.findIndexInList(selectedItem, this.target);
+                    if (indexInTarget !== -1) {
+                        this.source?.push(this.target?.splice(indexInTarget, 1)[0]);
+                    }
                     if (this.visibleOptionsTarget?.includes(selectedItem)) {
                         this.visibleOptionsTarget.splice(ObjectUtils.findIndexInList(selectedItem, this.visibleOptionsTarget), 1)[0];
                     }


### PR DESCRIPTION
Fixes #16260 