### PR TITLE
fix: fixed label of movebottom-button in picklist component

### DIFF
--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -663,7 +663,7 @@ export class PickList implements AfterViewChecked, AfterContentInit {
     }
 
     get moveBottomAriaLabel() {
-        return this.bottomButtonAriaLabel ? this.bottomButtonAriaLabel : this.config.translation.aria ? this.config.translation.aria.moveDown : undefined;
+        return this.bottomButtonAriaLabel ? this.bottomButtonAriaLabel : this.config.translation.aria ? this.config.translation.aria.moveBottom : undefined;
     }
 
     get moveToTargetAriaLabel() {


### PR DESCRIPTION
**### Issue for this PR: https://github.com/primefaces/primeng/issues/16498**

The Movebottom Button in the picklist component references the wrong aria label.
Instead of 'Move Down' it should be 'Move Bottom'.
![picklist](https://github.com/user-attachments/assets/aa10d115-acbb-4940-82c1-a29bffc0cbcb)
