### PR TITLE
Tooltip: Add support for mobile touch event

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -160,6 +160,10 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     blurListener: Nullable<Function>;
 
+    touchStartListener: Nullable<Function>;
+
+    touchEndListener: EventListener;
+
     scrollHandler: any;
 
     resizeListener: any;
@@ -201,6 +205,18 @@ export class Tooltip implements AfterViewInit, OnDestroy {
                     target.addEventListener('focus', this.focusListener);
                     target.addEventListener('blur', this.blurListener);
                 }
+
+                //Mobile touch event support
+                this.touchStartListener = this.onTouchStart.bind(this);
+                let target = this.el.nativeElement.querySelector('.p-component');
+
+                if (!target) {
+                    target = this.getTarget(this.el.nativeElement);
+                }
+                target.addEventListener('touchstart', this.touchStartListener);
+
+
+
             });
         }
     }
@@ -331,6 +347,17 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     onInputClick(e: Event) {
         this.deactivate();
+    }
+
+    onTouchStart(e: TouchEvent) {
+        this.activate();
+    }
+
+    onTouchEnd(_: Window, e: TouchEvent) {
+        const targetElement = this.getTarget(this.el.nativeElement);
+        if (!targetElement.contains(e.target as Node)) {
+            this.deactivate();
+        }
     }
 
     @HostListener('document:keydown.escape', ['$event'])
@@ -670,6 +697,20 @@ export class Tooltip implements AfterViewInit, OnDestroy {
         }
     }
 
+    bindTouchEndListener() {
+        this.zone.runOutsideAngular(() => {
+            this.touchEndListener = this.onTouchEnd.bind(this);
+            window.addEventListener('touchend', this.touchEndListener);
+        })
+    }
+
+    unbindTouchEndListener() {
+        if(this.touchEndListener) {
+            window.removeEventListener('touchend', this.touchEndListener);
+            this.touchEndListener = null;
+        }
+    }
+
     unbindEvents() {
         const tooltipEvent = this.getOption('tooltipEvent');
 
@@ -685,6 +726,15 @@ export class Tooltip implements AfterViewInit, OnDestroy {
                 target = this.getTarget(this.el.nativeElement);
             }
         }
+
+        let target = this.el.nativeElement.querySelector('.p-component');
+        if (!target) {
+            target = this.getTarget(this.el.nativeElement);
+        }
+
+        target.removeEventListener('touchstart', this.touchStartListener);
+        this.unbindTouchEndListener()
+
         this.unbindDocumentResizeListener();
     }
 

--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -720,11 +720,6 @@ export class Tooltip implements AfterViewInit, OnDestroy {
             }
         }
 
-        let target = this.el.nativeElement.querySelector('.p-component');
-        if (!target) {
-            target = this.getTarget(this.el.nativeElement);
-        }
-
         this.unbindTouchStartListener()
 
         this.unbindDocumentResizeListener();

--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -160,9 +160,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     blurListener: Nullable<Function>;
 
-    touchStartListener: Nullable<Function>;
-
-    touchEndListener: EventListener;
+    touchStartListener: EventListener;
 
     scrollHandler: any;
 
@@ -207,15 +205,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
                 }
 
                 //Mobile touch event support
-                this.touchStartListener = this.onTouchStart.bind(this);
-                let target = this.el.nativeElement.querySelector('.p-component');
-
-                if (!target) {
-                    target = this.getTarget(this.el.nativeElement);
-                }
-                target.addEventListener('touchstart', this.touchStartListener);
-
-
+                this.bindTouchStartListener()
 
             });
         }
@@ -350,15 +340,17 @@ export class Tooltip implements AfterViewInit, OnDestroy {
     }
 
     onTouchStart(e: TouchEvent) {
-        this.activate();
-    }
-
-    onTouchEnd(_: Window, e: TouchEvent) {
         const targetElement = this.getTarget(this.el.nativeElement);
-        if (!targetElement.contains(e.target as Node)) {
+        const hasTouchedTooltip = targetElement.contains(e.target as Node);
+
+        if(!this.active && hasTouchedTooltip) {
+            this.activate();
+        }
+        else {
             this.deactivate();
         }
     }
+
 
     @HostListener('document:keydown.escape', ['$event'])
     onPressEscape() {
@@ -697,17 +689,18 @@ export class Tooltip implements AfterViewInit, OnDestroy {
         }
     }
 
-    bindTouchEndListener() {
+    bindTouchStartListener() {
+        //We attach the event to the window to be able to detect when the user touches outside the component
         this.zone.runOutsideAngular(() => {
-            this.touchEndListener = this.onTouchEnd.bind(this);
-            window.addEventListener('touchend', this.touchEndListener);
+            this.touchStartListener = this.onTouchStart.bind(this);
+            window.addEventListener('touchstart', this.touchStartListener);
         })
     }
 
-    unbindTouchEndListener() {
-        if(this.touchEndListener) {
-            window.removeEventListener('touchend', this.touchEndListener);
-            this.touchEndListener = null;
+    unbindTouchStartListener() {
+        if(this.touchStartListener) {
+            window.removeEventListener('touchstart', this.touchStartListener);
+            this.touchStartListener = null;
         }
     }
 
@@ -732,8 +725,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
             target = this.getTarget(this.el.nativeElement);
         }
 
-        target.removeEventListener('touchstart', this.touchStartListener);
-        this.unbindTouchEndListener()
+        this.unbindTouchStartListener()
 
         this.unbindDocumentResizeListener();
     }


### PR DESCRIPTION
### Defect Fixes
Fixes https://github.com/primefaces/primeng/issues/8454
Currently it is not possible to trigger the display of tooltips on mobile, this fixes it.

With this pull request, we activate the tooltip if the user touches it, and we deactivate it if he either touches it again or touches anywhere else on the screen.