### PR TITLE
dropdown: added option to disable showing the panel on key down (#16462)

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -649,6 +649,11 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
      */
     @Input({ transform: booleanAttribute }) autofocusFilter: boolean = true;
     /**
+     * Determines if the panel will be shown when the input is focused and receives a character key down event.
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) autoShowPanelOnPrintableCharacterKeyDown: boolean = true;
+    /**
      * When present, it specifies that the component should be disabled.
      * @group Props
      */
@@ -1551,7 +1556,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
             default:
                 if (!event.metaKey && ObjectUtils.isPrintableCharacter(event.key)) {
-                    !this.overlayVisible && this.show();
+                    !this.overlayVisible && this.autoShowPanelOnPrintableCharacterKeyDown && this.show();
                     !this.editable && this.searchOptions(event, event.key);
                 }
 


### PR DESCRIPTION
Allows the dropdown to be filled by the user (in combination with `selectOnFocus` = `true`) with minimal keyboard input without showing the overlay panel. Usefull when the user already is familiar with the selectable options and just quickly wants to select a value and move on to the next input (e.g. via tab).

closes https://github.com/primefaces/primeng/issues/16462

