### PR TITLE
fix issue show am_pm calendar.ts as translate word

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -420,7 +420,7 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
                             <ChevronUpIcon *ngIf="!incrementIconTemplate" />
                             <ng-template *ngTemplateOutlet="incrementIconTemplate"></ng-template>
                         </button>
-                        <span>{{ pm ? 'PM' : 'AM' }}</span>
+                        <span>{{ pm ? getTranslation('pm') : getTranslation('am') }}</span>
                         <button class="p-link" type="button" (keydown)="onContainerButtonKeydown($event)" (click)="toggleAMPM($event)" (keydown.enter)="toggleAMPM($event)" [attr.aria-label]="getTranslation('pm')" pRipple>
                             <ChevronDownIcon *ngIf="!decrementIconTemplate" />
                             <ng-template *ngTemplateOutlet="decrementIconTemplate"></ng-template>


### PR DESCRIPTION
This PR addresses the issue where am_pm is not translated inside the PrimeNG calendar component. The fix allows am_pm to be localized based on the current language settings.