### PR TITLE
Support empty `TreeNode.key` in `findIndexInSelection`

### DIFF
--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -1438,12 +1438,12 @@ export class Tree implements OnInit, AfterContentInit, OnChanges, OnDestroy, Blo
         let index: number = -1;
         if (this.selectionMode && this.selection) {
             if (this.isSingleSelectionMode()) {
-                let areNodesEqual = (this.selection.key && this.selection.key === node.key) || this.selection == node;
+                let areNodesEqual = (this.selection.key !== undefined && this.selection.key === node.key) || this.selection == node;
                 index = areNodesEqual ? 0 : -1;
             } else {
                 for (let i = 0; i < this.selection.length; i++) {
                     let selectedNode = this.selection[i];
-                    let areNodesEqual = (selectedNode.key && selectedNode.key === node.key) || selectedNode == node;
+                    let areNodesEqual = (selectedNode.key !== undefined && selectedNode.key === node.key) || selectedNode == node;
                     if (areNodesEqual) {
                         index = i;
                         break;

--- a/src/app/components/treeselect/treeselect.ts
+++ b/src/app/components/treeselect/treeselect.ts
@@ -911,12 +911,12 @@ export class TreeSelect implements AfterContentInit {
 
         if (this.value) {
             if (this.selectionMode === 'single') {
-                let areNodesEqual = (this.value.key && this.value.key === node.key) || this.value == node;
+                let areNodesEqual = (this.value.key !== undefined && this.value.key === node.key) || this.value === node;
                 index = areNodesEqual ? 0 : -1;
             } else {
                 for (let i = 0; i < this.value.length; i++) {
                     let selectedNode = this.value[i];
-                    let areNodesEqual = (selectedNode.key && selectedNode.key === node.key) || selectedNode == node;
+                    let areNodesEqual = (selectedNode.key !== undefined && selectedNode.key === node.key) || selectedNode === node;
                     if (areNodesEqual) {
                         index = i;
                         break;


### PR DESCRIPTION
Fixes #16494
