### PR TITLE
RTL: Basic support

### DIFF
--- a/src/app/components/accordion/accordion.css
+++ b/src/app/components/accordion/accordion.css
@@ -26,7 +26,7 @@
 
     .p-accordion-toggle-icon-end {
         order: 1;
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-accordion-toggle-icon {

--- a/src/app/components/accordion/accordion.ts
+++ b/src/app/components/accordion/accordion.ts
@@ -59,7 +59,7 @@ import { UniqueComponentId } from 'primeng/utils';
                         </ng-container>
                         <ng-container *ngIf="!selected">
                             <span *ngIf="accordion.expandIcon" [class]="accordion.expandIcon" [ngClass]="iconClass" [attr.aria-hidden]="true"></span>
-                            <ChevronRightIcon *ngIf="!accordion.expandIcon" [ngClass]="iconClass" [attr.aria-hidden]="true" />
+                            <ChevronRightIcon *ngIf="!accordion.expandIcon" [ngClass]="iconClass" [styleClass]="'p-rtl-flip-icon'" [attr.aria-hidden]="true" />
                         </ng-container>
                     </ng-container>
                     <ng-template *ngTemplateOutlet="iconTemplate; context: { $implicit: selected }"></ng-template>
@@ -443,7 +443,8 @@ export class Accordion implements BlockableUI, AfterContentInit, OnDestroy {
 
     constructor(
         public el: ElementRef,
-        public changeDetector: ChangeDetectorRef
+        public changeDetector: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {}
 
     @HostListener('keydown', ['$event'])
@@ -501,7 +502,7 @@ export class Accordion implements BlockableUI, AfterContentInit, OnDestroy {
 
     changeFocusedTab(element) {
         if (element) {
-            DomHandler.focus(element);
+            this.domHandler.focus(element);
 
             if (this.selectOnFocus) {
                 this.tabs.forEach((tab, i) => {
@@ -538,16 +539,16 @@ export class Accordion implements BlockableUI, AfterContentInit, OnDestroy {
 
     findNextHeaderAction(tabElement, selfCheck = false) {
         const nextTabElement = selfCheck ? tabElement : tabElement.nextElementSibling;
-        const headerElement = DomHandler.findSingle(nextTabElement, '[data-pc-section="header"]');
+        const headerElement = this.domHandler.findSingle(nextTabElement, '[data-pc-section="header"]');
 
-        return headerElement ? (DomHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findNextHeaderAction(headerElement.parentElement.parentElement) : DomHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')) : null;
+        return headerElement ? (this.domHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findNextHeaderAction(headerElement.parentElement.parentElement) : this.domHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')) : null;
     }
 
     findPrevHeaderAction(tabElement, selfCheck = false) {
         const prevTabElement = selfCheck ? tabElement : tabElement.previousElementSibling;
-        const headerElement = DomHandler.findSingle(prevTabElement, '[data-pc-section="header"]');
+        const headerElement = this.domHandler.findSingle(prevTabElement, '[data-pc-section="header"]');
 
-        return headerElement ? (DomHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findPrevHeaderAction(headerElement.parentElement.parentElement) : DomHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')) : null;
+        return headerElement ? (this.domHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findPrevHeaderAction(headerElement.parentElement.parentElement) : this.domHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')) : null;
     }
 
     findFirstHeaderAction() {

--- a/src/app/components/animate/animate.ts
+++ b/src/app/components/animate/animate.ts
@@ -30,7 +30,8 @@ export class Animate implements OnInit, AfterViewInit {
     constructor(
         private host: ElementRef,
         public el: ElementRef,
-        public renderer: Renderer2
+        public renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -59,13 +60,13 @@ export class Animate implements OnInit, AfterViewInit {
 
     enter() {
         this.host.nativeElement.style.visibility = 'visible';
-        DomHandler.addClass(this.host.nativeElement, this.enterClass as string);
+        this.domHandler.addClass(this.host.nativeElement, this.enterClass as string);
     }
 
     leave() {
-        DomHandler.removeClass(this.host.nativeElement, this.enterClass as string);
+        this.domHandler.removeClass(this.host.nativeElement, this.enterClass as string);
         if (this.leaveClass) {
-            DomHandler.addClass(this.host.nativeElement, this.leaveClass);
+            this.domHandler.addClass(this.host.nativeElement, this.leaveClass);
         }
 
         const animationDuration = this.host.nativeElement.style.animationDuration || 500;

--- a/src/app/components/animateonscroll/animateonscroll.ts
+++ b/src/app/components/animateonscroll/animateonscroll.ts
@@ -65,7 +65,8 @@ export class AnimateOnScroll implements OnInit, AfterViewInit {
         @Inject(PLATFORM_ID) private platformId: any,
         private host: ElementRef,
         public el: ElementRef,
-        public renderer: Renderer2
+        public renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -109,7 +110,7 @@ export class AnimateOnScroll implements OnInit, AfterViewInit {
             ([entry]) => {
                 if (entry.boundingClientRect.top > 0 && !entry.isIntersecting) {
                     this.host.nativeElement.style.opacity = this.enterClass ? '0' : '';
-                    DomHandler.removeMultipleClasses(this.host.nativeElement, [this.enterClass, this.leaveClass]);
+                    this.domHandler.removeMultipleClasses(this.host.nativeElement, [this.enterClass, this.leaveClass]);
 
                     this.resetObserver.unobserve(this.host.nativeElement);
                 }
@@ -123,8 +124,8 @@ export class AnimateOnScroll implements OnInit, AfterViewInit {
     enter() {
         if (this.animationState !== 'enter' && this.enterClass) {
             this.host.nativeElement.style.opacity = '';
-            DomHandler.removeMultipleClasses(this.host.nativeElement, this.leaveClass);
-            DomHandler.addMultipleClasses(this.host.nativeElement, this.enterClass);
+            this.domHandler.removeMultipleClasses(this.host.nativeElement, this.leaveClass);
+            this.domHandler.addMultipleClasses(this.host.nativeElement, this.enterClass);
 
             this.once && this.unbindIntersectionObserver();
 
@@ -136,8 +137,8 @@ export class AnimateOnScroll implements OnInit, AfterViewInit {
     leave() {
         if (this.animationState !== 'leave' && this.leaveClass) {
             this.host.nativeElement.style.opacity = this.enterClass ? '0' : '';
-            DomHandler.removeMultipleClasses(this.host.nativeElement, this.enterClass);
-            DomHandler.addMultipleClasses(this.host.nativeElement, this.leaveClass);
+            this.domHandler.removeMultipleClasses(this.host.nativeElement, this.enterClass);
+            this.domHandler.addMultipleClasses(this.host.nativeElement, this.leaveClass);
 
             this.bindAnimationEvents();
             this.animationState = 'leave';
@@ -147,7 +148,7 @@ export class AnimateOnScroll implements OnInit, AfterViewInit {
     bindAnimationEvents() {
         if (!this.animationEndListener) {
             this.animationEndListener = this.renderer.listen(this.host.nativeElement, 'animationend', () => {
-                DomHandler.removeMultipleClasses(this.host.nativeElement, [this.enterClass, this.leaveClass]);
+                this.domHandler.removeMultipleClasses(this.host.nativeElement, [this.enterClass, this.leaveClass]);
                 !this.once && this.resetObserver.observe(this.host.nativeElement);
                 this.unbindAnimationEvents();
             });

--- a/src/app/components/autocomplete/autocomplete.css
+++ b/src/app/components/autocomplete/autocomplete.css
@@ -17,13 +17,13 @@
 
     .p-autocomplete-dd .p-autocomplete-input,
     .p-autocomplete-dd .p-autocomplete-multiple-container {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     .p-autocomplete-dd .p-autocomplete-dropdown {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0px;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0px;
     }
 
     .p-autocomplete-panel {

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -885,7 +885,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         return this.modelValue() != null && this.hasSelectedOption() && this.showClear && !this.disabled && !this.loading;
     }
 
-    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone) {
+    constructor(@Inject(DOCUMENT) private document: Document, public el: ElementRef, public renderer: Renderer2, public cd: ChangeDetectorRef, public config: PrimeNGConfig, public overlayService: OverlayService, private zone: NgZone, private domHandler: DomHandler) {
       
         effect(() => {
             this.filled = ObjectUtils.isNotEmpty(this.modelValue());
@@ -1072,7 +1072,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         }
 
         if (!this.overlayViewChild || !this.overlayViewChild.overlayViewChild?.nativeElement.contains(event.target)) {
-            DomHandler.focus(this.inputEL.nativeElement);
+            this.domHandler.focus(this.inputEL.nativeElement);
         }
     }
 
@@ -1082,7 +1082,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         if (this.overlayVisible) {
             this.hide(true);
         } else {
-            DomHandler.focus(this.inputEL.nativeElement);
+            this.domHandler.focus(this.inputEL.nativeElement);
             query = this.inputEL.nativeElement.value;
 
             if (this.dropdownMode === 'blank') this.search(event, '', 'dropdown');
@@ -1323,7 +1323,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         this.focusedOptionIndex.set(-1);
         if (this.multiple) {
             if (ObjectUtils.isEmpty(target.value) && this.hasSelectedOption()) {
-                DomHandler.focus(this.multiContainerEL.nativeElement);
+                this.domHandler.focus(this.multiContainerEL.nativeElement);
                 this.focusedMultipleOptionIndex.set(this.modelValue().length);
             } else {
                 event.stopPropagation(); // To prevent onArrowLeftKeyOnMultiple method
@@ -1422,7 +1422,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         this.focusedMultipleOptionIndex.set(optionIndex);
         if (optionIndex > this.modelValue().length - 1) {
             this.focusedMultipleOptionIndex.set(-1);
-            DomHandler.focus(this.inputEL.nativeElement);
+            this.domHandler.focus(this.inputEL.nativeElement);
         }
     }
 
@@ -1480,7 +1480,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
         this.updateModel(value);
         this.onUnselect.emit({ originalEvent: event, value: removedOption });
-        DomHandler.focus(this.inputEL.nativeElement);
+        this.domHandler.focus(this.inputEL.nativeElement);
     }
 
     updateModel(value) {
@@ -1512,7 +1512,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
         if (this.itemsViewChild && this.itemsViewChild.nativeElement) {
-            const element = DomHandler.findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
+            const element = this.domHandler.findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
             if (element) {
                 element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             } else if (!this.virtualScrollerDisabled) {
@@ -1539,9 +1539,9 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         this.overlayVisible = true;
         const focusedOptionIndex = this.focusedOptionIndex() !== -1 ? this.focusedOptionIndex() : this.autoOptionFocus ? this.findFirstFocusedOptionIndex() : -1;
         this.focusedOptionIndex.set(focusedOptionIndex);
-        isFocus && DomHandler.focus(this.inputEL.nativeElement);
+        isFocus && this.domHandler.focus(this.inputEL.nativeElement);
         if (isFocus) {
-            DomHandler.focus(this.inputEL.nativeElement);
+            this.domHandler.focus(this.inputEL.nativeElement);
         }
         this.onShow.emit();
         this.cd.markForCheck();
@@ -1552,7 +1552,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
             this.dirty = isFocus;
             this.overlayVisible = false;
             this.focusedOptionIndex.set(-1);
-            isFocus && DomHandler.focus(this.inputEL.nativeElement);
+            isFocus && this.domHandler.focus(this.inputEL.nativeElement);
             this.onHide.emit();
             this.cd.markForCheck();
         };
@@ -1644,7 +1644,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
 
     onOverlayAnimationStart(event: AnimationEvent) {
         if (event.toState === 'visible') {
-            this.itemsWrapper = DomHandler.findSingle(this.overlayViewChild.overlayViewChild?.nativeElement, this.virtualScroll ? '.p-scroller' : '.p-autocomplete-panel');
+            this.itemsWrapper = this.domHandler.findSingle(this.overlayViewChild.overlayViewChild?.nativeElement, this.virtualScroll ? '.p-scroller' : '.p-autocomplete-panel');
 
             if (this.virtualScroll) {
                 this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
@@ -1658,7 +1658,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
                         this.scroller?.scrollToIndex(selectedIndex);
                     }
                 } else {
-                    let selectedListItem = DomHandler.findSingle(this.itemsWrapper, '.p-autocomplete-item.p-highlight');
+                    let selectedListItem = this.domHandler.findSingle(this.itemsWrapper, '.p-autocomplete-item.p-highlight');
 
                     if (selectedListItem) {
                         selectedListItem.scrollIntoView({ block: 'nearest', inline: 'center' });

--- a/src/app/components/autofocus/autofocus.ts
+++ b/src/app/components/autofocus/autofocus.ts
@@ -27,6 +27,8 @@ export class AutoFocus {
 
     host: ElementRef = inject(ElementRef);
 
+    constructor(private domHandler: DomHandler) {}
+
     ngAfterContentChecked() {
         // This sets the `attr.autofocus` which is different than the Input `autofocus` attribute.
         if (this.autofocus === false) {
@@ -49,7 +51,7 @@ export class AutoFocus {
     autoFocus() {
         if (isPlatformBrowser(this.platformId) && this.autofocus) {
             setTimeout(() => {
-                const focusableElements = DomHandler.getFocusableElements(this.host?.nativeElement);
+                const focusableElements = this.domHandler.getFocusableElements(this.host?.nativeElement);
 
                 if (focusableElements.length === 0) {
                     this.host.nativeElement.focus();

--- a/src/app/components/avatargroup/avatargroup.css
+++ b/src/app/components/avatargroup/avatargroup.css
@@ -1,6 +1,6 @@
 @layer primeng {
     .p-avatar-group p-avatar + p-avatar {
-        margin-left: -1rem;
+        margin-inline-start: -1rem;
     }
 
     .p-avatar-group {

--- a/src/app/components/badge/badge.css
+++ b/src/app/components/badge/badge.css
@@ -13,10 +13,15 @@
     .p-overlay-badge .p-badge {
         position: absolute;
         top: 0;
-        right: 0;
+        inset-inline-end: 0;
         transform: translate(50%, -50%);
         transform-origin: 100% 0;
         margin: 0;
+    }
+
+    .p-overlay-badge .p-badge:dir(rtl) {
+        transform: translate(-50%, -50%);
+        transform-origin: 0 0;
     }
 
     .p-badge-dot {

--- a/src/app/components/badge/badge.ts
+++ b/src/app/components/badge/badge.ts
@@ -73,7 +73,8 @@ export class BadgeDirective implements OnChanges, AfterViewInit {
     constructor(
         @Inject(DOCUMENT) private document: Document,
         public el: ElementRef,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     public ngOnChanges({ value, size, severity, disabled, badgeStyle, badgeStyleClass }: SimpleChanges): void {
@@ -115,21 +116,21 @@ export class BadgeDirective implements OnChanges, AfterViewInit {
         }
 
         if (this.value != null) {
-            if (DomHandler.hasClass(badge, 'p-badge-dot')) {
-                DomHandler.removeClass(badge, 'p-badge-dot');
+            if (this.domHandler.hasClass(badge, 'p-badge-dot')) {
+                this.domHandler.removeClass(badge, 'p-badge-dot');
             }
 
             if (this.value && String(this.value).length === 1) {
-                DomHandler.addClass(badge, 'p-badge-no-gutter');
+                this.domHandler.addClass(badge, 'p-badge-no-gutter');
             } else {
-                DomHandler.removeClass(badge, 'p-badge-no-gutter');
+                this.domHandler.removeClass(badge, 'p-badge-no-gutter');
             }
         } else {
-            if (!DomHandler.hasClass(badge, 'p-badge-dot')) {
-                DomHandler.addClass(badge, 'p-badge-dot');
+            if (!this.domHandler.hasClass(badge, 'p-badge-dot')) {
+                this.domHandler.addClass(badge, 'p-badge-dot');
             }
 
-            DomHandler.removeClass(badge, 'p-badge-no-gutter');
+            this.domHandler.removeClass(badge, 'p-badge-no-gutter');
         }
 
         badge.innerHTML = '';
@@ -146,27 +147,27 @@ export class BadgeDirective implements OnChanges, AfterViewInit {
 
         if (this.badgeSize) {
             if (this.badgeSize === 'large') {
-                DomHandler.addClass(badge, 'p-badge-lg');
-                DomHandler.removeClass(badge, 'p-badge-xl');
+                this.domHandler.addClass(badge, 'p-badge-lg');
+                this.domHandler.removeClass(badge, 'p-badge-xl');
             }
 
             if (this.badgeSize === 'xlarge') {
-                DomHandler.addClass(badge, 'p-badge-xl');
-                DomHandler.removeClass(badge, 'p-badge-lg');
+                this.domHandler.addClass(badge, 'p-badge-xl');
+                this.domHandler.removeClass(badge, 'p-badge-lg');
             }
         } else if (this.size && !this.badgeSize) {
             if (this.size === 'large') {
-                DomHandler.addClass(badge, 'p-badge-lg');
-                DomHandler.removeClass(badge, 'p-badge-xl');
+                this.domHandler.addClass(badge, 'p-badge-lg');
+                this.domHandler.removeClass(badge, 'p-badge-xl');
             }
 
             if (this.size === 'xlarge') {
-                DomHandler.addClass(badge, 'p-badge-xl');
-                DomHandler.removeClass(badge, 'p-badge-lg');
+                this.domHandler.addClass(badge, 'p-badge-xl');
+                this.domHandler.removeClass(badge, 'p-badge-lg');
             }
         } else {
-            DomHandler.removeClass(badge, 'p-badge-lg');
-            DomHandler.removeClass(badge, 'p-badge-xl');
+            this.domHandler.removeClass(badge, 'p-badge-lg');
+            this.domHandler.removeClass(badge, 'p-badge-xl');
         }
     }
 
@@ -183,7 +184,7 @@ export class BadgeDirective implements OnChanges, AfterViewInit {
         this.setSeverity(null, badge);
         this.setSizeClasses(badge);
         this.setValue(badge);
-        DomHandler.addClass(el, 'p-overlay-badge');
+        this.domHandler.addClass(el, 'p-overlay-badge');
         this.renderer.appendChild(el, badge);
         this.badgeEl = badge;
         this.applyStyles();
@@ -208,11 +209,11 @@ export class BadgeDirective implements OnChanges, AfterViewInit {
         }
 
         if (this.severity) {
-            DomHandler.addClass(badge, `p-badge-${this.severity}`);
+            this.domHandler.addClass(badge, `p-badge-${this.severity}`);
         }
 
         if (oldSeverity) {
-            DomHandler.removeClass(badge, `p-badge-${oldSeverity}`);
+            this.domHandler.removeClass(badge, `p-badge-${oldSeverity}`);
         }
     }
 

--- a/src/app/components/blockui/blockui.css
+++ b/src/app/components/blockui/blockui.css
@@ -2,7 +2,7 @@
     .p-blockui {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 100%;
         background-color: transparent;

--- a/src/app/components/blockui/blockui.ts
+++ b/src/app/components/blockui/blockui.ts
@@ -102,7 +102,8 @@ export class BlockUI implements AfterViewInit, OnDestroy {
         public cd: ChangeDetectorRef,
         public config: PrimeNGConfig,
         private renderer: Renderer2,
-        @Inject(PLATFORM_ID) public platformId: any
+        @Inject(PLATFORM_ID) public platformId: any,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterViewInit() {
@@ -137,7 +138,7 @@ export class BlockUI implements AfterViewInit, OnDestroy {
                 this.target.getBlockableElement().style.position = 'relative';
             } else {
                 this.renderer.appendChild(this.document.body, (this.mask as ElementRef).nativeElement);
-                DomHandler.blockBodyScroll();
+                this.domHandler.blockBodyScroll();
             }
 
             if (this.autoZIndex) {
@@ -149,7 +150,7 @@ export class BlockUI implements AfterViewInit, OnDestroy {
     unblock() {
         if (isPlatformBrowser(this.platformId) && this.mask && !this.animationEndListener) {
             this.animationEndListener = this.renderer.listen(this.mask.nativeElement, 'animationend', this.destroyModal.bind(this));
-            DomHandler.addClass(this.mask.nativeElement, 'p-component-overlay-leave');
+            this.domHandler.addClass(this.mask.nativeElement, 'p-component-overlay-leave');
         }
     }
 
@@ -157,9 +158,9 @@ export class BlockUI implements AfterViewInit, OnDestroy {
         this._blocked = false;
         if (this.mask && isPlatformBrowser(this.platformId)) {
             ZIndexUtils.clear(this.mask.nativeElement);
-            DomHandler.removeClass(this.mask.nativeElement, 'p-component-overlay-leave');
+            this.domHandler.removeClass(this.mask.nativeElement, 'p-component-overlay-leave');
             this.renderer.removeChild(this.el.nativeElement, this.mask.nativeElement);
-            DomHandler.unblockBodyScroll();
+            this.domHandler.unblockBodyScroll();
         }
         this.unbindAnimationEndListener();
         this.cd.markForCheck();

--- a/src/app/components/breadcrumb/breadcrumb.ts
+++ b/src/app/components/breadcrumb/breadcrumb.ts
@@ -73,7 +73,7 @@ import { BreadcrumbItemClickEvent } from './breadcrumb.interface';
                     </a>
                 </li>
                 <li *ngIf="model && home" class="p-menuitem-separator" [attr.data-pc-section]="'separator'">
-                    <ChevronRightIcon *ngIf="!separatorTemplate" />
+                    <ChevronRightIcon *ngIf="!separatorTemplate" [styleClass]="'p-rtl-flip-icon'" />
                     <ng-template *ngTemplateOutlet="separatorTemplate"></ng-template>
                 </li>
                 <ng-template ngFor let-item let-end="last" [ngForOf]="model">
@@ -140,7 +140,7 @@ import { BreadcrumbItemClickEvent } from './breadcrumb.interface';
                         </a>
                     </li>
                     <li *ngIf="!end" class="p-menuitem-separator" [attr.data-pc-section]="'separator'">
-                        <ChevronRightIcon *ngIf="!separatorTemplate" />
+                        <ChevronRightIcon *ngIf="!separatorTemplate" [styleClass]="'p-rtl-flip-icon'" />
                         <ng-template *ngTemplateOutlet="separatorTemplate"></ng-template>
                     </li>
                 </ng-template>

--- a/src/app/components/button/button.css
+++ b/src/app/components/button/button.css
@@ -65,7 +65,7 @@
     .p-buttonset .p-button:not(:last-child):hover,
     .p-buttonset p-button:not(:last-child) .p-button,
     .p-buttonset p-button:not(:last-child) .p-button:hover {
-        border-right: 0 none;
+        border-inline-end: 0 none;
     }
 
     .p-button-group .p-button:not(:first-of-type):not(:last-of-type),
@@ -79,16 +79,16 @@
     .p-button-group p-button:first-of-type:not(:only-of-type) .p-button,
     .p-buttonset .p-button:first-of-type:not(:only-of-type),
     .p-buttonset p-button:first-of-type:not(:only-of-type) .p-button {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     .p-button-group .p-button:last-of-type:not(:only-of-type),
     .p-button-group p-button:last-of-type:not(:only-of-type) .p-button,
     .p-buttonset .p-button:last-of-type:not(:only-of-type),
     .p-buttonset p-button:last-of-type:not(:only-of-type) .p-button {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
     }
 
     p-button[iconpos='right'] spinnericon {

--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -157,11 +157,12 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
 
     constructor(
         public el: ElementRef,
-        @Inject(DOCUMENT) private document: Document
+        @Inject(DOCUMENT) private document: Document,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterViewInit() {
-        DomHandler.addMultipleClasses(this.htmlElement, this.getStyleClass().join(' '));
+        this.domHandler.addMultipleClasses(this.htmlElement, this.getStyleClass().join(' '));
 
         this.createIcon();
         this.createLabel();
@@ -234,7 +235,7 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
     }
 
     createLabel() {
-        const created = DomHandler.findSingle(this.htmlElement, '.p-button-label');
+        const created = this.domHandler.findSingle(this.htmlElement, '.p-button-label');
         if (!created && this.label) {
             let labelElement = this.document.createElement('span');
             if (this.icon && !this.label) {
@@ -249,7 +250,7 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
     }
 
     createIcon() {
-        const created = DomHandler.findSingle(this.htmlElement, '.p-button-icon');
+        const created = this.domHandler.findSingle(this.htmlElement, '.p-button-icon');
         if (!created && (this.icon || this.loading)) {
             let iconElement = this.document.createElement('span');
             iconElement.className = 'p-button-icon';
@@ -257,13 +258,13 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
             let iconPosClass = this.label ? 'p-button-icon-' + this.iconPos : null;
 
             if (iconPosClass) {
-                DomHandler.addClass(iconElement, iconPosClass);
+                this.domHandler.addClass(iconElement, iconPosClass);
             }
 
             let iconClass = this.getIconClass();
 
             if (iconClass) {
-                DomHandler.addMultipleClasses(iconElement, iconClass);
+                this.domHandler.addMultipleClasses(iconElement, iconClass);
             }
 
             this.htmlElement.insertBefore(iconElement, this.htmlElement.firstChild);
@@ -271,7 +272,7 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
     }
 
     updateLabel() {
-        let labelElement = DomHandler.findSingle(this.htmlElement, '.p-button-label');
+        let labelElement = this.domHandler.findSingle(this.htmlElement, '.p-button-label');
 
         if (!this.label) {
             labelElement && this.htmlElement.removeChild(labelElement);
@@ -282,8 +283,8 @@ export class ButtonDirective implements AfterViewInit, OnDestroy {
     }
 
     updateIcon() {
-        let iconElement = DomHandler.findSingle(this.htmlElement, '.p-button-icon');
-        let labelElement = DomHandler.findSingle(this.htmlElement, '.p-button-label');
+        let iconElement = this.domHandler.findSingle(this.htmlElement, '.p-button-icon');
+        let labelElement = this.domHandler.findSingle(this.htmlElement, '.p-button-label');
 
         if (iconElement) {
             if (this.iconPos) {

--- a/src/app/components/calendar/calendar.css
+++ b/src/app/components/calendar/calendar.css
@@ -12,13 +12,13 @@
     }
 
     .p-calendar-w-btn .p-inputtext {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     .p-calendar-w-btn .p-datepicker-trigger {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
     }
 
     /* Fluid */
@@ -39,7 +39,7 @@
         width: auto;
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-datepicker-inline {
@@ -144,9 +144,14 @@
     .p-calendar .p-datepicker-touch-ui {
         position: fixed;
         top: 50%;
-        left: 50%;
+        inset-inline-start: 50%;
         min-width: 80vw;
         transform: translate(-50%, -50%);
+    }
+
+    .p-datepicker-touch-ui:dir(rtl),
+    .p-calendar .p-datepicker-touch-ui:dir(rtl) {
+        transform: translate(50%, -50%);
     }
 
     /* Year Picker */

--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -57,7 +57,7 @@ import { DomHandler } from 'primeng/dom';
                         pRipple
                     >
                         <ng-container *ngIf="!previousIconTemplate">
-                            <ChevronLeftIcon *ngIf="!isVertical()" [styleClass]="'carousel-prev-icon'" />
+                            <ChevronLeftIcon *ngIf="!isVertical()" [styleClass]="'carousel-prev-icon p-rtl-flip-icon'" />
                             <ChevronUpIcon *ngIf="isVertical()" [styleClass]="'carousel-prev-icon'" />
                         </ng-container>
                         <span *ngIf="previousIconTemplate" class="p-carousel-prev-icon">
@@ -112,7 +112,7 @@ import { DomHandler } from 'primeng/dom';
                         [attr.aria-label]="ariaNextButtonLabel()"
                     >
                         <ng-container *ngIf="!nextIconTemplate">
-                            <ChevronRightIcon *ngIf="!isVertical()" [styleClass]="'carousel-prev-icon'" />
+                            <ChevronRightIcon *ngIf="!isVertical()" [styleClass]="'carousel-prev-icon p-rtl-flip-icon'" />
                             <ChevronDownIcon *ngIf="isVertical()" [styleClass]="'carousel-prev-icon'" />
                         </ng-container>
                         <span *ngIf="nextIconTemplate" class="p-carousel-prev-icon">
@@ -364,7 +364,8 @@ export class Carousel implements AfterContentInit {
         private renderer: Renderer2,
         @Inject(DOCUMENT) private document: Document,
         @Inject(PLATFORM_ID) private platformId: any,
-        private config: PrimeNGConfig
+        private config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {
         this.totalShiftedItems = this.page * this.numScroll * -1;
         this.window = this.document.defaultView as Window;
@@ -497,7 +498,7 @@ export class Carousel implements AfterContentInit {
                 this.prevState.value = [...(this._value as any[])];
 
                 if (this.totalDots() > 0 && this.itemsContainer.nativeElement) {
-                    this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
+                    this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${(this.domHandler.isRtl() ? -1 : 1) * totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
                 }
 
                 this.isCreated = true;
@@ -528,7 +529,7 @@ export class Carousel implements AfterContentInit {
         if (!this.carouselStyle) {
             this.carouselStyle = this.renderer.createElement('style');
             this.carouselStyle.type = 'text/css';
-            DomHandler.setAttribute(this.carouselStyle, 'nonce', this.config?.csp()?.nonce);
+            this.domHandler.setAttribute(this.carouselStyle, 'nonce', this.config?.csp()?.nonce);
             this.renderer.appendChild(this.document.head, this.carouselStyle);
         }
 
@@ -720,7 +721,7 @@ export class Carousel implements AfterContentInit {
     }
 
     onRightKey() {
-        const indicators = [...DomHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
+        const indicators = [...this.domHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, activeIndex + 1 === indicators.length ? indicators.length - 1 : activeIndex + 1);
@@ -738,17 +739,17 @@ export class Carousel implements AfterContentInit {
     }
 
     onEndKey() {
-        const indicators = [...DomHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]r')];
+        const indicators = [...this.domHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]r')];
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, indicators.length - 1);
     }
 
     onTabKey() {
-        const indicators = [...DomHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
-        const highlightedIndex = indicators.findIndex((ind) => DomHandler.getAttribute(ind, 'data-p-highlight') === true);
+        const indicators = [...this.domHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
+        const highlightedIndex = indicators.findIndex((ind) => this.domHandler.getAttribute(ind, 'data-p-highlight') === true);
 
-        const activeIndicator = DomHandler.findSingle(this.indicatorContent.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
+        const activeIndicator = this.domHandler.findSingle(this.indicatorContent.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
         const activeIndex = indicators.findIndex((ind) => ind === activeIndicator.parentElement);
 
         indicators[activeIndex].children[0].tabIndex = '-1';
@@ -756,14 +757,14 @@ export class Carousel implements AfterContentInit {
     }
 
     findFocusedIndicatorIndex() {
-        const indicators = [...DomHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
-        const activeIndicator = DomHandler.findSingle(this.indicatorContent.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
+        const indicators = [...this.domHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
+        const activeIndicator = this.domHandler.findSingle(this.indicatorContent.nativeElement, '[data-pc-section="indicator"] > button[tabindex="0"]');
 
         return indicators.findIndex((ind) => ind === activeIndicator.parentElement);
     }
 
     changedFocusedIndicator(prevInd, nextInd) {
-        const indicators = [...DomHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
+        const indicators = [...this.domHandler.find(this.indicatorContent.nativeElement, '[data-pc-section="indicator"]')];
 
         indicators[prevInd].children[0].tabIndex = '-1';
         indicators[nextInd].children[0].tabIndex = '0';
@@ -805,7 +806,7 @@ export class Carousel implements AfterContentInit {
         }
 
         if (this.itemsContainer) {
-            this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
+            this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${(this.domHandler.isRtl() ? -1 : 1) * totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
             this.itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
         }
 
@@ -851,7 +852,7 @@ export class Carousel implements AfterContentInit {
             this.itemsContainer.nativeElement.style.transition = '';
 
             if ((this.page === 0 || this.page === this.totalDots() - 1) && this.isCircular()) {
-                this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${this.totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${this.totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
+                this.itemsContainer.nativeElement.style.transform = this.isVertical() ? `translate3d(0, ${this.totalShiftedItems * (100 / this._numVisible)}%, 0)` : `translate3d(${(this.domHandler.isRtl() ? -1 : 1) * this.totalShiftedItems * (100 / this._numVisible)}%, 0, 0)`;
             }
         }
     }
@@ -860,7 +861,7 @@ export class Carousel implements AfterContentInit {
         let touchobj = e.changedTouches[0];
 
         this.startPos = {
-            x: touchobj.pageX,
+            x: this.domHandler.getPageX(touchobj),
             y: touchobj.pageY
         };
     }
@@ -876,7 +877,7 @@ export class Carousel implements AfterContentInit {
         if (this.isVertical()) {
             this.changePageOnTouch(e, touchobj.pageY - this.startPos.y);
         } else {
-            this.changePageOnTouch(e, touchobj.pageX - this.startPos.x);
+            this.changePageOnTouch(e, this.domHandler.getPageX(touchobj) - this.startPos.x);
         }
     }
 

--- a/src/app/components/cascadeselect/cascadeselect.css
+++ b/src/app/components/cascadeselect/cascadeselect.css
@@ -42,7 +42,7 @@
     }
 
     .p-cascadeselect-group-icon {
-        margin-left: auto;
+        margin-inline-start: auto;
         display: inline-flex;
     }
 
@@ -73,7 +73,7 @@
 
     .p-cascadeselect-item-active > .p-cascadeselect-sublist {
         display: block;
-        left: 100%;
+        inset-inline-start: 100%;
         top: 0;
     }
 
@@ -94,6 +94,6 @@
     }
 
     .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-sublist {
-        left: 0;
+        inset-inline-start: 0;
     }
 }

--- a/src/app/components/cascadeselect/cascadeselect.ts
+++ b/src/app/components/cascadeselect/cascadeselect.ts
@@ -75,8 +75,8 @@ export const CASCADESELECT_VALUE_ACCESSOR: any = {
                         <ng-template #defaultOptionTemplate>
                             <span class="p-cascadeselect-item-text" [attr.data-pc-section]="'text'">{{ getOptionLabelToRender(processedOption) }}</span>
                         </ng-template>
-                        <span class="p-cascadeselect-group-icon" *ngIf="isOptionGroup(processedOption)" [attr.data-pc-section]="'groupIcon'">
-                            <AngleRightIcon *ngIf="!groupIconTemplate" />
+                        <span class="p-cascadeselect-group-icon p-rtl-flip-icon" *ngIf="isOptionGroup(processedOption)" [attr.data-pc-section]="'groupIcon'">
+                            <AngleRightIcon *ngIf="!groupIconTemplate" [styleClass]="'p-rtl-flip-icon'" />
                             <ng-template *ngTemplateOutlet="groupIconTemplate"></ng-template>
                         </span>
                     </div>
@@ -144,7 +144,8 @@ export class CascadeSelectSub implements OnInit {
 
     constructor(
         private el: ElementRef,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -221,13 +222,13 @@ export class CascadeSelectSub implements OnInit {
 
     position() {
         const parentItem = this.el.nativeElement.parentElement;
-        const containerOffset = DomHandler.getOffset(parentItem);
-        const viewport = DomHandler.getViewport();
-        const sublistWidth = this.el.nativeElement.children[0].offsetParent ? this.el.nativeElement.children[0].offsetWidth : DomHandler.getHiddenElementOuterWidth(this.el.nativeElement.children[0]);
-        const itemOuterWidth = DomHandler.getOuterWidth(parentItem.children[0]);
+        const containerOffset = this.domHandler.getOffset(parentItem);
+        const viewport = this.domHandler.getViewport();
+        const sublistWidth = this.el.nativeElement.children[0].offsetParent ? this.el.nativeElement.children[0].offsetWidth : this.domHandler.getHiddenElementOuterWidth(this.el.nativeElement.children[0]);
+        const itemOuterWidth = this.domHandler.getOuterWidth(parentItem.children[0]);
 
-        if (parseInt(containerOffset.left, 10) + itemOuterWidth + sublistWidth > viewport.width - DomHandler.calculateScrollbarWidth()) {
-            this.el.nativeElement.children[0].style.left = '-200%';
+        if (parseInt(containerOffset.left, 10) + itemOuterWidth + sublistWidth > viewport.width - this.domHandler.calculateScrollbarWidth()) {
+            this.el.nativeElement.children[0].style.insetInlineStart = '-200%';
         }
     }
 }
@@ -1030,7 +1031,7 @@ export class CascadeSelect implements OnInit, AfterContentInit {
 
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
-        const element = DomHandler.findSingle(this.panelViewChild?.nativeElement, `li[id="${id}"]`);
+        const element = this.domHandler.findSingle(this.panelViewChild?.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
@@ -1064,7 +1065,7 @@ export class CascadeSelect implements OnInit, AfterContentInit {
         this.activeOptionPath.set(activeOptionPath);
 
         grouped ? this.onOptionGroupSelect({ originalEvent, value, isFocus: false }) : this.onOptionSelect({ originalEvent, value, isFocus });
-        isFocus && DomHandler.focus(this.focusInputViewChild.nativeElement);
+        isFocus && this.domHandler.focus(this.focusInputViewChild.nativeElement);
     }
 
     onOptionSelect(event) {
@@ -1235,7 +1236,7 @@ export class CascadeSelect implements OnInit, AfterContentInit {
             this.activeOptionPath.set([]);
             this.focusedOptionInfo.set({ index: -1, level: 0, parentKey: '' });
 
-            isFocus && DomHandler.focus(this.focusInputViewChild.nativeElement);
+            isFocus && this.domHandler.focus(this.focusInputViewChild.nativeElement);
             this.onHide.emit(event);
         };
 
@@ -1262,7 +1263,7 @@ export class CascadeSelect implements OnInit, AfterContentInit {
 
         this.focusedOptionInfo.set(focusedOptionInfo);
 
-        isFocus && DomHandler.focus(this.focusInputViewChild.nativeElement);
+        isFocus && this.domHandler.focus(this.focusInputViewChild.nativeElement);
     }
 
     clear(event?: MouseEvent) {
@@ -1310,7 +1311,8 @@ export class CascadeSelect implements OnInit, AfterContentInit {
         private el: ElementRef,
         private cd: ChangeDetectorRef,
         private config: PrimeNGConfig,
-        public overlayService: OverlayService
+        public overlayService: OverlayService,
+        private domHandler: DomHandler
     ) {
         effect(() => {
             const activeOptionPath = this.activeOptionPath();

--- a/src/app/components/chart/chart.ts
+++ b/src/app/components/chart/chart.ts
@@ -1,6 +1,7 @@
 import { NgModule, Component, ElementRef, AfterViewInit, OnDestroy, Input, Output, EventEmitter, ChangeDetectionStrategy, ViewEncapsulation, Inject, PLATFORM_ID, NgZone, booleanAttribute } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import Chart from 'chart.js/auto';
+import { DomHandler } from 'primeng/dom';
 /**
  * Chart groups a collection of contents in tabs.
  * @group Components
@@ -110,7 +111,8 @@ export class UIChart implements AfterViewInit, OnDestroy {
     constructor(
         @Inject(PLATFORM_ID) private platformId: any,
         public el: ElementRef,
-        private zone: NgZone
+        private zone: NgZone,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterViewInit() {
@@ -133,6 +135,19 @@ export class UIChart implements AfterViewInit, OnDestroy {
         if (isPlatformBrowser(this.platformId)) {
             let opts = this.options || {};
             opts.responsive = this.responsive;
+
+            if (this.domHandler.isRtl()) {
+                opts.scales ??= {};
+                opts.scales.x ??= {};
+                opts.scales.x.reverse = true;
+                opts.scales.y ??= {};
+                opts.scales.y.position = 'right';
+                opts.plugins ??= {};
+                opts.plugins.tooltip ??= {};
+                opts.plugins.tooltip.rtl = true;
+                opts.plugins.legend ??= {};
+                opts.plugins.legend.rtl = true;
+            }
 
             // allows chart to resize in responsive mode
             if (opts.responsive && (this.height || this.width)) {

--- a/src/app/components/colorpicker/colorpicker-images.css
+++ b/src/app/components/colorpicker/colorpicker-images.css
@@ -1,5 +1,19 @@
 .p-colorpicker-panel .p-colorpicker-color {
-    background: transparent url("./images/color.png") no-repeat left top; 
+    position: relative;
+}
+
+.p-colorpicker-panel .p-colorpicker-color::before {
+    content: '';
+    background: transparent url("./images/color.png") no-repeat left top;
+    position: absolute;
+    inset-block-start: 0;
+    inset-block-end: 0;
+    inset-inline-start: 0;
+    inset-inline-end: 0;
+}
+
+.p-colorpicker-panel .p-colorpicker-color:dir(rtl)::before {
+    transform: scaleX(-1);
 }
 
 .p-colorpicker-panel .p-colorpicker-hue {

--- a/src/app/components/colorpicker/colorpicker.css
+++ b/src/app/components/colorpicker/colorpicker.css
@@ -20,7 +20,7 @@
     .p-colorpicker-overlay-panel {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-colorpicker-preview {
@@ -35,7 +35,7 @@
         width: 150px;
         height: 150px;
         top: 8px;
-        left: 8px;
+        inset-inline-start: 8px;
         position: absolute;
     }
 
@@ -47,13 +47,16 @@
     .p-colorpicker-panel .p-colorpicker-color-handle {
         position: absolute;
         top: 0px;
-        left: 150px;
+        inset-inline-start: 150px;
         border-radius: 100%;
         width: 10px;
         height: 10px;
         border-width: 1px;
         border-style: solid;
-        margin: -5px 0 0 -5px;
+        margin-block-start: -5px;
+        margin-inline-end: 0;
+        margin-block-end: 0;
+        margin-inline-start: -5px;
         cursor: pointer;
         opacity: 0.85;
     }
@@ -62,7 +65,7 @@
         width: 17px;
         height: 150px;
         top: 8px;
-        left: 167px;
+        inset-inline-start: 167px;
         position: absolute;
         opacity: 0.85;
     }
@@ -70,9 +73,9 @@
     .p-colorpicker-panel .p-colorpicker-hue-handle {
         position: absolute;
         top: 150px;
-        left: 0px;
+        inset-inline-start: 0px;
         width: 21px;
-        margin-left: -2px;
+        margin-inline-start: -2px;
         margin-top: -5px;
         height: 10px;
         border-width: 2px;

--- a/src/app/components/common/common.css
+++ b/src/app/components/common/common.css
@@ -1,6 +1,6 @@
 .p-overflow-hidden {
     overflow: hidden;
-    padding-right: var(--scrollbar-width);
+    padding-inline-end: var(--scrollbar-width);
 }
 
 @layer primeng {
@@ -52,7 +52,7 @@
     .p-component-overlay {
         position: fixed;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 100%;
     }
@@ -95,7 +95,7 @@
     }
 
     .p-link {
-        text-align: left;
+        text-align: start;
         background-color: transparent;
         margin: 0;
         padding: 0;
@@ -155,6 +155,24 @@
         -webkit-animation: p-icon-spin 2s infinite linear;
         animation: p-icon-spin 2s infinite linear;
     }
+
+    .p-icon-spin:dir(rtl) {
+        -webkit-animation-name: p-icon-spin-rtl;
+        animation-name: p-icon-spin-rtl;
+    }
+
+    .p-rtl-flip-icon:dir(rtl) {
+        transform: scaleX(-1);
+    }
+
+    .p-rtl-flip-svg:dir(rtl) {
+        transform: rotateY(180deg);
+        transform-origin: center;
+    }
+
+    .p-rtl-flip-order:dir(rtl) {
+        flex-direction: row-reverse;
+    }
 }
 
 @-webkit-keyframes p-icon-spin {
@@ -168,6 +186,17 @@
     }
 }
 
+@-webkit-keyframes p-icon-spin-rtl {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(-359deg);
+        transform: rotate(-359deg);
+    }
+}
+
 @keyframes p-icon-spin {
     0% {
         -webkit-transform: rotate(0deg);
@@ -176,5 +205,16 @@
     100% {
         -webkit-transform: rotate(359deg);
         transform: rotate(359deg);
+    }
+}
+
+@keyframes p-icon-spin-rtl {
+    0% {
+        -webkit-transform: rotate(0deg);
+        transform: rotate(0deg);
+    }
+    100% {
+        -webkit-transform: rotate(-359deg);
+        transform: rotate(-359deg);
     }
 }

--- a/src/app/components/confirmdialog/confirmdialog.ts
+++ b/src/app/components/confirmdialog/confirmdialog.ts
@@ -326,12 +326,20 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
             case 'top-left':
             case 'bottom-left':
             case 'left':
-                this.transformOptions = 'translate3d(-100%, 0px, 0px)';
+                if (this.domHandler.isRtl()) {
+                    this.transformOptions = 'translate3d(100%, 0px, 0px)';
+                } else {
+                    this.transformOptions = 'translate3d(-100%, 0px, 0px)';
+                }
                 break;
             case 'top-right':
             case 'bottom-right':
             case 'right':
-                this.transformOptions = 'translate3d(100%, 0px, 0px)';
+                if (this.domHandler.isRtl()) {
+                    this.transformOptions = 'translate3d(-100%, 0px, 0px)';
+                } else {
+                    this.transformOptions = 'translate3d(100%, 0px, 0px)';
+                }
                 break;
             case 'bottom':
                 this.transformOptions = 'translate3d(0px, 100%, 0px)';
@@ -449,7 +457,8 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
         public zone: NgZone,
         private cd: ChangeDetectorRef,
         public config: PrimeNGConfig,
-        @Inject(DOCUMENT) private document: Document
+        @Inject(DOCUMENT) private document: Document,
+        private domHandler: DomHandler
     ) {
         this.subscription = this.confirmationService.requireConfirmation$.subscribe((confirmation) => {
             if (!confirmation) {
@@ -521,7 +530,7 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
             case 'visible':
                 this.container = event.element;
                 this.wrapper = this.container?.parentElement;
-                this.contentContainer = DomHandler.findSingle(this.container, '.p-dialog-content');
+                this.contentContainer = this.domHandler.findSingle(this.container, '.p-dialog-content');
                 this.container?.setAttribute(this.id, '');
                 this.appendContainer();
                 this.moveOnTop();
@@ -547,27 +556,27 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
     getElementToFocus() {
         switch (this.option('defaultFocus')) {
             case 'accept':
-                return DomHandler.findSingle(this.container, '.p-confirm-dialog-accept');
+                return this.domHandler.findSingle(this.container, '.p-confirm-dialog-accept');
 
             case 'reject':
-                return DomHandler.findSingle(this.container, '.p-confirm-dialog-reject');
+                return this.domHandler.findSingle(this.container, '.p-confirm-dialog-reject');
 
             case 'close':
-                return DomHandler.findSingle(this.container, '.p-dialog-header-close');
+                return this.domHandler.findSingle(this.container, '.p-dialog-header-close');
 
             case 'none':
                 return null;
 
             //backward compatibility
             default:
-                return DomHandler.findSingle(this.container, '.p-confirm-dialog-accept');
+                return this.domHandler.findSingle(this.container, '.p-confirm-dialog-accept');
         }
     }
 
     appendContainer() {
         if (this.appendTo) {
             if (this.appendTo === 'body') this.document.body.appendChild(this.wrapper as HTMLElement);
-            else DomHandler.appendChild(this.wrapper, this.appendTo);
+            else this.domHandler.appendChild(this.wrapper, this.appendTo);
         }
     }
 
@@ -579,7 +588,7 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
 
     enableModality() {
         if (this.option('blockScroll')) {
-            DomHandler.addClass(this.document.body, 'p-overflow-hidden');
+            this.domHandler.addClass(this.document.body, 'p-overflow-hidden');
         }
 
         if (this.option('dismissableMask')) {
@@ -595,7 +604,7 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
         this.maskVisible = false;
 
         if (this.option('blockScroll')) {
-            DomHandler.removeClass(this.document.body, 'p-overflow-hidden');
+            this.domHandler.removeClass(this.document.body, 'p-overflow-hidden');
         }
 
         if (this.dismissableMask) {
@@ -611,7 +620,7 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
         if (!this.styleElement) {
             this.styleElement = this.document.createElement('style');
             this.styleElement.type = 'text/css';
-            DomHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
+            this.domHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
             this.document.head.appendChild(this.styleElement);
             let innerHTML = '';
             for (let breakpoint in this.breakpoints) {
@@ -678,7 +687,7 @@ export class ConfirmDialog implements AfterContentInit, OnInit, OnDestroy {
                 if (event.which === 9 && this.focusTrap) {
                     event.preventDefault();
 
-                    let focusableElements = DomHandler.getFocusableElements(this.container as HTMLDivElement);
+                    let focusableElements = this.domHandler.getFocusableElements(this.container as HTMLDivElement);
 
                     if (focusableElements && focusableElements.length > 0) {
                         if (!focusableElements[0].ownerDocument.activeElement) {

--- a/src/app/components/confirmpopup/confirmpopup.css
+++ b/src/app/components/confirmpopup/confirmpopup.css
@@ -3,7 +3,7 @@
         position: absolute;
         margin-top: 10px;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-confirm-popup-flipped {
@@ -14,7 +14,7 @@
     .p-confirm-popup:after,
     .p-confirm-popup:before {
         bottom: 100%;
-        left: calc(var(--overlayArrowLeft, 0) + 1.25rem);
+        inset-inline-start: calc(var(--overlayArrowLeft, 0) + 1.25rem);
         content: ' ';
         height: 0;
         width: 0;
@@ -24,12 +24,12 @@
 
     .p-confirm-popup:after {
         border-width: 8px;
-        margin-left: -8px;
+        margin-inline-start: -8px;
     }
 
     .p-confirm-popup:before {
         border-width: 10px;
-        margin-left: -10px;
+        margin-inline-start: -10px;
     }
 
     .p-confirm-popup-flipped:after,

--- a/src/app/components/contextmenu/contextmenu.css
+++ b/src/app/components/contextmenu/contextmenu.css
@@ -33,10 +33,10 @@
     }
 
     .p-contextmenu .p-menuitem-link .p-submenu-icon:not(svg) {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-contextmenu .p-menuitem-link .p-icon-wrapper {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 }

--- a/src/app/components/defer/defer.ts
+++ b/src/app/components/defer/defer.ts
@@ -1,5 +1,6 @@
 import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { AfterViewInit, ChangeDetectorRef, ContentChild, Directive, ElementRef, EmbeddedViewRef, EventEmitter, Inject, NgModule, OnDestroy, Output, PLATFORM_ID, Renderer2, TemplateRef, ViewContainerRef } from '@angular/core';
+import { DomHandler } from 'primeng/dom';
 import { Nullable } from 'primeng/ts-helpers';
 /**
  * Defer postpones the loading the content that is initially not in the viewport until it becomes visible on scroll.
@@ -33,7 +34,8 @@ export class DeferredLoader implements AfterViewInit, OnDestroy {
         public el: ElementRef,
         public renderer: Renderer2,
         public viewContainer: ViewContainerRef,
-        private cd: ChangeDetectorRef
+        private cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {
         this.window = this.document.defaultView as Window;
     }
@@ -60,7 +62,7 @@ export class DeferredLoader implements AfterViewInit, OnDestroy {
         if (this.isLoaded()) {
             return false;
         } else {
-            let rect = this.el.nativeElement.getBoundingClientRect();
+            let rect = this.domHandler.getBoundingClientRect(this.el.nativeElement);
             let docElement = this.document.documentElement;
             let winHeight = docElement.clientHeight;
 

--- a/src/app/components/dialog/dialog.css
+++ b/src/app/components/dialog/dialog.css
@@ -2,7 +2,7 @@
     .p-dialog-mask {
         position: fixed;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 100%;
         display: flex;
@@ -82,7 +82,7 @@
         width: 100vw !important;
         height: 100vh !important;
         top: 0px !important;
-        left: 0px !important;
+        inset-inline-start: 0px !important;
         max-height: 100%;
         height: 100%;
     }
@@ -128,8 +128,12 @@
         cursor: se-resize;
         width: 12px;
         height: 12px;
-        right: 1px;
+        inset-inline-end: 1px;
         bottom: 1px;
+    }
+
+    .p-dialog .p-resizable-handle:dir(rtl) {
+        cursor: sw-resize;
     }
 
     .p-confirm-dialog .p-dialog-content {

--- a/src/app/components/divider/divider.css
+++ b/src/app/components/divider/divider.css
@@ -10,7 +10,7 @@
         position: absolute;
         display: block;
         top: 50%;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         content: '';
     }
@@ -43,7 +43,7 @@
         position: absolute;
         display: block;
         top: 0;
-        left: 50%;
+        inset-inline-start: 50%;
         height: 100%;
         content: '';
     }
@@ -65,7 +65,7 @@
     }
 
     .p-divider-solid.p-divider-vertical:before {
-        border-left-style: solid;
+        border-inline-start-style: solid;
     }
 
     .p-divider-dashed.p-divider-horizontal:before {
@@ -73,7 +73,7 @@
     }
 
     .p-divider-dashed.p-divider-vertical:before {
-        border-left-style: dashed;
+        border-inline-start-style: dashed;
     }
 
     .p-divider-dotted.p-divider-horizontal:before {
@@ -81,6 +81,6 @@
     }
 
     .p-divider-dotted.p-divider-vertical:before {
-        border-left-style: dotted;
+        border-inline-start-style: dotted;
     }
 }

--- a/src/app/components/dock/dock.css
+++ b/src/app/components/dock/dock.css
@@ -55,7 +55,7 @@
     /* Position */
     /* top */
     .p-dock-top {
-        left: 0;
+        inset-inline-start: 0;
         top: 0;
         width: 100%;
     }
@@ -66,7 +66,7 @@
 
     /* bottom */
     .p-dock-bottom {
-        left: 0;
+        inset-inline-start: 0;
         bottom: 0;
         width: 100%;
     }
@@ -77,7 +77,7 @@
 
     /* right */
     .p-dock-right {
-        right: 0;
+        inset-inline-end: 0;
         top: 0;
         height: 100%;
     }
@@ -86,19 +86,27 @@
         transform-origin: center right;
     }
 
+    .p-dock-right .p-dock-item:dir(rtl) {
+        transform-origin: center left;
+    }
+
     .p-dock-right .p-dock-list {
         flex-direction: column;
     }
 
     /* left */
     .p-dock-left {
-        left: 0;
+        inset-inline-start: 0;
         top: 0;
         height: 100%;
     }
 
     .p-dock-left .p-dock-item {
         transform-origin: center left;
+    }
+
+    .p-dock-left .p-dock-item:dir(rtl) {
+        transform-origin: center right;
     }
 
     .p-dock-left .p-dock-list {

--- a/src/app/components/dock/dock.ts
+++ b/src/app/components/dock/dock.ts
@@ -166,7 +166,8 @@ export class Dock implements AfterContentInit {
 
     constructor(
         private el: ElementRef,
-        public cd: ChangeDetectorRef
+        public cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {
         this.currentIndex = -3;
     }
@@ -304,25 +305,25 @@ export class Dock implements AfterContentInit {
     }
 
     onEndKey() {
-        this.changeFocusedOptionIndex(DomHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]').length - 1);
+        this.changeFocusedOptionIndex(this.domHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]').length - 1);
     }
 
     onSpaceKey() {
-        const element = DomHandler.findSingle(this.listViewChild.nativeElement, `li[id="${`${this.focusedOptionIndex}`}"]`);
-        const anchorElement = element && DomHandler.findSingle(element, '[data-pc-section="action"]');
+        const element = this.domHandler.findSingle(this.listViewChild.nativeElement, `li[id="${`${this.focusedOptionIndex}`}"]`);
+        const anchorElement = element && this.domHandler.findSingle(element, '[data-pc-section="action"]');
 
         anchorElement ? anchorElement.click() : element && element.click();
     }
 
     findNextOptionIndex(index) {
-        const menuitems = DomHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
+        const menuitems = this.domHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
         const matchedOptionIndex = [...menuitems].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex + 1 : 0;
     }
 
     changeFocusedOptionIndex(index) {
-        const menuitems = DomHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
+        const menuitems = this.domHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
 
         let order = index >= menuitems.length ? menuitems.length - 1 : index < 0 ? 0 : index;
 
@@ -330,7 +331,7 @@ export class Dock implements AfterContentInit {
     }
 
     findPrevOptionIndex(index) {
-        const menuitems = DomHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
+        const menuitems = this.domHandler.find(this.listViewChild.nativeElement, 'li[data-pc-section="menuitem"][data-p-disabled="false"]');
         const matchedOptionIndex = [...menuitems].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex - 1 : 0;

--- a/src/app/components/dom/connectedoverlayscrollhandler.ts
+++ b/src/app/components/dom/connectedoverlayscrollhandler.ts
@@ -1,19 +1,14 @@
+import { Injectable } from '@angular/core';
 import { DomHandler } from './domhandler';
 
 export class ConnectedOverlayScrollHandler {
-    element: any;
+    private scrollableParents: any;
 
-    listener: any;
-
-    scrollableParents: any;
-
-    constructor(element: any, listener: any = () => {}) {
-        this.element = element;
-        this.listener = listener;
+    constructor(private element: any, private listener: any = () => {}, private domHandler: DomHandler) {
     }
 
     bindScrollListener() {
-        this.scrollableParents = DomHandler.getScrollableParents(this.element);
+        this.scrollableParents = this.domHandler.getScrollableParents(this.element);
         for (let i = 0; i < this.scrollableParents.length; i++) {
             this.scrollableParents[i].addEventListener('scroll', this.listener);
         }
@@ -33,4 +28,13 @@ export class ConnectedOverlayScrollHandler {
         this.listener = null;
         this.scrollableParents = null;
     }
+}
+
+@Injectable({ providedIn: "root" })
+export class ConnectedOverlayScrollHandlerFactory {
+  constructor(private domHandler: DomHandler) {}
+
+  create(element: any, listener: any = () => {}): ConnectedOverlayScrollHandler {
+    return new ConnectedOverlayScrollHandler(element, listener, this.domHandler);
+  }
 }

--- a/src/app/components/dom/domhandler.ts
+++ b/src/app/components/dom/domhandler.ts
@@ -1,29 +1,26 @@
-/**
- * @dynamic is for runtime initializing DomHandler.browser
- *
- * If delete below comment, we can see this error message:
- *  Metadata collected contains an error that will be reported at runtime:
- *  Only initialized variables and constants can be referenced
- *  because the value of this variable is needed by the template compiler.
- */
-// @dynamic
+import { Directionality } from "@angular/cdk/bidi";
+import { Injectable } from "@angular/core";
+
+@Injectable({ providedIn: "root" })
 export class DomHandler {
-    public static zindex: number = 1000;
+    public zindex: number = 1000;
 
-    private static calculatedScrollbarWidth: number = null;
+    private calculatedScrollbarWidth: number = null;
 
-    private static calculatedScrollbarHeight: number = null;
+    private calculatedScrollbarHeight: number = null;
 
-    private static browser: any;
+    private browser: any;
 
-    public static addClass(element: any, className: string): void {
+    constructor(private dir: Directionality) {}
+
+    public addClass(element: any, className: string): void {
         if (element && className) {
             if (element.classList) element.classList.add(className);
             else element.className += ' ' + className;
         }
     }
 
-    public static addMultipleClasses(element: any, className: string): void {
+    public addMultipleClasses(element: any, className: string): void {
         if (element && className) {
             if (element.classList) {
                 let styles: string[] = className.trim().split(' ');
@@ -39,14 +36,14 @@ export class DomHandler {
         }
     }
 
-    public static removeClass(element: any, className: string): void {
+    public removeClass(element: any, className: string): void {
         if (element && className) {
             if (element.classList) element.classList.remove(className);
             else element.className = element.className.replace(new RegExp('(^|\\b)' + className.split(' ').join('|') + '(\\b|$)', 'gi'), ' ');
         }
     }
 
-    public static removeMultipleClasses(element, classNames) {
+    public removeMultipleClasses(element, classNames) {
         if (element && classNames) {
             [classNames]
                 .flat()
@@ -55,7 +52,7 @@ export class DomHandler {
         }
     }
 
-    public static hasClass(element: any, className: string): boolean {
+    public hasClass(element: any, className: string): boolean {
         if (element && className) {
             if (element.classList) return element.classList.contains(className);
             else return new RegExp('(^| )' + className + '( |$)', 'gi').test(element.className);
@@ -64,21 +61,21 @@ export class DomHandler {
         return false;
     }
 
-    public static siblings(element: any): any {
+    public siblings(element: any): any {
         return Array.prototype.filter.call(element.parentNode.children, function (child) {
             return child !== element;
         });
     }
 
-    public static find(element: any, selector: string): any[] {
+    public find(element: any, selector: string): any[] {
         return Array.from(element.querySelectorAll(selector));
     }
 
-    public static findSingle(element: any, selector: string): any {
+    public findSingle(element: any, selector: string): any {
         return this.isElement(element) ? element.querySelector(selector) : null;
     }
 
-    public static index(element: any): number {
+    public index(element: any): number {
         let children = element.parentNode.childNodes;
         let num = 0;
         for (var i = 0; i < children.length; i++) {
@@ -88,7 +85,7 @@ export class DomHandler {
         return -1;
     }
 
-    public static indexWithinGroup(element: any, attributeName: string): number {
+    public indexWithinGroup(element: any, attributeName: string): number {
         let children = element.parentNode ? element.parentNode.childNodes : [];
         let num = 0;
         for (var i = 0; i < children.length; i++) {
@@ -98,16 +95,16 @@ export class DomHandler {
         return -1;
     }
 
-    public static appendOverlay(overlay: any, target: any, appendTo: any = 'self') {
+    public appendOverlay(overlay: any, target: any, appendTo: any = 'self') {
         if (appendTo !== 'self' && overlay && target) {
             this.appendChild(overlay, target);
         }
     }
 
-    public static alignOverlay(overlay: any, target: any, appendTo: any = 'self', calculateMinWidth: boolean = true) {
+    public alignOverlay(overlay: any, target: any, appendTo: any = 'self', calculateMinWidth: boolean = true) {
         if (overlay && target) {
             if (calculateMinWidth) {
-                overlay.style.minWidth = `${DomHandler.getOuterWidth(target)}px`;
+                overlay.style.minWidth = `${this.getOuterWidth(target)}px`;
             }
 
             if (appendTo === 'self') {
@@ -118,7 +115,7 @@ export class DomHandler {
         }
     }
 
-    public static relativePosition(element: any, target: any, gutter: boolean = true): void {
+    public relativePosition(element: any, target: any, gutter: boolean = true): void {
         const getClosestRelativeElement = (el) => {
             if (!el) return;
 
@@ -126,13 +123,13 @@ export class DomHandler {
         };
 
         const elementDimensions = element.offsetParent ? { width: element.offsetWidth, height: element.offsetHeight } : this.getHiddenElementDimensions(element);
-        const targetHeight = target.offsetHeight ?? target.getBoundingClientRect().height;
-        const targetOffset = target.getBoundingClientRect();
+        const targetHeight = target.offsetHeight ?? this.getBoundingClientRect(target).height;
+        const targetOffset = this.getBoundingClientRect(target);
         const windowScrollTop = this.getWindowScrollTop();
         const windowScrollLeft = this.getWindowScrollLeft();
         const viewport = this.getViewport();
         const relativeElement = getClosestRelativeElement(element);
-        const relativeElementOffset = relativeElement?.getBoundingClientRect() || { top: -1 * windowScrollTop, left: -1 * windowScrollLeft };
+        const relativeElementOffset = this.getBoundingClientRect(relativeElement) || { top: -1 * windowScrollTop, left: -1 * windowScrollLeft };
         let top: number, left: number;
 
         if (targetOffset.top + targetHeight + elementDimensions.height > viewport.height) {
@@ -160,17 +157,17 @@ export class DomHandler {
         }
 
         element.style.top = top + 'px';
-        element.style.left = left + 'px';
+        element.style.insetInlineStart = left + 'px';
         gutter && (element.style.marginTop = origin === 'bottom' ? 'calc(var(--p-anchor-gutter) * -1)' : 'calc(var(--p-anchor-gutter))');
     }
 
-    public static absolutePosition(element: any, target: any, gutter: boolean = true): void {
+    public absolutePosition(element: any, target: any, gutter: boolean = true): void {
         const elementDimensions = element.offsetParent ? { width: element.offsetWidth, height: element.offsetHeight } : this.getHiddenElementDimensions(element);
         const elementOuterHeight = elementDimensions.height;
         const elementOuterWidth = elementDimensions.width;
-        const targetOuterHeight = target.offsetHeight ?? target.getBoundingClientRect().height;
-        const targetOuterWidth = target.offsetWidth ?? target.getBoundingClientRect().width;
-        const targetOffset = target.getBoundingClientRect();
+        const targetOuterHeight = target.offsetHeight ?? this.getBoundingClientRect(target).height;
+        const targetOuterWidth = target.offsetWidth ?? this.getBoundingClientRect(target).width;
+        const targetOffset = this.getBoundingClientRect(target);
         const windowScrollTop = this.getWindowScrollTop();
         const windowScrollLeft = this.getWindowScrollLeft();
         const viewport = this.getViewport();
@@ -188,19 +185,20 @@ export class DomHandler {
             element.style.transformOrigin = 'top';
         }
 
+        
         if (targetOffset.left + elementOuterWidth > viewport.width) left = Math.max(0, targetOffset.left + windowScrollLeft + targetOuterWidth - elementOuterWidth);
         else left = targetOffset.left + windowScrollLeft;
 
         element.style.top = top + 'px';
-        element.style.left = left + 'px';
+        element.style.insetInlineStart = left + 'px';
         gutter && (element.style.marginTop = origin === 'bottom' ? 'calc(var(--p-anchor-gutter) * -1)' : 'calc(var(--p-anchor-gutter))');
     }
 
-    static getParents(element: any, parents: any = []): any {
+    getParents(element: any, parents: any = []): any {
         return element['parentNode'] === null ? parents : this.getParents(element.parentNode, parents.concat([element.parentNode]));
     }
 
-    static getScrollableParents(element: any) {
+    getScrollableParents(element: any) {
         let scrollableParents = [];
 
         if (element) {
@@ -232,7 +230,7 @@ export class DomHandler {
         return scrollableParents;
     }
 
-    public static getHiddenElementOuterHeight(element: any): number {
+    public getHiddenElementOuterHeight(element: any): number {
         element.style.visibility = 'hidden';
         element.style.display = 'block';
         let elementHeight = element.offsetHeight;
@@ -242,7 +240,7 @@ export class DomHandler {
         return elementHeight;
     }
 
-    public static getHiddenElementOuterWidth(element: any): number {
+    public getHiddenElementOuterWidth(element: any): number {
         element.style.visibility = 'hidden';
         element.style.display = 'block';
         let elementWidth = element.offsetWidth;
@@ -252,7 +250,7 @@ export class DomHandler {
         return elementWidth;
     }
 
-    public static getHiddenElementDimensions(element: any): any {
+    public getHiddenElementDimensions(element: any): any {
         let dimensions: any = {};
         element.style.visibility = 'hidden';
         element.style.display = 'block';
@@ -264,13 +262,19 @@ export class DomHandler {
         return dimensions;
     }
 
-    public static scrollInView(container, item) {
+    public getBoundingClientRect(element) {
+        if (!element) return undefined;
+        const rect = element.getBoundingClientRect();
+        return this.isRtl() ? new DOMRect(document.body.clientWidth - rect.right, rect.y, rect.width, rect.height) : rect;
+    }
+
+    public scrollInView(container, item) {
         let borderTopValue: string = getComputedStyle(container).getPropertyValue('borderTopWidth');
         let borderTop: number = borderTopValue ? parseFloat(borderTopValue) : 0;
         let paddingTopValue: string = getComputedStyle(container).getPropertyValue('paddingTop');
         let paddingTop: number = paddingTopValue ? parseFloat(paddingTopValue) : 0;
-        let containerRect = container.getBoundingClientRect();
-        let itemRect = item.getBoundingClientRect();
+        let containerRect = this.getBoundingClientRect(container);
+        let itemRect = this.getBoundingClientRect(item);
         let offset = itemRect.top + document.body.scrollTop - (containerRect.top + document.body.scrollTop) - borderTop - paddingTop;
         let scroll = container.scrollTop;
         let elementHeight = container.clientHeight;
@@ -283,7 +287,7 @@ export class DomHandler {
         }
     }
 
-    public static fadeIn(element, duration: number): void {
+    public fadeIn(element, duration: number): void {
         element.style.opacity = 0;
 
         let last = +new Date();
@@ -301,7 +305,7 @@ export class DomHandler {
         tick();
     }
 
-    public static fadeOut(element, ms) {
+    public fadeOut(element, ms) {
         var opacity = 1,
             interval = 50,
             duration = ms,
@@ -319,17 +323,49 @@ export class DomHandler {
         }, interval);
     }
 
-    public static getWindowScrollTop(): number {
+    public getWindowScrollTop(): number {
         let doc = document.documentElement;
-        return (window.pageYOffset || doc.scrollTop) - (doc.clientTop || 0);
+        return (window.scrollY || doc.scrollTop) - (doc.clientTop || 0);
     }
 
-    public static getWindowScrollLeft(): number {
+    public getWindowScrollLeft(): number {
         let doc = document.documentElement;
-        return (window.pageXOffset || doc.scrollLeft) - (doc.clientLeft || 0);
+        return (this.getWindowScrollX() || this.getScrollLeft(doc)) - (this.getClientLeft(doc) || 0);
     }
 
-    public static matches(element, selector: string): boolean {
+    public getClientLeft(element) {
+        return this.isRtl() ? element.offsetWidth - element.clientWidth - element.clientLeft : element.clientLeft;
+    }
+
+    public getWindowScrollX() {
+        return Math.abs(window.scrollX);
+    }
+
+    public getScrollLeft(element) {
+        return Math.abs(element?.scrollLeft);
+    }
+
+    public setScrollLeft(element, value) {
+        element.scrollLeft = this.isRtl() ? -value : value;
+    }
+
+    public getOffsetLeft(element) {
+        return this.isRtl() ? element.offsetParent.offsetWidth - element.offsetLeft : element.offsetLeft;
+    }
+
+    public getPageX(event) {
+        return this.isRtl() ? document.body.scrollWidth - event.pageX : event.pageX;
+    }
+
+    public getClientX(event) {
+        return this.isRtl() ? document.body.clientWidth - event.clientX : event.clientX;
+    }
+
+    public getOffsetX(event) {
+        return this.isRtl() ? (event.target.offsetParent?.offsetWidth ?? event.target.parentElement.clientWidth) - event.offsetX : event.offsetX;
+    }
+
+    public matches(element, selector: string): boolean {
         var p = Element.prototype;
         var f =
             p['matches'] ||
@@ -342,44 +378,44 @@ export class DomHandler {
         return f.call(element, selector);
     }
 
-    public static getOuterWidth(el, margin?) {
+    public getOuterWidth(el, margin?) {
         let width = el.offsetWidth;
 
         if (margin) {
             let style = getComputedStyle(el);
-            width += parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+            width += parseFloat(style.marginInlineStart) + parseFloat(style.marginInlineEnd);
         }
 
         return width;
     }
 
-    public static getHorizontalPadding(el) {
+    public getHorizontalPadding(el) {
         let style = getComputedStyle(el);
-        return parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+        return parseFloat(style.paddingInlineStart) + parseFloat(style.paddingInlineEnd);
     }
 
-    public static getHorizontalMargin(el) {
+    public getHorizontalMargin(el) {
         let style = getComputedStyle(el);
-        return parseFloat(style.marginLeft) + parseFloat(style.marginRight);
+        return parseFloat(style.marginInlineStart) + parseFloat(style.marginInlineEnd);
     }
 
-    public static innerWidth(el) {
+    public innerWidth(el) {
         let width = el.offsetWidth;
         let style = getComputedStyle(el);
 
-        width += parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+        width += parseFloat(style.paddingInlineStart) + parseFloat(style.paddingInlineEnd);
         return width;
     }
 
-    public static width(el) {
+    public width(el) {
         let width = el.offsetWidth;
         let style = getComputedStyle(el);
 
-        width -= parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+        width -= parseFloat(style.paddingInlineStart) + parseFloat(style.paddingInlineEnd);
         return width;
     }
 
-    public static getInnerHeight(el) {
+    public getInnerHeight(el) {
         let height = el.offsetHeight;
         let style = getComputedStyle(el);
 
@@ -387,7 +423,7 @@ export class DomHandler {
         return height;
     }
 
-    public static getOuterHeight(el, margin?) {
+    public getOuterHeight(el, margin?) {
         let height = el.offsetHeight;
 
         if (margin) {
@@ -398,7 +434,7 @@ export class DomHandler {
         return height;
     }
 
-    public static getHeight(el): number {
+    public getHeight(el): number {
         let height = el.offsetHeight;
         let style = getComputedStyle(el);
 
@@ -407,16 +443,16 @@ export class DomHandler {
         return height;
     }
 
-    public static getWidth(el): number {
+    public getWidth(el): number {
         let width = el.offsetWidth;
         let style = getComputedStyle(el);
 
-        width -= parseFloat(style.paddingLeft) + parseFloat(style.paddingRight) + parseFloat(style.borderLeftWidth) + parseFloat(style.borderRightWidth);
+        width -= parseFloat(style.paddingInlineStart) + parseFloat(style.paddingInlineEnd) + parseFloat(style.borderInlineStartWidth) + parseFloat(style.borderInlineEndWidth);
 
         return width;
     }
 
-    public static getViewport(): any {
+    public getViewport(): any {
         let win = window,
             d = document,
             e = d.documentElement,
@@ -427,28 +463,28 @@ export class DomHandler {
         return { width: w, height: h };
     }
 
-    public static getOffset(el) {
-        var rect = el.getBoundingClientRect();
+    public getOffset(el) {
+        var rect = this.getBoundingClientRect(el);
 
         return {
-            top: rect.top + (window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0),
-            left: rect.left + (window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft || 0)
+            top: rect.top + (window.scrollY || document.documentElement.scrollTop || document.body.scrollTop || 0),
+            left: rect.left + (this.getWindowScrollX() || this.getScrollLeft(document.documentElement) || this.getScrollLeft(document.body) || 0)
         };
     }
 
-    public static replaceElementWith(element: any, replacementElement: any): any {
+    public replaceElementWith(element: any, replacementElement: any): any {
         let parentNode = element.parentNode;
         if (!parentNode) throw `Can't replace element`;
         return parentNode.replaceChild(replacementElement, element);
     }
 
-    public static getUserAgent(): string {
+    public getUserAgent(): string {
         if (navigator && this.isClient()) {
             return navigator.userAgent;
         }
     }
 
-    public static isIE() {
+    public isIE() {
         var ua = window.navigator.userAgent;
 
         var msie = ua.indexOf('MSIE ');
@@ -474,43 +510,43 @@ export class DomHandler {
         return false;
     }
 
-    public static isIOS() {
+    public isIOS() {
         return /iPad|iPhone|iPod/.test(navigator.userAgent) && !window['MSStream'];
     }
 
-    public static isAndroid() {
+    public isAndroid() {
         return /(android)/i.test(navigator.userAgent);
     }
 
-    public static isTouchDevice() {
+    public isTouchDevice() {
         return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
     }
 
-    public static appendChild(element: any, target: any) {
+    public appendChild(element: any, target: any) {
         if (this.isElement(target)) target.appendChild(element);
         else if (target && target.el && target.el.nativeElement) target.el.nativeElement.appendChild(element);
         else throw 'Cannot append ' + target + ' to ' + element;
     }
 
-    public static removeChild(element: any, target: any) {
+    public removeChild(element: any, target: any) {
         if (this.isElement(target)) target.removeChild(element);
         else if (target.el && target.el.nativeElement) target.el.nativeElement.removeChild(element);
         else throw 'Cannot remove ' + element + ' from ' + target;
     }
 
-    public static removeElement(element: Element) {
+    public removeElement(element: Element) {
         if (!('remove' in Element.prototype)) element.parentNode.removeChild(element);
         else element.remove();
     }
 
-    public static isElement(obj: any) {
+    public isElement(obj: any) {
         return typeof HTMLElement === 'object' ? obj instanceof HTMLElement : obj && typeof obj === 'object' && obj !== null && obj.nodeType === 1 && typeof obj.nodeName === 'string';
     }
 
-    public static calculateScrollbarWidth(el?: HTMLElement): number {
+    public calculateScrollbarWidth(el?: HTMLElement): number {
         if (el) {
             let style = getComputedStyle(el);
-            return el.offsetWidth - el.clientWidth - parseFloat(style.borderLeftWidth) - parseFloat(style.borderRightWidth);
+            return el.offsetWidth - el.clientWidth - parseFloat(style.borderInlineStartWidth) - parseFloat(style.borderInlineEndWidth);
         } else {
             if (this.calculatedScrollbarWidth !== null) return this.calculatedScrollbarWidth;
 
@@ -527,7 +563,7 @@ export class DomHandler {
         }
     }
 
-    public static calculateScrollbarHeight(): number {
+    public calculateScrollbarHeight(): number {
         if (this.calculatedScrollbarHeight !== null) return this.calculatedScrollbarHeight;
 
         let scrollDiv = document.createElement('div');
@@ -542,11 +578,11 @@ export class DomHandler {
         return scrollbarHeight;
     }
 
-    public static invokeElementMethod(element: any, methodName: string, args?: any[]): void {
+    public invokeElementMethod(element: any, methodName: string, args?: any[]): void {
         (element as any)[methodName].apply(element, args);
     }
 
-    public static clearSelection(): void {
+    public clearSelection(): void {
         if (window.getSelection) {
             if (window.getSelection().empty) {
                 window.getSelection().empty();
@@ -562,7 +598,7 @@ export class DomHandler {
         }
     }
 
-    public static getBrowser() {
+    public getBrowser() {
         if (!this.browser) {
             let matched = this.resolveUserAgent();
             this.browser = {};
@@ -582,7 +618,7 @@ export class DomHandler {
         return this.browser;
     }
 
-    public static resolveUserAgent() {
+    public resolveUserAgent() {
         let ua = navigator.userAgent.toLowerCase();
         let match =
             /(chrome)[ \/]([\w.]+)/.exec(ua) || /(webkit)[ \/]([\w.]+)/.exec(ua) || /(opera)(?:.*version|)[ \/]([\w.]+)/.exec(ua) || /(msie) ([\w.]+)/.exec(ua) || (ua.indexOf('compatible') < 0 && /(mozilla)(?:.*? rv:([\w.]+)|)/.exec(ua)) || [];
@@ -593,7 +629,7 @@ export class DomHandler {
         };
     }
 
-    public static isInteger(value): boolean {
+    public isInteger(value): boolean {
         if (Number.isInteger) {
             return Number.isInteger(value);
         } else {
@@ -601,23 +637,23 @@ export class DomHandler {
         }
     }
 
-    public static isHidden(element: HTMLElement): boolean {
+    public isHidden(element: HTMLElement): boolean {
         return !element || element.offsetParent === null;
     }
 
-    public static isVisible(element: HTMLElement) {
+    public isVisible(element: HTMLElement) {
         return element && element.offsetParent != null;
     }
 
-    public static isExist(element: HTMLElement) {
+    public isExist(element: HTMLElement) {
         return element !== null && typeof element !== 'undefined' && element.nodeName && element.parentNode;
     }
 
-    public static focus(element: HTMLElement, options?: FocusOptions): void {
+    public focus(element: HTMLElement, options?: FocusOptions): void {
         element && document.activeElement !== element && element.focus(options);
     }
 
-    public static getFocusableSelectorString(selector = ''): string {
+    public getFocusableSelectorString(selector = ''): string {
         return `button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
         [href][clientHeight][clientWidth]:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
         input:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
@@ -629,7 +665,7 @@ export class DomHandler {
         .p-button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector}`;
     }
 
-    public static getFocusableElements(element, selector = ''): any[] {
+    public getFocusableElements(element, selector = ''): any[] {
         let focusableElements = this.find(element, this.getFocusableSelectorString(selector));
 
         let visibleFocusableElements = [];
@@ -642,7 +678,7 @@ export class DomHandler {
         return visibleFocusableElements;
     }
 
-    public static getFocusableElement(element, selector = ''): any | null {
+    public getFocusableElement(element, selector = ''): any | null {
         let focusableElement = this.findSingle(element, this.getFocusableSelectorString(selector));
 
         if (focusableElement) {
@@ -653,20 +689,20 @@ export class DomHandler {
         return null;
     }
 
-    public static getFirstFocusableElement(element, selector = '') {
+    public getFirstFocusableElement(element, selector = '') {
         const focusableElements = this.getFocusableElements(element, selector);
 
         return focusableElements.length > 0 ? focusableElements[0] : null;
     }
 
-    public static getLastFocusableElement(element, selector) {
+    public getLastFocusableElement(element, selector) {
         const focusableElements = this.getFocusableElements(element, selector);
 
         return focusableElements.length > 0 ? focusableElements[focusableElements.length - 1] : null;
     }
 
-    public static getNextFocusableElement(element: HTMLElement, reverse = false) {
-        const focusableElements = DomHandler.getFocusableElements(element);
+    public getNextFocusableElement(element: HTMLElement, reverse = false) {
+        const focusableElements = this.getFocusableElements(element);
         let index = 0;
         if (focusableElements && focusableElements.length > 0) {
             const focusedIndex = focusableElements.indexOf(focusableElements[0].ownerDocument.activeElement);
@@ -685,12 +721,12 @@ export class DomHandler {
         return focusableElements[index];
     }
 
-    static generateZIndex() {
+    generateZIndex() {
         this.zindex = this.zindex || 999;
         return ++this.zindex;
     }
 
-    public static getSelection() {
+    public getSelection() {
         if (window.getSelection) return window.getSelection().toString();
         else if (document.getSelection) return document.getSelection().toString();
         else if (document['selection']) return document['selection'].createRange().text;
@@ -698,7 +734,7 @@ export class DomHandler {
         return null;
     }
 
-    public static getTargetElement(target: any, el?: HTMLElement) {
+    public getTargetElement(target: any, el?: HTMLElement) {
         if (!target) return null;
 
         switch (target) {
@@ -730,11 +766,11 @@ export class DomHandler {
         }
     }
 
-    public static isClient() {
+    public isClient() {
         return !!(typeof window !== 'undefined' && window.document && window.document.createElement);
     }
 
-    public static getAttribute(element, name) {
+    public getAttribute(element, name) {
         if (element) {
             const value = element.getAttribute(name);
 
@@ -752,21 +788,21 @@ export class DomHandler {
         return undefined;
     }
 
-    public static calculateBodyScrollbarWidth() {
+    public calculateBodyScrollbarWidth() {
         return window.innerWidth - document.documentElement.offsetWidth;
     }
 
-    public static blockBodyScroll(className = 'p-overflow-hidden') {
+    public blockBodyScroll(className = 'p-overflow-hidden') {
         document.body.style.setProperty('--scrollbar-width', this.calculateBodyScrollbarWidth() + 'px');
         this.addClass(document.body, className);
     }
 
-    public static unblockBodyScroll(className = 'p-overflow-hidden') {
+    public unblockBodyScroll(className = 'p-overflow-hidden') {
         document.body.style.removeProperty('--scrollbar-width');
         this.removeClass(document.body, className);
     }
 
-    public static createElement(type, attributes = {}, ...children) {
+    public createElement(type, attributes = {}, ...children) {
         if (type) {
             const element = document.createElement(type);
 
@@ -779,13 +815,13 @@ export class DomHandler {
         return undefined;
     }
 
-    public static setAttribute(element, attribute = '', value) {
+    public setAttribute(element, attribute = '', value) {
         if (this.isElement(element) && value !== null && value !== undefined) {
             element.setAttribute(attribute, value);
         }
     }
 
-    public static setAttributes(element, attributes = {}) {
+    public setAttributes(element, attributes = {}) {
         if (this.isElement(element)) {
             const computedStyles = (rule, value) => {
                 const styles = element?.$attrs?.[rule] ? [element?.$attrs?.[rule]] : [];
@@ -827,7 +863,7 @@ export class DomHandler {
         }
     }
 
-    public static isFocusableElement(element, selector = '') {
+    public isFocusableElement(element, selector = '') {
         return this.isElement(element)
             ? element.matches(`button:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
                 [href][clientHeight][clientWidth]:not([tabindex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
@@ -837,5 +873,9 @@ export class DomHandler {
                 [tabIndex]:not([tabIndex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector},
                 [contenteditable]:not([tabIndex = "-1"]):not([disabled]):not([style*="display:none"]):not([hidden])${selector}`)
             : false;
+    }
+
+    public isRtl() {
+      return this.dir.value === "rtl";
     }
 }

--- a/src/app/components/dragdrop/dragdrop.ts
+++ b/src/app/components/dragdrop/dragdrop.ts
@@ -56,7 +56,8 @@ export class Draggable implements AfterViewInit, OnDestroy {
     constructor(
         public el: ElementRef,
         public zone: NgZone,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     @Input() get pDraggableDisabled(): boolean {
@@ -152,7 +153,7 @@ export class Draggable implements AfterViewInit, OnDestroy {
     }
 
     allowDrag(): boolean {
-        if (this.dragHandle && this.handle) return DomHandler.matches(this.handle, this.dragHandle);
+        if (this.dragHandle && this.handle) return this.domHandler.matches(this.handle, this.dragHandle);
         else return true;
     }
 
@@ -202,7 +203,8 @@ export class Droppable implements AfterViewInit, OnDestroy {
     constructor(
         public el: ElementRef,
         public zone: NgZone,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     dragOverListener: VoidListener;
@@ -237,7 +239,7 @@ export class Droppable implements AfterViewInit, OnDestroy {
     @HostListener('drop', ['$event'])
     drop(event: DragEvent) {
         if (this.allowDrop(event)) {
-            DomHandler.removeClass(this.el.nativeElement, 'p-draggable-enter');
+            this.domHandler.removeClass(this.el.nativeElement, 'p-draggable-enter');
             event.preventDefault();
             this.onDrop.emit(event);
         }
@@ -251,7 +253,7 @@ export class Droppable implements AfterViewInit, OnDestroy {
             (event.dataTransfer as DataTransfer).dropEffect = this.dropEffect;
         }
 
-        DomHandler.addClass(this.el.nativeElement, 'p-draggable-enter');
+        this.domHandler.addClass(this.el.nativeElement, 'p-draggable-enter');
         this.onDragEnter.emit(event);
     }
 
@@ -260,7 +262,7 @@ export class Droppable implements AfterViewInit, OnDestroy {
         event.preventDefault();
 
         if (!this.el.nativeElement.contains(event.relatedTarget)) {
-            DomHandler.removeClass(this.el.nativeElement, 'p-draggable-enter');
+            this.domHandler.removeClass(this.el.nativeElement, 'p-draggable-enter');
             this.onDragLeave.emit(event);
         }
     }

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1024,7 +1024,8 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         public cd: ChangeDetectorRef,
         public zone: NgZone,
         public filterService: FilterService,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {
         effect(() => {
             const modelValue = this.modelValue();
@@ -1083,9 +1084,9 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         }
 
         if (this.selectedOptionUpdated && this.itemsWrapper) {
-            let selectedItem = DomHandler.findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, 'li.p-highlight');
+            let selectedItem = this.domHandler.findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, 'li.p-highlight');
             if (selectedItem) {
-                DomHandler.scrollInView(this.itemsWrapper, selectedItem);
+                this.domHandler.scrollInView(this.itemsWrapper, selectedItem);
             }
             this.selectedOptionUpdated = false;
         }
@@ -1378,7 +1379,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         this.focusedOptionIndex.set(focusedOptionIndex);
 
         if (isFocus) {
-            DomHandler.focus(this.focusInputViewChild?.nativeElement);
+            this.domHandler.focus(this.focusInputViewChild?.nativeElement);
         }
 
         this.cd.markForCheck();
@@ -1386,7 +1387,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
 
     onOverlayAnimationStart(event: AnimationEvent) {
         if (event.toState === 'visible') {
-            this.itemsWrapper = DomHandler.findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '.p-scroller' : '.p-dropdown-items-wrapper');
+            this.itemsWrapper = this.domHandler.findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '.p-scroller' : '.p-dropdown-items-wrapper');
             this.virtualScroll && this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
 
             if (this.options && this.options.length) {
@@ -1396,7 +1397,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
                         this.scroller?.scrollToIndex(selectedIndex);
                     }
                 } else {
-                    let selectedListItem = DomHandler.findSingle(this.itemsWrapper, '.p-dropdown-item.p-highlight');
+                    let selectedListItem = this.domHandler.findSingle(this.itemsWrapper, '.p-dropdown-item.p-highlight');
 
                     if (selectedListItem) {
                         selectedListItem.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -1431,7 +1432,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         this.searchValue = '';
 
         if (this.overlayOptions?.mode === 'modal') {
-            DomHandler.unblockBodyScroll();
+            this.domHandler.unblockBodyScroll();
         }
         if (this.filter && this.resetFilterOnHide) {
             this.resetFilter();
@@ -1439,12 +1440,12 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         if (isFocus) {
             if (this.focusInputViewChild) {
                 setTimeout(() => {
-                    DomHandler.focus(this.focusInputViewChild?.nativeElement);
+                    this.domHandler.focus(this.focusInputViewChild?.nativeElement);
                 });
             }
             if (this.editable && this.editableInputViewChild) {
                 setTimeout(() => {
-                    DomHandler.focus(this.editableInputViewChild?.nativeElement);
+                    this.domHandler.focus(this.editableInputViewChild?.nativeElement);
                 });
             }
         }
@@ -1643,7 +1644,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
 
         if (this.itemsViewChild && this.itemsViewChild.nativeElement) {
-            const element = DomHandler.findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
+            const element = this.domHandler.findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
             if (element) {
                 element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             } else if (!this.virtualScrollerDisabled) {
@@ -1820,7 +1821,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     onTabKey(event, pressedInInputText = false) {
         if (!pressedInInputText) {
             if (this.overlayVisible && this.hasFocusableElements()) {
-                DomHandler.focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay.nativeElement : this.firstHiddenFocusableElementOnOverlay.nativeElement);
+                this.domHandler.focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay.nativeElement : this.firstHiddenFocusableElementOnOverlay.nativeElement);
                 event.preventDefault();
             } else {
                 if (this.focusedOptionIndex() !== -1 && this.overlayVisible) {
@@ -1834,21 +1835,21 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     onFirstHiddenFocus(event) {
-        const focusableEl = event.relatedTarget === this.focusInputViewChild?.nativeElement ? DomHandler.getFirstFocusableElement(this.overlayViewChild.el?.nativeElement, ':not(.p-hidden-focusable)') : this.focusInputViewChild?.nativeElement;
-        DomHandler.focus(focusableEl);
+        const focusableEl = event.relatedTarget === this.focusInputViewChild?.nativeElement ? this.domHandler.getFirstFocusableElement(this.overlayViewChild.el?.nativeElement, ':not(.p-hidden-focusable)') : this.focusInputViewChild?.nativeElement;
+        this.domHandler.focus(focusableEl);
     }
 
     onLastHiddenFocus(event) {
         const focusableEl =
             event.relatedTarget === this.focusInputViewChild?.nativeElement
-                ? DomHandler.getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])')
+                ? this.domHandler.getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])')
                 : this.focusInputViewChild?.nativeElement;
 
-        DomHandler.focus(focusableEl);
+        this.domHandler.focus(focusableEl);
     }
 
     hasFocusableElements() {
-        return DomHandler.getFocusableElements(this.overlayViewChild.overlayViewChild.nativeElement, ':not([data-p-hidden-focusable="true"]):not([class="p-dropdown-items-wrapper"])').length > 0;
+        return this.domHandler.getFocusableElements(this.overlayViewChild.overlayViewChild.nativeElement, ':not([data-p-hidden-focusable="true"]):not([class="p-dropdown-items-wrapper"])').length > 0;
     }
 
     onBackspaceKey(event: KeyboardEvent, pressedInInputText = false) {
@@ -1922,8 +1923,8 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
     }
 
     applyFocus(): void {
-        if (this.editable) DomHandler.findSingle(this.el.nativeElement, '.p-dropdown-label.p-inputtext').focus();
-        else DomHandler.focus(this.focusInputViewChild?.nativeElement);
+        if (this.editable) this.domHandler.findSingle(this.el.nativeElement, '.p-dropdown-label.p-inputtext').focus();
+        else this.domHandler.focus(this.focusInputViewChild?.nativeElement);
     }
     /**
      * Applies focus.

--- a/src/app/components/dynamicdialog/dialogservice.ts
+++ b/src/app/components/dynamicdialog/dialogservice.ts
@@ -17,7 +17,8 @@ export class DialogService {
     constructor(
         private appRef: ApplicationRef,
         private injector: Injector,
-        @Inject(DOCUMENT) private document: Document
+        @Inject(DOCUMENT) private document: Document,
+        private domHandler: DomHandler
     ) {}
     /**
      * Displays the dialog using the dynamic dialog object options.
@@ -71,7 +72,7 @@ export class DialogService {
         if (!config.appendTo || config.appendTo === 'body') {
             this.document.body.appendChild(domElem);
         } else {
-            DomHandler.appendChild(domElem, config.appendTo);
+            this.domHandler.appendChild(domElem, config.appendTo);
         }
 
         this.dialogComponentRefMap.set(dialogRef, componentRef);

--- a/src/app/components/editor/editor.css
+++ b/src/app/components/editor/editor.css
@@ -2,3 +2,30 @@
     width: auto;
     height: auto;
 }
+
+.ql-toolbar:dir(rtl) {
+    button {
+        float: inline-start;
+
+        &.ql-blockquote,
+        &.ql-list,
+        &.ql-indent,
+        &.ql-direction,
+        &.ql-align,
+        &.ql-link {
+            transform: scaleX(-1);
+        }
+    }
+
+    .ql-picker-label {
+        padding-left: unset;
+        padding-right: unset;
+        padding-inline-start: 8px;
+        padding-inline-end: 2px;
+
+        &:not(.ql-color-picker):not(.ql-icon-picker) > svg {
+            right: unset;
+            inset-inline-end: 0;
+        }
+    }
+}

--- a/src/app/components/editor/editor.ts
+++ b/src/app/components/editor/editor.ts
@@ -196,6 +196,7 @@ export class Editor implements AfterContentInit, ControlValueAccessor {
 
     constructor(
         public el: ElementRef,
+        private domHandler: DomHandler,
         @Inject(PLATFORM_ID) private platformId: object
     ) {
         /**
@@ -301,9 +302,17 @@ export class Editor implements AfterContentInit, ControlValueAccessor {
             this.quill.setContents(this.quill.clipboard.convert(isQuill2 ? { html: this.value } : this.value));
         }
 
+        if (this.domHandler.isRtl()) {
+            this.quill.format('align', 'right');
+            this.quill.format('direction', 'rtl');
+        } else {
+            this.quill.format('align', 'left');
+            this.quill.format('direction', 'ltr');
+        }
+
         this.quill.on('text-change', (delta: any, oldContents: any, source: any) => {
             if (source === 'user') {
-                let html = isQuill2 ? this.quill.getSemanticHTML() : DomHandler.findSingle(editorElement, '.ql-editor').innerHTML;
+                let html = isQuill2 ? this.quill.getSemanticHTML() : this.domHandler.findSingle(editorElement, '.ql-editor').innerHTML;
                 let text = this.quill.getText().trim();
                 if (html === '<p><br></p>') {
                     html = null;
@@ -337,8 +346,8 @@ export class Editor implements AfterContentInit, ControlValueAccessor {
     private initQuillElements(): void {
         if (!this.quillElements) {
             this.quillElements = {
-                editorElement: DomHandler.findSingle(this.el.nativeElement, 'div.p-editor-content'),
-                toolbarElement: DomHandler.findSingle(this.el.nativeElement, 'div.p-editor-toolbar')
+                editorElement: this.domHandler.findSingle(this.el.nativeElement, 'div.p-editor-content'),
+                toolbarElement: this.domHandler.findSingle(this.el.nativeElement, 'div.p-editor-toolbar')
             };
         }
     }

--- a/src/app/components/fileupload/fileupload.css
+++ b/src/app/components/fileupload/fileupload.css
@@ -14,14 +14,14 @@
     }
 
     .p-fileupload-row > div:last-child {
-        text-align: right;
+        text-align: end;
     }
 
     .p-fileupload-content .p-progressbar {
         width: 100%;
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-button.p-fileupload-choose {

--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -536,7 +536,8 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
         public zone: NgZone,
         private http: HttpClient,
         public cd: ChangeDetectorRef,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterContentInit() {
@@ -914,7 +915,7 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
 
     onDragOver(e: DragEvent) {
         if (!this.disabled) {
-            DomHandler.addClass(this.content?.nativeElement, 'p-fileupload-highlight');
+            this.domHandler.addClass(this.content?.nativeElement, 'p-fileupload-highlight');
             this.dragHighlight = true;
             e.stopPropagation();
             e.preventDefault();
@@ -923,13 +924,13 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
 
     onDragLeave(event: DragEvent) {
         if (!this.disabled) {
-            DomHandler.removeClass(this.content?.nativeElement, 'p-fileupload-highlight');
+            this.domHandler.removeClass(this.content?.nativeElement, 'p-fileupload-highlight');
         }
     }
 
     onDrop(event: any) {
         if (!this.disabled) {
-            DomHandler.removeClass(this.content?.nativeElement, 'p-fileupload-highlight');
+            this.domHandler.removeClass(this.content?.nativeElement, 'p-fileupload-highlight');
             event.stopPropagation();
             event.preventDefault();
 

--- a/src/app/components/focustrap/focustrap.ts
+++ b/src/app/components/focustrap/focustrap.ts
@@ -25,6 +25,8 @@ export class FocusTrap {
 
     document: Document = inject(DOCUMENT);
 
+    domHandler = inject(DomHandler);
+
     firstHiddenFocusableElement!: HTMLElement;
 
     lastHiddenFocusableElement!: HTMLElement;
@@ -62,7 +64,7 @@ export class FocusTrap {
         const tabindex = '0';
 
         const createFocusableElement = (onFocus) => {
-            return DomHandler.createElement('span', {
+            return this.domHandler.createElement('span', {
                 class: 'p-hidden-accessible p-hidden-focusable',
                 tabindex,
                 role: 'presentation',
@@ -85,17 +87,17 @@ export class FocusTrap {
     onFirstHiddenElementFocus(event) {
         const { currentTarget, relatedTarget } = event;
         const focusableElement =
-            relatedTarget === this.lastHiddenFocusableElement || !this.host.nativeElement?.contains(relatedTarget) ? DomHandler.getFirstFocusableElement(currentTarget.parentElement, ':not(.p-hidden-focusable)') : this.lastHiddenFocusableElement;
+            relatedTarget === this.lastHiddenFocusableElement || !this.host.nativeElement?.contains(relatedTarget) ? this.domHandler.getFirstFocusableElement(currentTarget.parentElement, ':not(.p-hidden-focusable)') : this.lastHiddenFocusableElement;
 
-        DomHandler.focus(focusableElement);
+        this.domHandler.focus(focusableElement);
     }
 
     onLastHiddenElementFocus(event) {
         const { currentTarget, relatedTarget } = event;
         const focusableElement =
-            relatedTarget === this.firstHiddenFocusableElement || !this.host.nativeElement?.contains(relatedTarget) ? DomHandler.getLastFocusableElement(currentTarget.parentElement, ':not(.p-hidden-focusable)') : this.firstHiddenFocusableElement;
+            relatedTarget === this.firstHiddenFocusableElement || !this.host.nativeElement?.contains(relatedTarget) ? this.domHandler.getLastFocusableElement(currentTarget.parentElement, ':not(.p-hidden-focusable)') : this.firstHiddenFocusableElement;
 
-        DomHandler.focus(focusableElement);
+        this.domHandler.focus(focusableElement);
     }
 }
 

--- a/src/app/components/galleria/galleria.css
+++ b/src/app/components/galleria/galleria.css
@@ -27,15 +27,15 @@
     }
 
     .p-galleria-item-prev {
-        left: 0;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        inset-inline-start: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
     }
 
     .p-galleria-item-next {
-        right: 0;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        inset-inline-end: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     .p-galleria-item {
@@ -69,7 +69,7 @@
     .p-galleria-caption {
         position: absolute;
         bottom: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
     }
 
@@ -210,13 +210,13 @@
 
     .p-galleria-indicator-onitem.p-galleria-indicators-top .p-galleria-indicators {
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         align-items: flex-start;
     }
 
     .p-galleria-indicator-onitem.p-galleria-indicators-right .p-galleria-indicators {
-        right: 0;
+        inset-inline-end: 0;
         top: 0;
         height: 100%;
         align-items: flex-end;
@@ -224,13 +224,13 @@
 
     .p-galleria-indicator-onitem.p-galleria-indicators-bottom .p-galleria-indicators {
         bottom: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         align-items: flex-end;
     }
 
     .p-galleria-indicator-onitem.p-galleria-indicators-left .p-galleria-indicators {
-        left: 0;
+        inset-inline-start: 0;
         top: 0;
         height: 100%;
         align-items: flex-start;
@@ -240,7 +240,7 @@
     .p-galleria-mask {
         position: fixed;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 100%;
         display: flex;
@@ -253,7 +253,7 @@
     .p-galleria-close {
         position: absolute;
         top: 0;
-        right: 0;
+        inset-inline-end: 0;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/src/app/components/galleria/galleria.ts
+++ b/src/app/components/galleria/galleria.ts
@@ -291,7 +291,8 @@ export class Galleria implements OnChanges, OnDestroy {
         @Inject(PLATFORM_ID) public platformId: any,
         public element: ElementRef,
         public cd: ChangeDetectorRef,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterContentInit() {
@@ -361,12 +362,12 @@ export class Galleria implements OnChanges, OnDestroy {
             case 'visible':
                 this.enableModality();
                 setTimeout(() => {
-                    DomHandler.focus(DomHandler.findSingle(this.container.nativeElement, '[data-pc-section="closebutton"]'));
+                    this.domHandler.focus(this.domHandler.findSingle(this.container.nativeElement, '[data-pc-section="closebutton"]'));
                 }, 25);
                 break;
 
             case 'void':
-                DomHandler.addClass(this.mask?.nativeElement, 'p-component-overlay-leave');
+                this.domHandler.addClass(this.mask?.nativeElement, 'p-component-overlay-leave');
                 break;
         }
     }
@@ -380,7 +381,7 @@ export class Galleria implements OnChanges, OnDestroy {
     }
 
     enableModality() {
-        DomHandler.blockBodyScroll();
+        this.domHandler.blockBodyScroll();
         this.cd.markForCheck();
 
         if (this.mask) {
@@ -389,7 +390,7 @@ export class Galleria implements OnChanges, OnDestroy {
     }
 
     disableModality() {
-        DomHandler.unblockBodyScroll();
+        this.domHandler.unblockBodyScroll();
         this.maskVisible = false;
         this.cd.markForCheck();
 
@@ -400,7 +401,7 @@ export class Galleria implements OnChanges, OnDestroy {
 
     ngOnDestroy() {
         if (this.fullScreen) {
-            DomHandler.removeClass(this.document.body, 'p-overflow-hidden');
+            this.domHandler.removeClass(this.document.body, 'p-overflow-hidden');
         }
 
         if (this.mask) {
@@ -683,7 +684,7 @@ export class GalleriaItemSlot {
                     (focus)="onButtonFocus('left')"
                     (blur)="onButtonBlur('left')"
                 >
-                    <ChevronLeftIcon *ngIf="!galleria.itemPreviousIconTemplate" [styleClass]="'p-galleria-item-prev-icon'" />
+                    <ChevronLeftIcon *ngIf="!galleria.itemPreviousIconTemplate" [styleClass]="'p-galleria-item-prev-icon p-rtl-flip-icon'" />
                     <ng-template *ngTemplateOutlet="galleria.itemPreviousIconTemplate"></ng-template>
                 </button>
                 <div [id]="id + '_item_' + activeIndex" role="group" [attr.aria-label]="ariaSlideNumber(activeIndex + 1)" [attr.aria-roledescription]="ariaSlideLabel()" [style.width]="'100%'">
@@ -700,7 +701,7 @@ export class GalleriaItemSlot {
                     (focus)="onButtonFocus('right')"
                     (blur)="onButtonBlur('right')"
                 >
-                    <ChevronRightIcon *ngIf="!galleria.itemNextIconTemplate" [styleClass]="'p-galleria-item-next-icon'" />
+                    <ChevronRightIcon *ngIf="!galleria.itemNextIconTemplate" [styleClass]="'p-galleria-item-next-icon p-rtl-flip-icon'" />
                     <ng-template *ngTemplateOutlet="galleria.itemNextIconTemplate"></ng-template>
                 </button>
                 <div class="p-galleria-caption" *ngIf="captionFacet">
@@ -905,7 +906,7 @@ export class GalleriaItem implements OnChanges {
                     [attr.aria-label]="ariaPrevButtonLabel()"
                 >
                     <ng-container *ngIf="!galleria.previousThumbnailIconTemplate">
-                        <ChevronLeftIcon *ngIf="!isVertical" [styleClass]="'p-galleria-thumbnail-prev-icon'" />
+                        <ChevronLeftIcon *ngIf="!isVertical" [styleClass]="'p-galleria-thumbnail-prev-icon p-rtl-flip-icon'" />
                         <ChevronUpIcon *ngIf="isVertical" [styleClass]="'p-galleria-thumbnail-prev-icon'" />
                     </ng-container>
                     <ng-template *ngTemplateOutlet="galleria.previousThumbnailIconTemplate"></ng-template>
@@ -951,7 +952,7 @@ export class GalleriaItem implements OnChanges {
                     [attr.aria-label]="ariaNextButtonLabel()"
                 >
                     <ng-container *ngIf="!galleria.nextThumbnailIconTemplate">
-                        <ChevronRightIcon *ngIf="!isVertical" [ngClass]="'p-galleria-thumbnail-next-icon'" />
+                        <ChevronRightIcon *ngIf="!isVertical" [ngClass]="'p-galleria-thumbnail-next-icon p-rtl-flip-icon'" />
                         <ChevronDownIcon *ngIf="isVertical" [ngClass]="'p-galleria-thumbnail-next-icon'" />
                     </ng-container>
                     <ng-template *ngTemplateOutlet="galleria.nextThumbnailIconTemplate"></ng-template>
@@ -1031,10 +1032,12 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
 
     constructor(
         public galleria: Galleria,
+        private el: ElementRef,
         @Inject(DOCUMENT) private document: Document,
         @Inject(PLATFORM_ID) private platformId: any,
         private renderer: Renderer2,
-        private cd: ChangeDetectorRef
+        private cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -1066,11 +1069,11 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
             }
 
             if (this.itemsContainer && this.itemsContainer.nativeElement) {
-                this.itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
+                this.itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${(this.domHandler.isRtl() ? -1 : 1) * totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
             }
 
             if (this._oldactiveIndex !== this._activeIndex) {
-                DomHandler.removeClass(this.itemsContainer.nativeElement, 'p-items-hidden');
+                this.domHandler.removeClass(this.itemsContainer.nativeElement, 'p-items-hidden');
                 this.itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
             }
 
@@ -1127,7 +1130,7 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
         }
 
         this.thumbnailsStyle.innerHTML = innerHTML;
-        DomHandler.setAttribute(this.thumbnailsStyle, 'nonce', this.galleria.config?.csp()?.nonce);
+        this.domHandler.setAttribute(this.thumbnailsStyle, 'nonce', this.galleria.config?.csp()?.nonce);
     }
 
     calculatePosition() {
@@ -1255,7 +1258,7 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
     }
 
     onRightKey() {
-        const indicators = DomHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]');
+        const indicators = this.domHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]');
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, activeIndex + 1 === indicators.length ? indicators.length - 1 : activeIndex + 1);
@@ -1274,17 +1277,17 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
     }
 
     onEndKey() {
-        const indicators = DomHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]');
+        const indicators = this.domHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]');
         const activeIndex = this.findFocusedIndicatorIndex();
 
         this.changedFocusedIndicator(activeIndex, indicators.length - 1);
     }
 
     onTabKey() {
-        const indicators = [...DomHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]')];
-        const highlightedIndex = indicators.findIndex((ind) => DomHandler.getAttribute(ind, 'data-p-active') === true);
+        const indicators = [...this.domHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]')];
+        const highlightedIndex = indicators.findIndex((ind) => this.domHandler.getAttribute(ind, 'data-p-active') === true);
 
-        const activeIndicator = DomHandler.findSingle(this.itemsContainer.nativeElement, '[tabindex="0"]');
+        const activeIndicator = this.domHandler.findSingle(this.itemsContainer.nativeElement, '[tabindex="0"]');
 
         const activeIndex = indicators.findIndex((ind) => ind === activeIndicator.parentElement);
 
@@ -1293,14 +1296,14 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
     }
 
     findFocusedIndicatorIndex() {
-        const indicators = [...DomHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]')];
-        const activeIndicator = DomHandler.findSingle(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"] > [tabindex="0"]');
+        const indicators = [...this.domHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]')];
+        const activeIndicator = this.domHandler.findSingle(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"] > [tabindex="0"]');
 
         return indicators.findIndex((ind) => ind === activeIndicator.parentElement);
     }
 
     changedFocusedIndicator(prevInd, nextInd) {
-        const indicators = DomHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]');
+        const indicators = this.domHandler.find(this.itemsContainer.nativeElement, '[data-pc-section="thumbnailitem"]');
 
         indicators[prevInd].children[0].tabIndex = '-1';
         indicators[nextInd].children[0].tabIndex = '0';
@@ -1325,8 +1328,8 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
         }
 
         if (this.itemsContainer) {
-            DomHandler.removeClass(this.itemsContainer.nativeElement, 'p-items-hidden');
-            this.itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
+            this.domHandler.removeClass(this.itemsContainer.nativeElement, 'p-items-hidden');
+            this.itemsContainer.nativeElement.style.transform = this.isVertical ? `translate3d(0, ${totalShiftedItems * (100 / this.d_numVisible)}%, 0)` : `translate3d(${(this.domHandler.isRtl() ? -1 : 1) * totalShiftedItems * (100 / this.d_numVisible)}%, 0, 0)`;
             this.itemsContainer.nativeElement.style.transition = 'transform 500ms ease 0s';
         }
 
@@ -1361,7 +1364,7 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
 
     onTransitionEnd() {
         if (this.itemsContainer && this.itemsContainer.nativeElement) {
-            DomHandler.addClass(this.itemsContainer.nativeElement, 'p-items-hidden');
+            this.domHandler.addClass(this.itemsContainer.nativeElement, 'p-items-hidden');
             this.itemsContainer.nativeElement.style.transition = '';
         }
     }
@@ -1372,7 +1375,7 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
         if (this.isVertical) {
             this.changePageOnTouch(e, touchobj.pageY - (<{ x: number; y: number }>this.startPos).y);
         } else {
-            this.changePageOnTouch(e, touchobj.pageX - (<{ x: number; y: number }>this.startPos).x);
+            this.changePageOnTouch(e, this.domHandler.getPageX(touchobj) - (<{ x: number; y: number }>this.startPos).x);
         }
     }
 
@@ -1386,7 +1389,7 @@ export class GalleriaThumbnails implements OnInit, AfterContentChecked, AfterVie
         let touchobj = e.changedTouches[0];
 
         this.startPos = {
-            x: touchobj.pageX,
+            x: this.domHandler.getPageX(touchobj),
             y: touchobj.pageY
         };
     }

--- a/src/app/components/image/image.css
+++ b/src/app/components/image/image.css
@@ -13,7 +13,7 @@
 
     .p-image-preview-indicator {
         position: absolute;
-        left: 0;
+        inset-inline-start: 0;
         top: 0;
         width: 100%;
         height: 100%;
@@ -47,7 +47,7 @@
     .p-image-toolbar {
         position: absolute;
         top: 0;
-        right: 0;
+        inset-inline-end: 0;
         display: flex;
         z-index: 1;
     }

--- a/src/app/components/image/image.ts
+++ b/src/app/components/image/image.ts
@@ -257,7 +257,8 @@ export class Image implements AfterContentInit {
         @Inject(DOCUMENT) private document: Document,
         private config: PrimeNGConfig,
         private cd: ChangeDetectorRef,
-        public el: ElementRef
+        public el: ElementRef,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterContentInit() {
@@ -298,7 +299,7 @@ export class Image implements AfterContentInit {
         if (this.preview) {
             this.maskVisible = true;
             this.previewVisible = true;
-            DomHandler.blockBodyScroll();
+            this.domHandler.blockBodyScroll();
         }
     }
 
@@ -315,7 +316,7 @@ export class Image implements AfterContentInit {
             case 'Escape':
                 this.onMaskClick();
                 setTimeout(() => {
-                    DomHandler.focus(this.previewButton.nativeElement);
+                    this.domHandler.focus(this.previewButton.nativeElement);
                 }, 25);
                 event.preventDefault();
 
@@ -359,12 +360,12 @@ export class Image implements AfterContentInit {
                 this.moveOnTop();
 
                 setTimeout(() => {
-                    DomHandler.focus(this.closeButton.nativeElement);
+                    this.domHandler.focus(this.closeButton.nativeElement);
                 }, 25);
                 break;
 
             case 'void':
-                DomHandler.addClass(this.wrapper, 'p-component-overlay-leave');
+                this.domHandler.addClass(this.wrapper, 'p-component-overlay-leave');
                 break;
         }
     }
@@ -392,12 +393,12 @@ export class Image implements AfterContentInit {
     appendContainer() {
         if (this.appendTo) {
             if (this.appendTo === 'body') this.document.body.appendChild(this.wrapper as HTMLElement);
-            else DomHandler.appendChild(this.wrapper, this.appendTo);
+            else this.domHandler.appendChild(this.wrapper, this.appendTo);
         }
     }
 
     imagePreviewStyle() {
-        return { transform: 'rotate(' + this.rotate + 'deg) scale(' + this.scale + ')' };
+        return { transform: 'rotate(' + ((this.domHandler.isRtl() ? -1 : 1) * this.rotate) + 'deg) scale(' + this.scale + ')' };
     }
 
     get zoomImageAriaLabel() {
@@ -419,7 +420,7 @@ export class Image implements AfterContentInit {
         this.previewVisible = false;
         this.rotate = 0;
         this.scale = this.zoomSettings.default;
-        DomHandler.unblockBodyScroll();
+        this.domHandler.unblockBodyScroll();
     }
 
     imageError(event: Event) {

--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -360,7 +360,8 @@ export class InputMask implements OnInit, ControlValueAccessor {
         @Inject(PLATFORM_ID) private platformId: any,
         public el: ElementRef,
         public cd: ChangeDetectorRef,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -610,7 +611,7 @@ export class InputMask implements OnInit, ControlValueAccessor {
             end;
         let iPhone;
         if (isPlatformBrowser(this.platformId)) {
-            iPhone = /iphone/i.test(DomHandler.getUserAgent());
+            iPhone = /iphone/i.test(this.domHandler.getUserAgent());
         }
         this.oldVal = this.inputViewChild?.nativeElement.value;
 
@@ -682,7 +683,7 @@ export class InputMask implements OnInit, ControlValueAccessor {
                     this.writeBuffer();
                     next = this.seekNext(p);
 
-                    if (DomHandler.isClient() && /android/i.test(DomHandler.getUserAgent())) {
+                    if (this.domHandler.isClient() && /android/i.test(this.domHandler.getUserAgent())) {
                         let proxy = () => {
                             this.caret(next);
                         };

--- a/src/app/components/inputnumber/inputnumber.css
+++ b/src/app/components/inputnumber/inputnumber.css
@@ -17,21 +17,21 @@
     }
 
     .p-inputnumber-buttons-stacked .p-button.p-inputnumber-button-up {
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
+        border-end-end-radius: 0;
         padding: 0;
     }
 
     .p-inputnumber-buttons-stacked .p-inputnumber-input {
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     .p-inputnumber-buttons-stacked .p-button.p-inputnumber-button-down {
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
-        border-bottom-left-radius: 0;
+        border-start-start-radius: 0;
+        border-start-end-radius: 0;
+        border-end-start-radius: 0;
         padding: 0;
     }
 
@@ -46,8 +46,8 @@
 
     .p-inputnumber-buttons-horizontal .p-button.p-inputnumber-button-up {
         order: 3;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
     }
 
     .p-inputnumber-buttons-horizontal .p-inputnumber-input {
@@ -57,8 +57,8 @@
 
     .p-inputnumber-buttons-horizontal .p-button.p-inputnumber-button-down {
         order: 1;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
     }
 
     .p-inputnumber-buttons-vertical {
@@ -67,8 +67,8 @@
 
     .p-inputnumber-buttons-vertical .p-button.p-inputnumber-button-up {
         order: 1;
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
+        border-end-start-radius: 0;
+        border-end-end-radius: 0;
         width: 100%;
     }
 
@@ -80,8 +80,8 @@
 
     .p-inputnumber-buttons-vertical .p-button.p-inputnumber-button-down {
         order: 3;
-        border-top-left-radius: 0;
-        border-top-right-radius: 0;
+        border-start-start-radius: 0;
+        border-start-end-radius: 0;
         width: 100%;
     }
 

--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -522,7 +522,8 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
         public el: ElementRef,
         private cd: ChangeDetectorRef,
         private readonly injector: Injector,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngOnChanges(simpleChange: SimpleChanges) {
@@ -1250,7 +1251,7 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
     onInputClick() {
         const currentValue = this.input?.nativeElement.value;
 
-        if (!this.readonly && currentValue !== DomHandler.getSelection()) {
+        if (!this.readonly && currentValue !== this.domHandler.getSelection()) {
             this.initCursor();
         }
     }

--- a/src/app/components/inputswitch/inputswitch.css
+++ b/src/app/components/inputswitch/inputswitch.css
@@ -9,8 +9,8 @@
         position: absolute;
         cursor: pointer;
         top: 0;
-        left: 0;
-        right: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
         bottom: 0;
         border: 1px solid transparent;
     }

--- a/src/app/components/keyfilter/keyfilter.ts
+++ b/src/app/components/keyfilter/keyfilter.ts
@@ -116,10 +116,11 @@ export class KeyFilter implements Validator {
     constructor(
         @Inject(DOCUMENT) private document: Document,
         @Inject(PLATFORM_ID) private platformId: any,
-        public el: ElementRef
+        public el: ElementRef,
+        private domHandler: DomHandler
     ) {
         if (isPlatformBrowser(this.platformId)) {
-            this.isAndroid = DomHandler.isAndroid();
+            this.isAndroid = this.domHandler.isAndroid();
         } else {
             this.isAndroid = false;
         }
@@ -127,7 +128,7 @@ export class KeyFilter implements Validator {
 
     isNavKeyPress(e: KeyboardEvent) {
         let k = e.keyCode;
-        k = DomHandler.getBrowser().safari ? (SAFARI_KEYS as any)[k] || k : k;
+        k = this.domHandler.getBrowser().safari ? (SAFARI_KEYS as any)[k] || k : k;
 
         return (k >= 33 && k <= 40) || k == KEYS.RETURN || k == KEYS.TAB || k == KEYS.ESC;
     }
@@ -135,12 +136,12 @@ export class KeyFilter implements Validator {
     isSpecialKey(e: KeyboardEvent) {
         let k = e.keyCode || e.charCode;
 
-        return k == 9 || k == 13 || k == 27 || k == 16 || k == 17 || (k >= 18 && k <= 20) || (DomHandler.getBrowser().opera && !e.shiftKey && (k == 8 || (k >= 33 && k <= 35) || (k >= 36 && k <= 39) || (k >= 44 && k <= 45)));
+        return k == 9 || k == 13 || k == 27 || k == 16 || k == 17 || (k >= 18 && k <= 20) || (this.domHandler.getBrowser().opera && !e.shiftKey && (k == 8 || (k >= 33 && k <= 35) || (k >= 36 && k <= 39) || (k >= 44 && k <= 45)));
     }
 
     getKey(e: KeyboardEvent) {
         let k = e.keyCode || e.charCode;
-        return DomHandler.getBrowser().safari ? (SAFARI_KEYS as any)[k] || k : k;
+        return this.domHandler.getBrowser().safari ? (SAFARI_KEYS as any)[k] || k : k;
     }
 
     getCharCode(e: KeyboardEvent) {
@@ -208,7 +209,7 @@ export class KeyFilter implements Validator {
             return;
         }
 
-        let browser = DomHandler.getBrowser();
+        let browser = this.domHandler.getBrowser();
         let k = this.getKey(e);
 
         if (browser.mozilla && (e.ctrlKey || e.altKey)) {

--- a/src/app/components/knob/knob.ts
+++ b/src/app/components/knob/knob.ts
@@ -1,6 +1,7 @@
 import { CommonModule, DOCUMENT } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Inject, Input, NgModule, Output, Renderer2, ViewEncapsulation, booleanAttribute, forwardRef, numberAttribute } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { DomHandler } from 'primeng/dom';
 import { VoidListener } from 'primeng/ts-helpers';
 
 export const KNOB_VALUE_ACCESSOR: any = {
@@ -36,7 +37,7 @@ export const KNOB_VALUE_ACCESSOR: any = {
                 [attr.data-pc-section]="'svg'"
             >
                 <path [attr.d]="rangePath()" [attr.stroke-width]="strokeWidth" [attr.stroke]="rangeColor" class="p-knob-range"></path>
-                <path [attr.d]="valuePath()" [attr.stroke-width]="strokeWidth" [attr.stroke]="valueColor" class="p-knob-value"></path>
+                <path [attr.d]="valuePath()" [attr.stroke-width]="strokeWidth" [attr.stroke]="valueColor" class="p-knob-value p-rtl-flip-svg"></path>
                 <text *ngIf="showValue" [attr.x]="50" [attr.y]="57" text-anchor="middle" [attr.fill]="textColor" class="p-knob-text" [attr.name]="name">{{ valueToDisplay() }}</text>
             </svg>
         </div>
@@ -175,7 +176,8 @@ export class Knob {
         @Inject(DOCUMENT) private document: Document,
         private renderer: Renderer2,
         private cd: ChangeDetectorRef,
-        private el: ElementRef
+        private el: ElementRef,
+        private domHandler: DomHandler
     ) {}
 
     mapRange(x: number, inMin: number, inMax: number, outMin: number, outMax: number) {
@@ -184,7 +186,7 @@ export class Knob {
 
     onClick(event: MouseEvent) {
         if (!this.disabled && !this.readonly) {
-            this.updateValue(event.offsetX, event.offsetY);
+            this.updateValue(this.domHandler.getOffsetX(event), event.offsetY);
         }
     }
 
@@ -257,17 +259,17 @@ export class Knob {
 
     onMouseMove(event: MouseEvent) {
         if (!this.disabled && !this.readonly) {
-            this.updateValue(event.offsetX, event.offsetY);
+            this.updateValue(this.domHandler.getOffsetX(event), event.offsetY);
             event.preventDefault();
         }
     }
 
     onTouchMove(event: Event) {
         if (!this.disabled && !this.readonly && event instanceof TouchEvent && event.touches.length === 1) {
-            const rect = this.el.nativeElement.children[0].getBoundingClientRect();
+            const rect = this.domHandler.getBoundingClientRect(this.el.nativeElement.children[0]);
             const touch = event.targetTouches.item(0);
             if (touch) {
-                const offsetX = touch.clientX - rect.left;
+                const offsetX = this.domHandler.getClientX(touch) - rect.left;
                 const offsetY = touch.clientY - rect.top;
                 this.updateValue(offsetX, offsetY);
             }

--- a/src/app/components/listbox/listbox.ts
+++ b/src/app/components/listbox/listbox.ts
@@ -663,7 +663,8 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
         public cd: ChangeDetectorRef,
         public filterService: FilterService,
         public config: PrimeNGConfig,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -863,7 +864,7 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
         if (this.disabled || this.readonly) {
             return;
         }
-        DomHandler.focus(this.headerCheckboxViewChild.nativeElement);
+        this.domHandler.focus(this.headerCheckboxViewChild.nativeElement);
 
         if (this.selectAll !== null) {
             this.onSelectAllChange.emit({
@@ -919,8 +920,8 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
     }
 
     onFirstHiddenFocus(event: FocusEvent) {
-        DomHandler.focus(this.listViewChild.nativeElement);
-        const firstFocusableEl = DomHandler.getFirstFocusableElement(this.el.nativeElement, ':not([data-p-hidden-focusable="true"])');
+        this.domHandler.focus(this.listViewChild.nativeElement);
+        const firstFocusableEl = this.domHandler.getFirstFocusableElement(this.el.nativeElement, ':not([data-p-hidden-focusable="true"])');
         this.lastHiddenFocusableElement.nativeElement.tabIndex = ObjectUtils.isEmpty(firstFocusableEl) ? '-1' : undefined;
         this.firstHiddenFocusableElement.nativeElement.tabIndex = -1;
     }
@@ -929,12 +930,12 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
         const relatedTarget = event.relatedTarget;
 
         if (relatedTarget === this.listViewChild.nativeElement) {
-            const firstFocusableEl = DomHandler.getFirstFocusableElement(this.el.nativeElement, ':not(.p-hidden-focusable)');
+            const firstFocusableEl = this.domHandler.getFirstFocusableElement(this.el.nativeElement, ':not(.p-hidden-focusable)');
 
-            DomHandler.focus(firstFocusableEl);
+            this.domHandler.focus(firstFocusableEl);
             this.firstHiddenFocusableElement.nativeElement.tabIndex = undefined;
         } else {
-            DomHandler.focus(this.firstHiddenFocusableElement.nativeElement);
+            this.domHandler.focus(this.firstHiddenFocusableElement.nativeElement);
         }
         this.lastHiddenFocusableElement.nativeElement.tabIndex = -1;
     }
@@ -995,7 +996,7 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
     }
 
     onHeaderCheckboxTabKeyDown(event) {
-        DomHandler.focus(this.listViewChild.nativeElement);
+        this.domHandler.focus(this.listViewChild.nativeElement);
         event.preventDefault();
     }
 
@@ -1312,7 +1313,7 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
 
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
-        const element = DomHandler.findSingle(this.listViewChild.nativeElement, `li[id="${id}"]`);
+        const element = this.domHandler.findSingle(this.listViewChild.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });

--- a/src/app/components/megamenu/megamenu.css
+++ b/src/app/components/megamenu/megamenu.css
@@ -51,7 +51,7 @@
     }
 
     .p-megamenu-horizontal .p-megamenu-end {
-        margin-left: auto;
+        margin-inline-start: auto;
         align-self: center;
     }
 
@@ -61,16 +61,16 @@
     }
 
     .p-megamenu-vertical .p-megamenu-root-list > .p-menuitem-active > .p-megamenu-panel {
-        left: 100%;
+        inset-inline-start: 100%;
         top: 0;
     }
 
     .p-megamenu-vertical .p-megamenu-root-list > .p-menuitem > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:not(svg) {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-megamenu-vertical .p-megamenu-root-list > .p-menuitem > .p-menuitem-content > .p-menuitem-link > .p-icon-wrapper {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-megamenu-grid {

--- a/src/app/components/megamenu/megamenu.ts
+++ b/src/app/components/megamenu/megamenu.ts
@@ -116,7 +116,7 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                                 <ng-container *ngIf="isItemGroup(processedItem)">
                                     <ng-container *ngIf="!megaMenu.submenuIconTemplate">
                                         <AngleDownIcon [styleClass]="'p-submenu-icon'" [attr.data-pc-section]="'submenuicon'" *ngIf="orientation === 'horizontal'" />
-                                        <AngleRightIcon [styleClass]="'p-submenu-icon'" [attr.data-pc-section]="'submenuicon'" *ngIf="orientation === 'vertical'" />
+                                        <AngleRightIcon [styleClass]="'p-submenu-icon p-rtl-flip-icon'" [attr.data-pc-section]="'submenuicon'" *ngIf="orientation === 'vertical'" />
                                     </ng-container>
                                     <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate" [attr.data-pc-section]="'submenuicon'"></ng-template>
                                 </ng-container>
@@ -154,7 +154,7 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                                 <ng-container *ngIf="isItemGroup(processedItem)">
                                     <ng-container *ngIf="!megaMenu.submenuIconTemplate">
                                         <AngleDownIcon [styleClass]="'p-submenu-icon'" [attr.data-pc-section]="'submenuicon'" *ngIf="orientation === 'horizontal'" />
-                                        <AngleRightIcon [styleClass]="'p-submenu-icon'" [attr.data-pc-section]="'submenuicon'" *ngIf="orientation === 'vertical'" />
+                                        <AngleRightIcon [styleClass]="'p-submenu-icon p-rtl-flip-icon'" [attr.data-pc-section]="'submenuicon'" *ngIf="orientation === 'vertical'" />
                                     </ng-container>
                                     <ng-template *ngTemplateOutlet="megaMenu.submenuIconTemplate" [attr.data-pc-section]="'submenuicon'"></ng-template>
                                 </ng-container>
@@ -534,7 +534,8 @@ export class MegaMenu implements AfterContentInit, OnDestroy, OnInit {
         public el: ElementRef,
         public renderer: Renderer2,
         public config: PrimeNGConfig,
-        public cd: ChangeDetectorRef
+        public cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {
         effect(() => {
             const activeItem = this.activeItem();
@@ -622,7 +623,7 @@ export class MegaMenu implements AfterContentInit, OnDestroy, OnInit {
             this.focusedItemInfo.set({ index, key, parentKey, item });
 
             this.dirty = !root;
-            DomHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
+            this.domHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
         } else {
             if (grouped) {
                 this.onItemChange(event);
@@ -631,20 +632,20 @@ export class MegaMenu implements AfterContentInit, OnDestroy, OnInit {
                 this.hide(originalEvent);
                 this.changeFocusedItemInfo(originalEvent, rootProcessedItem ? rootProcessedItem.index : -1);
 
-                DomHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
+                this.domHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
             }
         }
     }
 
     onItemMouseEnter(event: any) {
-        if (!DomHandler.isTouchDevice()) {
+        if (!this.domHandler.isTouchDevice()) {
             this.onItemChange(event);
         }
     }
 
     scrollInView(index: number = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedItemId;
-        const element = DomHandler.findSingle(this.rootmenu?.el.nativeElement, `li[id="${id}"]`);
+        const element = this.domHandler.findSingle(this.rootmenu?.el.nativeElement, `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -665,14 +666,14 @@ export class MegaMenu implements AfterContentInit, OnDestroy, OnInit {
         this.focusedItemInfo.set({ index, key, parentKey, item });
 
         grouped && (this.dirty = true);
-        isFocus && DomHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
+        isFocus && this.domHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
     }
 
     hide(event?, isFocus?: boolean) {
         this.activeItem.set(null);
         this.focusedItemInfo.set({ index: -1, key: '', parentKey: '', item: null });
 
-        isFocus && DomHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
+        isFocus && this.domHandler.focus(this.rootmenu?.menubarViewChild?.nativeElement);
         this.dirty = false;
     }
 
@@ -999,8 +1000,8 @@ export class MegaMenu implements AfterContentInit, OnDestroy, OnInit {
 
     onEnterKey(event: KeyboardEvent) {
         if (this.focusedItemInfo().index !== -1) {
-            const element = DomHandler.findSingle(this.rootmenu?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
-            const anchorElement = element && DomHandler.findSingle(element, 'a[data-pc-section="action"]');
+            const element = this.domHandler.findSingle(this.rootmenu?.el?.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const anchorElement = element && this.domHandler.findSingle(element, 'a[data-pc-section="action"]');
 
             anchorElement ? anchorElement.click() : element && element.click();
 

--- a/src/app/components/menu/menu.css
+++ b/src/app/components/menu/menu.css
@@ -2,7 +2,7 @@
     .p-menu-overlay {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-menu ul {

--- a/src/app/components/menubar/menubar.css
+++ b/src/app/components/menubar/menubar.css
@@ -50,25 +50,25 @@
 
     .p-menubar .p-submenu-list > .p-menuitem-active > p-menubarsub > .p-submenu-list {
         display: block;
-        left: 100%;
+        inset-inline-start: 100%;
         top: 0;
     }
 
     .p-menubar .p-submenu-list .p-menuitem-link .p-submenu-icon:not(svg) {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-menubar .p-menubar-root-list .p-icon-wrapper {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-menubar .p-submenu-list .p-menuitem-link .p-icon-wrapper {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-menubar .p-menubar-custom,
     .p-menubar .p-menubar-end {
-        margin-left: auto;
+        margin-inline-start: auto;
         align-self: center;
     }
 

--- a/src/app/components/messages/messages.css
+++ b/src/app/components/messages/messages.css
@@ -12,7 +12,7 @@
     }
 
     .p-message-close.p-link {
-        margin-left: auto;
+        margin-inline-start: auto;
         overflow: hidden;
         position: relative;
     }

--- a/src/app/components/messages/messages.ts
+++ b/src/app/components/messages/messages.ts
@@ -78,7 +78,7 @@ import { Subscription, timer } from 'rxjs';
     animations: [
         trigger('messageAnimation', [
             transition(':enter', [style({ opacity: 0, transform: 'translateY(-25%)' }), animate('{{showTransitionParams}}')]),
-            transition(':leave', [animate('{{hideTransitionParams}}', style({ height: 0, marginTop: 0, marginBottom: 0, marginLeft: 0, marginRight: 0, opacity: 0 }))])
+            transition(':leave', [animate('{{hideTransitionParams}}', style({ height: 0, marginTop: 0, marginBottom: 0, marginInlineStart: 0, marginInlineEnd: 0, opacity: 0 }))])
         ])
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/metergroup/metergroup.ts
+++ b/src/app/components/metergroup/metergroup.ts
@@ -144,9 +144,11 @@ export class MeterGroup implements AfterContentInit {
 
     @ViewChild('container', { read: ElementRef }) container: ElementRef;
 
+    constructor(private domHandler: DomHandler) {}
+
     ngAfterViewInit() {
         const _container = this.container.nativeElement;
-        const height = DomHandler.getOuterHeight(_container);
+        const height = this.domHandler.getOuterHeight(_container);
         this.vertical && (_container.style.height = height + 'px');
     }
 

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1195,7 +1195,8 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         public zone: NgZone,
         public filterService: FilterService,
         public config: PrimeNGConfig,
-        public overlayService: OverlayService
+        public overlayService: OverlayService,
+        private domHandler: DomHandler
     ) {
         effect(() => {
             const modelValue = this.modelValue();
@@ -1382,7 +1383,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         this.updateModel(value, originalEvent);
         index !== -1 && this.focusedOptionIndex.set(index);
 
-        isFocus && DomHandler.focus(this.focusInputViewChild?.nativeElement);
+        isFocus && this.domHandler.focus(this.focusInputViewChild?.nativeElement);
 
         this.onChange.emit({
             originalEvent: { ...event, selected: !event.selected },
@@ -1800,7 +1801,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     onTabKey(event, pressedInInputText = false) {
         if (!pressedInInputText) {
             if (this.overlayVisible && this.hasFocusableElements()) {
-                DomHandler.focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay.nativeElement : this.firstHiddenFocusableElementOnOverlay.nativeElement);
+                this.domHandler.focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay.nativeElement : this.firstHiddenFocusableElementOnOverlay.nativeElement);
 
                 event.preventDefault();
             } else {
@@ -1846,10 +1847,10 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     onFirstHiddenFocus(event) {
         const focusableEl =
             event.relatedTarget === this.focusInputViewChild?.nativeElement
-                ? DomHandler.getFirstFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])')
+                ? this.domHandler.getFirstFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])')
                 : this.focusInputViewChild?.nativeElement;
 
-        DomHandler.focus(focusableEl);
+        this.domHandler.focus(focusableEl);
     }
 
     onInputFocus(event: Event) {
@@ -1885,10 +1886,10 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     onLastHiddenFocus(event) {
         const focusableEl =
             event.relatedTarget === this.focusInputViewChild?.nativeElement
-                ? DomHandler.getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])')
+                ? this.domHandler.getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])')
                 : this.focusInputViewChild?.nativeElement;
 
-        DomHandler.focus(focusableEl);
+        this.domHandler.focus(focusableEl);
     }
 
     onOptionMouseEnter(event, index) {
@@ -1968,7 +1969,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         }
 
         this.onChange.emit({ originalEvent: event, value: this.value });
-        DomHandler.focus(this.headerCheckboxViewChild?.nativeElement);
+        this.domHandler.focus(this.headerCheckboxViewChild?.nativeElement);
         this.headerCheckboxFocus = true;
 
         event.preventDefault();
@@ -1989,7 +1990,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     scrollInView(index = -1) {
         const id = index !== -1 ? `${this.id}_${index}` : this.focusedOptionId;
         if (this.itemsViewChild && this.itemsViewChild.nativeElement) {
-            const element = DomHandler.findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
+            const element = this.domHandler.findSingle(this.itemsViewChild.nativeElement, `li[id="${id}"]`);
             if (element) {
                 element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
             } else if (!this.virtualScrollerDisabled) {
@@ -2046,7 +2047,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
         this.focusedOptionIndex.set(focusedOptionIndex);
 
         if (isFocus) {
-            DomHandler.focus(this.focusInputViewChild?.nativeElement);
+            this.domHandler.focus(this.focusInputViewChild?.nativeElement);
         }
 
         this.cd.markForCheck();
@@ -2064,10 +2065,10 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
             this.resetFilter();
         }
         if (this.overlayOptions?.mode === 'modal') {
-            DomHandler.unblockBodyScroll();
+            this.domHandler.unblockBodyScroll();
         }
 
-        isFocus && DomHandler.focus(this.focusInputViewChild?.nativeElement);
+        isFocus && this.domHandler.focus(this.focusInputViewChild?.nativeElement);
         this.onPanelHide.emit();
         this.cd.markForCheck();
     }
@@ -2075,7 +2076,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     onOverlayAnimationStart(event: AnimationEvent) {
         switch (event.toState) {
             case 'visible':
-                this.itemsWrapper = DomHandler.findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '.p-scroller' : '.p-multiselect-items-wrapper');
+                this.itemsWrapper = this.domHandler.findSingle(this.overlayViewChild?.overlayViewChild?.nativeElement, this.virtualScroll ? '.p-scroller' : '.p-multiselect-items-wrapper');
                 this.virtualScroll && this.scroller?.setContentEl(this.itemsViewChild?.nativeElement);
 
                 if (this._options() && this._options().length) {
@@ -2085,7 +2086,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
                             this.scroller?.scrollToIndex(selectedIndex);
                         }
                     } else {
-                        let selectedListItem = DomHandler.findSingle(this.itemsWrapper, '[data-p-highlight="true"]');
+                        let selectedListItem = this.domHandler.findSingle(this.itemsWrapper, '[data-p-highlight="true"]');
 
                         if (selectedListItem) {
                             selectedListItem.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -2154,14 +2155,14 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     findNextItem(item: any): HTMLElement | null {
         let nextItem = item.nextElementSibling;
 
-        if (nextItem) return DomHandler.hasClass(nextItem.children[0], 'p-disabled') || DomHandler.isHidden(nextItem.children[0]) || DomHandler.hasClass(nextItem, 'p-multiselect-item-group') ? this.findNextItem(nextItem) : nextItem.children[0];
+        if (nextItem) return this.domHandler.hasClass(nextItem.children[0], 'p-disabled') || this.domHandler.isHidden(nextItem.children[0]) || this.domHandler.hasClass(nextItem, 'p-multiselect-item-group') ? this.findNextItem(nextItem) : nextItem.children[0];
         else return null;
     }
 
     findPrevItem(item: any): HTMLElement | null {
         let prevItem = item.previousElementSibling;
 
-        if (prevItem) return DomHandler.hasClass(prevItem.children[0], 'p-disabled') || DomHandler.isHidden(prevItem.children[0]) || DomHandler.hasClass(prevItem, 'p-multiselect-item-group') ? this.findPrevItem(prevItem) : prevItem.children[0];
+        if (prevItem) return this.domHandler.hasClass(prevItem.children[0], 'p-disabled') || this.domHandler.isHidden(prevItem.children[0]) || this.domHandler.hasClass(prevItem, 'p-multiselect-item-group') ? this.findPrevItem(prevItem) : prevItem.children[0];
         else return null;
     }
 
@@ -2260,7 +2261,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
     }
 
     hasFocusableElements() {
-        return DomHandler.getFocusableElements(this.overlayViewChild.overlayViewChild.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return this.domHandler.getFocusableElements(this.overlayViewChild.overlayViewChild.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     hasFilter() {

--- a/src/app/components/orderlist/orderlist.ts
+++ b/src/app/components/orderlist/orderlist.ts
@@ -416,7 +416,8 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
         public el: ElementRef,
         public cd: ChangeDetectorRef,
         public filterService: FilterService,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -484,14 +485,14 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
 
     ngAfterViewChecked() {
         if (this.movedUp || this.movedDown) {
-            let listItems = DomHandler.find(this.listViewChild?.nativeElement, 'li.p-highlight');
+            let listItems = this.domHandler.find(this.listViewChild?.nativeElement, 'li.p-highlight');
             let listItem;
 
             if (listItems.length > 0) {
                 if (this.movedUp) listItem = listItems[0];
                 else listItem = listItems[listItems.length - 1];
 
-                DomHandler.scrollInView(this.listViewChild?.nativeElement, listItem);
+                this.domHandler.scrollInView(this.listViewChild?.nativeElement, listItem);
             }
             this.movedUp = false;
             this.movedDown = false;
@@ -691,7 +692,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     }
 
     onListFocus(event) {
-        const focusableEl = DomHandler.findSingle(this.listViewChild.nativeElement, '[data-p-highlight="true"]') || DomHandler.findSingle(this.listViewChild.nativeElement, '[data-pc-section="item"]');
+        const focusableEl = this.domHandler.findSingle(this.listViewChild.nativeElement, '[data-p-highlight="true"]') || this.domHandler.findSingle(this.listViewChild.nativeElement, '[data-pc-section="item"]');
 
         if (focusableEl) {
             const findIndex = ObjectUtils.findIndexInList(focusableEl, this.listViewChild.nativeElement.children);
@@ -802,7 +803,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
             this.d_selection = [...this.value].slice(focusedIndex, visibleOptions.length - 1);
             this.selectionChange.emit(this.d_selection);
         } else {
-            this.changeFocusedOptionIndex(DomHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]').length - 1);
+            this.changeFocusedOptionIndex(this.domHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]').length - 1);
         }
 
         event.preventDefault();
@@ -835,14 +836,14 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     }
 
     findNextOptionIndex(index) {
-        const items = DomHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]');
+        const items = this.domHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]');
         const matchedOptionIndex = [...items].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex + 1 : 0;
     }
 
     findPrevOptionIndex(index) {
-        const items = DomHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]');
+        const items = this.domHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]');
         const matchedOptionIndex = [...items].findIndex((link) => link.id === index);
 
         return matchedOptionIndex > -1 ? matchedOptionIndex - 1 : 0;
@@ -865,7 +866,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     }
 
     changeFocusedOptionIndex(index) {
-        const items = DomHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]');
+        const items = this.domHandler.find(this.listViewChild.nativeElement, '[data-pc-section="item"]');
 
         let order = index >= items.length ? items.length - 1 : index < 0 ? 0 : index;
 
@@ -876,7 +877,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     }
 
     scrollInView(id) {
-        const element = DomHandler.findSingle(this.listViewChild.nativeElement, `[data-pc-section="item"][id="${id}"]`);
+        const element = this.domHandler.findSingle(this.listViewChild.nativeElement, `[data-pc-section="item"][id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -886,14 +887,14 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
     findNextItem(item: any): HTMLElement | null {
         let nextItem = item.nextElementSibling;
 
-        if (nextItem) return !DomHandler.hasClass(nextItem, 'p-orderlist-item') || DomHandler.isHidden(nextItem) ? this.findNextItem(nextItem) : nextItem;
+        if (nextItem) return !this.domHandler.hasClass(nextItem, 'p-orderlist-item') || this.domHandler.isHidden(nextItem) ? this.findNextItem(nextItem) : nextItem;
         else return null;
     }
 
     findPrevItem(item: any): HTMLElement | null {
         let prevItem = item.previousElementSibling;
 
-        if (prevItem) return !DomHandler.hasClass(prevItem, 'p-orderlist-item') || DomHandler.isHidden(prevItem) ? this.findPrevItem(prevItem) : prevItem;
+        if (prevItem) return !this.domHandler.hasClass(prevItem, 'p-orderlist-item') || this.domHandler.isHidden(prevItem) ? this.findPrevItem(prevItem) : prevItem;
         else return null;
     }
 
@@ -913,7 +914,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
                 this.renderer.setAttribute(this.el.nativeElement.children[0], this.id, '');
                 this.styleElement = this.renderer.createElement('style');
                 this.renderer.setAttribute(this.styleElement, 'type', 'text/css');
-                DomHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
+                this.domHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
                 this.renderer.appendChild(this.document.head, this.styleElement);
 
                 let innerHTML = `
@@ -928,12 +929,12 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
                         }
 
                         .p-orderlist[${this.id}] .p-orderlist-controls .p-button {
-                            margin-right: var(--inline-spacing);
+                            margin-inline-end: var(--inline-spacing);
                             margin-bottom: 0;
                         }
 
                         .p-orderlist[${this.id}] .p-orderlist-controls .p-button:last-child {
-                            margin-right: 0;
+                            margin-inline-end: 0;
                         }
                     }
                 `;

--- a/src/app/components/organizationchart/organizationchart.css
+++ b/src/app/components/organizationchart/organizationchart.css
@@ -19,9 +19,9 @@
     .p-organizationchart-node-content .p-node-toggler {
         position: absolute;
         bottom: -0.75rem;
-        margin-left: -0.75rem;
+        margin-inline-start: -0.75rem;
         z-index: 2;
-        left: 50%;
+        inset-inline-start: 50%;
         user-select: none;
         cursor: pointer;
         width: 1.5rem;

--- a/src/app/components/organizationchart/organizationchart.ts
+++ b/src/app/components/organizationchart/organizationchart.ts
@@ -252,7 +252,8 @@ export class OrganizationChart implements AfterContentInit {
 
     constructor(
         public el: ElementRef,
-        public cd: ChangeDetectorRef
+        public cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {}
 
     get root(): TreeNode<any> | null {
@@ -283,7 +284,7 @@ export class OrganizationChart implements AfterContentInit {
     onNodeClick(event: Event, node: TreeNode) {
         let eventTarget = <Element>event.target;
 
-        if (eventTarget.className && (DomHandler.hasClass(eventTarget, 'p-node-toggler') || DomHandler.hasClass(eventTarget, 'p-node-toggler-icon'))) {
+        if (eventTarget.className && (this.domHandler.hasClass(eventTarget, 'p-node-toggler') || this.domHandler.hasClass(eventTarget, 'p-node-toggler-icon'))) {
             return;
         } else if (this.selectionMode) {
             if (node.selectable === false) {

--- a/src/app/components/overlay/overlay.css
+++ b/src/app/components/overlay/overlay.css
@@ -2,7 +2,7 @@
     .p-overlay {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-overlay-modal {
@@ -11,7 +11,7 @@
         justify-content: center;
         position: fixed;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 100%;
     }

--- a/src/app/components/overlaypanel/overlaypanel.css
+++ b/src/app/components/overlaypanel/overlaypanel.css
@@ -3,7 +3,7 @@
         position: absolute;
         margin-top: 10px;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-overlaypanel-flipped {
@@ -22,7 +22,7 @@
     .p-overlaypanel:after,
     .p-overlaypanel:before {
         bottom: 100%;
-        left: calc(var(--overlayArrowLeft, 0) + 1.25rem);
+        inset-inline-start: calc(var(--overlayArrowLeft, 0) + 1.25rem);
         content: ' ';
         height: 0;
         width: 0;
@@ -32,19 +32,19 @@
 
     .p-overlaypanel:after {
         border-width: 8px;
-        margin-left: -8px;
+        margin-inline-start: -8px;
     }
 
     .p-overlaypanel:before {
         border-width: 10px;
-        margin-left: -10px;
+        margin-inline-start: -10px;
     }
 
     .p-overlaypanel-shifted:after,
     .p-overlaypanel-shifted:before {
-        left: auto;
-        right: 1.25em;
-        margin-left: auto;
+        inset-inline-start: auto;
+        inset-inline-end: 1.25em;
+        margin-inline-start: auto;
     }
 
     .p-overlaypanel-flipped:after,

--- a/src/app/components/paginator/paginator.css
+++ b/src/app/components/paginator/paginator.css
@@ -7,11 +7,11 @@
     }
 
     .p-paginator-left-content {
-        margin-right: auto;
+        margin-inline-end: auto;
     }
 
     .p-paginator-right-content {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-paginator-page,

--- a/src/app/components/paginator/paginator.ts
+++ b/src/app/components/paginator/paginator.ts
@@ -52,7 +52,7 @@ import { PaginatorState } from './paginator.interface';
                 [ngClass]="{ 'p-disabled': isFirstPage() || empty() }"
                 [attr.aria-label]="getAriaLabel('firstPageLabel')"
             >
-                <AngleDoubleLeftIcon *ngIf="!firstPageLinkIconTemplate" [styleClass]="'p-paginator-icon'" />
+                <AngleDoubleLeftIcon *ngIf="!firstPageLinkIconTemplate" [styleClass]="'p-paginator-icon p-rtl-flip-icon'" />
                 <span class="p-paginator-icon" *ngIf="firstPageLinkIconTemplate">
                     <ng-template *ngTemplateOutlet="firstPageLinkIconTemplate"></ng-template>
                 </span>
@@ -66,7 +66,7 @@ import { PaginatorState } from './paginator.interface';
                 [ngClass]="{ 'p-disabled': isFirstPage() || empty() }"
                 [attr.aria-label]="getAriaLabel('prevPageLabel')"
             >
-                <AngleLeftIcon *ngIf="!previousPageLinkIconTemplate" [styleClass]="'p-paginator-icon'" />
+                <AngleLeftIcon *ngIf="!previousPageLinkIconTemplate" [styleClass]="'p-paginator-icon p-rtl-flip-icon'" />
                 <span class="p-paginator-icon" *ngIf="previousPageLinkIconTemplate">
                     <ng-template *ngTemplateOutlet="previousPageLinkIconTemplate"></ng-template>
                 </span>
@@ -115,7 +115,7 @@ import { PaginatorState } from './paginator.interface';
                 [ngClass]="{ 'p-disabled': isLastPage() || empty() }"
                 [attr.aria-label]="getAriaLabel('nextPageLabel')"
             >
-                <AngleRightIcon *ngIf="!nextPageLinkIconTemplate" [styleClass]="'p-paginator-icon'" />
+                <AngleRightIcon *ngIf="!nextPageLinkIconTemplate" [styleClass]="'p-paginator-icon p-rtl-flip-icon'" />
                 <span class="p-paginator-icon" *ngIf="nextPageLinkIconTemplate">
                     <ng-template *ngTemplateOutlet="nextPageLinkIconTemplate"></ng-template>
                 </span>
@@ -130,7 +130,7 @@ import { PaginatorState } from './paginator.interface';
                 [ngClass]="{ 'p-disabled': isLastPage() || empty() }"
                 [attr.aria-label]="getAriaLabel('lastPageLabel')"
             >
-                <AngleDoubleRightIcon *ngIf="!lastPageLinkIconTemplate" [styleClass]="'p-paginator-icon'" />
+                <AngleDoubleRightIcon *ngIf="!lastPageLinkIconTemplate" [styleClass]="'p-paginator-icon p-rtl-flip-icon'" />
                 <span class="p-paginator-icon" *ngIf="lastPageLinkIconTemplate">
                     <ng-template *ngTemplateOutlet="lastPageLinkIconTemplate"></ng-template>
                 </span>

--- a/src/app/components/panelmenu/panelmenu.ts
+++ b/src/app/components/panelmenu/panelmenu.ts
@@ -83,7 +83,7 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                                 <ng-container *ngIf="isItemGroup(processedItem)">
                                     <ng-container *ngIf="!panelMenu.submenuIconTemplate">
                                         <AngleDownIcon [styleClass]="'p-submenu-icon'" *ngIf="isItemActive(processedItem)" [ngStyle]="getItemProp(processedItem, 'iconStyle')" />
-                                        <AngleRightIcon [styleClass]="'p-submenu-icon'" *ngIf="!isItemActive(processedItem)" [ngStyle]="getItemProp(processedItem, 'iconStyle')" />
+                                        <AngleRightIcon [styleClass]="'p-submenu-icon p-rtl-flip-icon'" *ngIf="!isItemActive(processedItem)" [ngStyle]="getItemProp(processedItem, 'iconStyle')" />
                                     </ng-container>
                                     <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate"></ng-template>
                                 </ng-container>
@@ -114,7 +114,7 @@ import { ObjectUtils, UniqueComponentId } from 'primeng/utils';
                                 <ng-container *ngIf="isItemGroup(processedItem)">
                                     <ng-container *ngIf="!panelMenu.submenuIconTemplate">
                                         <AngleDownIcon *ngIf="isItemActive(processedItem)" [styleClass]="'p-submenu-icon'" [ngStyle]="getItemProp(processedItem, 'iconStyle')" />
-                                        <AngleRightIcon *ngIf="!isItemActive(processedItem)" [styleClass]="'p-submenu-icon'" [ngStyle]="getItemProp(processedItem, 'iconStyle')" />
+                                        <AngleRightIcon *ngIf="!isItemActive(processedItem)" [styleClass]="'p-submenu-icon p-rtl-flip-icon'" [ngStyle]="getItemProp(processedItem, 'iconStyle')" />
                                     </ng-container>
                                     <ng-template *ngTemplateOutlet="panelMenu.submenuIconTemplate"></ng-template>
                                 </ng-container>
@@ -354,7 +354,7 @@ export class PanelMenuList implements OnChanges {
         return focusedItem && focusedItem.item?.id ? focusedItem.item.id : ObjectUtils.isNotEmpty(this.focusedItem()) ? `${this.panelId}_${this.focusedItem().key}` : undefined;
     }
 
-    constructor(private el: ElementRef) {}
+    constructor(private el: ElementRef, private domHandler: DomHandler) {}
 
     ngOnChanges(changes: SimpleChanges) {
         this.processedItems.set(this.createProcessedItems(changes?.items?.currentValue || this.items || []));
@@ -480,7 +480,7 @@ export class PanelMenuList implements OnChanges {
     }
 
     scrollInView() {
-        const element = DomHandler.findSingle(this.subMenuViewChild.listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+        const element = this.domHandler.findSingle(this.subMenuViewChild.listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'nearest' });
@@ -633,8 +633,8 @@ export class PanelMenuList implements OnChanges {
 
     onEnterKey(event) {
         if (ObjectUtils.isNotEmpty(this.focusedItem())) {
-            const element = DomHandler.findSingle(this.subMenuViewChild.listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
-            const anchorElement = element && (DomHandler.findSingle(element, '[data-pc-section="action"]') || DomHandler.findSingle(element, 'a,button'));
+            const element = this.domHandler.findSingle(this.subMenuViewChild.listViewChild.nativeElement, `li[id="${`${this.focusedItemId}`}"]`);
+            const anchorElement = element && (this.domHandler.findSingle(element, '[data-pc-section="action"]') || this.domHandler.findSingle(element, 'a,button'));
 
             anchorElement ? anchorElement.click() : element && element.click();
         }
@@ -758,7 +758,7 @@ export class PanelMenuList implements OnChanges {
                                     <ng-container *ngIf="isItemGroup(item)">
                                         <ng-container *ngIf="!submenuIconTemplate">
                                             <ChevronDownIcon [styleClass]="'p-submenu-icon'" *ngIf="isItemActive(item)" />
-                                            <ChevronRightIcon [styleClass]="'p-submenu-icon'" *ngIf="!isItemActive(item)" />
+                                            <ChevronRightIcon [styleClass]="'p-submenu-icon p-rtl-flip-icon'" *ngIf="!isItemActive(item)" />
                                         </ng-container>
                                         <ng-template *ngTemplateOutlet="submenuIconTemplate"></ng-template>
                                     </ng-container>
@@ -789,7 +789,7 @@ export class PanelMenuList implements OnChanges {
                                 <ng-container *ngIf="isItemGroup(item)">
                                     <ng-container *ngIf="!submenuIconTemplate">
                                         <ChevronDownIcon [styleClass]="'p-submenu-icon'" *ngIf="isItemActive(item)" />
-                                        <ChevronRightIcon [styleClass]="'p-submenu-icon'" *ngIf="!isItemActive(item)" />
+                                        <ChevronRightIcon [styleClass]="'p-submenu-icon p-rtl-flip-icon'" *ngIf="!isItemActive(item)" />
                                     </ng-container>
                                     <ng-template *ngTemplateOutlet="submenuIconTemplate"></ng-template>
                                 </ng-container>
@@ -925,7 +925,7 @@ export class PanelMenu implements AfterContentInit {
         });
     }
 
-    constructor(private cd: ChangeDetectorRef) {}
+    constructor(private cd: ChangeDetectorRef, private domHandler: DomHandler) {}
 
     /**
      * Collapses open panels.
@@ -996,27 +996,27 @@ export class PanelMenu implements AfterContentInit {
     updateFocusedHeader(event) {
         const { originalEvent, focusOnNext, selfCheck } = event;
         const panelElement = originalEvent.currentTarget.closest('[data-pc-section="panel"]');
-        const header = selfCheck ? DomHandler.findSingle(panelElement, '[data-pc-section="header"]') : focusOnNext ? this.findNextHeader(panelElement) : this.findPrevHeader(panelElement);
+        const header = selfCheck ? this.domHandler.findSingle(panelElement, '[data-pc-section="header"]') : focusOnNext ? this.findNextHeader(panelElement) : this.findPrevHeader(panelElement);
 
         header ? this.changeFocusedHeader(originalEvent, header) : focusOnNext ? this.onHeaderHomeKey(originalEvent) : this.onHeaderEndKey(originalEvent);
     }
 
     changeFocusedHeader(event, element) {
-        element && DomHandler.focus(element);
+        element && this.domHandler.focus(element);
     }
 
     findNextHeader(panelElement, selfCheck = false) {
         const nextPanelElement = selfCheck ? panelElement : panelElement.nextElementSibling;
-        const headerElement = DomHandler.findSingle(nextPanelElement, '[data-pc-section="header"]');
+        const headerElement = this.domHandler.findSingle(nextPanelElement, '[data-pc-section="header"]');
 
-        return headerElement ? (DomHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findNextHeader(headerElement.parentElement) : headerElement) : null;
+        return headerElement ? (this.domHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findNextHeader(headerElement.parentElement) : headerElement) : null;
     }
 
     findPrevHeader(panelElement, selfCheck = false) {
         const prevPanelElement = selfCheck ? panelElement : panelElement.previousElementSibling;
-        const headerElement = DomHandler.findSingle(prevPanelElement, '[data-pc-section="header"]');
+        const headerElement = this.domHandler.findSingle(prevPanelElement, '[data-pc-section="header"]');
 
-        return headerElement ? (DomHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findPrevHeader(headerElement.parentElement) : headerElement) : null;
+        return headerElement ? (this.domHandler.getAttribute(headerElement, 'data-p-disabled') ? this.findPrevHeader(headerElement.parentElement) : headerElement) : null;
     }
 
     findFirstHeader() {
@@ -1049,7 +1049,7 @@ export class PanelMenu implements AfterContentInit {
         item.expanded = !item.expanded;
         this.changeActiveItem(event, item, index);
         this.animating = true;
-        DomHandler.focus(event.currentTarget as HTMLElement);
+        this.domHandler.focus(event.currentTarget as HTMLElement);
     }
 
     onHeaderKeyDown(event, item, index) {
@@ -1081,17 +1081,17 @@ export class PanelMenu implements AfterContentInit {
     }
 
     onHeaderArrowDownKey(event) {
-        const rootList = DomHandler.getAttribute(event.currentTarget, 'data-p-highlight') === true ? DomHandler.findSingle(event.currentTarget.nextElementSibling, '[data-pc-section="menu"]') : null;
+        const rootList = this.domHandler.getAttribute(event.currentTarget, 'data-p-highlight') === true ? this.domHandler.findSingle(event.currentTarget.nextElementSibling, '[data-pc-section="menu"]') : null;
 
-        rootList ? DomHandler.focus(rootList) : this.updateFocusedHeader({ originalEvent: event, focusOnNext: true });
+        rootList ? this.domHandler.focus(rootList) : this.updateFocusedHeader({ originalEvent: event, focusOnNext: true });
         event.preventDefault();
     }
 
     onHeaderArrowUpKey(event) {
         const prevHeader = this.findPrevHeader(event.currentTarget.parentElement) || this.findLastHeader();
-        const rootList = DomHandler.getAttribute(prevHeader, 'data-p-highlight') === true ? DomHandler.findSingle(prevHeader.nextElementSibling, '[data-pc-section="menu"]') : null;
+        const rootList = this.domHandler.getAttribute(prevHeader, 'data-p-highlight') === true ? this.domHandler.findSingle(prevHeader.nextElementSibling, '[data-pc-section="menu"]') : null;
 
-        rootList ? DomHandler.focus(rootList) : this.updateFocusedHeader({ originalEvent: event, focusOnNext: false });
+        rootList ? this.domHandler.focus(rootList) : this.updateFocusedHeader({ originalEvent: event, focusOnNext: false });
         event.preventDefault();
     }
 
@@ -1106,7 +1106,7 @@ export class PanelMenu implements AfterContentInit {
     }
 
     onHeaderEnterKey(event, item, index) {
-        const headerAction = DomHandler.findSingle(event.currentTarget, '[data-pc-section="headeraction"]');
+        const headerAction = this.domHandler.findSingle(event.currentTarget, '[data-pc-section="headeraction"]');
 
         headerAction ? headerAction.click() : this.onHeaderClick(event, item, index);
         event.preventDefault();

--- a/src/app/components/password/password.css
+++ b/src/app/components/password/password.css
@@ -7,7 +7,7 @@
     .p-password-panel {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-password .p-password-panel {

--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -195,28 +195,28 @@ import {
             <div class="p-picklist-buttons p-picklist-transfer-buttons" [attr.data-pc-section]="'buttons'" [attr.data-pc-group-section]="'controls'">
                 <button type="button" [attr.aria-label]="moveToTargetAriaLabel" pButton pRipple class="p-button-icon-only" [disabled]="moveRightDisabled()" (click)="moveRight()" [attr.data-pc-section]="'moveToTargetButton'">
                     <ng-container *ngIf="!moveToTargetIconTemplate">
-                        <AngleRightIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movetotargeticon'" />
+                        <AngleRightIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movetotargeticon'" [styleClass]="'p-rtl-flip-icon'" />
                         <AngleDownIcon *ngIf="viewChanged" [attr.data-pc-section]="'movetotargeticon'" />
                     </ng-container>
                     <ng-template *ngTemplateOutlet="moveToTargetIconTemplate; context: { $implicit: viewChanged }"></ng-template>
                 </button>
                 <button type="button" [attr.aria-label]="moveAllToTargetAriaLabel" pButton pRipple class="p-button-icon-only" [disabled]="moveAllRightDisabled()" (click)="moveAllRight()" [attr.data-pc-section]="'moveAllToTargetButton'">
                     <ng-container *ngIf="!moveAllToTargetIconTemplate">
-                        <AngleDoubleRightIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movealltotargeticon'" />
+                        <AngleDoubleRightIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movealltotargeticon'" [styleClass]="'p-rtl-flip-icon'" />
                         <AngleDoubleDownIcon *ngIf="viewChanged" [attr.data-pc-section]="'movealltotargeticon'" />
                     </ng-container>
                     <ng-template *ngTemplateOutlet="moveAllToTargetIconTemplate; context: { $implicit: viewChanged }"></ng-template>
                 </button>
                 <button type="button" [attr.aria-label]="moveToSourceAriaLabel" pButton pRipple class="p-button-icon-only" [disabled]="moveLeftDisabled()" (click)="moveLeft()" [attr.data-pc-section]="'moveToSourceButton'">
                     <ng-container *ngIf="!moveToSourceIconTemplate">
-                        <AngleLeftIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movedownsourceticon'" />
+                        <AngleLeftIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movedownsourceticon'" [styleClass]="'p-rtl-flip-icon'" />
                         <AngleUpIcon *ngIf="viewChanged" [attr.data-pc-section]="'movedownsourceticon'" />
                     </ng-container>
                     <ng-template *ngTemplateOutlet="moveToSourceIconTemplate; context: { $implicit: viewChanged }"></ng-template>
                 </button>
                 <button type="button" [attr.aria-label]="moveAllToSourceAriaLabel" pButton pRipple class="p-button-icon-only" [disabled]="moveAllLeftDisabled()" (click)="moveAllLeft()" [attr.data-pc-section]="'moveAllToSourceButton'">
                     <ng-container *ngIf="!moveAllToSourceIconTemplate">
-                        <AngleDoubleLeftIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movealltosourceticon'" />
+                        <AngleDoubleLeftIcon *ngIf="!viewChanged" [attr.data-pc-section]="'movealltosourceticon'" [styleClass]="'p-rtl-flip-icon'" />
                         <AngleDoubleUpIcon *ngIf="viewChanged" [attr.data-pc-section]="'movealltosourceticon'" />
                     </ng-container>
                     <ng-template *ngTemplateOutlet="moveAllToSourceIconTemplate; context: { $implicit: viewChanged }"></ng-template>
@@ -792,7 +792,8 @@ export class PickList implements AfterViewChecked, AfterContentInit {
         public el: ElementRef,
         public cd: ChangeDetectorRef,
         public filterService: FilterService,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {
         this.window = this.document.defaultView as Window;
     }
@@ -904,13 +905,13 @@ export class PickList implements AfterViewChecked, AfterContentInit {
 
     ngAfterViewChecked() {
         if (this.movedUp || this.movedDown) {
-            let listItems = DomHandler.find(this.reorderedListElement, 'li.p-highlight');
+            let listItems = this.domHandler.find(this.reorderedListElement, 'li.p-highlight');
             let listItem;
 
             if (this.movedUp) listItem = listItems[0];
             else listItem = listItems[listItems.length - 1];
 
-            DomHandler.scrollInView(this.reorderedListElement, listItem);
+            this.domHandler.scrollInView(this.reorderedListElement, listItem);
             this.movedUp = false;
             this.movedDown = false;
             this.reorderedListElement = null;
@@ -1323,7 +1324,7 @@ export class PickList implements AfterViewChecked, AfterContentInit {
 
     onListFocus(event, listType) {
         let listElement = this.getListElement(listType);
-        const selectedFirstItem = DomHandler.findSingle(listElement, 'li.p-picklist-item.p-highlight') || DomHandler.findSingle(listElement, 'li.p-picklist-item');
+        const selectedFirstItem = this.domHandler.findSingle(listElement, 'li.p-picklist-item.p-highlight') || this.domHandler.findSingle(listElement, 'li.p-picklist-item');
         const findIndex = ObjectUtils.findIndexInList(selectedFirstItem, listElement.children);
         this.focused[listType === this.SOURCE_LIST ? 'sourceList' : 'targetList'] = true;
 
@@ -1348,7 +1349,7 @@ export class PickList implements AfterViewChecked, AfterContentInit {
     getListItems(listType: number) {
         let listElemet = this.getListElement(listType);
 
-        return DomHandler.find(listElemet, 'li.p-picklist-item');
+        return this.domHandler.find(listElemet, 'li.p-picklist-item');
     }
 
     getLatestSelectedVisibleOptionIndex(visibleList: any[], selectedItems: any[]): number {
@@ -1447,7 +1448,7 @@ export class PickList implements AfterViewChecked, AfterContentInit {
     }
 
     scrollInView(id, listType) {
-        const element = DomHandler.findSingle(this.getListElement(listType), `li[id="${id}"]`);
+        const element = this.domHandler.findSingle(this.getListElement(listType), `li[id="${id}"]`);
 
         if (element) {
             element.scrollIntoView && element.scrollIntoView({ block: 'nearest', inline: 'start' });
@@ -1581,14 +1582,14 @@ export class PickList implements AfterViewChecked, AfterContentInit {
     findNextItem(item: any): HTMLElement | null {
         let nextItem = item.nextElementSibling;
 
-        if (nextItem) return !DomHandler.hasClass(nextItem, 'p-picklist-item') || DomHandler.isHidden(nextItem) ? this.findNextItem(nextItem) : nextItem;
+        if (nextItem) return !this.domHandler.hasClass(nextItem, 'p-picklist-item') || this.domHandler.isHidden(nextItem) ? this.findNextItem(nextItem) : nextItem;
         else return null;
     }
 
     findPrevItem(item: any): HTMLElement | null {
         let prevItem = item.previousElementSibling;
 
-        if (prevItem) return !DomHandler.hasClass(prevItem, 'p-picklist-item') || DomHandler.isHidden(prevItem) ? this.findPrevItem(prevItem) : prevItem;
+        if (prevItem) return !this.domHandler.hasClass(prevItem, 'p-picklist-item') || this.domHandler.isHidden(prevItem) ? this.findPrevItem(prevItem) : prevItem;
         else return null;
     }
 
@@ -1626,7 +1627,7 @@ export class PickList implements AfterViewChecked, AfterContentInit {
                 this.renderer.setAttribute(this.el.nativeElement.children[0], this.id, '');
                 this.styleElement = this.renderer.createElement('style');
                 this.renderer.setAttribute(this.styleElement, 'type', 'text/css');
-                DomHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
+                this.domHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
                 this.renderer.appendChild(this.document.head, this.styleElement);
 
                 let innerHTML = `
@@ -1641,12 +1642,12 @@ export class PickList implements AfterViewChecked, AfterContentInit {
                     }
 
                     .p-picklist[${this.id}] .p-picklist-buttons .p-button {
-                        margin-right: var(--inline-spacing);
+                        margin-inline-end: var(--inline-spacing);
                         margin-bottom: 0;
                     }
 
                     .p-picklist[${this.id}] .p-picklist-buttons .p-button:last-child {
-                        margin-right: 0;
+                        margin-inline-end: 0;
                     }
                 }`;
 

--- a/src/app/components/progressbar/progressbar.css
+++ b/src/app/components/progressbar/progressbar.css
@@ -29,7 +29,7 @@
         position: absolute;
         background-color: inherit;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         bottom: 0;
         will-change: left, right;
         -webkit-animation: p-progressbar-indeterminate-anim 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite;
@@ -41,7 +41,7 @@
         position: absolute;
         background-color: inherit;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         bottom: 0;
         will-change: left, right;
         -webkit-animation: p-progressbar-indeterminate-anim-short 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) infinite;
@@ -53,58 +53,58 @@
 
 @-webkit-keyframes p-progressbar-indeterminate-anim {
     0% {
-        left: -35%;
-        right: 100%;
+        inset-inline-start: -35%;
+        inset-inline-end: 100%;
     }
     60% {
-        left: 100%;
-        right: -90%;
+        inset-inline-start: 100%;
+        inset-inline-end: -90%;
     }
     100% {
-        left: 100%;
-        right: -90%;
+        inset-inline-start: 100%;
+        inset-inline-end: -90%;
     }
 }
 @keyframes p-progressbar-indeterminate-anim {
     0% {
-        left: -35%;
-        right: 100%;
+        inset-inline-start: -35%;
+        inset-inline-end: 100%;
     }
     60% {
-        left: 100%;
-        right: -90%;
+        inset-inline-start: 100%;
+        inset-inline-end: -90%;
     }
     100% {
-        left: 100%;
-        right: -90%;
+        inset-inline-start: 100%;
+        inset-inline-end: -90%;
     }
 }
 
 @-webkit-keyframes p-progressbar-indeterminate-anim-short {
     0% {
-        left: -200%;
-        right: 100%;
+        inset-inline-start: -200%;
+        inset-inline-end: 100%;
     }
     60% {
-        left: 107%;
-        right: -8%;
+        inset-inline-start: 107%;
+        inset-inline-end: -8%;
     }
     100% {
-        left: 107%;
-        right: -8%;
+        inset-inline-start: 107%;
+        inset-inline-end: -8%;
     }
 }
 @keyframes p-progressbar-indeterminate-anim-short {
     0% {
-        left: -200%;
-        right: 100%;
+        inset-inline-start: -200%;
+        inset-inline-end: 100%;
     }
     60% {
-        left: 107%;
-        right: -8%;
+        inset-inline-start: 107%;
+        inset-inline-end: -8%;
     }
     100% {
-        left: 107%;
-        right: -8%;
+        inset-inline-start: 107%;
+        inset-inline-end: -8%;
     }
 }

--- a/src/app/components/progressspinner/progressspinner.css
+++ b/src/app/components/progressspinner/progressspinner.css
@@ -21,9 +21,13 @@
         position: absolute;
         top: 0;
         bottom: 0;
-        left: 0;
-        right: 0;
+        inset-inline-start: 0;
+        inset-inline-end: 0;
         margin: auto;
+    }
+
+    .p-progress-spinner-svg:dir(rtl) {
+        animation-name: p-progress-spinner-rotate-rtl;
     }
 
     .p-progress-spinner-circle {
@@ -33,11 +37,21 @@
         animation: p-progress-spinner-dash 1.5s ease-in-out infinite, p-progress-spinner-color 6s ease-in-out infinite;
         stroke-linecap: round;
     }
+
+    .p-progress-spinner-circle:dir(rtl) {
+        animation-name: p-progress-spinner-dash-rtl, p-progress-spinner-color;
+    }
 }
 
 @keyframes p-progress-spinner-rotate {
     100% {
         transform: rotate(360deg);
+    }
+}
+
+@keyframes p-progress-spinner-rotate-rtl {
+    100% {
+        transform: rotate(-360deg);
     }
 }
 
@@ -53,6 +67,21 @@
     100% {
         stroke-dasharray: 89, 200;
         stroke-dashoffset: -124px;
+    }
+}
+
+@keyframes p-progress-spinner-dash-rtl {
+    0% {
+        stroke-dasharray: 89, 200;
+        stroke-dashoffset: -124px;
+    }
+    50% {
+        stroke-dasharray: 89, 200;
+        stroke-dashoffset: -35px;
+    }
+    100% {
+        stroke-dasharray: 1, 200;
+        stroke-dashoffset: 0;
     }
 }
 

--- a/src/app/components/rating/rating.ts
+++ b/src/app/components/rating/rating.ts
@@ -197,7 +197,8 @@ export class Rating implements OnInit, ControlValueAccessor {
 
     constructor(
         private cd: ChangeDetectorRef,
-        private config: PrimeNGConfig
+        private config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -230,9 +231,9 @@ export class Rating implements OnInit, ControlValueAccessor {
         if (!this.readonly && !this.disabled) {
             this.onOptionSelect(event, value);
             this.isFocusVisibleItem = false;
-            const firstFocusableEl = DomHandler.getFirstFocusableElement(event.currentTarget, '');
+            const firstFocusableEl = this.domHandler.getFirstFocusableElement(event.currentTarget, '');
 
-            firstFocusableEl && DomHandler.focus(firstFocusableEl);
+            firstFocusableEl && this.domHandler.focus(firstFocusableEl);
         }
     }
 

--- a/src/app/components/ripple/ripple.ts
+++ b/src/app/components/ripple/ripple.ts
@@ -21,7 +21,8 @@ export class Ripple implements AfterViewInit, OnDestroy {
         private renderer: Renderer2,
         public el: ElementRef,
         public zone: NgZone,
-        @Optional() public config: PrimeNGConfig
+        @Optional() public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     animationListener: VoidListener;
@@ -47,25 +48,25 @@ export class Ripple implements AfterViewInit, OnDestroy {
             return;
         }
 
-        DomHandler.removeClass(ink, 'p-ink-active');
-        if (!DomHandler.getHeight(ink) && !DomHandler.getWidth(ink)) {
-            let d = Math.max(DomHandler.getOuterWidth(this.el.nativeElement), DomHandler.getOuterHeight(this.el.nativeElement));
+        this.domHandler.removeClass(ink, 'p-ink-active');
+        if (!this.domHandler.getHeight(ink) && !this.domHandler.getWidth(ink)) {
+            let d = Math.max(this.domHandler.getOuterWidth(this.el.nativeElement), this.domHandler.getOuterHeight(this.el.nativeElement));
             ink.style.height = d + 'px';
             ink.style.width = d + 'px';
         }
 
-        let offset = DomHandler.getOffset(this.el.nativeElement);
-        let x = event.pageX - offset.left + this.document.body.scrollTop - DomHandler.getWidth(ink) / 2;
-        let y = event.pageY - offset.top + this.document.body.scrollLeft - DomHandler.getHeight(ink) / 2;
+        let offset = this.domHandler.getOffset(this.el.nativeElement);
+        let x = this.domHandler.getPageX(event) - offset.left + this.document.body.scrollTop - this.domHandler.getWidth(ink) / 2;
+        let y = event.pageY - offset.top + this.domHandler.getScrollLeft(this.document.body) - this.domHandler.getHeight(ink) / 2;
 
         this.renderer.setStyle(ink, 'top', y + 'px');
-        this.renderer.setStyle(ink, 'left', x + 'px');
-        DomHandler.addClass(ink, 'p-ink-active');
+        this.renderer.setStyle(ink, 'inset-inline-start', x + 'px');
+        this.domHandler.addClass(ink, 'p-ink-active');
 
         this.timeout = setTimeout(() => {
             let ink = this.getInk();
             if (ink) {
-                DomHandler.removeClass(ink, 'p-ink-active');
+                this.domHandler.removeClass(ink, 'p-ink-active');
             }
         }, 401);
     }
@@ -83,7 +84,7 @@ export class Ripple implements AfterViewInit, OnDestroy {
     resetInk() {
         let ink = this.getInk();
         if (ink) {
-            DomHandler.removeClass(ink, 'p-ink-active');
+            this.domHandler.removeClass(ink, 'p-ink-active');
         }
     }
 
@@ -91,7 +92,7 @@ export class Ripple implements AfterViewInit, OnDestroy {
         if (this.timeout) {
             clearTimeout(this.timeout);
         }
-        DomHandler.removeClass(event.currentTarget, 'p-ink-active');
+        this.domHandler.removeClass(event.currentTarget, 'p-ink-active');
     }
 
     create() {
@@ -114,7 +115,7 @@ export class Ripple implements AfterViewInit, OnDestroy {
             this.mouseDownListener = null;
             this.animationListener = null;
 
-            DomHandler.removeElement(ink);
+            this.domHandler.removeElement(ink);
         }
     }
 

--- a/src/app/components/scroller/scroller.css
+++ b/src/app/components/scroller/scroller.css
@@ -16,7 +16,7 @@
     .p-scroller-content {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         /*contain: content;*/
         min-height: 100%;
         min-width: 100%;
@@ -26,17 +26,21 @@
     .p-scroller-spacer {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         height: 1px;
         width: 1px;
         transform-origin: 0 0;
         pointer-events: none;
     }
 
+    .p-scroller-spacer:dir(rtl) {
+        transform-origin: 100% 0;
+    }
+
     .p-scroller-loader {
         position: sticky;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 100%;
     }

--- a/src/app/components/scrollpanel/scrollpanel.css
+++ b/src/app/components/scrollpanel/scrollpanel.css
@@ -4,13 +4,16 @@
         width: 100%;
         height: 100%;
         position: relative;
-        float: left;
+        float: inline-start;
     }
 
     .p-scrollpanel-content {
         height: calc(100% + 18px);
         width: calc(100% + 18px);
-        padding: 0 18px 18px 0;
+        padding-block-start: 0;
+        padding-inline-end: 18px;
+        padding-block-end: 18px;
+        padding-inline-start: 0;
         position: relative;
         overflow: auto;
         box-sizing: border-box;

--- a/src/app/components/scrolltop/scrolltop.css
+++ b/src/app/components/scrolltop/scrolltop.css
@@ -2,7 +2,7 @@
     .p-scrolltop {
         position: fixed;
         bottom: 20px;
-        right: 20px;
+        inset-inline-end: 20px;
         display: flex;
         align-items: center;
         justify-content: center;
@@ -13,6 +13,6 @@
     }
 
     .p-scrolltop-sticky.p-link {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 }

--- a/src/app/components/scrolltop/scrolltop.ts
+++ b/src/app/components/scrolltop/scrolltop.ts
@@ -123,7 +123,8 @@ export class ScrollTop implements OnInit, OnDestroy {
         private renderer: Renderer2,
         public el: ElementRef,
         private cd: ChangeDetectorRef,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {
         this.window = this.document.defaultView;
     }
@@ -189,7 +190,7 @@ export class ScrollTop implements OnInit, OnDestroy {
     bindDocumentScrollListener() {
         if (isPlatformBrowser(this.platformId)) {
             this.documentScrollListener = this.renderer.listen(this.window, 'scroll', () => {
-                this.checkVisibility(DomHandler.getWindowScrollTop());
+                this.checkVisibility(this.domHandler.getWindowScrollTop());
             });
         }
     }

--- a/src/app/components/sidebar/sidebar.css
+++ b/src/app/components/sidebar/sidebar.css
@@ -25,33 +25,33 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-sidebar-left {
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 20rem;
         height: 100%;
     }
 
     .p-sidebar-right {
         top: 0;
-        right: 0;
+        inset-inline-end: 0;
         width: 20rem;
         height: 100%;
     }
 
     .p-sidebar-top {
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 10rem;
     }
 
     .p-sidebar-bottom {
         bottom: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
         height: 10rem;
     }
@@ -60,7 +60,7 @@
         width: 100%;
         height: 100%;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         -webkit-transition: none;
         transition: none;
     }

--- a/src/app/components/sidebar/sidebar.ts
+++ b/src/app/components/sidebar/sidebar.ts
@@ -186,10 +186,18 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
 
         switch (value) {
             case 'left':
-                this.transformOptions = 'translate3d(-100%, 0px, 0px)';
+                if (this.domHandler.isRtl()) {
+                    this.transformOptions = 'translate3d(100%, 0px, 0px)';
+                } else {
+                    this.transformOptions = 'translate3d(-100%, 0px, 0px)';
+                }
                 break;
             case 'right':
-                this.transformOptions = 'translate3d(100%, 0px, 0px)';
+                if (this.domHandler.isRtl()) {
+                    this.transformOptions = 'translate3d(-100%, 0px, 0px)';
+                } else {
+                    this.transformOptions = 'translate3d(100%, 0px, 0px)';
+                }
                 break;
             case 'bottom':
                 this.transformOptions = 'translate3d(0px, 100%, 0px)';
@@ -240,7 +248,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
 
     container: Nullable<HTMLDivElement>;
 
-    transformOptions: any = 'translate3d(-100%, 0px, 0px)';
+    transformOptions: any;
 
     mask: Nullable<HTMLDivElement>;
 
@@ -265,8 +273,11 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
         public el: ElementRef,
         public renderer: Renderer2,
         public cd: ChangeDetectorRef,
-        public config: PrimeNGConfig
-    ) {}
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
+    ) {
+        this.transformOptions = this.domHandler.isRtl() ? 'translate3d(100%, 0px, 0px)' : 'translate3d(-100%, 0px, 0px)';
+    }
 
     ngAfterViewInit() {
         this.initialized = true;
@@ -341,7 +352,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
         if (!this.mask) {
             this.mask = this.renderer.createElement('div');
             this.renderer.setStyle(this.mask, 'zIndex', zIndex);
-            DomHandler.addMultipleClasses(this.mask, 'p-component-overlay p-sidebar-mask p-component-overlay p-component-overlay-enter');
+            this.domHandler.addMultipleClasses(this.mask, 'p-component-overlay p-sidebar-mask p-component-overlay p-component-overlay-enter');
 
             if (this.dismissible) {
                 this.maskClickListener = this.renderer.listen(this.mask, 'click', (event: any) => {
@@ -353,14 +364,14 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
 
             this.renderer.appendChild(this.document.body, this.mask);
             if (this.blockScroll) {
-                DomHandler.blockBodyScroll();
+                this.domHandler.blockBodyScroll();
             }
         }
     }
 
     disableModality() {
         if (this.mask) {
-            DomHandler.addClass(this.mask, 'p-component-overlay-leave');
+            this.domHandler.addClass(this.mask, 'p-component-overlay-leave');
             this.animationEndListener = this.renderer.listen(this.mask, 'animationend', this.destroyModal.bind(this));
         }
     }
@@ -373,7 +384,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
         }
 
         if (this.blockScroll) {
-            DomHandler.unblockBodyScroll();
+            this.domHandler.unblockBodyScroll();
         }
 
         this.unbindAnimationEndListener();
@@ -407,7 +418,7 @@ export class Sidebar implements AfterViewInit, AfterContentInit, OnDestroy {
     appendContainer() {
         if (this.appendTo) {
             if (this.appendTo === 'body') this.renderer.appendChild(this.document.body, this.container);
-            else DomHandler.appendChild(this.container, this.appendTo);
+            else this.domHandler.appendChild(this.container, this.appendTo);
         }
     }
 

--- a/src/app/components/skeleton/skeleton.css
+++ b/src/app/components/skeleton/skeleton.css
@@ -8,19 +8,25 @@
         content: '';
         animation: p-skeleton-animation 1.2s infinite;
         height: 100%;
-        left: 0;
+        inset-inline-start: 0;
         position: absolute;
-        right: 0;
+        inset-inline-end: 0;
         top: 0;
         transform: translateX(-100%);
         z-index: 1;
+    }
+
+    .p-skeleton:dir(rtl)::after {
+        animation-name: p-skeleton-animation-rtl;
+        transform: translateX(100%);
     }
 
     .p-skeleton.p-skeleton-circle {
         border-radius: 50%;
     }
 
-    .p-skeleton-none::after {
+    .p-skeleton-none::after,
+    .p-skeleton-none:dir(rtl)::after {
         animation: none;
     }
 }
@@ -32,4 +38,13 @@
     to {
         transform: translateX(100%);
     }
+}
+
+@keyframes p-skeleton-animation-rtl {
+  from {
+      transform: translateX(100%);
+  }
+  to {
+      transform: translateX(-100%);
+  }
 }

--- a/src/app/components/slidemenu/slidemenu.css
+++ b/src/app/components/slidemenu/slidemenu.css
@@ -7,7 +7,7 @@
     .p-slidemenu-overlay {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-slidemenu .p-menuitem-active {
@@ -56,16 +56,16 @@
     }
 
     .p-slidemenu .p-menuitem-link .p-submenu-icon:not(svg) {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-slidemenu .p-menuitem-link .p-icon-wrapper {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-slidemenu .p-menuitem-active > p-slidemenusub > .p-submenu-list {
         display: block;
-        left: 100%;
+        inset-inline-start: 100%;
         top: 0;
     }
 

--- a/src/app/components/slider/slider.css
+++ b/src/app/components/slider/slider.css
@@ -17,7 +17,7 @@
 
     .p-slider-horizontal .p-slider-range {
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
         height: 100%;
     }
 
@@ -30,12 +30,12 @@
     }
 
     .p-slider-vertical .p-slider-handle {
-        left: 50%;
+        inset-inline-start: 50%;
     }
 
     .p-slider-vertical .p-slider-range {
         bottom: 0;
-        left: 0;
+        inset-inline-start: 0;
         width: 100%;
     }
 }

--- a/src/app/components/speeddial/speeddial.css
+++ b/src/app/components/speeddial/speeddial.css
@@ -54,7 +54,7 @@
 
     .p-speeddial-mask {
         position: absolute;
-        left: 0;
+        inset-inline-start: 0;
         top: 0;
         width: 100%;
         height: 100%;
@@ -79,6 +79,10 @@
 
     .p-speeddial-opened .p-speeddial-rotate {
         transform: rotate(45deg);
+    }
+
+    .p-speeddial-opened .p-speeddial-rotate:dir(rtl) {
+        transform: rotate(-45deg);
     }
 
     /* Direction */

--- a/src/app/components/speeddial/speeddial.ts
+++ b/src/app/components/speeddial/speeddial.ts
@@ -323,7 +323,8 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
         private el: ElementRef,
         public cd: ChangeDetectorRef,
         @Inject(DOCUMENT) private document: Document,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -333,8 +334,8 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
     ngAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
             if (this.type !== 'linear') {
-                const button = DomHandler.findSingle(this.container?.nativeElement, '.p-speeddial-button');
-                const firstItem = DomHandler.findSingle(this.list?.nativeElement, '.p-speeddial-item');
+                const button = this.domHandler.findSingle(this.container?.nativeElement, '.p-speeddial-button');
+                const firstItem = this.domHandler.findSingle(this.list?.nativeElement, '.p-speeddial-item');
 
                 if (button && firstItem) {
                     const wDiff = Math.abs(button.offsetWidth - firstItem.offsetWidth);
@@ -503,23 +504,23 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
     }
 
     onEnterKey(event: any) {
-        const items = DomHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
+        const items = this.domHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
         const itemIndex = [...items].findIndex((item) => item.id === this.focusedOptionIndex());
 
         this.onItemClick(event, this.model[itemIndex]);
         this.onBlur(event);
 
-        const buttonEl = DomHandler.findSingle(this.container.nativeElement, 'button');
+        const buttonEl = this.domHandler.findSingle(this.container.nativeElement, 'button');
 
-        buttonEl && DomHandler.focus(buttonEl);
+        buttonEl && this.domHandler.focus(buttonEl);
     }
 
     onEscapeKey(event: KeyboardEvent) {
         this.hide();
 
-        const buttonEl = DomHandler.findSingle(this.container.nativeElement, 'button');
+        const buttonEl = this.domHandler.findSingle(this.container.nativeElement, 'button');
 
-        buttonEl && DomHandler.focus(buttonEl);
+        buttonEl && this.domHandler.focus(buttonEl);
     }
 
     onTogglerKeydown(event: KeyboardEvent) {
@@ -548,7 +549,7 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
 
     onTogglerArrowUp(event) {
         this.focused = true;
-        DomHandler.focus(this.list.nativeElement);
+        this.domHandler.focus(this.list.nativeElement);
 
         this.show();
         this.navigatePrevItem(event);
@@ -558,7 +559,7 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
 
     onTogglerArrowDown(event) {
         this.focused = true;
-        DomHandler.focus(this.list.nativeElement);
+        this.domHandler.focus(this.list.nativeElement);
 
         this.show();
         this.navigateNextItem(event);
@@ -583,9 +584,9 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
     }
 
     findPrevOptionIndex(index) {
-        const items = DomHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
+        const items = this.domHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
 
-        const filteredItems = [...items].filter((item) => !DomHandler.hasClass(DomHandler.findSingle(item, 'a'), 'p-disabled'));
+        const filteredItems = [...items].filter((item) => !this.domHandler.hasClass(this.domHandler.findSingle(item, 'a'), 'p-disabled'));
         const newIndex = index === -1 ? filteredItems[filteredItems.length - 1].id : index;
         let matchedOptionIndex = filteredItems.findIndex((link) => link.getAttribute('id') === newIndex);
 
@@ -595,8 +596,8 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
     }
 
     findNextOptionIndex(index) {
-        const items = DomHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
-        const filteredItems = [...items].filter((item) => !DomHandler.hasClass(DomHandler.findSingle(item, 'a'), 'p-disabled'));
+        const items = this.domHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
+        const filteredItems = [...items].filter((item) => !this.domHandler.hasClass(this.domHandler.findSingle(item, 'a'), 'p-disabled'));
         const newIndex = index === -1 ? filteredItems[0].id : index;
         let matchedOptionIndex = filteredItems.findIndex((link) => link.getAttribute('id') === newIndex);
 
@@ -606,8 +607,8 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
     }
 
     changeFocusedOptionIndex(index) {
-        const items = DomHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
-        const filteredItems = [...items].filter((item) => !DomHandler.hasClass(DomHandler.findSingle(item, 'a'), 'p-disabled'));
+        const items = this.domHandler.find(this.container.nativeElement, '[data-pc-section="menuitem"]');
+        const filteredItems = [...items].filter((item) => !this.domHandler.hasClass(this.domHandler.findSingle(item, 'a'), 'p-disabled'));
 
         if (filteredItems[index]) {
             this.focusedOptionIndex.set(filteredItems[index].getAttribute('id'));
@@ -625,7 +626,7 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
                 const step = (2 * Math.PI) / length;
 
                 return {
-                    left: `calc(${radius * Math.cos(step * index)}px + var(--item-diff-x, 0px))`,
+                    "inset-inline-start": `calc(${radius * Math.cos(step * index)}px + var(--item-diff-x, 0px))`,
                     top: `calc(${radius * Math.sin(step * index)}px + var(--item-diff-y, 0px))`
                 };
             } else if (type === 'semi-circle') {
@@ -634,13 +635,13 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
                 const x = `calc(${radius * Math.cos(step * index)}px + var(--item-diff-x, 0px))`;
                 const y = `calc(${radius * Math.sin(step * index)}px + var(--item-diff-y, 0px))`;
                 if (direction === 'up') {
-                    return { left: x, bottom: y };
+                    return { "inset-inline-start": x, bottom: y };
                 } else if (direction === 'down') {
-                    return { left: x, top: y };
+                    return { "inset-inline-start": x, top: y };
                 } else if (direction === 'left') {
-                    return { right: y, top: x };
+                    return { "inset-inline-end": y, top: x };
                 } else if (direction === 'right') {
-                    return { left: y, top: x };
+                    return { "inset-inline-start": y, top: x };
                 }
             } else if (type === 'quarter-circle') {
                 const direction = this.direction;
@@ -648,13 +649,13 @@ export class SpeedDial implements AfterViewInit, AfterContentInit, OnDestroy {
                 const x = `calc(${radius * Math.cos(step * index)}px + var(--item-diff-x, 0px))`;
                 const y = `calc(${radius * Math.sin(step * index)}px + var(--item-diff-y, 0px))`;
                 if (direction === 'up-left') {
-                    return { right: x, bottom: y };
+                    return { "inset-inline-end": x, bottom: y };
                 } else if (direction === 'up-right') {
-                    return { left: x, bottom: y };
+                    return { "inset-inline-start": x, bottom: y };
                 } else if (direction === 'down-left') {
-                    return { right: y, top: x };
+                    return { "inset-inline-end": y, top: x };
                 } else if (direction === 'down-right') {
-                    return { left: y, top: x };
+                    return { "inset-inline-start": y, top: x };
                 }
             }
         }

--- a/src/app/components/spinner/spinner.css
+++ b/src/app/components/spinner/spinner.css
@@ -9,7 +9,7 @@
 
     .ui-spinner-input {
         vertical-align: middle;
-        padding-right: 1.5em;
+        padding-inline-end: 1.5em;
     }
 
     .ui-spinner-button {
@@ -20,7 +20,7 @@
         overflow: hidden;
         padding: 0;
         position: absolute;
-        right: 0;
+        inset-inline-end: 0;
         text-align: center;
         vertical-align: middle;
         width: 1.5em;
@@ -29,9 +29,9 @@
     .ui-spinner .ui-spinner-button-icon {
         position: absolute;
         top: 50%;
-        left: 50%;
+        inset-inline-start: 50%;
         margin-top: -0.5em;
-        margin-left: -0.5em;
+        margin-inline-start: -0.5em;
         width: 1em;
     }
 
@@ -49,7 +49,7 @@
     }
 
     .ui-fluid .ui-spinner .ui-spinner-input {
-        padding-right: 2em;
+        padding-inline-end: 2em;
         width: 100%;
     }
 
@@ -58,6 +58,6 @@
     }
 
     .ui-fluid .ui-spinner .ui-spinner-button .ui-spinner-button-icon {
-        left: 0.7em;
+        inset-inline-start: 0.7em;
     }
 }

--- a/src/app/components/splitbutton/splitbutton.css
+++ b/src/app/components/splitbutton/splitbutton.css
@@ -8,9 +8,9 @@
     .p-splitbutton.p-button-rounded > .p-splitbutton-defaultbutton.p-button,
     .p-splitbutton.p-button-outlined > .p-splitbutton-defaultbutton.p-button {
         flex: 1 1 auto;
-        border-top-right-radius: 0;
-        border-bottom-right-radius: 0;
-        border-right: 0 none;
+        border-start-end-radius: 0;
+        border-end-end-radius: 0;
+        border-inline-end: 0 none;
     }
 
     .p-splitbutton-menubutton,
@@ -19,8 +19,8 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        border-top-left-radius: 0;
-        border-bottom-left-radius: 0;
+        border-start-start-radius: 0;
+        border-end-start-radius: 0;
     }
 
     .p-splitbutton .p-menu {

--- a/src/app/components/splitter/splitter.ts
+++ b/src/app/components/splitter/splitter.ts
@@ -112,7 +112,7 @@ export class Splitter {
         this._panelSizes = val;
 
         if (this.el && this.el.nativeElement && this.panels.length > 0) {
-            let children = [...this.el.nativeElement.children[0].children].filter((child) => DomHandler.hasClass(child, 'p-splitter-panel'));
+            let children = [...this.el.nativeElement.children[0].children].filter((child) => this.domHandler.hasClass(child, 'p-splitter-panel'));
             let _panelSizes = [];
 
             this.panels.map((panel, i) => {
@@ -183,7 +183,8 @@ export class Splitter {
         @Inject(PLATFORM_ID) private platformId: any,
         private renderer: Renderer2,
         public cd: ChangeDetectorRef,
-        private el: ElementRef
+        private el: ElementRef,
+        private domHandler: DomHandler
     ) {
         this.window = this.document.defaultView as Window;
     }
@@ -214,7 +215,7 @@ export class Splitter {
                 }
 
                 if (!initialized) {
-                    let children = [...this.el.nativeElement.children[0].children].filter((child) => DomHandler.hasClass(child, 'p-splitter-panel'));
+                    let children = [...this.el.nativeElement.children[0].children].filter((child) => this.domHandler.hasClass(child, 'p-splitter-panel'));
                     let _panelSizes = [];
 
                     this.panels.map((panel, i) => {
@@ -234,28 +235,28 @@ export class Splitter {
 
     resizeStart(event: TouchEvent | MouseEvent, index: number, isKeyDown?: boolean) {
         this.gutterElement = (event.currentTarget as HTMLElement) || (event.target as HTMLElement).parentElement;
-        this.size = this.horizontal() ? DomHandler.getWidth((this.containerViewChild as ElementRef).nativeElement) : DomHandler.getHeight((this.containerViewChild as ElementRef).nativeElement);
+        this.size = this.horizontal() ? this.domHandler.getWidth((this.containerViewChild as ElementRef).nativeElement) : this.domHandler.getHeight((this.containerViewChild as ElementRef).nativeElement);
 
         if (!isKeyDown) {
             this.dragging = true;
-            this.startPos = this.horizontal() ? (event instanceof MouseEvent ? event.pageX : event.changedTouches[0].pageX) : event instanceof MouseEvent ? event.pageY : event.changedTouches[0].pageY;
+            this.startPos = this.horizontal() ? (event instanceof MouseEvent ? this.domHandler.getPageX(event) : this.domHandler.getPageX(event.changedTouches[0])) : event instanceof MouseEvent ? event.pageY : event.changedTouches[0].pageY;
         }
 
         this.prevPanelElement = this.gutterElement.previousElementSibling as HTMLElement;
         this.nextPanelElement = this.gutterElement.nextElementSibling as HTMLElement;
 
         if (isKeyDown) {
-            this.prevPanelSize = this.horizontal() ? DomHandler.getOuterWidth(this.prevPanelElement, true) : DomHandler.getOuterHeight(this.prevPanelElement, true);
-            this.nextPanelSize = this.horizontal() ? DomHandler.getOuterWidth(this.nextPanelElement, true) : DomHandler.getOuterHeight(this.nextPanelElement, true);
+            this.prevPanelSize = this.horizontal() ? this.domHandler.getOuterWidth(this.prevPanelElement, true) : this.domHandler.getOuterHeight(this.prevPanelElement, true);
+            this.nextPanelSize = this.horizontal() ? this.domHandler.getOuterWidth(this.nextPanelElement, true) : this.domHandler.getOuterHeight(this.nextPanelElement, true);
         } else {
-            this.prevPanelSize = (100 * (this.horizontal() ? DomHandler.getOuterWidth(this.prevPanelElement, true) : DomHandler.getOuterHeight(this.prevPanelElement, true))) / this.size;
-            this.nextPanelSize = (100 * (this.horizontal() ? DomHandler.getOuterWidth(this.nextPanelElement, true) : DomHandler.getOuterHeight(this.nextPanelElement, true))) / this.size;
+            this.prevPanelSize = (100 * (this.horizontal() ? this.domHandler.getOuterWidth(this.prevPanelElement, true) : this.domHandler.getOuterHeight(this.prevPanelElement, true))) / this.size;
+            this.nextPanelSize = (100 * (this.horizontal() ? this.domHandler.getOuterWidth(this.nextPanelElement, true) : this.domHandler.getOuterHeight(this.nextPanelElement, true))) / this.size;
         }
 
         this.prevPanelIndex = index;
-        DomHandler.addClass(this.gutterElement, 'p-splitter-gutter-resizing');
+        this.domHandler.addClass(this.gutterElement, 'p-splitter-gutter-resizing');
         this.gutterElement.setAttribute('data-p-gutter-resizing', 'true');
-        DomHandler.addClass((this.containerViewChild as ElementRef).nativeElement, 'p-splitter-resizing');
+        this.domHandler.addClass((this.containerViewChild as ElementRef).nativeElement, 'p-splitter-resizing');
         this.containerViewChild.nativeElement.setAttribute('data-p-resizing', 'true');
         this.onResizeStart.emit({ originalEvent: event, sizes: this._panelSizes as number[] });
     }
@@ -272,7 +273,7 @@ export class Splitter {
                 newNextPanelSize = (100 * (this.nextPanelSize + step)) / this.size;
             }
         } else {
-            if (this.horizontal()) newPos = (event.pageX * 100) / this.size - (this.startPos * 100) / this.size;
+            if (this.horizontal()) newPos = (this.domHandler.getPageX(event) * 100) / this.size - (this.startPos * 100) / this.size;
             else newPos = (event.pageY * 100) / this.size - (this.startPos * 100) / this.size;
 
             newPrevPanelSize = (this.prevPanelSize as number) + newPos;
@@ -295,8 +296,8 @@ export class Splitter {
         }
 
         this.onResizeEnd.emit({ originalEvent: event, sizes: this._panelSizes });
-        DomHandler.removeClass(this.gutterElement, 'p-splitter-gutter-resizing');
-        DomHandler.removeClass((this.containerViewChild as ElementRef).nativeElement, 'p-splitter-resizing');
+        this.domHandler.removeClass(this.gutterElement, 'p-splitter-gutter-resizing');
+        this.domHandler.removeClass((this.containerViewChild as ElementRef).nativeElement, 'p-splitter-resizing');
         this.clear();
     }
 
@@ -476,7 +477,7 @@ export class Splitter {
     isNested() {
         if (this.el.nativeElement) {
             let parent = this.el.nativeElement.parentElement;
-            while (parent && !DomHandler.hasClass(parent, 'p-splitter')) {
+            while (parent && !this.domHandler.hasClass(parent, 'p-splitter')) {
                 parent = parent.parentElement;
             }
 
@@ -517,7 +518,7 @@ export class Splitter {
 
         if (stateString) {
             this._panelSizes = JSON.parse(stateString);
-            let children = [...(this.containerViewChild as ElementRef).nativeElement.children].filter((child) => DomHandler.hasClass(child, 'p-splitter-panel'));
+            let children = [...(this.containerViewChild as ElementRef).nativeElement.children].filter((child) => this.domHandler.hasClass(child, 'p-splitter-panel'));
             children.forEach((child, i) => {
                 child.style.flexBasis = 'calc(' + this._panelSizes[i] + '% - ' + (this.panels.length - 1) * this.gutterSize + 'px)';
             });

--- a/src/app/components/steps/steps.ts
+++ b/src/app/components/steps/steps.ts
@@ -124,7 +124,8 @@ export class Steps implements OnInit, OnDestroy {
     constructor(
         private router: Router,
         private route: ActivatedRoute,
-        private cd: ChangeDetectorRef
+        private cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {}
 
     subscription: Subscription | undefined;
@@ -182,7 +183,7 @@ export class Steps implements OnInit, OnDestroy {
 
             case 'Tab':
                 if (i !== this.activeIndex) {
-                    const siblings = DomHandler.find(this.listViewChild.nativeElement, '[data-pc-section="menuitem"]');
+                    const siblings = this.domHandler.find(this.listViewChild.nativeElement, '[data-pc-section="menuitem"]');
                     siblings[i].children[0].tabIndex = '-1';
                     siblings[this.activeIndex].children[0].tabIndex = '0';
                 }
@@ -231,12 +232,12 @@ export class Steps implements OnInit, OnDestroy {
         return prevItem ? prevItem.children[0] : null;
     }
     findFirstItem() {
-        const firstSibling = DomHandler.findSingle(this.listViewChild.nativeElement, '[data-pc-section="menuitem"]');
+        const firstSibling = this.domHandler.findSingle(this.listViewChild.nativeElement, '[data-pc-section="menuitem"]');
 
         return firstSibling ? firstSibling.children[0] : null;
     }
     findLastItem() {
-        const siblings = DomHandler.find(this.listViewChild.nativeElement, '[data-pc-section="menuitem"]');
+        const siblings = this.domHandler.find(this.listViewChild.nativeElement, '[data-pc-section="menuitem"]');
 
         return siblings ? siblings[siblings.length - 1].children[0] : null;
     }

--- a/src/app/components/styleclass/styleclass.ts
+++ b/src/app/components/styleclass/styleclass.ts
@@ -16,7 +16,8 @@ export class StyleClass implements OnDestroy {
     constructor(
         public el: ElementRef,
         public renderer: Renderer2,
-        private zone: NgZone
+        private zone: NgZone,
+        private domHandler: DomHandler
     ) {}
     /**
      * Selector to define the target element. Available selectors are '@next', '@prev', '@parent' and '@grandparent'.
@@ -124,8 +125,8 @@ export class StyleClass implements OnDestroy {
     }
 
     toggle() {
-        if (DomHandler.hasClass(this.target, this.toggleClass as string)) DomHandler.removeClass(this.target, this.toggleClass as string);
-        else DomHandler.addClass(this.target, this.toggleClass as string);
+        if (this.domHandler.hasClass(this.target, this.toggleClass as string)) this.domHandler.removeClass(this.target, this.toggleClass as string);
+        else this.domHandler.addClass(this.target, this.toggleClass as string);
     }
 
     enter() {
@@ -135,21 +136,21 @@ export class StyleClass implements OnDestroy {
 
                 if (this.enterActiveClass === 'slidedown') {
                     (this.target as HTMLElement).style.height = '0px';
-                    DomHandler.removeClass(this.target, 'hidden');
+                    this.domHandler.removeClass(this.target, 'hidden');
                     (this.target as HTMLElement).style.maxHeight = (this.target as HTMLElement).scrollHeight + 'px';
-                    DomHandler.addClass(this.target, 'hidden');
+                    this.domHandler.addClass(this.target, 'hidden');
                     (this.target as HTMLElement).style.height = '';
                 }
 
-                DomHandler.addClass(this.target, this.enterActiveClass);
+                this.domHandler.addClass(this.target, this.enterActiveClass);
                 if (this.enterClass || this.enterFromClass) {
-                    DomHandler.removeClass(this.target, this.enterClass || this.enterFromClass);
+                    this.domHandler.removeClass(this.target, this.enterClass || this.enterFromClass);
                 }
 
                 this.enterListener = this.renderer.listen(this.target, 'animationend', () => {
-                    DomHandler.removeClass(this.target, this.enterActiveClass as string);
+                    this.domHandler.removeClass(this.target, this.enterActiveClass as string);
                     if (this.enterToClass) {
-                        DomHandler.addClass(this.target, this.enterToClass);
+                        this.domHandler.addClass(this.target, this.enterToClass);
                     }
                     this.enterListener && this.enterListener();
 
@@ -161,11 +162,11 @@ export class StyleClass implements OnDestroy {
             }
         } else {
             if (this.enterClass || this.enterFromClass) {
-                DomHandler.removeClass(this.target, this.enterClass || this.enterFromClass);
+                this.domHandler.removeClass(this.target, this.enterClass || this.enterFromClass);
             }
 
             if (this.enterToClass) {
-                DomHandler.addClass(this.target, this.enterToClass);
+                this.domHandler.addClass(this.target, this.enterToClass);
             }
         }
 
@@ -182,15 +183,15 @@ export class StyleClass implements OnDestroy {
         if (this.leaveActiveClass) {
             if (!this.animating) {
                 this.animating = true;
-                DomHandler.addClass(this.target, this.leaveActiveClass);
+                this.domHandler.addClass(this.target, this.leaveActiveClass);
                 if (this.leaveClass || this.leaveFromClass) {
-                    DomHandler.removeClass(this.target, this.leaveClass || this.leaveFromClass);
+                    this.domHandler.removeClass(this.target, this.leaveClass || this.leaveFromClass);
                 }
 
                 this.leaveListener = this.renderer.listen(this.target, 'animationend', () => {
-                    DomHandler.removeClass(this.target, this.leaveActiveClass as string);
+                    this.domHandler.removeClass(this.target, this.leaveActiveClass as string);
                     if (this.leaveToClass) {
-                        DomHandler.addClass(this.target, this.leaveToClass);
+                        this.domHandler.addClass(this.target, this.leaveToClass);
                     }
                     this.leaveListener && this.leaveListener();
                     this.animating = false;
@@ -198,11 +199,11 @@ export class StyleClass implements OnDestroy {
             }
         } else {
             if (this.leaveClass || this.leaveFromClass) {
-                DomHandler.removeClass(this.target, this.leaveClass || this.leaveFromClass);
+                this.domHandler.removeClass(this.target, this.leaveClass || this.leaveFromClass);
             }
 
             if (this.leaveToClass) {
-                DomHandler.addClass(this.target, this.leaveToClass);
+                this.domHandler.addClass(this.target, this.leaveToClass);
             }
         }
 

--- a/src/app/components/table/table.css
+++ b/src/app/components/table/table.css
@@ -108,7 +108,7 @@
         display: block;
         position: absolute !important;
         top: 0;
-        right: 0;
+        inset-inline-end: 0;
         margin: 0;
         width: 0.5rem;
         height: 100%;
@@ -196,7 +196,7 @@
     .p-column-filter-overlay {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-column-filter-row-items {
@@ -244,6 +244,6 @@
         min-height: 0;
         position: sticky;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 }

--- a/src/app/components/tabmenu/tabmenu.css
+++ b/src/app/components/tabmenu/tabmenu.css
@@ -26,11 +26,11 @@
     }
 
     .p-tabmenu-nav-prev {
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-tabmenu-nav-next {
-        right: 0;
+        inset-inline-end: 0;
     }
 
     .p-tabview-nav-content::-webkit-scrollbar {

--- a/src/app/components/tabview/tabview.css
+++ b/src/app/components/tabview/tabview.css
@@ -59,11 +59,11 @@
     }
 
     .p-tabview-nav-prev {
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-tabview-nav-next {
-        right: 0;
+        inset-inline-end: 0;
     }
 
     .p-tabview-nav-content::-webkit-scrollbar {

--- a/src/app/components/tabview/tabview.ts
+++ b/src/app/components/tabview/tabview.ts
@@ -288,7 +288,7 @@ export class TabPanel implements AfterContentInit, OnDestroy {
                     type="button"
                     pRipple
                 >
-                    <ChevronLeftIcon *ngIf="!previousIconTemplate" [attr.aria-hidden]="true" />
+                    <ChevronLeftIcon *ngIf="!previousIconTemplate" [attr.aria-hidden]="true" [styleClass]="'p-rtl-flip-icon'" />
                     <ng-template *ngTemplateOutlet="previousIconTemplate"></ng-template>
                 </button>
                 <div #content class="p-tabview-nav-content" (scroll)="onScroll($event)" [attr.data-pc-section]="'navcontent'">
@@ -346,7 +346,7 @@ export class TabPanel implements AfterContentInit, OnDestroy {
                     type="button"
                     pRipple
                 >
-                    <ChevronRightIcon *ngIf="!nextIconTemplate" [attr.aria-hidden]="true" />
+                    <ChevronRightIcon *ngIf="!nextIconTemplate" [attr.aria-hidden]="true" [styleClass]="'p-rtl-flip-icon'" />
                     <ng-template *ngTemplateOutlet="nextIconTemplate"></ng-template>
                 </button>
             </div>
@@ -499,7 +499,8 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
         @Inject(PLATFORM_ID) private platformId: any,
         public el: ElementRef,
         public cd: ChangeDetectorRef,
-        private renderer: Renderer2
+        private renderer: Renderer2,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterContentInit() {
@@ -537,8 +538,8 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
     }
 
     bindResizeObserver() {
-        this.container = DomHandler.findSingle(this.el.nativeElement, '[data-pc-section="navcontent"]');
-        this.list = DomHandler.findSingle(this.el.nativeElement, '[data-pc-section="nav"]');
+        this.container = this.domHandler.findSingle(this.el.nativeElement, '[data-pc-section="navcontent"]');
+        this.list = this.domHandler.findSingle(this.el.nativeElement, '[data-pc-section="nav"]');
 
         this.resizeObserver = new ResizeObserver(() => {
             if (this.list.offsetWidth >= this.container.offsetWidth) {
@@ -635,7 +636,7 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
 
     onTabArrowLeftKey(event: KeyboardEvent) {
         const prevHeaderAction = this.findPrevHeaderAction((<HTMLElement>event.target).parentElement);
-        const index = DomHandler.getAttribute(prevHeaderAction, 'data-pc-index');
+        const index = this.domHandler.getAttribute(prevHeaderAction, 'data-pc-index');
 
         prevHeaderAction ? this.changeFocusedTab(event, prevHeaderAction, index) : this.onTabEndKey(event);
         event.preventDefault();
@@ -643,7 +644,7 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
 
     onTabArrowRightKey(event: KeyboardEvent) {
         const nextHeaderAction = this.findNextHeaderAction((<HTMLElement>event.target).parentElement);
-        const index = DomHandler.getAttribute(nextHeaderAction, 'data-pc-index');
+        const index = this.domHandler.getAttribute(nextHeaderAction, 'data-pc-index');
 
         nextHeaderAction ? this.changeFocusedTab(event, nextHeaderAction, index) : this.onTabHomeKey(event);
         event.preventDefault();
@@ -651,7 +652,7 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
 
     onTabHomeKey(event: KeyboardEvent) {
         const firstHeaderAction = this.findFirstHeaderAction();
-        const index = DomHandler.getAttribute(firstHeaderAction, 'data-pc-index');
+        const index = this.domHandler.getAttribute(firstHeaderAction, 'data-pc-index');
 
         this.changeFocusedTab(event, firstHeaderAction, index);
         event.preventDefault();
@@ -659,7 +660,7 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
 
     onTabEndKey(event: KeyboardEvent) {
         const lastHeaderAction = this.findLastHeaderAction();
-        const index = DomHandler.getAttribute(lastHeaderAction, 'data-pc-index');
+        const index = this.domHandler.getAttribute(lastHeaderAction, 'data-pc-index');
 
         this.changeFocusedTab(event, lastHeaderAction, index);
         event.preventDefault();
@@ -667,7 +668,7 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
 
     changeFocusedTab(event: KeyboardEvent, element: any, index: number) {
         if (element) {
-            DomHandler.focus(element);
+            this.domHandler.focus(element);
             element.scrollIntoView({ block: 'nearest' });
 
             if (this.selectOnFocus) {
@@ -680,9 +681,9 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
     findNextHeaderAction(tabElement: any, selfCheck = false) {
         const headerElement = selfCheck ? tabElement : tabElement.nextElementSibling;
         return headerElement
-            ? DomHandler.getAttribute(headerElement, 'data-p-disabled') || DomHandler.getAttribute(headerElement, 'data-pc-section') === 'inkbar'
+            ? this.domHandler.getAttribute(headerElement, 'data-p-disabled') || this.domHandler.getAttribute(headerElement, 'data-pc-section') === 'inkbar'
                 ? this.findNextHeaderAction(headerElement)
-                : DomHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')
+                : this.domHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')
             : null;
     }
 
@@ -690,9 +691,9 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
         const headerElement = selfCheck ? tabElement : tabElement.previousElementSibling;
 
         return headerElement
-            ? DomHandler.getAttribute(headerElement, 'data-p-disabled') || DomHandler.getAttribute(headerElement, 'data-pc-section') === 'inkbar'
+            ? this.domHandler.getAttribute(headerElement, 'data-p-disabled') || this.domHandler.getAttribute(headerElement, 'data-pc-section') === 'inkbar'
                 ? this.findPrevHeaderAction(headerElement)
-                : DomHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')
+                : this.domHandler.findSingle(headerElement, '[data-pc-section="headeraction"]')
             : null;
     }
 
@@ -703,7 +704,7 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
 
     findLastHeaderAction() {
         const lastEl = this.navbar.nativeElement.lastElementChild;
-        const lastHeaderAction = DomHandler.getAttribute(lastEl, 'data-pc-section') === 'inkbar' ? lastEl.previousElementSibling : lastEl;
+        const lastHeaderAction = this.domHandler.getAttribute(lastEl, 'data-pc-section') === 'inkbar' ? lastEl.previousElementSibling : lastEl;
         return this.findPrevHeaderAction(lastHeaderAction, true);
     }
 
@@ -803,14 +804,14 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
     updateInkBar() {
         if (isPlatformBrowser(this.platformId)) {
             if (this.navbar) {
-                const tabHeader: HTMLElement | null = DomHandler.findSingle(this.navbar.nativeElement, 'li.p-highlight');
+                const tabHeader: HTMLElement | null = this.domHandler.findSingle(this.navbar.nativeElement, 'li.p-highlight');
 
                 if (!tabHeader) {
                     return;
                 }
 
-                (this.inkbar as ElementRef).nativeElement.style.width = DomHandler.getWidth(tabHeader) + 'px';
-                (this.inkbar as ElementRef).nativeElement.style.left = DomHandler.getOffset(tabHeader).left - DomHandler.getOffset(this.navbar.nativeElement).left + 'px';
+                (this.inkbar as ElementRef).nativeElement.style.width = this.domHandler.getWidth(tabHeader) + 'px';
+                (this.inkbar as ElementRef).nativeElement.style.insetInlineStart = this.domHandler.getOffset(tabHeader).left - this.domHandler.getOffset(this.navbar.nativeElement).left + 'px';
             }
         }
     }
@@ -825,16 +826,17 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
 
     updateButtonState() {
         const content = (this.content as ElementRef).nativeElement;
-        const { scrollLeft, scrollWidth } = content;
-        const width = DomHandler.getWidth(content);
+        const scrollWidth = content.scrollWidth;
+        const scrollLeft = this.domHandler.getScrollLeft(content);
+        const width = this.domHandler.getWidth(content);
 
         this.backwardIsDisabled = scrollLeft === 0;
         this.forwardIsDisabled = Math.round(scrollLeft) === scrollWidth - width;
     }
 
     refreshButtonState() {
-        this.container = DomHandler.findSingle(this.el.nativeElement, '[data-pc-section="navcontent"]');
-        this.list = DomHandler.findSingle(this.el.nativeElement, '[data-pc-section="nav"]');
+        this.container = this.domHandler.findSingle(this.el.nativeElement, '[data-pc-section="navcontent"]');
+        this.list = this.domHandler.findSingle(this.el.nativeElement, '[data-pc-section="nav"]');
         if (this.list.offsetWidth >= this.container.offsetWidth) {
             if (this.list.offsetWidth >= this.container.offsetWidth) {
                 this.buttonVisible = true;
@@ -853,23 +855,23 @@ export class TabView implements AfterContentInit, AfterViewChecked, OnDestroy, B
     }
 
     getVisibleButtonWidths() {
-        return [this.prevBtn?.nativeElement, this.nextBtn?.nativeElement].reduce((acc, el) => (el ? acc + DomHandler.getWidth(el) : acc), 0);
+        return [this.prevBtn?.nativeElement, this.nextBtn?.nativeElement].reduce((acc, el) => (el ? acc + this.domHandler.getWidth(el) : acc), 0);
     }
 
     navBackward() {
         const content = (this.content as ElementRef).nativeElement;
-        const width = DomHandler.getWidth(content) - this.getVisibleButtonWidths();
-        const pos = content.scrollLeft - width;
-        content.scrollLeft = pos <= 0 ? 0 : pos;
+        const width = this.domHandler.getWidth(content) - this.getVisibleButtonWidths();
+        const pos = this.domHandler.getScrollLeft(content) - width;
+        this.domHandler.setScrollLeft(content, pos <= 0 ? 0 : pos);
     }
 
     navForward() {
         const content = (this.content as ElementRef).nativeElement;
-        const width = DomHandler.getWidth(content) - this.getVisibleButtonWidths();
-        const pos = content.scrollLeft + width;
+        const width = this.domHandler.getWidth(content) - this.getVisibleButtonWidths();
+        const pos = this.domHandler.getScrollLeft(content) + width;
         const lastPos = content.scrollWidth - width;
 
-        content.scrollLeft = pos >= lastPos ? lastPos : pos;
+        this.domHandler.setScrollLeft(content, pos >= lastPos ? lastPos : pos);
     }
 }
 

--- a/src/app/components/terminal/terminal.ts
+++ b/src/app/components/terminal/terminal.ts
@@ -68,7 +68,8 @@ export class Terminal implements AfterViewInit, AfterViewChecked, OnDestroy {
     constructor(
         public el: ElementRef,
         public terminalService: TerminalService,
-        public cd: ChangeDetectorRef
+        public cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {
         this.subscription = terminalService.responseHandler.subscribe((response) => {
             this.commands[this.commands.length - 1].response = response;
@@ -77,7 +78,7 @@ export class Terminal implements AfterViewInit, AfterViewChecked, OnDestroy {
     }
 
     ngAfterViewInit() {
-        this.container = DomHandler.find(this.el.nativeElement, '.p-terminal')[0];
+        this.container = this.domHandler.find(this.el.nativeElement, '.p-terminal')[0];
     }
 
     ngAfterViewChecked() {

--- a/src/app/components/tieredmenu/tieredmenu.css
+++ b/src/app/components/tieredmenu/tieredmenu.css
@@ -2,7 +2,7 @@
     .p-tieredmenu-overlay {
         position: absolute;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 
     .p-tieredmenu ul {
@@ -36,20 +36,20 @@
     }
 
     .p-tieredmenu .p-menuitem-link .p-submenu-icon:not(svg) {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-tieredmenu .p-menuitem-link .p-icon-wrapper {
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-tieredmenu .p-menuitem-active > p-tieredmenusub > .p-submenu-list {
         display: block;
-        left: 100%;
+        inset-inline-start: 100%;
         top: 0;
     }
 
     .p-tieredmenu .p-menuitem-active > p-tieredmenusub > .p-submenu-list.p-submenu-list-flipped {
-        left: -100%;
+        inset-inline-start: -100%;
     }
 }

--- a/src/app/components/timeline/timeline.css
+++ b/src/app/components/timeline/timeline.css
@@ -6,11 +6,11 @@
     }
 
     .p-timeline-left .p-timeline-event-opposite {
-        text-align: right;
+        text-align: end;
     }
 
     .p-timeline-left .p-timeline-event-content {
-        text-align: left;
+        text-align: start;
     }
 
     .p-timeline-right .p-timeline-event {
@@ -18,11 +18,11 @@
     }
 
     .p-timeline-right .p-timeline-event-opposite {
-        text-align: left;
+        text-align: start;
     }
 
     .p-timeline-right .p-timeline-event-content {
-        text-align: right;
+        text-align: end;
     }
 
     .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(even) {
@@ -30,19 +30,19 @@
     }
 
     .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(odd) .p-timeline-event-opposite {
-        text-align: right;
+        text-align: end;
     }
 
     .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(odd) .p-timeline-event-content {
-        text-align: left;
+        text-align: start;
     }
 
     .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(even) .p-timeline-event-opposite {
-        text-align: left;
+        text-align: start;
     }
 
     .p-timeline-vertical.p-timeline-alternate .p-timeline-event:nth-child(even) .p-timeline-event-content {
-        text-align: right;
+        text-align: end;
     }
 
     .p-timeline-event {

--- a/src/app/components/toast/toast.css
+++ b/src/app/components/toast/toast.css
@@ -19,41 +19,53 @@
 
     .p-toast-top-right {
         top: 20px;
-        right: 20px;
+        inset-inline-end: 20px;
     }
 
     .p-toast-top-left {
         top: 20px;
-        left: 20px;
+        inset-inline-start: 20px;
     }
 
     .p-toast-bottom-left {
         bottom: 20px;
-        left: 20px;
+        inset-inline-start: 20px;
     }
 
     .p-toast-bottom-right {
         bottom: 20px;
-        right: 20px;
+        inset-inline-end: 20px;
     }
 
     .p-toast-top-center {
         top: 20px;
-        left: 50%;
+        inset-inline-start: 50%;
         transform: translateX(-50%);
+    }
+
+    .p-toast-top-center:dir(rtl) {
+        transform: translateX(50%);
     }
 
     .p-toast-bottom-center {
         bottom: 20px;
-        left: 50%;
+        inset-inline-start: 50%;
         transform: translateX(-50%);
     }
 
+    .p-toast-bottom-center:dir(rtl) {
+        transform: translateX(50%);
+    }
+
     .p-toast-center {
-        left: 50%;
+        inset-inline-start: 50%;
         top: 50%;
         min-width: 20vw;
         transform: translate(-50%, -50%);
+    }
+
+    .p-toast-center:dir(rtl) {
+        transform: translate(50%, -50%);
     }
 
     .p-toast-icon-close {

--- a/src/app/components/toast/toast.ts
+++ b/src/app/components/toast/toast.ts
@@ -354,7 +354,8 @@ export class Toast implements OnInit, AfterContentInit, OnDestroy {
         private renderer: Renderer2,
         public messageService: MessageService,
         private cd: ChangeDetectorRef,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     styleElement: any;
@@ -476,7 +477,7 @@ export class Toast implements OnInit, AfterContentInit, OnDestroy {
         if (!this.styleElement) {
             this.styleElement = this.renderer.createElement('style');
             this.styleElement.type = 'text/css';
-            DomHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
+            this.domHandler.setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
             this.renderer.appendChild(this.document.head, this.styleElement);
             let innerHTML = '';
             for (let breakpoint in this.breakpoints) {

--- a/src/app/components/tooltip/tooltip.css
+++ b/src/app/components/tooltip/tooltip.css
@@ -33,16 +33,22 @@
 
     .p-tooltip-right .p-tooltip-arrow {
         top: 50%;
-        left: 0;
+        inset-inline-start: 0;
         margin-top: -0.25rem;
-        border-width: 0.25em 0.25em 0.25em 0;
+        border-block-start-width: 0.25em;
+        border-inline-end-width: 0.25em;
+        border-block-end-width: 0.25em;
+        border-inline-start-width: 0;
     }
 
     .p-tooltip-left .p-tooltip-arrow {
         top: 50%;
-        right: 0;
+        inset-inline-end: 0;
         margin-top: -0.25rem;
-        border-width: 0.25em 0 0.25em 0.25rem;
+        border-block-start-width: 0.25em;
+        border-inline-end-width: 0;
+        border-block-end-width: 0.25em;
+        border-inline-start-width: 0.25rem;
     }
 
     .p-tooltip.p-tooltip-top {
@@ -51,15 +57,15 @@
 
     .p-tooltip-top .p-tooltip-arrow {
         bottom: 0;
-        left: 50%;
-        margin-left: -0.25rem;
+        inset-inline-start: 50%;
+        margin-inline-start: -0.25rem;
         border-width: 0.25em 0.25em 0;
     }
 
     .p-tooltip-bottom .p-tooltip-arrow {
         top: 0;
-        left: 50%;
-        margin-left: -0.25rem;
+        inset-inline-start: 50%;
+        margin-inline-start: -0.25rem;
         border-width: 0 0.25em 0.25rem;
     }
 }

--- a/src/app/components/tree/tree.css
+++ b/src/app/components/tree/tree.css
@@ -92,8 +92,8 @@
 
     .p-tree-horizontal {
         width: auto;
-        padding-left: 0;
-        padding-right: 0;
+        padding-inline-start: 0;
+        padding-inline-end: 0;
         overflow: auto;
     }
 
@@ -108,7 +108,10 @@
 
     .p-tree-horizontal .p-treenode-content {
         font-weight: normal;
-        padding: 0.4em 1em 0.4em 0.2em;
+        padding-block-start: 0.4em;
+        padding-inline-end: 1em;
+        padding-block-end: 0.4em;
+        padding-inline-start: 0.2em;
         display: flex;
         align-items: center;
     }
@@ -125,7 +128,7 @@
 
     .p-tree.p-tree-horizontal .p-treenode.p-treenode-leaf,
     .p-tree.p-tree-horizontal .p-treenode.p-treenode-collapsed {
-        padding-right: 0;
+        padding-inline-end: 0;
     }
 
     .p-tree.p-tree-horizontal .p-treenode-children {

--- a/src/app/components/treeselect/treeselect.css
+++ b/src/app/components/treeselect/treeselect.css
@@ -72,7 +72,7 @@
         flex-shrink: 0;
         overflow: hidden;
         position: relative;
-        margin-left: auto;
+        margin-inline-start: auto;
     }
 
     .p-treeselect-clear-icon {

--- a/src/app/components/treeselect/treeselect.ts
+++ b/src/app/components/treeselect/treeselect.ts
@@ -565,7 +565,8 @@ export class TreeSelect implements AfterContentInit {
         public config: PrimeNGConfig,
         public cd: ChangeDetectorRef,
         public el: ElementRef,
-        public overlayService: OverlayService
+        public overlayService: OverlayService,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit() {
@@ -639,7 +640,7 @@ export class TreeSelect implements AfterContentInit {
                     ObjectUtils.isNotEmpty(this.filterValue) && this.treeViewChild?._filter(<any>this.filterValue);
                     this.filterInputAutoFocus && this.filterViewChild?.nativeElement.focus();
                 } else {
-                    let focusableElements = DomHandler.getFocusableElements(this.panelEl.nativeElement);
+                    let focusableElements = this.domHandler.getFocusableElements(this.panelEl.nativeElement);
 
                     if (focusableElements && focusableElements.length > 0) {
                         focusableElements[0].focus();
@@ -650,7 +651,7 @@ export class TreeSelect implements AfterContentInit {
     }
 
     onOverlayBeforeHide(event: Event) {
-        let focusableElements = DomHandler.getFocusableElements(this.containerEl.nativeElement);
+        let focusableElements = this.domHandler.getFocusableElements(this.containerEl.nativeElement);
 
         if (focusableElements && focusableElements.length > 0) {
             focusableElements[0].focus();
@@ -670,9 +671,9 @@ export class TreeSelect implements AfterContentInit {
 
         if (
             !this.overlayViewChild?.el?.nativeElement?.contains(event.target) &&
-            !DomHandler.hasClass(event.target, 'p-treeselect-close') &&
-            !DomHandler.hasClass(event.target, 'p-checkbox-box') &&
-            !DomHandler.hasClass(event.target, 'p-checkbox-icon')
+            !this.domHandler.hasClass(event.target, 'p-treeselect-close') &&
+            !this.domHandler.hasClass(event.target, 'p-checkbox-box') &&
+            !this.domHandler.hasClass(event.target, 'p-checkbox-icon')
         ) {
             if (this.overlayVisible) {
                 this.hide();
@@ -738,7 +739,7 @@ export class TreeSelect implements AfterContentInit {
 
     onArrowDown(event: KeyboardEvent) {
         if (this.overlayVisible && this.panelEl?.nativeElement) {
-            let focusableElements = DomHandler.getFocusableElements(this.panelEl.nativeElement, '.p-treenode');
+            let focusableElements = this.domHandler.getFocusableElements(this.panelEl.nativeElement, '.p-treenode');
 
             if (focusableElements && focusableElements.length > 0) {
                 focusableElements[0].focus();
@@ -750,16 +751,16 @@ export class TreeSelect implements AfterContentInit {
 
     onFirstHiddenFocus(event) {
         const focusableEl =
-            event.relatedTarget === this.focusInput?.nativeElement ? DomHandler.getFirstFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInput?.nativeElement;
+            event.relatedTarget === this.focusInput?.nativeElement ? this.domHandler.getFirstFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInput?.nativeElement;
 
-        DomHandler.focus(focusableEl);
+        this.domHandler.focus(focusableEl);
     }
 
     onLastHiddenFocus(event) {
         const focusableEl =
-            event.relatedTarget === this.focusInput?.nativeElement ? DomHandler.getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInput?.nativeElement;
+            event.relatedTarget === this.focusInput?.nativeElement ? this.domHandler.getLastFocusableElement(this.overlayViewChild?.overlayViewChild?.nativeElement, ':not([data-p-hidden-focusable="true"])') : this.focusInput?.nativeElement;
 
-        DomHandler.focus(focusableEl);
+        this.domHandler.focus(focusableEl);
     }
 
     show() {
@@ -791,7 +792,7 @@ export class TreeSelect implements AfterContentInit {
     onTabKey(event, pressedInInputText = false) {
         if (!pressedInInputText) {
             if (this.overlayVisible && this.hasFocusableElements()) {
-                DomHandler.focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay.nativeElement : this.firstHiddenFocusableElementOnOverlay.nativeElement);
+                this.domHandler.focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay.nativeElement : this.firstHiddenFocusableElementOnOverlay.nativeElement);
 
                 event.preventDefault();
             } else {
@@ -801,7 +802,7 @@ export class TreeSelect implements AfterContentInit {
     }
 
     hasFocusableElements() {
-        return DomHandler.getFocusableElements(this.overlayViewChild.overlayViewChild.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
+        return this.domHandler.getFocusableElements(this.overlayViewChild.overlayViewChild.nativeElement, ':not([data-p-hidden-focusable="true"])').length > 0;
     }
 
     resetFilter() {

--- a/src/app/components/treetable/treetable.css
+++ b/src/app/components/treetable/treetable.css
@@ -87,7 +87,7 @@
     }
 
     .p-treetable-frozen-view > .p-treetable-scrollable-body > table > .p-treetable-tbody > tr > td:last-child {
-        border-right: 0 none;
+        border-inline-end: 0 none;
     }
 
     .p-treetable-unfrozen-view {
@@ -139,7 +139,7 @@
         display: block;
         position: absolute !important;
         top: 0;
-        right: 0;
+        inset-inline-end: 0;
         margin: 0;
         width: 0.5rem;
         height: 100%;
@@ -200,6 +200,6 @@
         min-height: 0;
         position: sticky;
         top: 0;
-        left: 0;
+        inset-inline-start: 0;
     }
 }

--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -194,7 +194,7 @@ export class TreeTableService {
                     [ngStyle]="{ width: frozenWidth }"
                     [scrollHeight]="scrollHeight"
                 ></div>
-                <div class="p-treetable-scrollable-view" #scrollableView [ttScrollableView]="columns" [frozen]="false" [scrollHeight]="scrollHeight" [ngStyle]="{ left: frozenWidth, width: 'calc(100% - ' + frozenWidth + ')' }"></div>
+                <div class="p-treetable-scrollable-view" #scrollableView [ttScrollableView]="columns" [frozen]="false" [scrollHeight]="scrollHeight" [ngStyle]="{ 'inset-inline-start': frozenWidth, width: 'calc(100% - ' + frozenWidth + ')' }"></div>
             </div>
 
             <p-paginator
@@ -976,7 +976,8 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
         public zone: NgZone,
         public tableService: TreeTableService,
         public filterService: FilterService,
-        public config: PrimeNGConfig
+        public config: PrimeNGConfig,
+        private domHandler: DomHandler
     ) {}
 
     ngOnChanges(simpleChange: SimpleChanges) {
@@ -1379,23 +1380,23 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
     }
 
     onColumnResizeBegin(event: MouseEvent) {
-        let containerLeft = DomHandler.getOffset(this.containerViewChild?.nativeElement).left;
-        this.lastResizerHelperX = event.pageX - containerLeft + this.containerViewChild?.nativeElement.scrollLeft;
+        let containerLeft = this.domHandler.getOffset(this.containerViewChild?.nativeElement).left;
+        this.lastResizerHelperX = this.domHandler.getPageX(event) - containerLeft + this.domHandler.getScrollLeft(this.containerViewChild?.nativeElement);
         event.preventDefault();
     }
 
     onColumnResize(event: MouseEvent) {
-        let containerLeft = DomHandler.getOffset(this.containerViewChild?.nativeElement).left;
-        DomHandler.addClass(this.containerViewChild?.nativeElement, 'p-unselectable-text');
+        let containerLeft = this.domHandler.getOffset(this.containerViewChild?.nativeElement).left;
+        this.domHandler.addClass(this.containerViewChild?.nativeElement, 'p-unselectable-text');
         (<ElementRef>this.resizeHelperViewChild).nativeElement.style.height = this.containerViewChild?.nativeElement.offsetHeight + 'px';
         (<ElementRef>this.resizeHelperViewChild).nativeElement.style.top = 0 + 'px';
-        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.left = event.pageX - containerLeft + this.containerViewChild?.nativeElement.scrollLeft + 'px';
+        (<ElementRef>this.resizeHelperViewChild).nativeElement.style.insetInlineStart = this.domHandler.getPageX(event) - containerLeft + this.domHandler.getScrollLeft(this.containerViewChild?.nativeElement) + 'px';
 
         (<ElementRef>this.resizeHelperViewChild).nativeElement.style.display = 'block';
     }
 
     onColumnResizeEnd(event: MouseEvent, column: any) {
-        let delta = (<ElementRef>this.resizeHelperViewChild).nativeElement.offsetLeft - <number>this.lastResizerHelperX;
+        let delta = this.domHandler.getOffsetLeft((<ElementRef>this.resizeHelperViewChild).nativeElement) - <number>this.lastResizerHelperX;
         let columnWidth = column.offsetWidth;
         let newColumnWidth = columnWidth + delta;
         let minWidth = column.style.minWidth || 15;
@@ -1414,10 +1415,10 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
                     if (newColumnWidth > 15 && nextColumnWidth > parseInt(nextColumnMinWidth)) {
                         if (this.scrollable) {
                             let scrollableView = this.findParentScrollableView(column);
-                            let scrollableBodyTable = DomHandler.findSingle(scrollableView, '.p-treetable-scrollable-body table') || DomHandler.findSingle(scrollableView, '.p-scroller-viewport table');
-                            let scrollableHeaderTable = DomHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-header-table');
-                            let scrollableFooterTable = DomHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-footer-table');
-                            let resizeColumnIndex = DomHandler.index(column);
+                            let scrollableBodyTable = this.domHandler.findSingle(scrollableView, '.p-treetable-scrollable-body table') || this.domHandler.findSingle(scrollableView, '.p-scroller-viewport table');
+                            let scrollableHeaderTable = this.domHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-header-table');
+                            let scrollableFooterTable = this.domHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-footer-table');
+                            let resizeColumnIndex = this.domHandler.index(column);
 
                             this.resizeColGroup(scrollableHeaderTable, resizeColumnIndex, newColumnWidth, nextColumnWidth);
                             this.resizeColGroup(scrollableBodyTable, resizeColumnIndex, newColumnWidth, nextColumnWidth);
@@ -1433,13 +1434,13 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
             } else if (this.columnResizeMode === 'expand') {
                 if (this.scrollable) {
                     let scrollableView = this.findParentScrollableView(column);
-                    let scrollableBody = DomHandler.findSingle(scrollableView, '.p-treetable-scrollable-body') || DomHandler.findSingle(scrollableView, '.p-scroller-viewport');
-                    let scrollableHeader = DomHandler.findSingle(scrollableView, '.p-treetable-scrollable-header');
-                    let scrollableFooter = DomHandler.findSingle(scrollableView, '.p-treetable-scrollable-footer');
-                    let scrollableBodyTable = DomHandler.findSingle(scrollableView, '.p-treetable-scrollable-body table') || DomHandler.findSingle(scrollableView, '.p-scroller-viewport table');
-                    let scrollableHeaderTable = DomHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-header-table');
-                    let scrollableFooterTable = DomHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-footer-table');
-                    let resizeColumnIndex = DomHandler.index(column);
+                    let scrollableBody = this.domHandler.findSingle(scrollableView, '.p-treetable-scrollable-body') || this.domHandler.findSingle(scrollableView, '.p-scroller-viewport');
+                    let scrollableHeader = this.domHandler.findSingle(scrollableView, '.p-treetable-scrollable-header');
+                    let scrollableFooter = this.domHandler.findSingle(scrollableView, '.p-treetable-scrollable-footer');
+                    let scrollableBodyTable = this.domHandler.findSingle(scrollableView, '.p-treetable-scrollable-body table') || this.domHandler.findSingle(scrollableView, '.p-scroller-viewport table');
+                    let scrollableHeaderTable = this.domHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-header-table');
+                    let scrollableFooterTable = this.domHandler.findSingle(scrollableView, 'table.p-treetable-scrollable-footer-table');
+                    let resizeColumnIndex = this.domHandler.index(column);
 
                     const scrollableBodyTableWidth = column ? scrollableBodyTable.offsetWidth + delta : newColumnWidth;
                     const scrollableHeaderTableWidth = column ? scrollableHeaderTable.offsetWidth + delta : newColumnWidth;
@@ -1447,7 +1448,7 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
 
                     let setWidth = (container: HTMLElement, table: HTMLElement, width: number, isContainerInViewport: boolean) => {
                         if (container && table) {
-                            container.style.width = isContainerInViewport ? width + DomHandler.calculateScrollbarWidth(scrollableBody) + 'px' : 'auto';
+                            container.style.width = isContainerInViewport ? width + this.domHandler.calculateScrollbarWidth(scrollableBody) + 'px' : 'auto';
                             table.style.width = width + 'px';
                         }
                     };
@@ -1474,13 +1475,13 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
         }
 
         (this.resizeHelperViewChild as ElementRef).nativeElement.style.display = 'none';
-        DomHandler.removeClass(this.containerViewChild?.nativeElement, 'p-unselectable-text');
+        this.domHandler.removeClass(this.containerViewChild?.nativeElement, 'p-unselectable-text');
     }
 
     findParentScrollableView(column: any) {
         if (column) {
             let parent = column.parentElement;
-            while (parent && !DomHandler.hasClass(parent, 'p-treetable-scrollable-view')) {
+            while (parent && !this.domHandler.hasClass(parent, 'p-treetable-scrollable-view')) {
                 parent = parent.parentElement;
             }
 
@@ -1509,8 +1510,8 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
     }
 
     onColumnDragStart(event: DragEvent, columnElement: any) {
-        this.reorderIconWidth = DomHandler.getHiddenElementOuterWidth(this.reorderIndicatorUpViewChild?.nativeElement);
-        this.reorderIconHeight = DomHandler.getHiddenElementOuterHeight(this.reorderIndicatorDownViewChild?.nativeElement);
+        this.reorderIconWidth = this.domHandler.getHiddenElementOuterWidth(this.reorderIndicatorUpViewChild?.nativeElement);
+        this.reorderIconHeight = this.domHandler.getHiddenElementOuterHeight(this.reorderIndicatorDownViewChild?.nativeElement);
         this.draggedColumn = columnElement;
         (<any>event).dataTransfer.setData('text', 'b'); // For firefox
     }
@@ -1518,8 +1519,8 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
     onColumnDragEnter(event: DragEvent, dropHeader: any) {
         if (this.reorderableColumns && this.draggedColumn && dropHeader) {
             event.preventDefault();
-            let containerOffset = DomHandler.getOffset(this.containerViewChild?.nativeElement);
-            let dropHeaderOffset = DomHandler.getOffset(dropHeader);
+            let containerOffset = this.domHandler.getOffset(this.containerViewChild?.nativeElement);
+            let dropHeaderOffset = this.domHandler.getOffset(dropHeader);
 
             if (this.draggedColumn != dropHeader) {
                 let targetLeft = dropHeaderOffset.left - containerOffset.left;
@@ -1529,13 +1530,13 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
                 (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top - (<number>this.reorderIconHeight - 1) + 'px';
                 (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.top = dropHeaderOffset.top - containerOffset.top + dropHeader.offsetHeight + 'px';
 
-                if (event.pageX > columnCenter) {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                if (this.domHandler.getPageX(event) > columnCenter) {
+                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.insetInlineStart = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.insetInlineStart = targetLeft + dropHeader.offsetWidth - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
                     this.dropPosition = 1;
                 } else {
-                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
-                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.left = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorUpViewChild).nativeElement.style.insetInlineStart = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
+                    (<ElementRef>this.reorderIndicatorDownViewChild).nativeElement.style.insetInlineStart = targetLeft - Math.ceil(<number>this.reorderIconWidth / 2) + 'px';
                     this.dropPosition = -1;
                 }
 
@@ -1558,8 +1559,8 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
     onColumnDrop(event: DragEvent, dropColumn: any) {
         event.preventDefault();
         if (this.draggedColumn) {
-            let dragIndex = DomHandler.indexWithinGroup(this.draggedColumn, 'ttreorderablecolumn');
-            let dropIndex = DomHandler.indexWithinGroup(dropColumn, 'ttreorderablecolumn');
+            let dragIndex = this.domHandler.indexWithinGroup(this.draggedColumn, 'ttreorderablecolumn');
+            let dropIndex = this.domHandler.indexWithinGroup(dropColumn, 'ttreorderablecolumn');
             let allowDrop = dragIndex != dropIndex;
             if (allowDrop && ((dropIndex - dragIndex == 1 && this.dropPosition === -1) || (dragIndex - dropIndex == 1 && this.dropPosition === 1))) {
                 allowDrop = false;
@@ -1593,7 +1594,7 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
 
     handleRowClick(event: any) {
         let targetNode = (<HTMLElement>event.originalEvent.target).nodeName;
-        if (targetNode == 'INPUT' || targetNode == 'BUTTON' || targetNode == 'A' || DomHandler.hasClass(event.originalEvent.target, 'p-clickable')) {
+        if (targetNode == 'INPUT' || targetNode == 'BUTTON' || targetNode == 'A' || this.domHandler.hasClass(event.originalEvent.target, 'p-clickable')) {
             return;
         }
 
@@ -2192,14 +2193,14 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
     }
 
     isEditingCellValid() {
-        return this.editingCell && DomHandler.find(this.editingCell, '.ng-invalid.ng-dirty').length === 0;
+        return this.editingCell && this.domHandler.find(this.editingCell, '.ng-invalid.ng-dirty').length === 0;
     }
 
     bindDocumentEditListener() {
         if (!this.documentEditListener) {
             this.documentEditListener = this.renderer.listen(this.document, 'click', (event) => {
                 if (this.editingCell && !this.editingCellClick && this.isEditingCellValid()) {
-                    DomHandler.removeClass(this.editingCell, 'p-cell-editing');
+                    this.domHandler.removeClass(this.editingCell, 'p-cell-editing');
                     this.editingCell = null;
                     this.onEditComplete.emit({ field: this.editingCellField, data: this.editingCellData });
                     this.editingCellField = null;
@@ -2415,31 +2416,32 @@ export class TTScrollableView implements AfterViewInit, OnDestroy {
         private renderer: Renderer2,
         public tt: TreeTable,
         public el: ElementRef,
-        public zone: NgZone
+        public zone: NgZone,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
             if (!this.frozen) {
                 if (this.tt.frozenColumns || this.tt.frozenBodyTemplate) {
-                    DomHandler.addClass(this.el.nativeElement, 'p-treetable-unfrozen-view');
+                    this.domHandler.addClass(this.el.nativeElement, 'p-treetable-unfrozen-view');
                 }
 
                 let frozenView = this.el.nativeElement.previousElementSibling;
                 if (frozenView) {
-                    if (this.tt.virtualScroll) this.frozenSiblingBody = DomHandler.findSingle(frozenView, '.p-scroller-viewport');
-                    else this.frozenSiblingBody = DomHandler.findSingle(frozenView, '.p-treetable-scrollable-body');
+                    if (this.tt.virtualScroll) this.frozenSiblingBody = this.domHandler.findSingle(frozenView, '.p-scroller-viewport');
+                    else this.frozenSiblingBody = this.domHandler.findSingle(frozenView, '.p-treetable-scrollable-body');
                 }
 
-                let scrollBarWidth = DomHandler.calculateScrollbarWidth();
-                (this.scrollHeaderBoxViewChild as ElementRef).nativeElement.style.paddingRight = scrollBarWidth + 'px';
+                let scrollBarWidth = this.domHandler.calculateScrollbarWidth();
+                (this.scrollHeaderBoxViewChild as ElementRef).nativeElement.style.paddingInlineEnd = scrollBarWidth + 'px';
 
                 if (this.scrollFooterBoxViewChild && this.scrollFooterBoxViewChild.nativeElement) {
-                    this.scrollFooterBoxViewChild.nativeElement.style.paddingRight = scrollBarWidth + 'px';
+                    this.scrollFooterBoxViewChild.nativeElement.style.paddingInlineEnd = scrollBarWidth + 'px';
                 }
             } else {
                 if (this.scrollableAlignerViewChild && this.scrollableAlignerViewChild.nativeElement) {
-                    this.scrollableAlignerViewChild.nativeElement.style.height = DomHandler.calculateScrollbarHeight() + 'px';
+                    this.scrollableAlignerViewChild.nativeElement.style.height = this.domHandler.calculateScrollbarHeight() + 'px';
                 }
             }
 
@@ -2502,23 +2504,23 @@ export class TTScrollableView implements AfterViewInit, OnDestroy {
     }
 
     onHeaderScroll() {
-        const scrollLeft = this.scrollHeaderViewChild?.nativeElement.scrollLeft;
+        const scrollLeft = this.domHandler.getScrollLeft(this.scrollHeaderViewChild?.nativeElement);
 
-        (this.scrollBodyViewChild as ElementRef).nativeElement.scrollLeft = scrollLeft;
+        this.domHandler.setScrollLeft((this.scrollBodyViewChild as ElementRef).nativeElement, scrollLeft);
 
         if (this.scrollFooterViewChild && this.scrollFooterViewChild.nativeElement) {
-            this.scrollFooterViewChild.nativeElement.scrollLeft = scrollLeft;
+            this.domHandler.setScrollLeft(this.scrollFooterViewChild.nativeElement, scrollLeft);
         }
 
         this.preventBodyScrollPropagation = true;
     }
 
     onFooterScroll() {
-        const scrollLeft = this.scrollFooterViewChild?.nativeElement.scrollLeft;
-        (this.scrollBodyViewChild as ElementRef).nativeElement.scrollLeft = scrollLeft;
+        const scrollLeft = this.domHandler.getScrollLeft(this.scrollFooterViewChild?.nativeElement);
+        this.domHandler.setScrollLeft((this.scrollBodyViewChild as ElementRef).nativeElement, scrollLeft);
 
         if (this.scrollHeaderViewChild && this.scrollHeaderViewChild.nativeElement) {
-            this.scrollHeaderViewChild.nativeElement.scrollLeft = scrollLeft;
+            this.domHandler.setScrollLeft(this.scrollHeaderViewChild.nativeElement, scrollLeft);
         }
 
         this.preventBodyScrollPropagation = true;
@@ -2531,11 +2533,11 @@ export class TTScrollableView implements AfterViewInit, OnDestroy {
         }
 
         if (this.scrollHeaderViewChild && this.scrollHeaderViewChild.nativeElement) {
-            (this.scrollHeaderBoxViewChild as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
+            (this.scrollHeaderBoxViewChild as ElementRef).nativeElement.style.marginInlineStart = -1 * this.domHandler.getScrollLeft(event.target) + 'px';
         }
 
         if (this.scrollFooterViewChild && this.scrollFooterViewChild.nativeElement) {
-            (this.scrollFooterBoxViewChild as ElementRef).nativeElement.style.marginLeft = -1 * event.target.scrollLeft + 'px';
+            (this.scrollFooterBoxViewChild as ElementRef).nativeElement.style.marginInlineStart = -1 * this.domHandler.getScrollLeft(event.target) + 'px';
         }
 
         if (this.frozenSiblingBody) {
@@ -2556,7 +2558,7 @@ export class TTScrollableView implements AfterViewInit, OnDestroy {
             if (this.scrollBodyViewChild?.nativeElement.scrollTo) {
                 this.scrollBodyViewChild.nativeElement.scrollTo(options);
             } else {
-                (this.scrollBodyViewChild as ElementRef).nativeElement.scrollLeft = options.left;
+                this.domHandler.setScrollLeft((this.scrollBodyViewChild as ElementRef).nativeElement, options.left);
                 (this.scrollBodyViewChild as ElementRef).nativeElement.scrollTop = options.top;
             }
         }
@@ -2595,7 +2597,7 @@ export class TTSortableColumn implements OnInit, OnDestroy {
         else return 'none';
     }
 
-    constructor(public tt: TreeTable) {
+    constructor(public tt: TreeTable, private domHandler: DomHandler) {
         if (this.isEnabled()) {
             this.subscription = this.tt.tableService.sortSource$.subscribe((sortMeta) => {
                 this.updateSortState();
@@ -2622,7 +2624,7 @@ export class TTSortableColumn implements OnInit, OnDestroy {
                 field: this.field
             });
 
-            DomHandler.clearSelection();
+            this.domHandler.clearSelection();
         }
     }
 
@@ -2645,9 +2647,9 @@ export class TTSortableColumn implements OnInit, OnDestroy {
 @Component({
     selector: 'p-treeTableSortIcon',
     template: ` <ng-container *ngIf="!tt.sortIconTemplate">
-            <SortAltIcon [styleClass]="'p-sortable-column-icon'" *ngIf="sortOrder === 0" />
-            <SortAmountUpAltIcon [styleClass]="'p-sortable-column-icon'" *ngIf="sortOrder === 1" />
-            <SortAmountDownIcon [styleClass]="'p-sortable-column-icon'" *ngIf="sortOrder === -1" />
+            <SortAltIcon [styleClass]="'p-sortable-column-icon p-rtl-flip-icon'" *ngIf="sortOrder === 0" />
+            <SortAmountUpAltIcon [styleClass]="'p-sortable-column-icon p-rtl-flip-icon'" *ngIf="sortOrder === 1" />
+            <SortAmountDownIcon [styleClass]="'p-sortable-column-icon p-rtl-flip-icon'" *ngIf="sortOrder === -1" />
         </ng-container>
         <span *ngIf="tt.sortIconTemplate" class="p-sortable-column-icon">
             <ng-template *ngTemplateOutlet="tt.sortIconTemplate; context: { $implicit: sortOrder }"></ng-template>
@@ -2726,13 +2728,14 @@ export class TTResizableColumn implements AfterViewInit, OnDestroy {
         private renderer: Renderer2,
         public tt: TreeTable,
         public el: ElementRef,
-        public zone: NgZone
+        public zone: NgZone,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterViewInit() {
         if (isPlatformBrowser(this.platformId)) {
             if (this.isEnabled()) {
-                DomHandler.addClass(this.el.nativeElement, 'p-resizable-column');
+                this.domHandler.addClass(this.el.nativeElement, 'p-resizable-column');
                 this.resizer = this.renderer.createElement('span');
                 this.renderer.addClass(this.resizer, 'p-column-resizer');
                 this.renderer.appendChild(this.el.nativeElement, this.resizer);
@@ -2816,7 +2819,8 @@ export class TTReorderableColumn implements AfterViewInit, OnDestroy {
         private renderer: Renderer2,
         public tt: TreeTable,
         public el: ElementRef,
-        public zone: NgZone
+        public zone: NgZone,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterViewInit() {
@@ -2862,7 +2866,7 @@ export class TTReorderableColumn implements AfterViewInit, OnDestroy {
     }
 
     onMouseDown(event: any) {
-        if (event.target.nodeName === 'INPUT' || event.target.nodeName === 'TEXTAREA' || DomHandler.hasClass(event.target, 'p-column-resizer')) this.el.nativeElement.draggable = false;
+        if (event.target.nodeName === 'INPUT' || event.target.nodeName === 'TEXTAREA' || this.domHandler.hasClass(event.target, 'p-column-resizer')) this.el.nativeElement.draggable = false;
         else this.el.nativeElement.draggable = true;
     }
 
@@ -3134,7 +3138,8 @@ export class TTCheckbox {
     constructor(
         public tt: TreeTable,
         public tableService: TreeTableService,
-        public cd: ChangeDetectorRef
+        public cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {
         this.subscription = this.tt.tableService.selectionSource$.subscribe(() => {
             if (this.tt.selectionKeys) {
@@ -3175,7 +3180,7 @@ export class TTCheckbox {
                 });
             }
         }
-        DomHandler.clearSelection();
+        this.domHandler.clearSelection();
     }
 
     onFocus() {
@@ -3232,7 +3237,8 @@ export class TTHeaderCheckbox {
     constructor(
         public tt: TreeTable,
         public tableService: TreeTableService,
-        private cd: ChangeDetectorRef
+        private cd: ChangeDetectorRef,
+        private domHandler: DomHandler
     ) {
         this.valueChangeSubscription = this.tt.tableService.uiUpdateSource$.subscribe(() => {
             this.checked = this.updateCheckedState();
@@ -3252,7 +3258,7 @@ export class TTHeaderCheckbox {
             this.tt.toggleNodesWithCheckbox(event, !checked);
         }
 
-        DomHandler.clearSelection();
+        this.domHandler.clearSelection();
     }
 
     onFocus() {
@@ -3324,12 +3330,13 @@ export class TTEditableColumn implements AfterViewInit {
     constructor(
         public tt: TreeTable,
         public el: ElementRef,
-        public zone: NgZone
+        public zone: NgZone,
+        private domHandler: DomHandler
     ) {}
 
     ngAfterViewInit() {
         if (this.isEnabled()) {
-            DomHandler.addClass(this.el.nativeElement, 'p-editable-column');
+            this.domHandler.addClass(this.el.nativeElement, 'p-editable-column');
         }
     }
 
@@ -3344,7 +3351,7 @@ export class TTEditableColumn implements AfterViewInit {
                         return;
                     }
 
-                    DomHandler.removeClass(this.tt.editingCell, 'p-cell-editing');
+                    this.domHandler.removeClass(this.tt.editingCell, 'p-cell-editing');
                     this.openCell();
                 }
             } else {
@@ -3355,12 +3362,12 @@ export class TTEditableColumn implements AfterViewInit {
 
     openCell() {
         this.tt.updateEditingCell(this.el.nativeElement, this.data, this.field);
-        DomHandler.addClass(this.el.nativeElement, 'p-cell-editing');
+        this.domHandler.addClass(this.el.nativeElement, 'p-cell-editing');
         this.tt.onEditInit.emit({ field: this.field, data: this.data });
         this.tt.editingCellClick = true;
         this.zone.runOutsideAngular(() => {
             setTimeout(() => {
-                let focusable = DomHandler.findSingle(this.el.nativeElement, 'input, textarea');
+                let focusable = this.domHandler.findSingle(this.el.nativeElement, 'input, textarea');
                 if (focusable) {
                     focusable.focus();
                 }
@@ -3369,7 +3376,7 @@ export class TTEditableColumn implements AfterViewInit {
     }
 
     closeEditingCell() {
-        DomHandler.removeClass(this.tt.editingCell, 'p-checkbox-icon');
+        this.domHandler.removeClass(this.tt.editingCell, 'p-checkbox-icon');
         this.tt.editingCell = null;
         this.tt.unbindDocumentEditListener();
     }
@@ -3379,7 +3386,7 @@ export class TTEditableColumn implements AfterViewInit {
         if (this.isEnabled()) {
             if (event.code == 'Enter' && !event.shiftKey) {
                 if (this.tt.isEditingCellValid()) {
-                    DomHandler.removeClass(this.tt.editingCell, 'p-cell-editing');
+                    this.domHandler.removeClass(this.tt.editingCell, 'p-cell-editing');
                     this.closeEditingCell();
                     this.tt.onEditComplete.emit({ field: this.field, data: this.data });
                 }
@@ -3387,7 +3394,7 @@ export class TTEditableColumn implements AfterViewInit {
                 event.preventDefault();
             } else if (event.code == 'Escape') {
                 if (this.tt.isEditingCellValid()) {
-                    DomHandler.removeClass(this.tt.editingCell, 'p-cell-editing');
+                    this.domHandler.removeClass(this.tt.editingCell, 'p-cell-editing');
                     this.closeEditingCell();
                     this.tt.onEditCancel.emit({ field: this.field, data: this.data });
                 }
@@ -3405,7 +3412,7 @@ export class TTEditableColumn implements AfterViewInit {
     findCell(element: any) {
         if (element) {
             let cell = element;
-            while (cell && !DomHandler.hasClass(cell, 'p-cell-editing')) {
+            while (cell && !this.domHandler.hasClass(cell, 'p-cell-editing')) {
                 cell = cell.parentElement;
             }
 
@@ -3421,7 +3428,7 @@ export class TTEditableColumn implements AfterViewInit {
         let targetCell = this.findPreviousEditableColumn(currentCell);
 
         if (targetCell) {
-            DomHandler.invokeElementMethod(targetCell, 'click');
+            this.domHandler.invokeElementMethod(targetCell, 'click');
             event.preventDefault();
         }
     }
@@ -3432,7 +3439,7 @@ export class TTEditableColumn implements AfterViewInit {
         let targetCell = this.findNextEditableColumn(currentCell);
 
         if (targetCell) {
-            DomHandler.invokeElementMethod(targetCell, 'click');
+            this.domHandler.invokeElementMethod(targetCell, 'click');
             event.preventDefault();
         }
     }
@@ -3448,7 +3455,7 @@ export class TTEditableColumn implements AfterViewInit {
         }
 
         if (prevCell) {
-            if (DomHandler.hasClass(prevCell, 'p-editable-column')) return prevCell;
+            if (this.domHandler.hasClass(prevCell, 'p-editable-column')) return prevCell;
             else return this.findPreviousEditableColumn(prevCell);
         } else {
             return null;
@@ -3466,7 +3473,7 @@ export class TTEditableColumn implements AfterViewInit {
         }
 
         if (nextCell) {
-            if (DomHandler.hasClass(nextCell, 'p-editable-column')) return nextCell;
+            if (this.domHandler.hasClass(nextCell, 'p-editable-column')) return nextCell;
             else return this.findNextEditableColumn(nextCell);
         } else {
             return null;
@@ -3550,7 +3557,8 @@ export class TTRow {
     constructor(
         public tt: TreeTable,
         public el: ElementRef,
-        public zone: NgZone
+        public zone: NgZone,
+        private domHandler: DomHandler
     ) {}
 
     @HostListener('keydown', ['$event'])
@@ -3609,7 +3617,7 @@ export class TTRow {
 
     onArrowRightKey(event: KeyboardEvent) {
         const currentTarget = <HTMLElement>event.currentTarget;
-        const isHiddenIcon = DomHandler.findSingle(currentTarget, 'button').style.visibility === 'hidden';
+        const isHiddenIcon = this.domHandler.findSingle(currentTarget, 'button').style.visibility === 'hidden';
 
         if (!isHiddenIcon && !this.expanded && this.rowNode.node['children']) {
             this.expand(event);
@@ -3621,43 +3629,43 @@ export class TTRow {
 
     onArrowLeftKey(event: KeyboardEvent) {
         const container = this.tt.containerViewChild?.nativeElement;
-        const expandedRows = DomHandler.find(container, '[aria-expanded="true"]');
+        const expandedRows = this.domHandler.find(container, '[aria-expanded="true"]');
         const lastExpandedRow = expandedRows[expandedRows.length - 1];
 
         if (this.expanded) {
             this.collapse(event);
         }
         if (lastExpandedRow) {
-            this.tt.toggleRowIndex = DomHandler.index(lastExpandedRow);
+            this.tt.toggleRowIndex = this.domHandler.index(lastExpandedRow);
         }
         this.restoreFocus();
         event.preventDefault();
     }
 
     onHomeKey(event: KeyboardEvent) {
-        const firstElement = DomHandler.findSingle(this.tt.containerViewChild?.nativeElement, `tr[aria-level="${this.level}"]`);
-        firstElement && DomHandler.focus(firstElement);
+        const firstElement = this.domHandler.findSingle(this.tt.containerViewChild?.nativeElement, `tr[aria-level="${this.level}"]`);
+        firstElement && this.domHandler.focus(firstElement);
         event.preventDefault();
     }
 
     onEndKey(event: KeyboardEvent) {
-        const nodes = DomHandler.find(this.tt.containerViewChild?.nativeElement, `tr[aria-level="${this.level}"]`);
+        const nodes = this.domHandler.find(this.tt.containerViewChild?.nativeElement, `tr[aria-level="${this.level}"]`);
         const lastElement = nodes[nodes.length - 1];
-        DomHandler.focus(lastElement);
+        this.domHandler.focus(lastElement);
         event.preventDefault();
     }
 
     onTabKey(event: KeyboardEvent) {
-        const rows = this.el.nativeElement ? [...DomHandler.find(this.el.nativeElement.parentNode, 'tr')] : undefined;
+        const rows = this.el.nativeElement ? [...this.domHandler.find(this.el.nativeElement.parentNode, 'tr')] : undefined;
 
         if (rows && ObjectUtils.isNotEmpty(rows)) {
-            const hasSelectedRow = rows.some((row) => DomHandler.getAttribute(row, 'data-p-highlight') || row.getAttribute('aria-checked') === 'true');
+            const hasSelectedRow = rows.some((row) => this.domHandler.getAttribute(row, 'data-p-highlight') || row.getAttribute('aria-checked') === 'true');
             rows.forEach((row) => {
                 row.tabIndex = -1;
             });
 
             if (hasSelectedRow) {
-                const selectedNodes = rows.filter((node) => DomHandler.getAttribute(node, 'data-p-highlight') || node.getAttribute('aria-checked') === 'true');
+                const selectedNodes = rows.filter((node) => this.domHandler.getAttribute(node, 'data-p-highlight') || node.getAttribute('aria-checked') === 'true');
                 selectedNodes[0].tabIndex = 0;
 
                 return;
@@ -3668,7 +3676,7 @@ export class TTRow {
     }
 
     expand(event: Event) {
-        this.tt.toggleRowIndex = DomHandler.index(this.el.nativeElement);
+        this.tt.toggleRowIndex = this.domHandler.index(this.el.nativeElement);
         this.rowNode.node['expanded'] = true;
 
         this.tt.updateSerializedValue();
@@ -3694,15 +3702,15 @@ export class TTRow {
         firstFocusableRow.tabIndex = '-1';
         currentFocusedRow.tabIndex = '0';
 
-        DomHandler.focus(currentFocusedRow);
+        this.domHandler.focus(currentFocusedRow);
     }
 
     restoreFocus(index?) {
         this.zone.runOutsideAngular(() => {
             setTimeout(() => {
                 const container = this.tt.containerViewChild?.nativeElement;
-                const row = DomHandler.findSingle(container, '.p-treetable-tbody').children[<number>index || this.tt.toggleRowIndex];
-                const rows = [...DomHandler.find(container, 'tr')];
+                const row = this.domHandler.findSingle(container, '.p-treetable-tbody').children[<number>index || this.tt.toggleRowIndex];
+                const rows = [...this.domHandler.find(container, 'tr')];
 
                 rows &&
                     rows.forEach((r) => {
@@ -3731,7 +3739,7 @@ export class TTRow {
             pRipple
             [ngStyle]="{
                 visibility: rowNode.node.leaf === false || (rowNode.node.children && rowNode.node.children.length) ? 'visible' : 'hidden',
-                'margin-left': rowNode.level * 16 + 'px'
+                'margin-inline-start': rowNode.level * 16 + 'px'
             }"
             [attr.data-pc-section]="'rowtoggler'"
             [attr.data-pc-group-section]="'rowactionbutton'"
@@ -3739,7 +3747,7 @@ export class TTRow {
         >
             <ng-container *ngIf="!tt.togglerIconTemplate">
                 <ChevronDownIcon *ngIf="rowNode.node.expanded" [attr.aria-hidden]="true" />
-                <ChevronRightIcon *ngIf="!rowNode.node.expanded" [attr.aria-hidden]="true" />
+                <ChevronRightIcon *ngIf="!rowNode.node.expanded" [attr.aria-hidden]="true" [styleClass]="'p-rtl-flip-icon'" />
             </ng-container>
             <ng-template *ngTemplateOutlet="tt.togglerIconTemplate; context: { $implicit: rowNode.node.expanded }"></ng-template>
         </button>

--- a/src/app/showcase/layout/app.main.component.ts
+++ b/src/app/showcase/layout/app.main.component.ts
@@ -32,7 +32,8 @@ import { AppTopBarComponent } from './topbar/app.topbar.component';
 export class AppMainComponent {
     constructor(
         @Inject(DOCUMENT) private document: Document,
-        private configService: AppConfigService
+        private configService: AppConfigService,
+        private domHandler: DomHandler
     ) {}
 
     get isNewsActive(): boolean {
@@ -79,6 +80,6 @@ export class AppMainComponent {
 
     hideMenu() {
         this.configService.hideMenu();
-        DomHandler.unblockBodyScroll('blocked-scroll');
+        this.domHandler.unblockBodyScroll('blocked-scroll');
     }
 }

--- a/src/app/showcase/layout/doc/app.docsection-nav.component.ts
+++ b/src/app/showcase/layout/doc/app.docsection-nav.component.ts
@@ -60,7 +60,8 @@ export class AppDocSectionNavComponent implements OnInit, OnDestroy {
         private location: Location,
         private zone: NgZone,
         private renderer: Renderer2,
-        private router: Router
+        private router: Router,
+        private domHandler: DomHandler
     ) {}
 
     ngOnInit(): void {
@@ -96,7 +97,7 @@ export class AppDocSectionNavComponent implements OnInit, OnDestroy {
     }
 
     getLabels() {
-        return [...Array.from(this.document.querySelectorAll(':is(h1,h2,h3).doc-section-label'))].filter((el: any) => DomHandler.isVisible(el));
+        return [...Array.from(this.document.querySelectorAll(':is(h1,h2,h3).doc-section-label'))].filter((el: any) => this.domHandler.isVisible(el));
     }
 
     onScroll() {
@@ -105,14 +106,14 @@ export class AppDocSectionNavComponent implements OnInit, OnDestroy {
                 this.zone.run(() => {
                     if (typeof document !== 'undefined') {
                         const labels = this.getLabels();
-                        const windowScrollTop = DomHandler.getWindowScrollTop();
+                        const windowScrollTop = this.domHandler.getWindowScrollTop();
 
                         labels.forEach((label) => {
-                            const { top } = DomHandler.getOffset(label);
+                            const { top } = this.domHandler.getOffset(label);
                             const threshold = this.getThreshold(label);
 
                             if (top - threshold <= windowScrollTop) {
-                                const link = DomHandler.findSingle(label, 'a');
+                                const link = this.domHandler.findSingle(label, 'a');
                                 this.activeId = link.id;
                             }
                         });
@@ -124,7 +125,7 @@ export class AppDocSectionNavComponent implements OnInit, OnDestroy {
             this.scrollEndTimer = setTimeout(() => {
                 this.isScrollBlocked = false;
 
-                const activeItem = DomHandler.findSingle(this.nav.nativeElement, '.active-navbar-item');
+                const activeItem = this.domHandler.findSingle(this.nav.nativeElement, '.active-navbar-item');
 
                 activeItem && activeItem.scrollIntoView({ block: 'nearest', inline: 'start' });
             }, 50);
@@ -144,13 +145,13 @@ export class AppDocSectionNavComponent implements OnInit, OnDestroy {
     getThreshold(label) {
         if (typeof document !== undefined) {
             if (!this.topbarHeight) {
-                const topbar = DomHandler.findSingle(document.body, '.layout-topbar');
+                const topbar = this.domHandler.findSingle(document.body, '.layout-topbar');
 
-                this.topbarHeight = topbar ? DomHandler.getHeight(topbar) : 0;
+                this.topbarHeight = topbar ? this.domHandler.getHeight(topbar) : 0;
             }
         }
 
-        return this.topbarHeight + DomHandler.getHeight(label) * 3.5;
+        return this.topbarHeight + this.domHandler.getHeight(label) * 3.5;
     }
 
     scrollToLabelById(id) {

--- a/src/app/showcase/layout/menu/app.menu.component.ts
+++ b/src/app/showcase/layout/menu/app.menu.component.ts
@@ -41,7 +41,8 @@ export class AppMenuComponent implements OnDestroy {
     constructor(
         private configService: AppConfigService,
         private el: ElementRef,
-        private router: Router
+        private router: Router,
+        private domHandler: DomHandler
     ) {
         this.menu = MenuData.data;
 
@@ -53,7 +54,7 @@ export class AppMenuComponent implements OnDestroy {
             this.routerSubscription = this.router.events.subscribe((event) => {
                 if (event instanceof NavigationEnd && this.configService.state.menuActive) {
                     this.configService.hideMenu();
-                    DomHandler.unblockBodyScroll('blocked-scroll');
+                    this.domHandler.unblockBodyScroll('blocked-scroll');
                 }
             });
         });
@@ -64,14 +65,14 @@ export class AppMenuComponent implements OnDestroy {
     }
 
     scrollToActiveItem() {
-        let activeItem = DomHandler.findSingle(this.el.nativeElement, '.router-link-active');
+        let activeItem = this.domHandler.findSingle(this.el.nativeElement, '.router-link-active');
         if (activeItem && !this.isInViewport(activeItem)) {
             activeItem.scrollIntoView({ block: 'center' });
         }
     }
 
     isInViewport(element) {
-        const rect = element.getBoundingClientRect();
+        const rect = this.domHandler.getBoundingClientRect(element);
         return rect.top >= 0 && rect.left >= 0 && rect.bottom <= (window.innerHeight || (document.documentElement.clientHeight && rect.right <= (window.innerWidth || document.documentElement.clientWidth)));
     }
 

--- a/src/app/showcase/layout/topbar/app.topbar.component.ts
+++ b/src/app/showcase/layout/topbar/app.topbar.component.ts
@@ -32,7 +32,8 @@ export class AppTopBarComponent implements OnDestroy {
         private el: ElementRef,
         private renderer: Renderer2,
         private router: Router,
-        private configService: AppConfigService
+        private configService: AppConfigService,
+        private domHandler: DomHandler
     ) {
         this.window = this.document.defaultView as Window;
 
@@ -49,10 +50,10 @@ export class AppTopBarComponent implements OnDestroy {
     toggleMenu() {
         if (this.configService.state.menuActive) {
             this.configService.hideMenu();
-            DomHandler.unblockBodyScroll('blocked-scroll');
+            this.domHandler.unblockBodyScroll('blocked-scroll');
         } else {
             this.configService.showMenu();
-            DomHandler.blockBodyScroll('blocked-scroll');
+            this.domHandler.blockBodyScroll('blocked-scroll');
         }
     }
 

--- a/src/assets/components/themes/arya-blue/theme.css
+++ b/src/assets/components/themes/arya-blue/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #383838;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #383838;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #121212;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #64B5F6;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #383838;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #64B5F6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(100, 181, 246, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #383838;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #383838;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #64B5F6;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #383838;
-    border-left: 1px solid #383838;
+    border-inline-start: 1px solid #383838;
     border-bottom: 1px solid #383838;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(100, 181, 246, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #383838;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #64B5F6;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #383838;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #93cbf9;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #93cbf9;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #242424;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #383838;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
     border-color: #383838;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #93cbf9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #383838;
@@ -3884,10 +4016,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #383838;
+    border-inline-start: 1px #383838;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #383838;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #64B5F6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1e1e1e;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #64B5F6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #93cbf9;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #43a5f4;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #383838;
+    border-inline-end-color: #383838;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #383838;
+    border-inline-start-color: #383838;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #383838;
@@ -4586,11 +4742,11 @@
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #64B5F6;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #383838;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #383838;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #64B5F6;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #64B5F6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1e1e1e;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #64B5F6;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/arya-green/theme.css
+++ b/src/assets/components/themes/arya-green/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #383838;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #383838;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #121212;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #81C784;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #383838;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #81C784;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(129, 199, 132, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #383838;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #383838;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #81C784;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #383838;
-    border-left: 1px solid #383838;
+    border-inline-start: 1px solid #383838;
     border-bottom: 1px solid #383838;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(129, 199, 132, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #383838;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #81C784;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #383838;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #a7d8a9;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #a7d8a9;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #242424;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #383838;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
     border-color: #383838;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #a7d8a9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #383838;
@@ -3884,10 +4016,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #383838;
+    border-inline-start: 1px #383838;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #383838;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #81C784;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1e1e1e;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #81C784;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #a7d8a9;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #6abd6e;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #383838;
+    border-inline-end-color: #383838;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #383838;
+    border-inline-start-color: #383838;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #383838;
@@ -4586,11 +4742,11 @@
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #81C784;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #383838;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #383838;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #81C784;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #81C784;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1e1e1e;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #81C784;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/arya-orange/theme.css
+++ b/src/assets/components/themes/arya-orange/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #383838;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #383838;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #121212;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #FFD54F;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #383838;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #FFD54F;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(255, 213, 79, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #383838;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #383838;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #FFD54F;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #383838;
-    border-left: 1px solid #383838;
+    border-inline-start: 1px solid #383838;
     border-bottom: 1px solid #383838;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(255, 213, 79, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #383838;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #FFD54F;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #383838;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #ffe284;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #ffe284;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #242424;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #383838;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
     border-color: #383838;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #ffe284;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #383838;
@@ -3884,10 +4016,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #383838;
+    border-inline-start: 1px #383838;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #383838;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #FFD54F;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1e1e1e;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #FFD54F;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #ffe284;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #ffcd2e;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #383838;
+    border-inline-end-color: #383838;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #383838;
+    border-inline-start-color: #383838;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #383838;
@@ -4586,11 +4742,11 @@
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #FFD54F;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #383838;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #383838;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #FFD54F;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #FFD54F;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1e1e1e;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #FFD54F;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/arya-purple/theme.css
+++ b/src/assets/components/themes/arya-purple/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #383838;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #383838;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #121212;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #BA68C8;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #383838;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #BA68C8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(186, 104, 200, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #383838;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #383838;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #BA68C8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #383838;
-    border-left: 1px solid #383838;
+    border-inline-start: 1px solid #383838;
     border-bottom: 1px solid #383838;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(186, 104, 200, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #383838;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #BA68C8;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #383838;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #383838;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #cf95d9;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #cf95d9;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #242424;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #383838;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #383838;
+    border-inline-end: 1px solid #383838;
     border-color: #383838;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #cf95d9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #383838;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #383838;
@@ -3884,10 +4016,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #383838;
+    border-inline-start: 1px #383838;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #383838;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #BA68C8;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1e1e1e;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #BA68C8;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #cf95d9;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #b052c0;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #383838;
+    border-inline-end-color: #383838;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #383838;
+    border-inline-start-color: #383838;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #383838;
@@ -4586,11 +4742,11 @@
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #BA68C8;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #383838;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1e1e1e;
     border-color: #383838;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #383838;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #383838;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #BA68C8;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #383838;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #383838 transparent;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #BA68C8;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1e1e1e;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #BA68C8;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/aura-dark-amber/theme.css
+++ b/src/assets/components/themes/aura-dark-amber/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #fbbf24;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(251, 191, 36, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(251, 191, 36, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(251, 191, 36, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(251, 191, 36, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(251, 191, 36, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(251, 191, 36, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #fbbf24;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #fbbf24;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #fbbf24;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #fcd34d;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #fbbf24;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #fbbf24;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #fbbf24;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #fbbf24;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-blue/theme.css
+++ b/src/assets/components/themes/aura-dark-blue/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #60a5fa;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(96, 165, 250, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(96, 165, 250, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(96, 165, 250, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(96, 165, 250, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(96, 165, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(96, 165, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #60a5fa;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #60a5fa;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #60a5fa;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #93c5fd;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #60a5fa;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #60a5fa;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #60a5fa;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #60a5fa;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-cyan/theme.css
+++ b/src/assets/components/themes/aura-dark-cyan/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #22d3ee;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(34, 211, 238, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(34, 211, 238, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(34, 211, 238, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(34, 211, 238, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(34, 211, 238, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(34, 211, 238, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #22d3ee;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #22d3ee;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #22d3ee;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #67e8f9;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #22d3ee;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #22d3ee;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #22d3ee;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #22d3ee;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-green/theme.css
+++ b/src/assets/components/themes/aura-dark-green/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #34d399;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(52, 211, 153, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(52, 211, 153, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(52, 211, 153, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(52, 211, 153, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(52, 211, 153, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(52, 211, 153, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #34d399;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #34d399;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #34d399;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #6ee7b7;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #34d399;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #34d399;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #34d399;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #34d399;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-indigo/theme.css
+++ b/src/assets/components/themes/aura-dark-indigo/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #818cf8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(129, 140, 248, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(129, 140, 248, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(129, 140, 248, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(129, 140, 248, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 140, 248, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 140, 248, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #818cf8;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #818cf8;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #818cf8;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #a5b4fc;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #818cf8;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #818cf8;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #818cf8;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #818cf8;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-lime/theme.css
+++ b/src/assets/components/themes/aura-dark-lime/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #a3e635;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(163, 230, 53, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(163, 230, 53, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(163, 230, 53, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(163, 230, 53, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(163, 230, 53, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(163, 230, 53, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #a3e635;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #a3e635;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #a3e635;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #bef264;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #a3e635;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #a3e635;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #a3e635;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #a3e635;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-noir/theme.css
+++ b/src/assets/components/themes/aura-dark-noir/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #fafafa;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(250, 250, 250, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(250, 250, 250, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(250, 250, 250, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(250, 250, 250, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(250, 250, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(250, 250, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #fafafa;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #fafafa;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #fafafa;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #f4f4f5;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #fafafa;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #fafafa;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #fafafa;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #fafafa;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-pink/theme.css
+++ b/src/assets/components/themes/aura-dark-pink/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #f472b6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(244, 114, 182, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(244, 114, 182, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(244, 114, 182, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(244, 114, 182, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(244, 114, 182, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(244, 114, 182, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #f472b6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #f472b6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #f472b6;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #f9a8d4;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #f472b6;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #f472b6;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #f472b6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #f472b6;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-purple/theme.css
+++ b/src/assets/components/themes/aura-dark-purple/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #a78bfa;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(167, 139, 250, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(167, 139, 250, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(167, 139, 250, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(167, 139, 250, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(167, 139, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(167, 139, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #a78bfa;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #a78bfa;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #a78bfa;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #c4b5fd;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #a78bfa;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #a78bfa;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #a78bfa;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #a78bfa;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-dark-teal/theme.css
+++ b/src/assets/components/themes/aura-dark-teal/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #18181b;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f3f46;
@@ -244,8 +244,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f3f46;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #09090b;
   color: #ffffff;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #52525b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3f3f46;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -505,14 +505,20 @@
     background: transparent;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #ffffff;
     background: transparent;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #3f3f46;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,11 +557,14 @@
     color: #2dd4bf;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -593,7 +602,10 @@
     background: rgba(45, 212, 191, 0.16);
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #3f3f46;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -635,7 +647,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -647,7 +662,10 @@
     background: rgba(45, 212, 191, 0.16);
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -659,18 +677,18 @@
     background: rgba(45, 212, 191, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f3f46;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #3f3f46;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +716,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a1a1aa;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +764,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +838,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +932,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +954,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -940,7 +964,7 @@
     color: #ffffff;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -959,11 +983,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1025,7 @@
     border-color: #52525b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1042,12 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1046,20 +1070,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1162,13 @@
     background: #18181b;
     color: #a1a1aa;
     border-top: 1px solid #3f3f46;
-    border-left: 1px solid #3f3f46;
+    border-inline-start: 1px solid #3f3f46;
     border-bottom: 1px solid #3f3f46;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1180,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1198,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1212,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1229,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
@@ -1213,11 +1243,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1265,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1313,16 @@
     background: #a1a1aa;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1356,7 +1389,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1400,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1445,23 +1478,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1483,7 +1522,7 @@
     background: rgba(45, 212, 191, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1586,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #27272a;
@@ -1577,11 +1616,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1592,26 +1631,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -1661,7 +1706,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1695,7 +1740,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
@@ -1717,19 +1765,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a1a1aa;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1849,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1941,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1950,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1974,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2052,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f3f46;
     color: #ffffff;
     border-radius: 16px;
@@ -2013,8 +2061,8 @@
     background: transparent;
     color: #a1a1aa;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #27272a;
@@ -2042,29 +2090,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2105,11 +2159,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a1a1aa;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2194,10 +2248,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2260,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2300,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2737,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2804,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2823,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2788,32 +2851,41 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2894,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(45, 212, 191, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2927,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2964,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2925,58 +3000,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1f1f22;
@@ -3023,18 +3146,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3048,22 +3180,28 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,16 +3294,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #ffffff;
     background: #18181b;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #3f3f46;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3178,14 +3325,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3218,10 +3374,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3453,7 @@
     background: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f3f46;
+    border-inline-end: 1px solid #3f3f46;
     border-color: #3f3f46;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3464,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3351,24 +3510,24 @@
     color: #ffffff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3404,7 +3563,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3437,10 +3599,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-picklist .p-picklist-list {
@@ -3530,7 +3692,10 @@
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3548,7 +3713,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #a1a1aa;
@@ -3568,11 +3733,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a1a1aa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3614,14 +3779,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #a1a1aa;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3817,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a1a1aa;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3841,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3692,25 +3869,34 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #ffffff;
     background: #18181b;
@@ -3720,7 +3906,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #a1a1aa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3915,7 @@
     line-height: 1rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(45, 212, 191, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3953,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #ffffff;
@@ -3781,7 +3970,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #ffffff;
@@ -3834,16 +4023,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4090,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3903,15 +4107,21 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #27272a;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #a1a1aa;
     background: #18181b;
@@ -3920,7 +4130,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3936,8 +4146,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #18181b;
@@ -3945,15 +4155,18 @@
     color: #ffffff;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3971,16 +4184,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4003,10 +4216,16 @@
     color: #a1a1aa;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4027,7 +4246,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f3f46;
+    border-inline-start: 1px #3f3f46;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4058,7 +4277,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4071,7 +4290,10 @@
     color: #ffffff;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4079,8 +4301,8 @@
     padding: 1.125rem;
     background: #18181b;
     color: #ffffff;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4108,32 +4330,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     background: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4180,23 +4408,32 @@
   .p-tabview .p-tabview-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4214,13 +4451,13 @@
     color: #2dd4bf;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #18181b;
@@ -4236,11 +4473,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4347,7 +4587,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #ffffff;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4374,7 +4614,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #18181b;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #ffffff;
   }
   .p-stepper .p-stepper-separator {
@@ -4407,7 +4650,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4419,7 +4662,7 @@
     background-color: #2dd4bf;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4430,14 +4673,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4467,7 +4719,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4480,8 +4732,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4495,7 +4747,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #ffffff;
@@ -4508,28 +4760,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #18181b;
     color: #ffffff;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4540,7 +4801,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4551,7 +4812,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #2dd4bf;
@@ -4562,7 +4826,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #5eead4;
@@ -4620,7 +4884,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4634,10 +4901,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4652,11 +4919,11 @@
     border: 1px solid #3f3f46;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4665,11 +4932,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #18181b;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #3f3f46;
     color: #ffffff;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #2dd4bf;
@@ -4719,7 +4989,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4763,7 +5036,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4910,7 +5183,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4964,8 +5237,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4993,11 +5266,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5034,7 +5307,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5086,8 +5359,8 @@
     color: #71717a;
     background: #18181b;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
@@ -5102,9 +5375,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5131,11 +5404,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #ffffff;
@@ -5163,7 +5436,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5262,11 +5535,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5278,33 +5554,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5320,14 +5602,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #a1a1aa;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5343,8 +5628,8 @@
     background: #18181b;
     border-color: #18181b;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5358,10 +5643,10 @@
     background: #18181b;
     color: #ffffff;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5381,7 +5666,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5423,14 +5708,17 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f3f46;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5448,16 +5736,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5489,7 +5777,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5570,9 +5858,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5614,7 +5902,7 @@
     border-top: 1px solid #3f3f46;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5623,7 +5911,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #18181b;
     border: 1px solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #2dd4bf;
@@ -5634,28 +5925,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3f3f46;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3f3f46 transparent;
     background: #18181b;
     color: #a1a1aa;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5673,10 +5970,10 @@
     color: #2dd4bf;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #18181b;
@@ -5729,7 +6026,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5825,7 +6122,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5835,7 +6132,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5914,7 +6211,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5924,7 +6221,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #27272a;
@@ -5955,7 +6252,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5964,7 +6264,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5977,7 +6280,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6119,7 +6425,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6191,10 +6497,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6291,16 +6597,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6404,12 +6710,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6419,12 +6725,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6472,6 +6778,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #2dd4bf;
@@ -6498,7 +6807,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6518,7 +6827,10 @@
     background: #18181b;
     color: #ffffff;
     border: 1px solid #3f3f46;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6538,8 +6850,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6560,13 +6878,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6749,13 +7067,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6771,13 +7089,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6819,16 +7137,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6846,8 +7164,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6862,7 +7180,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6904,7 +7225,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6968,18 +7292,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #a1a1aa;
@@ -7006,10 +7330,10 @@
     color: #ffffff;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7035,7 +7359,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7077,7 +7401,10 @@
     color: #a1a1aa;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7145,8 +7472,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7161,10 +7488,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7222,17 +7549,20 @@
     color: #ffffff;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-text {
     /*line-height: 1.5;*/
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7298,11 +7628,14 @@
     color: #ffffff;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #3f3f46;
@@ -7310,8 +7643,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7338,17 +7671,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #3f3f46;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #3f3f46;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7367,7 +7703,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #ffffff;
@@ -7420,11 +7756,14 @@
     color: #ffffff;
     border: 1px solid #3f3f46;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #a1a1aa;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7435,8 +7774,8 @@
     background: #18181b;
     color: #ffffff;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7484,7 +7823,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7599,6 +7938,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7676,7 +8018,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7802,7 +8144,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7820,24 +8162,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #27272a;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-amber/theme.css
+++ b/src/assets/components/themes/aura-light-amber/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #f59e0b;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #fffbeb;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #fffbeb;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #fffbeb;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #fffbeb;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #b45309;
     background: #fffbeb;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #b45309;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #b45309;
     background: #fffbeb;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #f59e0b;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #f59e0b;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #f59e0b;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #d97706;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #f59e0b;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #f59e0b;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #f59e0b;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #b45309;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #f59e0b;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-blue/theme.css
+++ b/src/assets/components/themes/aura-light-blue/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #3B82F6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #EFF6FF;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #EFF6FF;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #EFF6FF;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #EFF6FF;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #1D4ED8;
     background: #EFF6FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #1D4ED8;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #1D4ED8;
     background: #EFF6FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #3B82F6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #3B82F6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #3B82F6;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #2563eb;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #3B82F6;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #3B82F6;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #3B82F6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #1D4ED8;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #3B82F6;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-cyan/theme.css
+++ b/src/assets/components/themes/aura-light-cyan/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #06b6d4;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #ecfeff;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #ecfeff;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #ecfeff;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #ecfeff;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #0e7490;
     background: #ecfeff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #0e7490;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #0e7490;
     background: #ecfeff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #06b6d4;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #06b6d4;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #06b6d4;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0891b2;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #06b6d4;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #06b6d4;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #06b6d4;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #0e7490;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #06b6d4;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-green/theme.css
+++ b/src/assets/components/themes/aura-light-green/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #10b981;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #ecfdf5;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #ecfdf5;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #ecfdf5;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #ecfdf5;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #047857;
     background: #ecfdf5;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #047857;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #047857;
     background: #ecfdf5;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #10b981;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #10b981;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #10b981;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #059669;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #10b981;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #10b981;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #10b981;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #047857;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #10b981;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-indigo/theme.css
+++ b/src/assets/components/themes/aura-light-indigo/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #6366F1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #EEF2FF;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #EEF2FF;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #EEF2FF;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #EEF2FF;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #4338CA;
     background: #EEF2FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #4338CA;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #4338CA;
     background: #EEF2FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #6366F1;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #6366F1;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #6366F1;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #4F46E5;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #6366F1;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #6366F1;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #6366F1;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #4338CA;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #6366F1;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-lime/theme.css
+++ b/src/assets/components/themes/aura-light-lime/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #84cc16;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #f7fee7;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #f7fee7;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #f7fee7;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #f7fee7;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #4d7c0f;
     background: #f7fee7;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #4d7c0f;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #4d7c0f;
     background: #f7fee7;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #84cc16;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #84cc16;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #84cc16;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #65a30d;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #84cc16;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #84cc16;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #84cc16;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #4d7c0f;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #84cc16;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-noir/theme.css
+++ b/src/assets/components/themes/aura-light-noir/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #020617;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #020617;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #020617;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #020617;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -936,7 +960,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -946,7 +970,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -965,11 +989,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1031,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1048,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1052,20 +1076,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1168,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1186,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1204,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1218,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1235,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1219,11 +1249,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1271,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1319,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1362,7 +1395,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1373,38 +1406,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1451,23 +1484,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1489,7 +1528,7 @@
     background: #020617;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1592,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1583,11 +1622,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1598,26 +1637,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1667,7 +1712,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1701,7 +1746,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1723,19 +1771,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1855,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1903,7 +1951,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1912,7 +1960,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1936,7 +1984,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2014,7 +2062,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2023,8 +2071,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2052,29 +2100,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2115,11 +2169,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2204,10 +2258,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2216,7 +2270,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2256,10 +2310,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2693,14 +2747,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2760,7 +2814,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2779,18 +2833,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2798,32 +2861,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2832,7 +2904,7 @@
     line-height: 1rem;
     color: #ffffff;
     background: #020617;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2865,9 +2937,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2899,7 +2974,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2935,58 +3010,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3033,18 +3156,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3058,22 +3190,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3166,16 +3304,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3188,14 +3335,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3228,10 +3384,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3307,7 +3463,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3318,7 +3474,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3361,24 +3520,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3414,7 +3573,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3447,10 +3609,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3540,7 +3702,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3558,7 +3723,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3578,11 +3743,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3624,14 +3789,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3659,14 +3827,14 @@
     color: #ffffff;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3683,18 +3851,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3702,25 +3879,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3730,7 +3916,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3739,7 +3925,7 @@
     line-height: 1rem;
     color: #ffffff;
     background: #020617;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3761,9 +3947,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3774,7 +3963,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3791,7 +3980,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3844,16 +4033,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3899,7 +4100,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3913,15 +4117,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3930,7 +4140,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3946,8 +4156,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3955,15 +4165,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3981,16 +4194,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4013,10 +4226,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4037,7 +4256,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4068,7 +4287,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4081,7 +4300,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4089,8 +4311,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4118,32 +4340,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4190,23 +4418,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4224,13 +4461,13 @@
     color: #020617;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4246,11 +4483,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4357,7 +4597,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4384,7 +4624,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4417,7 +4660,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4429,7 +4672,7 @@
     background-color: #020617;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4440,14 +4683,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4477,7 +4729,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4490,8 +4742,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4505,7 +4757,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4518,28 +4770,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4550,7 +4811,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4561,7 +4822,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #020617;
@@ -4572,7 +4836,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0f172a;
@@ -4630,7 +4894,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4644,10 +4911,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4662,11 +4929,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4675,11 +4942,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #020617;
@@ -4729,7 +4999,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4773,7 +5046,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4920,7 +5193,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4974,8 +5247,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -5003,11 +5276,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5044,7 +5317,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5096,8 +5369,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5112,9 +5385,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5141,11 +5414,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5173,7 +5446,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5272,11 +5545,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5288,33 +5564,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,14 +5612,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5353,8 +5638,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5368,10 +5653,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5391,7 +5676,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5433,14 +5718,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5458,16 +5746,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5499,7 +5787,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5580,9 +5868,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5624,7 +5912,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5633,7 +5921,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #020617;
@@ -5644,28 +5935,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5683,10 +5980,10 @@
     color: #020617;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5739,7 +6036,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5835,7 +6132,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5845,7 +6142,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5924,7 +6221,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5934,7 +6231,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5965,7 +6262,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5974,7 +6274,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5987,7 +6290,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6129,7 +6435,7 @@
     color: #ffffff;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6201,10 +6507,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6301,16 +6607,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6414,12 +6720,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6429,12 +6735,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6482,6 +6788,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #020617;
@@ -6508,7 +6817,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6528,7 +6837,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6548,8 +6860,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6570,13 +6888,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6758,13 +7076,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6780,13 +7098,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6828,16 +7146,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6855,8 +7173,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6871,7 +7189,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6913,7 +7234,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6977,18 +7301,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7015,10 +7339,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7044,7 +7368,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7086,7 +7410,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7154,8 +7481,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7170,10 +7497,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7231,14 +7558,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7304,11 +7634,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7316,8 +7649,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7344,17 +7677,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7373,7 +7709,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7426,11 +7762,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7441,8 +7780,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7490,7 +7829,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7608,6 +7947,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7685,7 +8027,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7811,7 +8153,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7829,24 +8171,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-pink/theme.css
+++ b/src/assets/components/themes/aura-light-pink/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #ec4899;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #fdf2f8;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #fdf2f8;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #fdf2f8;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #fdf2f8;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #be185d;
     background: #fdf2f8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #be185d;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #be185d;
     background: #fdf2f8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #ec4899;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #ec4899;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #ec4899;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #db2777;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #ec4899;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #ec4899;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #ec4899;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #be185d;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #ec4899;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-purple/theme.css
+++ b/src/assets/components/themes/aura-light-purple/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #8B5CF6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #F5F3FF;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #F5F3FF;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #F5F3FF;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #F5F3FF;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #6D28D9;
     background: #F5F3FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #6D28D9;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #6D28D9;
     background: #F5F3FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #8B5CF6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #8B5CF6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #8B5CF6;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #7C3AED;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #8B5CF6;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #8B5CF6;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #8B5CF6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #6D28D9;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #8B5CF6;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/aura-light-teal/theme.css
+++ b/src/assets/components/themes/aura-light-teal/theme.css
@@ -194,8 +194,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e2e8f0;
@@ -246,8 +246,8 @@
   padding: 0.5rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e2e8f0;
@@ -255,8 +255,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #334155;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -367,10 +367,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #94a3b8;
@@ -403,7 +403,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e2e8f0;
@@ -468,16 +468,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -507,14 +507,20 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0 0.5rem 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0;
     color: #334155;
     background: #ffffff;
     font-weight: 500;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     border-bottom: 1px solid #e2e8f0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -553,11 +559,14 @@
     color: #14b8a6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker table th {
     padding: 0.25rem;
@@ -595,7 +604,10 @@
     background: #f0fdfa;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.5rem 0 0 0;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
     border-top: 1px solid #e2e8f0;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -637,7 +649,10 @@
     border-top: 0 none;
   }
   .p-datepicker .p-monthpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-monthpicker .p-monthpicker-month {
     padding: 0.25rem;
@@ -649,7 +664,10 @@
     background: #f0fdfa;
   }
   .p-datepicker .p-yearpicker {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-yearpicker .p-yearpicker-year {
     padding: 0.25rem;
@@ -661,18 +679,18 @@
     background: #f0fdfa;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e2e8f0;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #e2e8f0;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f1f5f9;
@@ -700,16 +718,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #94a3b8;
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -748,8 +766,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f87171;
@@ -822,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -910,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -932,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -942,7 +966,7 @@
     color: #0f172a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -961,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1003,7 +1027,7 @@
     border-color: #94a3b8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1020,12 +1044,12 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f87171;
@@ -1048,20 +1072,26 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-dropdown-panel .p-dropdown-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1134,13 +1164,13 @@
     background: #ffffff;
     color: #64748b;
     border-top: 1px solid #cbd5e1;
-    border-left: 1px solid #cbd5e1;
+    border-inline-start: 1px solid #cbd5e1;
     border-bottom: 1px solid #cbd5e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.5rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #cbd5e1;
+    border-inline-end: 1px solid #cbd5e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1152,7 +1182,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1170,13 +1200,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1184,13 +1214,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1201,12 +1231,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
@@ -1215,11 +1245,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1237,18 +1267,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.25rem;
+    inset-inline-end: 3.25rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1285,13 +1315,16 @@
     background: #ffffff;
     width: 1rem;
     height: 1rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.5rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 1px solid var(--p-focus-ring-color);
@@ -1358,7 +1391,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #64748b;
     transition-duration: 0.2s;
   }
@@ -1369,38 +1402,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1447,23 +1480,29 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-listbox .p-listbox-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0.25rem;
@@ -1485,7 +1524,7 @@
     background: #f0fdfa;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1549,20 +1588,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8fafc;
@@ -1579,11 +1618,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-multiselect-panel {
@@ -1594,26 +1633,32 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-multiselect-panel .p-multiselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -1663,7 +1708,7 @@
     background: #f1f5f9;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1697,7 +1742,10 @@
   }
 
   .p-password-panel {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
@@ -1719,19 +1767,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #94a3b8;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1803,7 +1851,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1895,7 +1943,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1904,7 +1952,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1928,7 +1976,7 @@
     border-color: transparent;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2006,7 +2054,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #f1f5f9;
     color: #1e293b;
     border-radius: 16px;
@@ -2015,8 +2063,8 @@
     background: transparent;
     color: #94a3b8;
     width: 2.5rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8fafc;
@@ -2044,29 +2092,35 @@
     box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
   }
   .p-treeselect-panel .p-treeselect-header {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1.75rem;
@@ -2107,11 +2161,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #94a3b8;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-button {
@@ -2196,10 +2250,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2208,7 +2262,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2248,10 +2302,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2685,14 +2739,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2752,7 +2806,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2771,18 +2825,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -2790,32 +2853,41 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2824,7 +2896,7 @@
     line-height: 1rem;
     color: #0f766e;
     background: #f0fdfa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -2857,9 +2929,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2891,7 +2966,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid var(--p-focus-ring-color);
@@ -2927,58 +3002,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8fafc;
@@ -3025,18 +3148,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3050,22 +3182,28 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
   }
   .p-dataview .p-dataview-emptymessage {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3158,16 +3296,25 @@
   }
 
   .p-column-filter-overlay-menu .p-column-filter-operator {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0;
+    padding-inline-start: 0.5rem;
     border-bottom: 0 none;
     color: #334155;
     background: #ffffff;
-    margin: 0 0 0 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-bottom: 1px solid #e2e8f0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-matchmode-dropdown {
@@ -3180,14 +3327,23 @@
     border-bottom: 0 none;
   }
   .p-column-filter-overlay-menu .p-column-filter-add-rule {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-buttonbar {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-orderlist .p-orderlist-controls {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-orderlist .p-orderlist-controls .p-button {
     margin-bottom: 0.5rem;
@@ -3220,10 +3376,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-orderlist .p-orderlist-list {
@@ -3299,7 +3455,7 @@
     background: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e2e8f0;
+    border-inline-end: 1px solid #e2e8f0;
     border-color: #e2e8f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3310,7 +3466,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-organizationchart .p-organizationchart-node-content .p-node-toggler {
     background: inherit;
@@ -3353,24 +3512,24 @@
     color: #475569;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.5rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.5rem;
@@ -3406,7 +3565,10 @@
   }
 
   .p-picklist .p-picklist-buttons {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-picklist .p-picklist-buttons .p-button {
     margin-bottom: 0.5rem;
@@ -3439,10 +3601,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-picklist .p-picklist-list {
@@ -3532,7 +3694,10 @@
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border-radius: 6px;
   }
   .p-tree .p-tree-container .p-treenode {
@@ -3550,7 +3715,7 @@
     padding: 0.25rem 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1.75rem;
     height: 1.75rem;
     color: #64748b;
@@ -3570,11 +3735,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #475569;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3616,14 +3781,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #94a3b8;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3651,14 +3819,14 @@
     color: #0f766e;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #475569;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3675,18 +3843,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3694,25 +3871,34 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #334155;
     background: #ffffff;
@@ -3722,7 +3908,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #64748b;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3731,7 +3917,7 @@
     line-height: 1rem;
     color: #0f766e;
     background: #f0fdfa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f1f5f9;
@@ -3753,9 +3939,12 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3766,7 +3955,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #475569;
@@ -3783,7 +3972,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #334155;
@@ -3836,16 +4025,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3891,7 +4092,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
   }
@@ -3905,15 +4109,21 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #64748b;
     background: #ffffff;
@@ -3922,7 +4132,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -3938,8 +4148,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e2e8f0;
@@ -3947,15 +4157,18 @@
     color: #334155;
   }
   .p-accordion .p-accordion-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3973,16 +4186,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -4005,10 +4218,16 @@
     color: #64748b;
   }
   .p-card .p-card-content {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-card .p-card-footer {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4029,7 +4248,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e2e8f0;
+    border-inline-start: 1px #e2e8f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4060,7 +4279,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4073,7 +4292,10 @@
     color: #1e293b;
   }
   .p-fieldset .p-fieldset-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
 
   .p-panel .p-panel-header {
@@ -4081,8 +4303,8 @@
     padding: 1.125rem;
     background: #ffffff;
     color: #334155;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,32 +4332,38 @@
     padding: 0.75rem 1.125rem;
   }
   .p-panel .p-panel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     background: #ffffff;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4182,23 +4410,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4216,13 +4453,13 @@
     color: #14b8a6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4238,11 +4475,14 @@
   }
   .p-tabview .p-tabview-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 0 none;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4349,7 +4589,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #334155;
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
@@ -4376,7 +4616,10 @@
   }
   .p-stepper .p-stepper-panels {
     background: #ffffff;
-    padding: 0.875rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0.875rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     color: #334155;
   }
   .p-stepper .p-stepper-separator {
@@ -4409,7 +4652,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4421,7 +4664,7 @@
     background-color: #14b8a6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4432,14 +4675,23 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-confirm-popup .p-confirm-popup-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    text-align: end;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4469,7 +4721,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4482,8 +4734,8 @@
     background: #ffffff;
     color: #334155;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4497,7 +4749,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #475569;
@@ -4510,28 +4762,37 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #334155;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4542,7 +4803,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4553,7 +4814,10 @@
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
   }
   .p-overlaypanel .p-overlaypanel-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-overlaypanel .p-overlaypanel-close {
     background: #14b8a6;
@@ -4564,7 +4828,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.875rem;
-    right: -0.875rem;
+    inset-inline-end: -0.875rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0d9488;
@@ -4622,7 +4886,10 @@
     padding-top: 0;
   }
   .p-sidebar .p-sidebar-content {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-sidebar .p-sidebar-footer {
     padding: 1.125rem;
@@ -4636,10 +4903,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #334155;
+    border-inline-end-color: #334155;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #334155;
+    border-inline-start-color: #334155;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #334155;
@@ -4654,11 +4921,11 @@
     border: 1px solid #e2e8f0;
     color: #334155;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 1px solid var(--p-focus-ring-color);
@@ -4667,11 +4934,14 @@
   }
   .p-fileupload .p-fileupload-content {
     background: #ffffff;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     border: 1px solid #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #14b8a6;
@@ -4721,7 +4991,10 @@
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #94a3b8;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4765,7 +5038,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4912,7 +5185,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -4966,8 +5239,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0.25rem;
@@ -4995,11 +5268,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5036,7 +5309,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5088,8 +5361,8 @@
     color: #94a3b8;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
@@ -5104,9 +5377,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5133,11 +5406,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #334155;
@@ -5165,7 +5438,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5264,11 +5537,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5280,33 +5556,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5322,14 +5604,17 @@
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action {
     color: #64748b;
-    padding: 1.125rem 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 1.125rem;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5345,8 +5630,8 @@
     background: #ffffff;
     border-color: #e2e8f0;
     color: #334155;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5360,10 +5645,10 @@
     background: #ffffff;
     color: #334155;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5383,7 +5668,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5425,14 +5710,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e2e8f0;
     margin: 2px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5450,16 +5738,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5491,7 +5779,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5572,9 +5860,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5616,7 +5904,7 @@
     border-top: 1px solid #e2e8f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5625,7 +5913,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #14b8a6;
@@ -5636,28 +5927,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e2e8f0;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e2e8f0 transparent;
     background: #ffffff;
     color: #64748b;
     padding: 1rem 1.125rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 1px solid var(--p-focus-ring-color);
@@ -5675,10 +5972,10 @@
     color: #14b8a6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5731,7 +6028,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #94a3b8;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #94a3b8;
@@ -5827,7 +6124,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5837,7 +6134,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5916,7 +6213,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5926,7 +6223,7 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #f1f5f9;
@@ -5957,7 +6254,10 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
@@ -5966,7 +6266,10 @@
     border-width: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.125rem;
@@ -5979,7 +6282,10 @@
     font-weight: 500;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.125rem;
@@ -6121,7 +6427,7 @@
     color: #0f766e;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6193,10 +6499,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #ffffff;
@@ -6293,16 +6599,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6406,12 +6712,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6421,12 +6727,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6474,6 +6780,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #14b8a6;
@@ -6500,7 +6809,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6520,7 +6829,10 @@
     background: #ffffff;
     color: #334155;
     border: 1px solid #e2e8f0;
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
   }
   .p-terminal .p-terminal-input {
     font-family: var(--font-family);
@@ -6540,8 +6852,14 @@
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
     transform: rotate(90deg);
   }
+  .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(-90deg);
+  }
   .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-header.p-highlight .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline-offset: -2px;
@@ -6562,13 +6880,13 @@
     margin: 0;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container:has(.p-autocomplete-token) .p-autocomplete-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-autocomplete.p-disabled {
     opacity: 1;
@@ -6750,13 +7068,13 @@
     margin: 0;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips .p-chips-multiple-container:has(.p-chips-token) .p-chips-input-token {
-    margin-left: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chips.p-disabled .p-chips-multiple-container {
     opacity: 1;
@@ -6772,13 +7090,13 @@
     margin-bottom: 0;
   }
   .p-chip .p-chip-remove-icon {
-    margin-left: 0.375rem;
+    margin-inline-end: 0.375rem;
   }
   .p-chip:has(.p-chip-remove-icon) {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-chip img {
-    margin-left: -0.5rem;
+    margin-inline-start: -0.5rem;
   }
 
   .p-colorpicker-preview {
@@ -6820,16 +7138,16 @@
     border-radius: 0;
   }
   .p-dialog .p-dialog-header {
-    border-top-right-radius: 12px;
-    border-top-left-radius: 12px;
+    border-start-end-radius: 12px;
+    border-start-start-radius: 12px;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
   .p-dialog .p-dialog-footer {
-    border-bottom-right-radius: 12px;
-    border-bottom-left-radius: 12px;
+    border-end-end-radius: 12px;
+    border-end-start-radius: 12px;
   }
 
   .p-dropdown {
@@ -6847,8 +7165,8 @@
   }
 
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item .p-dropdown-check-icon {
-    margin-left: -0.375rem;
-    margin-right: 0.375rem;
+    margin-inline-end: -0.375rem;
+    margin-inline-end: 0.375rem;
   }
 
   .p-treetable .p-treetable-tbody > tr:has(+ .p-highlight) > td {
@@ -6863,7 +7181,10 @@
   }
 
   .p-fieldset {
-    padding: 0 1.125rem 1.125rem 1.125rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.125rem;
+    padding-block-end: 1.125rem;
+    padding-inline-start: 1.125rem;
     margin: 0;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a {
@@ -6905,7 +7226,10 @@
     gap: 0.5rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
-    padding: 0 0 0 0;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint .p-column-filter-remove-button {
     margin-bottom: 0.5rem;
@@ -6969,18 +7293,18 @@
     position: relative;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-input {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button-group {
     position: absolute;
     top: 1px;
-    right: 1px;
+    inset-inline-end: 1px;
     height: calc(100% - 2px);
   }
   .p-inputnumber.p-inputnumber-buttons-stacked .p-inputnumber-button {
-    border-top-right-radius: 5px;
-    border-bottom-right-radius: 5px;
+    border-end-start-radius: 5px;
+    border-end-end-radius: 5px;
     background-color: transparent;
     border: 0 none;
     color: #64748b;
@@ -7007,10 +7331,10 @@
     color: #334155;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-up {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-horizontal .p-inputnumber-button.p-inputnumber-button-down {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-inputnumber.p-inputnumber-buttons-vertical .p-inputnumber-button {
     background-color: transparent;
@@ -7036,7 +7360,7 @@
     border: 0 none;
   }
   .p-inputswitch.p-highlight p-inputswitch-slider:before {
-    left: 1.25rem;
+    inset-inline-start: 1.25rem;
     transform: none;
   }
   .p-inputswitch.p-invalid > .p-inputswitch-slider {
@@ -7078,7 +7402,10 @@
     color: #64748b;
   }
   .p-listbox .p-listbox-header:has(.p-checkbox) {
-    padding: 0.5rem 1rem 0 1rem;
+    padding-block-start: 0.5rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
 
   .p-message {
@@ -7146,8 +7473,8 @@
   }
 
   .p-multiselect-panel .p-multiselect-header {
-    padding-left: 1rem;
-    padding-right: 1rem;
+    padding-inline-start: 1rem;
+    padding-inline-end: 1rem;
   }
 
   .p-multiselect {
@@ -7162,10 +7489,10 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     border-radius: 4px;
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.375rem;
+    margin-inline-start: 0.375rem;
   }
 
   .p-inputwrapper-filled .p-multiselect-chip .p-multiselect-label {
@@ -7223,14 +7550,17 @@
     color: #334155;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content {
     border-radius: 6px;
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem:first-child {
     margin-top: 2px;
@@ -7296,11 +7626,14 @@
     color: #334155;
     border: 0 none;
     border-bottom: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list {
     border: 1px solid #cbd5e1;
@@ -7308,8 +7641,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     border-radius: 6px;
@@ -7336,17 +7669,20 @@
     position: static;
   }
   .p-organizationchart .p-organizationchart-node-content:has(.p-node-toggler) {
-    padding: 0.75rem 1rem 1.25rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1rem;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-left) {
-    border-right: 0 none;
+    border-inline-end: 0 none;
   }
   .p-organizationchart .p-organizationchart-lines :nth-last-child(1 of .p-organizationchart-line-left) {
-    border-top-right-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-organizationchart .p-organizationchart-lines :nth-child(1 of .p-organizationchart-line-right) {
-    border-left: 1px solid #e2e8f0;
-    border-top-left-radius: 6px;
+    border-inline-start: 1px solid #e2e8f0;
+    border-start-start-radius: 6px;
   }
 
   .p-overlaypanel {
@@ -7365,7 +7701,7 @@
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
     top: 0.25rem;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     color: #475569;
@@ -7418,11 +7754,14 @@
     color: #334155;
     border: 1px solid #cbd5e1;
     border: 0 none;
-    padding: 0.75rem 1rem 0.5rem 1rem;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 1rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 1rem;
     font-weight: 600;
     color: #64748b;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-end-start-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-picklist .p-picklist-filter-container {
     border: 0;
@@ -7433,8 +7772,8 @@
     background: #ffffff;
     color: #334155;
     padding: 0.25rem 0.25rem;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     border-radius: 6px;
@@ -7482,7 +7821,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7600,6 +7939,9 @@
     width: calc(50% + 1rem);
     transform: translateX(100%);
   }
+  .p-steps .p-steps-item:first-child:dir(rtl)::before {
+    transform: translateX(-100%);
+  }
   .p-steps .p-steps-item:last-child::before {
     width: 50%;
   }
@@ -7677,7 +8019,7 @@
     border-radius: 6px;
   }
   .p-terminal .p-terminal-prompt {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
   }
   .p-terminal .p-terminal-response {
     margin: 2px 0;
@@ -7803,7 +8145,7 @@
     background-color: transparent;
     transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, outline-color 0.2s;
     position: absolute;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     top: 0.25rem;
     width: calc(100% - 0.5rem);
     height: calc(100% - 0.5rem);
@@ -7821,24 +8163,42 @@
     border-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label {
     background: #ffffff;
     box-shadow: 2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-icon:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), 2px 2px 2px 0px rgba(0, 0, 0, 0.04);
+  }
+  .p-togglebutton.p-highlight:has(.p-button-icon) .p-button-label:dir(rtl) {
+    box-shadow: -2px 2px 2px 0px rgba(0, 0, 0, 0.02), -2px 2px 2px 0px rgba(0, 0, 0, 0.04);
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
     border: none;
-    border-radius: 4px 0px 0px 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
   }
   .p-togglebutton:has(:not(.p-highlight)):has(.p-button-icon) .p-button-label {
-    border-radius: 0px 4px 4px 0px;
+    border-start-start-radius: 0px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 0px;
   }
   .p-togglebutton.p-disabled {
     opacity: 1;

--- a/src/assets/components/themes/bootstrap4-dark-blue/theme.css
+++ b/src/assets/components/themes/bootstrap4-dark-blue/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #2a323d;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f4b5b;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1.5rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f4b5b;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #20262e;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #3f4b5b;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #4c5866;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #3f4b5b;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #8dd0ff;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #8dd0ff;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f4b5b;
-    padding-right: 0;
-    padding-left: 0;
+    border-inline-start: 1px solid #3f4b5b;
+    padding-inline-end: 0;
+    padding-inline-start: 0;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f19ea6;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +923,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -927,7 +933,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -946,11 +952,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +994,7 @@
     border-color: #8dd0ff;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1011,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f19ea6;
@@ -1038,15 +1044,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1125,13 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #3f4b5b;
-    border-left: 1px solid #3f4b5b;
+    border-inline-start: 1px solid #3f4b5b;
     border-bottom: 1px solid #3f4b5b;
     padding: 0.5rem 0.75rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f4b5b;
+    border-inline-end: 1px solid #3f4b5b;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1143,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1161,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1175,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1192,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1200,11 +1206,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1228,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1276,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 4px;
     transition-duration: 0.15s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1352,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.15s;
   }
@@ -1354,38 +1363,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1446,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1470,7 +1479,7 @@
     background: #8dd0ff;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1543,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #3f4b5b;
@@ -1564,11 +1573,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1593,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1648,7 +1657,7 @@
     background: rgba(255, 255, 255, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1713,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1797,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1897,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1906,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1930,7 @@
     border-color: #56bdff;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, left 0.15s;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, inset-inline-start 0.15s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.15s;
@@ -1999,7 +2008,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2008,8 +2017,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #3f4b5b;
@@ -2042,24 +2051,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2109,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2198,10 @@
     transition-duration: 0.15s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2210,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2250,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2678,14 +2687,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2745,7 +2754,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2768,14 +2777,20 @@
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2783,32 +2798,41 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2817,7 +2841,7 @@
     line-height: 1.143rem;
     color: #151515;
     background: #8dd0ff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -2850,9 +2874,12 @@
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2884,7 +2911,7 @@
     box-shadow: 0 0 0 1px #e3f3fe;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #e3f3fe;
@@ -2920,58 +2947,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #2f3641;
@@ -3022,14 +3097,20 @@
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3043,11 +3124,14 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3058,7 +3142,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,8 +3240,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3213,10 +3297,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3292,7 +3376,7 @@
     background: #3f4b5b;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f4b5b;
+    border-inline-end: 1px solid #3f4b5b;
     border-color: #3f4b5b;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3333,7 +3417,10 @@
     color: #8dd0ff;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3346,24 +3433,24 @@
     color: #8dd0ff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3374,7 +3461,10 @@
     color: #8dd0ff;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     padding: 0 0.5rem;
   }
   .p-paginator .p-paginator-pages .p-paginator-page {
@@ -3383,7 +3473,10 @@
     color: #8dd0ff;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3432,10 +3525,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3543,7 +3636,7 @@
     padding: 0.286rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3563,11 +3656,11 @@
     box-shadow: 0 0 0 1px #e3f3fe;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3609,14 +3702,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3644,14 +3740,14 @@
     color: #151515;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3672,14 +3768,20 @@
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3687,25 +3789,34 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
@@ -3715,7 +3826,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3724,7 +3835,7 @@
     line-height: 1.143rem;
     color: #151515;
     background: #8dd0ff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -3746,9 +3857,12 @@
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3759,7 +3873,7 @@
     background: transparent;
     border-radius: 50%;
     transition: color 0.15s, box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3776,7 +3890,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3829,16 +3943,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3884,7 +4010,10 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3898,11 +4027,14 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3915,7 +4047,7 @@
     transition: box-shadow 0.15s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3931,8 +4063,8 @@
     background: #2a323d;
     border-color: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #3f4b5b;
@@ -3945,10 +4077,10 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3966,16 +4098,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4001,7 +4133,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4022,7 +4157,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f4b5b;
+    border-inline-start: 1px #3f4b5b;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4053,7 +4188,7 @@
     transition: box-shadow 0.15s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4074,8 +4209,8 @@
     padding: 1rem 1.25rem;
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,25 +4245,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1.25rem;
     border: 1px solid #3f4b5b;
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4175,10 +4310,13 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid;
@@ -4188,10 +4326,13 @@
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4209,13 +4350,13 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #2a323d;
@@ -4234,8 +4375,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4342,7 +4483,7 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: color 0.15s, box-shadow 0.15s;
@@ -4402,7 +4543,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4414,7 +4555,7 @@
     background-color: #8dd0ff;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4428,11 +4569,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4462,7 +4606,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4475,8 +4619,8 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     padding: 1rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4490,7 +4634,7 @@
     background: transparent;
     border-radius: 50%;
     transition: color 0.15s, box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4503,7 +4647,7 @@
     box-shadow: 0 0 0 1px #e3f3fe;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #2a323d;
@@ -4511,20 +4655,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #3f4b5b;
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     padding: 1rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4535,7 +4682,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4557,7 +4704,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #56bdff;
@@ -4629,10 +4776,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f4b5b;
+    border-inline-end-color: #3f4b5b;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f4b5b;
+    border-inline-start-color: #3f4b5b;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f4b5b;
@@ -4647,11 +4794,11 @@
     border: 1px solid #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4663,8 +4810,8 @@
     padding: 2rem 1rem;
     border: 1px solid #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #8dd0ff;
@@ -4714,7 +4861,10 @@
     color: #8dd0ff;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4758,7 +4908,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4905,7 +5055,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4959,8 +5109,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4988,11 +5138,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5029,7 +5179,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5081,8 +5231,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f4b5b;
@@ -5097,9 +5247,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5126,11 +5276,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5158,7 +5308,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5257,11 +5407,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.15s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5276,30 +5429,33 @@
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
+    }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5319,10 +5475,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5338,8 +5494,8 @@
     background: #2a323d;
     border-color: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5353,10 +5509,10 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5376,7 +5532,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5418,14 +5574,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f4b5b;
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5443,16 +5602,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5484,7 +5643,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5565,9 +5724,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5609,7 +5768,7 @@
     border-top: 1px solid #3f4b5b;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5618,7 +5777,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #8dd0ff;
@@ -5629,12 +5791,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid;
@@ -5644,13 +5806,16 @@
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5668,10 +5833,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #2a323d;
@@ -5724,7 +5889,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5820,7 +5985,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5830,7 +5995,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5909,7 +6074,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5919,14 +6084,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
     border-radius: 4px;
   }
@@ -5935,7 +6103,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5948,7 +6119,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6070,7 +6244,7 @@
     color: #151515;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6142,10 +6316,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: color 0.15s, box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6234,16 +6408,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6347,12 +6521,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6362,12 +6536,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6415,6 +6589,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #8dd0ff;
@@ -6441,7 +6618,7 @@
     color: #151515;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/bootstrap4-dark-purple/theme.css
+++ b/src/assets/components/themes/bootstrap4-dark-purple/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #2a323d;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3f4b5b;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1.5rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3f4b5b;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #20262e;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #3f4b5b;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #4c5866;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #3f4b5b;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #c298d8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #c298d8;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3f4b5b;
-    padding-right: 0;
-    padding-left: 0;
+    border-inline-start: 1px solid #3f4b5b;
+    padding-inline-end: 0;
+    padding-inline-start: 0;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f19ea6;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +923,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -927,7 +933,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -946,11 +952,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +994,7 @@
     border-color: #c298d8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1011,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f19ea6;
@@ -1038,15 +1044,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1125,13 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #3f4b5b;
-    border-left: 1px solid #3f4b5b;
+    border-inline-start: 1px solid #3f4b5b;
     border-bottom: 1px solid #3f4b5b;
     padding: 0.5rem 0.75rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3f4b5b;
+    border-inline-end: 1px solid #3f4b5b;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1143,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1161,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1175,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1192,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1200,11 +1206,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1228,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1276,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 4px;
     transition-duration: 0.15s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1352,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.15s;
   }
@@ -1354,38 +1363,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1446,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1470,7 +1479,7 @@
     background: #c298d8;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1543,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #3f4b5b;
@@ -1564,11 +1573,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1593,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1648,7 +1657,7 @@
     background: rgba(255, 255, 255, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1713,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1797,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1897,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1906,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1930,7 @@
     border-color: #aa70c7;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, left 0.15s;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, inset-inline-start 0.15s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.15s;
@@ -1999,7 +2008,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2008,8 +2017,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #3f4b5b;
@@ -2042,24 +2051,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2109,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2198,10 @@
     transition-duration: 0.15s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2210,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2250,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2678,14 +2687,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2745,7 +2754,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2768,14 +2777,20 @@
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2783,32 +2798,41 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2817,7 +2841,7 @@
     line-height: 1.143rem;
     color: #151515;
     background: #c298d8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -2850,9 +2874,12 @@
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2884,7 +2911,7 @@
     box-shadow: 0 0 0 1px #f0e6f5;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #f0e6f5;
@@ -2920,58 +2947,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #2f3641;
@@ -3022,14 +3097,20 @@
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3043,11 +3124,14 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3058,7 +3142,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,8 +3240,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3213,10 +3297,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3292,7 +3376,7 @@
     background: #3f4b5b;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3f4b5b;
+    border-inline-end: 1px solid #3f4b5b;
     border-color: #3f4b5b;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3333,7 +3417,10 @@
     color: #c298d8;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3346,24 +3433,24 @@
     color: #c298d8;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3374,7 +3461,10 @@
     color: #c298d8;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     padding: 0 0.5rem;
   }
   .p-paginator .p-paginator-pages .p-paginator-page {
@@ -3383,7 +3473,10 @@
     color: #c298d8;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3432,10 +3525,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3543,7 +3636,7 @@
     padding: 0.286rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3563,11 +3656,11 @@
     box-shadow: 0 0 0 1px #f0e6f5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3609,14 +3702,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3644,14 +3740,14 @@
     color: #151515;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3672,14 +3768,20 @@
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3687,25 +3789,34 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
@@ -3715,7 +3826,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3724,7 +3835,7 @@
     line-height: 1.143rem;
     color: #151515;
     background: #c298d8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -3746,9 +3857,12 @@
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3759,7 +3873,7 @@
     background: transparent;
     border-radius: 50%;
     transition: color 0.15s, box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3776,7 +3890,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3829,16 +3943,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3884,7 +4010,10 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.6);
     border: solid #3f4b5b;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3898,11 +4027,14 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3f4b5b;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3915,7 +4047,7 @@
     transition: box-shadow 0.15s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3931,8 +4063,8 @@
     background: #2a323d;
     border-color: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #3f4b5b;
@@ -3945,10 +4077,10 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3966,16 +4098,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4001,7 +4133,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4022,7 +4157,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3f4b5b;
+    border-inline-start: 1px #3f4b5b;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4053,7 +4188,7 @@
     transition: box-shadow 0.15s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4074,8 +4209,8 @@
     padding: 1rem 1.25rem;
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,25 +4245,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1.25rem;
     border: 1px solid #3f4b5b;
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4175,10 +4310,13 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid;
@@ -4188,10 +4326,13 @@
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4209,13 +4350,13 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #2a323d;
@@ -4234,8 +4375,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4342,7 +4483,7 @@
     transition: color 0.15s, box-shadow 0.15s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: color 0.15s, box-shadow 0.15s;
@@ -4402,7 +4543,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4414,7 +4555,7 @@
     background-color: #c298d8;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4428,11 +4569,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4462,7 +4606,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4475,8 +4619,8 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     padding: 1rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4490,7 +4634,7 @@
     background: transparent;
     border-radius: 50%;
     transition: color 0.15s, box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4503,7 +4647,7 @@
     box-shadow: 0 0 0 1px #f0e6f5;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #2a323d;
@@ -4511,20 +4655,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #3f4b5b;
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     padding: 1rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4535,7 +4682,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4557,7 +4704,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #aa70c7;
@@ -4629,10 +4776,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f4b5b;
+    border-inline-end-color: #3f4b5b;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f4b5b;
+    border-inline-start-color: #3f4b5b;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f4b5b;
@@ -4647,11 +4794,11 @@
     border: 1px solid #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4663,8 +4810,8 @@
     padding: 2rem 1rem;
     border: 1px solid #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #c298d8;
@@ -4714,7 +4861,10 @@
     color: #c298d8;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4758,7 +4908,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4905,7 +5055,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4959,8 +5109,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4988,11 +5138,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5029,7 +5179,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5081,8 +5231,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2a323d;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3f4b5b;
@@ -5097,9 +5247,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5126,11 +5276,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5158,7 +5308,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5257,11 +5407,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.15s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5276,30 +5429,33 @@
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
+    }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5319,10 +5475,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5338,8 +5494,8 @@
     background: #2a323d;
     border-color: #3f4b5b;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5353,10 +5509,10 @@
     background: #2a323d;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5376,7 +5532,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5418,14 +5574,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3f4b5b;
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5443,16 +5602,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5484,7 +5643,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5565,9 +5724,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5609,7 +5768,7 @@
     border-top: 1px solid #3f4b5b;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5618,7 +5777,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #3f4b5b;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #c298d8;
@@ -5629,12 +5791,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid;
@@ -5644,13 +5806,16 @@
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5668,10 +5833,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #2a323d;
@@ -5724,7 +5889,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5820,7 +5985,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5830,7 +5995,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5909,7 +6074,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5919,14 +6084,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
     border-radius: 4px;
   }
@@ -5935,7 +6103,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5948,7 +6119,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6070,7 +6244,7 @@
     color: #151515;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6142,10 +6316,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: color 0.15s, box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6234,16 +6408,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6347,12 +6521,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6362,12 +6536,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6415,6 +6589,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #c298d8;
@@ -6441,7 +6618,7 @@
     color: #151515;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/bootstrap4-light-blue/theme.css
+++ b/src/assets/components/themes/bootstrap4-light-blue/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #efefef;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dee2e6;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1.5rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dee2e6;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #495057;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #ced4da;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #ced4da;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #495057;
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #dee2e6;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #007bff;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #007bff;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dee2e6;
-    padding-right: 0;
-    padding-left: 0;
+    border-inline-start: 1px solid #dee2e6;
+    padding-inline-end: 0;
+    padding-inline-start: 0;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #e9ecef;
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #495057;
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #dc3545;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +923,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #212529;
     border-radius: 16px;
@@ -927,7 +933,7 @@
     color: #212529;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -946,11 +952,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +994,7 @@
     border-color: #007bff;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1011,12 @@
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #dc3545;
@@ -1038,15 +1044,15 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1125,13 @@
     background: #e9ecef;
     color: #495057;
     border-top: 1px solid #ced4da;
-    border-left: 1px solid #ced4da;
+    border-inline-start: 1px solid #ced4da;
     border-bottom: 1px solid #ced4da;
     padding: 0.5rem 0.75rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #ced4da;
+    border-inline-end: 1px solid #ced4da;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1143,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1161,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1175,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1192,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #495057;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
 
@@ -1200,11 +1206,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1228,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1276,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 4px;
     transition-duration: 0.15s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1352,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6c757d;
     transition-duration: 0.15s;
   }
@@ -1354,38 +1363,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #495057;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1446,18 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1470,7 +1479,7 @@
     background: #007bff;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1543,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #212529;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #efefef;
@@ -1564,11 +1573,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1593,21 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -1648,7 +1657,7 @@
     background: #e9ecef;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1713,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #495057;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1797,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1897,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1906,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1930,7 @@
     border-color: #0069d9;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, left 0.15s;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, inset-inline-start 0.15s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.15s;
@@ -1999,7 +2008,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #212529;
     border-radius: 16px;
@@ -2008,8 +2017,8 @@
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #efefef;
@@ -2042,24 +2051,24 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2109,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2198,10 @@
     transition-duration: 0.15s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2210,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2250,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2678,14 +2687,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2745,7 +2754,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2764,18 +2773,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2783,32 +2801,41 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2817,7 +2844,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #007bff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -2850,9 +2877,12 @@
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2884,7 +2914,7 @@
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(38, 143, 255, 0.5);
@@ -2920,58 +2950,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: rgba(0, 0, 0, 0.05);
@@ -3018,18 +3096,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3043,11 +3130,14 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3058,7 +3148,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,8 +3246,8 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3213,10 +3303,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-orderlist .p-orderlist-list {
@@ -3292,7 +3382,7 @@
     background: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dee2e6;
+    border-inline-end: 1px solid #dee2e6;
     border-color: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3333,7 +3423,10 @@
     color: #007bff;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3346,24 +3439,24 @@
     color: #007bff;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3374,7 +3467,10 @@
     color: #007bff;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     padding: 0 0.5rem;
   }
   .p-paginator .p-paginator-pages .p-paginator-page {
@@ -3383,7 +3479,10 @@
     color: #007bff;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3432,10 +3531,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-picklist .p-picklist-list {
@@ -3543,7 +3642,7 @@
     padding: 0.286rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -3563,11 +3662,11 @@
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #212529;
@@ -3609,14 +3708,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3644,14 +3746,14 @@
     color: #ffffff;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3668,18 +3770,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3687,25 +3798,34 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
@@ -3715,7 +3835,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3724,7 +3844,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #007bff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -3746,9 +3866,12 @@
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3759,7 +3882,7 @@
     background: transparent;
     border-radius: 50%;
     transition: box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #495057;
@@ -3776,7 +3899,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #212529;
@@ -3829,16 +3952,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3884,7 +4019,10 @@
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3898,11 +4036,14 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3915,7 +4056,7 @@
     transition: box-shadow 0.15s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3931,8 +4072,8 @@
     background: #efefef;
     border-color: #dee2e6;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dee2e6;
@@ -3945,10 +4086,10 @@
     background: #ffffff;
     color: #212529;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3966,16 +4107,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4001,7 +4142,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4022,7 +4166,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dee2e6;
+    border-inline-start: 1px #dee2e6;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4053,7 +4197,7 @@
     transition: box-shadow 0.15s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4074,8 +4218,8 @@
     padding: 1rem 1.25rem;
     background: #efefef;
     color: #212529;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,25 +4254,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1.25rem;
     border: 1px solid #dee2e6;
     background: #ffffff;
     color: #212529;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4175,10 +4319,13 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #dee2e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid;
@@ -4188,10 +4335,13 @@
     color: #6c757d;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4209,13 +4359,13 @@
     color: #495057;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4234,8 +4384,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #212529;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4342,7 +4492,7 @@
     transition: box-shadow 0.15s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
     font-weight: 600;
     transition: box-shadow 0.15s;
@@ -4402,7 +4552,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4414,7 +4564,7 @@
     background-color: #007bff;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4428,11 +4578,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4462,7 +4615,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4475,8 +4628,8 @@
     background: #ffffff;
     color: #212529;
     padding: 1rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4490,7 +4643,7 @@
     background: transparent;
     border-radius: 50%;
     transition: box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #495057;
@@ -4503,7 +4656,7 @@
     box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
@@ -4511,20 +4664,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #e9ecef;
     background: #ffffff;
     color: #212529;
     padding: 1rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4535,7 +4691,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4557,7 +4713,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0069d9;
@@ -4629,10 +4785,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #212529;
+    border-inline-end-color: #212529;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #212529;
+    border-inline-start-color: #212529;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #212529;
@@ -4647,11 +4803,11 @@
     border: 1px solid #dee2e6;
     color: #212529;
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4663,8 +4819,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dee2e6;
     color: #212529;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #007bff;
@@ -4714,7 +4870,10 @@
     color: #007bff;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4758,7 +4917,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -4905,7 +5064,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -4959,8 +5118,8 @@
     color: #212529;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4988,11 +5147,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.7);
@@ -5029,7 +5188,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5081,8 +5240,8 @@
     color: #212529;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
@@ -5097,9 +5256,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5126,11 +5285,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.7);
@@ -5158,7 +5317,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5257,11 +5416,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.15s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5276,30 +5438,33 @@
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
+    }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5319,10 +5484,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5338,8 +5503,8 @@
     background: #efefef;
     border-color: #dee2e6;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5353,10 +5518,10 @@
     background: #ffffff;
     color: #212529;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5376,7 +5541,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5418,14 +5583,17 @@
     color: #212529;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5443,16 +5611,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5484,7 +5652,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5565,9 +5733,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5609,7 +5777,7 @@
     border-top: 1px solid #dee2e6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5618,7 +5786,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #dee2e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #007bff;
@@ -5629,12 +5800,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid;
@@ -5644,13 +5815,16 @@
     color: #6c757d;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5668,10 +5842,10 @@
     color: #495057;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5724,7 +5898,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5820,7 +5994,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5830,7 +6004,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5909,7 +6083,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5919,14 +6093,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
     border-radius: 4px;
   }
@@ -5935,7 +6112,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5948,7 +6128,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6070,7 +6253,7 @@
     color: #ffffff;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6142,10 +6325,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6234,16 +6417,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6347,12 +6530,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6362,12 +6545,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6415,6 +6598,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #007bff;
@@ -6441,7 +6627,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/bootstrap4-light-purple/theme.css
+++ b/src/assets/components/themes/bootstrap4-light-purple/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #efefef;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dee2e6;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1.5rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dee2e6;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #495057;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #ced4da;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #ced4da;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #495057;
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #dee2e6;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #883cae;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #883cae;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dee2e6;
-    padding-right: 0;
-    padding-left: 0;
+    border-inline-start: 1px solid #dee2e6;
+    padding-inline-end: 0;
+    padding-inline-start: 0;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #e9ecef;
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #495057;
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #dc3545;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +923,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #212529;
     border-radius: 16px;
@@ -927,7 +933,7 @@
     color: #212529;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -946,11 +952,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +994,7 @@
     border-color: #883cae;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1011,12 @@
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #dc3545;
@@ -1038,15 +1044,15 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1125,13 @@
     background: #e9ecef;
     color: #495057;
     border-top: 1px solid #ced4da;
-    border-left: 1px solid #ced4da;
+    border-inline-start: 1px solid #ced4da;
     border-bottom: 1px solid #ced4da;
     padding: 0.5rem 0.75rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #ced4da;
+    border-inline-end: 1px solid #ced4da;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1143,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1161,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1175,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1192,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #495057;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
 
@@ -1200,11 +1206,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1228,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.107rem;
+    inset-inline-end: 3.107rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1276,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 4px;
     transition-duration: 0.15s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1352,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6c757d;
     transition-duration: 0.15s;
   }
@@ -1354,38 +1363,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #495057;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1446,18 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1470,7 +1479,7 @@
     background: #883cae;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1543,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #212529;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #efefef;
@@ -1564,11 +1573,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1593,21 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -1648,7 +1657,7 @@
     background: #e9ecef;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1713,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #495057;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #495057;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1797,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1897,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1906,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1930,7 @@
     border-color: #7a38a7;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, left 0.15s;
+    transition: background-color 0.15s, border-color 0.15s, box-shadow 0.15s, inset-inline-start 0.15s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.15s;
@@ -1999,7 +2008,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #212529;
     border-radius: 16px;
@@ -2008,8 +2017,8 @@
     background: transparent;
     color: #495057;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #efefef;
@@ -2042,24 +2051,24 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2109,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #495057;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2198,10 @@
     transition-duration: 0.15s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2210,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2250,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2678,14 +2687,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2745,7 +2754,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2764,18 +2773,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2783,32 +2801,41 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2817,7 +2844,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #883cae;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -2850,9 +2877,12 @@
     transition: box-shadow 0.15s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2884,7 +2914,7 @@
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(136, 60, 174, 0.5);
@@ -2920,58 +2950,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: rgba(0, 0, 0, 0.05);
@@ -3018,18 +3096,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3043,11 +3130,14 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3058,7 +3148,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3156,8 +3246,8 @@
     color: #212529;
     background: #efefef;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3213,10 +3303,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-orderlist .p-orderlist-list {
@@ -3292,7 +3382,7 @@
     background: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dee2e6;
+    border-inline-end: 1px solid #dee2e6;
     border-color: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3333,7 +3423,10 @@
     color: #883cae;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3346,24 +3439,24 @@
     color: #883cae;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3374,7 +3467,10 @@
     color: #883cae;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     padding: 0 0.5rem;
   }
   .p-paginator .p-paginator-pages .p-paginator-page {
@@ -3383,7 +3479,10 @@
     color: #883cae;
     min-width: 2.357rem;
     height: 2.357rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: box-shadow 0.15s;
     border-radius: 0;
   }
@@ -3432,10 +3531,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-picklist .p-picklist-list {
@@ -3543,7 +3642,7 @@
     padding: 0.286rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -3563,11 +3662,11 @@
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #212529;
@@ -3609,14 +3708,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #495057;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3644,14 +3746,14 @@
     color: #ffffff;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3668,18 +3770,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3687,25 +3798,34 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 2px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #212529;
     background: #ffffff;
@@ -3715,7 +3835,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3724,7 +3844,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #883cae;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -3746,9 +3866,12 @@
     transition: box-shadow 0.15s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3759,7 +3882,7 @@
     background: transparent;
     border-radius: 50%;
     transition: box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #495057;
@@ -3776,7 +3899,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #212529;
@@ -3829,16 +3952,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3884,7 +4019,10 @@
     background: #efefef;
     color: #212529;
     border: solid #dee2e6;
-    border-width: 1px 0 0 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3898,11 +4036,14 @@
     background: #efefef;
     color: #212529;
     border: 1px solid #dee2e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3915,7 +4056,7 @@
     transition: box-shadow 0.15s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3931,8 +4072,8 @@
     background: #efefef;
     border-color: #dee2e6;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dee2e6;
@@ -3945,10 +4086,10 @@
     background: #ffffff;
     color: #212529;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3966,16 +4107,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4001,7 +4142,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4022,7 +4166,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dee2e6;
+    border-inline-start: 1px #dee2e6;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4053,7 +4197,7 @@
     transition: box-shadow 0.15s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4074,8 +4218,8 @@
     padding: 1rem 1.25rem;
     background: #efefef;
     color: #212529;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4110,25 +4254,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1.25rem;
     border: 1px solid #dee2e6;
     background: #ffffff;
     color: #212529;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4175,10 +4319,13 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #dee2e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid;
@@ -4188,10 +4335,13 @@
     color: #6c757d;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4209,13 +4359,13 @@
     color: #495057;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4234,8 +4384,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #212529;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4342,7 +4492,7 @@
     transition: box-shadow 0.15s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
     font-weight: 600;
     transition: box-shadow 0.15s;
@@ -4402,7 +4552,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4414,7 +4564,7 @@
     background-color: #883cae;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4428,11 +4578,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4462,7 +4615,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4475,8 +4628,8 @@
     background: #ffffff;
     color: #212529;
     padding: 1rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4490,7 +4643,7 @@
     background: transparent;
     border-radius: 50%;
     transition: box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #495057;
@@ -4503,7 +4656,7 @@
     box-shadow: 0 0 0 0.2rem rgba(136, 60, 174, 0.5);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
@@ -4511,20 +4664,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #e9ecef;
     background: #ffffff;
     color: #212529;
     padding: 1rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4535,7 +4691,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4557,7 +4713,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #7a38a7;
@@ -4629,10 +4785,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #212529;
+    border-inline-end-color: #212529;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #212529;
+    border-inline-start-color: #212529;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #212529;
@@ -4647,11 +4803,11 @@
     border: 1px solid #dee2e6;
     color: #212529;
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4663,8 +4819,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dee2e6;
     color: #212529;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #883cae;
@@ -4714,7 +4870,10 @@
     color: #883cae;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4758,7 +4917,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -4905,7 +5064,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -4959,8 +5118,8 @@
     color: #212529;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4988,11 +5147,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.7);
@@ -5029,7 +5188,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5081,8 +5240,8 @@
     color: #212529;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
@@ -5097,9 +5256,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5126,11 +5285,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.5);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.7);
@@ -5158,7 +5317,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5257,11 +5416,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.15s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5276,30 +5438,33 @@
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
+    }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5319,10 +5484,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5338,8 +5503,8 @@
     background: #efefef;
     border-color: #dee2e6;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5353,10 +5518,10 @@
     background: #ffffff;
     color: #212529;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5376,7 +5541,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5418,14 +5583,17 @@
     color: #212529;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5443,16 +5611,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5484,7 +5652,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5565,9 +5733,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5609,7 +5777,7 @@
     border-top: 1px solid #dee2e6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5618,7 +5786,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #dee2e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #883cae;
@@ -5629,12 +5800,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid;
@@ -5644,13 +5815,16 @@
     color: #6c757d;
     padding: 0.75rem 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: box-shadow 0.15s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5668,10 +5842,10 @@
     color: #495057;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5724,7 +5898,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #212529;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #212529;
@@ -5820,7 +5994,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5830,7 +6004,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5909,7 +6083,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5919,14 +6093,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
     border-radius: 4px;
   }
@@ -5935,7 +6112,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5948,7 +6128,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6070,7 +6253,7 @@
     color: #ffffff;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6142,10 +6325,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: box-shadow 0.15s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6234,16 +6417,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6347,12 +6530,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6362,12 +6545,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6415,6 +6598,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #883cae;
@@ -6441,7 +6627,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/fluent-light/theme.css
+++ b/src/assets/components/themes/fluent-light/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #faf9f8;
-  border-top-right-radius: 2px;
-  border-top-left-radius: 2px;
+  border-start-end-radius: 2px;
+  border-start-start-radius: 2px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #a19f9d;
@@ -227,8 +227,8 @@
   padding: 0.75rem 0.5rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 2px;
-  border-bottom-left-radius: 2px;
+  border-end-end-radius: 2px;
+  border-end-start-radius: 2px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #a19f9d;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #323130;
-  border-bottom-right-radius: 2px;
-  border-bottom-left-radius: 2px;
+  border-end-end-radius: 2px;
+  border-end-start-radius: 2px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #323130;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e1dfdd;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #605e5c;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #605e5c;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -488,14 +488,17 @@
     background: #ffffff;
   }
   .p-datepicker .p-datepicker-header {
-    padding: 0 0.5rem 0.5rem 0.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 0.5rem;
+    padding-block-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     color: #323130;
     background: #ffffff;
     font-weight: 600;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +537,7 @@
     color: #0078d4;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +645,18 @@
     background: #edebe9;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #edebe9;
-    padding-right: 0.75rem;
-    padding-left: 0.75rem;
+    border-inline-start: 1px solid #edebe9;
+    padding-inline-end: 0.75rem;
+    padding-inline-start: 0.75rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f2f1;
@@ -681,16 +684,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #605e5c;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #605e5c;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +732,8 @@
     background: transparent;
     color: #605e5c;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a4252c;
@@ -803,20 +806,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #605e5c;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +900,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +922,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #edebe9;
     color: #323130;
     border-radius: 16px;
@@ -923,7 +932,7 @@
     color: #323130;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +951,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #605e5c;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +993,7 @@
     border-color: #0078d4;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1010,12 @@
     background: transparent;
     color: #605e5c;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #605e5c;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #a4252c;
@@ -1034,15 +1043,15 @@
     color: #323130;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1124,13 @@
     background: #f3f2f1;
     color: #605e5c;
     border-top: 1px solid #605e5c;
-    border-left: 1px solid #605e5c;
+    border-inline-start: 1px solid #605e5c;
     border-bottom: 1px solid #605e5c;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #605e5c;
+    border-inline-end: 1px solid #605e5c;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1142,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1160,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-start-radius: 2px;
+    border-end-start-radius: 2px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-start-radius: 2px;
+    border-end-start-radius: 2px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1174,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1191,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #605e5c;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
 
@@ -1196,11 +1205,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #605e5c;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1227,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #605e5c;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1275,16 @@
     background: #605e5c;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1351,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #605e5c;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1362,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #605e5c;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1445,18 @@
     color: #323130;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1466,7 +1478,7 @@
     background: #edebe9;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1542,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #edebe9;
     color: #323130;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #605e5c;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-multiselect.p-variant-filled {
     background: #faf9f8;
@@ -1560,11 +1572,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #605e5c;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1592,21 @@
     color: #323130;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #605e5c;
@@ -1644,7 +1656,7 @@
     background: #f3f2f1;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1712,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #605e5c;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #605e5c;
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1796,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1888,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -8px;
-    margin-left: -8px;
+    margin-inline-start: -8px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1897,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 16px;
     width: 16px;
-    margin-left: -8px;
+    margin-inline-start: -8px;
     margin-bottom: -8px;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1921,7 @@
     border-color: #005a9e;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1999,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #edebe9;
     color: #323130;
     border-radius: 16px;
@@ -1996,8 +2008,8 @@
     background: transparent;
     color: #605e5c;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #faf9f8;
@@ -2030,24 +2042,24 @@
     color: #323130;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2100,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #605e5c;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2189,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2201,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2241,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2629,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2696,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2715,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
   }
@@ -2722,32 +2743,41 @@
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #323130;
     background: #ffffff;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #323130;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #605e5c;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2786,7 @@
     line-height: 1.143rem;
     color: #323130;
     background: #edebe9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f2f1;
@@ -2789,9 +2819,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2856,7 @@
     box-shadow: inset 0 0 0 1px #605e5c;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #605e5c;
@@ -2859,58 +2892,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #faf9f8;
@@ -2957,18 +3038,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
   }
@@ -2982,11 +3072,14 @@
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-end-start-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3090,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3188,8 @@
     color: #323130;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3245,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3324,7 @@
     background: #a19f9d;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #a19f9d;
+    border-inline-end: 1px solid #a19f9d;
     border-color: #a19f9d;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3378,24 @@
     color: #323130;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-start-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3464,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3575,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #605e5c;
@@ -3502,11 +3595,11 @@
     box-shadow: inset 0 0 0 1px #605e5c;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #323130;
@@ -3548,14 +3641,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #605e5c;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3679,14 @@
     color: #323130;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #605e5c;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3703,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
   }
@@ -3626,25 +3731,34 @@
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #323130;
     background: #ffffff;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #323130;
     background: #ffffff;
@@ -3654,7 +3768,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #605e5c;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3777,7 @@
     line-height: 1.143rem;
     color: #323130;
     background: #edebe9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f2f1;
@@ -3685,9 +3799,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3815,7 @@
     background: transparent;
     border-radius: 2px;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #605e5c;
@@ -3715,7 +3832,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #323130;
@@ -3768,16 +3885,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3952,10 @@
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
   }
@@ -3837,11 +3969,14 @@
     background: #ffffff;
     color: #323130;
     border: 1px solid #f3f2f1;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 600;
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-end-start-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3989,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4005,8 @@
     background: #faf9f8;
     border-color: #a19f9d;
     color: #323130;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #a19f9d;
@@ -3884,10 +4019,10 @@
     background: #ffffff;
     color: #323130;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3916,7 +4051,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3937,7 +4075,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #edebe9;
+    border-inline-start: 1px #edebe9;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3968,7 +4106,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3989,8 +4127,8 @@
     padding: 1rem;
     background: #faf9f8;
     color: #323130;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4025,25 +4163,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #a19f9d;
     background: #ffffff;
     color: #323130;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4090,23 +4228,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 0 none;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #a19f9d;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent transparent transparent;
     background: #ffffff;
     color: #605e5c;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
     transition: box-shadow 0.2s;
-    margin: 0 0.5rem -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4124,13 +4271,13 @@
     color: #323130;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4149,8 +4296,8 @@
     padding: 1rem;
     border: 0 none;
     color: #323130;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
 
   .p-toolbar {
@@ -4257,7 +4404,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #605e5c;
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4314,7 +4461,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4323,7 +4470,7 @@
     margin-inline-start: calc(1.75rem + 2px);
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4337,11 +4484,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4371,7 +4521,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4384,8 +4534,8 @@
     background: #ffffff;
     color: #323130;
     padding: 1.5rem;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4399,7 +4549,7 @@
     background: transparent;
     border-radius: 2px;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #605e5c;
@@ -4412,28 +4562,37 @@
     box-shadow: inset 0 0 0 1px #605e5c;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #323130;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #323130;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4444,7 +4603,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4466,7 +4625,7 @@
     border-radius: 2px;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #106ebe;
@@ -4538,10 +4697,10 @@
     border-radius: 2px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #ffffff;
+    border-inline-end-color: #ffffff;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #ffffff;
+    border-inline-start-color: #ffffff;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #ffffff;
@@ -4556,11 +4715,11 @@
     border: 1px solid #a19f9d;
     color: #323130;
     border-bottom: 0 none;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4572,8 +4731,8 @@
     padding: 2rem 1rem;
     border: 1px solid #a19f9d;
     color: #323130;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #0078d4;
@@ -4623,7 +4782,10 @@
     color: #0078d4;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #323130;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4667,7 +4829,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
@@ -4814,7 +4976,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
@@ -4868,8 +5030,8 @@
     color: #0078d4;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4897,11 +5059,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #323130;
@@ -4938,7 +5100,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
@@ -4990,8 +5152,8 @@
     color: #0078d4;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #edebe9;
@@ -5006,9 +5168,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 2px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5035,11 +5197,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #323130;
@@ -5067,7 +5229,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
@@ -5166,11 +5328,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5182,33 +5347,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5228,10 +5399,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5247,8 +5418,8 @@
     background: #faf9f8;
     border-color: #a19f9d;
     color: #323130;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5262,10 +5433,10 @@
     background: #ffffff;
     color: #323130;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5285,7 +5456,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
@@ -5327,14 +5498,17 @@
     color: #0078d4;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #edebe9;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5369,7 +5543,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
@@ -5450,9 +5624,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 2px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5494,7 +5668,7 @@
     border-top: 1px solid #edebe9;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5503,7 +5677,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 0 none;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #0078d4;
@@ -5514,28 +5691,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 2px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #a19f9d;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent transparent transparent;
     background: #ffffff;
     color: #605e5c;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
     transition: box-shadow 0.2s;
-    margin: 0 0.5rem -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5553,10 +5736,10 @@
     color: #323130;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5609,7 +5792,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #0078d4;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #0078d4;
@@ -5705,7 +5888,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5715,7 +5898,7 @@
     font-size: 90%;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5743,7 +5926,10 @@
   .p-message.p-message-info {
     background: #f3f2f1;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5755,7 +5941,10 @@
   .p-message.p-message-success {
     background: #dff6dd;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5767,7 +5956,10 @@
   .p-message.p-message-warn {
     background: #fff4ce;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5779,7 +5971,10 @@
   .p-message.p-message-error {
     background: #fde7e9;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5794,7 +5989,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1rem;
@@ -5804,14 +5999,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 2px;
   }
@@ -5820,7 +6018,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 1.25rem;
@@ -5833,7 +6034,10 @@
     font-weight: 600;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 1.25rem;
@@ -5853,7 +6057,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #f3f2f1;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5863,7 +6070,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #dff6dd;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5873,7 +6083,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #fff4ce;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5883,7 +6096,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #fde7e9;
     border: 0 none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #323130;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5955,7 +6171,7 @@
     color: #323130;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6027,10 +6243,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6119,16 +6335,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 2px;
@@ -6232,12 +6448,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-start-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6247,12 +6463,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 2px;
-    border-top-right-radius: 2px;
+    border-start-start-radius: 2px;
+    border-start-end-radius: 2px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-end-start-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-progressbar {
@@ -6300,6 +6516,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #0078d4;
@@ -6326,7 +6545,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6392,7 +6611,10 @@
 
   .p-datepicker .p-datepicker-header .p-datepicker-title {
     order: 1;
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-datepicker .p-datepicker-prev {
     order: 2;

--- a/src/assets/components/themes/lara-dark-amber/theme.css
+++ b/src/assets/components/themes/lara-dark-amber/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #fbbf24;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #fbbf24;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(251, 191, 36, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #fbbf24;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1021,15 +1027,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: rgba(251, 191, 36, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1593,7 +1602,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #fbbf24;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2591,14 +2600,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2658,7 +2667,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2677,18 +2686,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2696,32 +2714,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2730,7 +2757,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(251, 191, 36, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2763,9 +2790,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2797,7 +2827,7 @@
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(251, 191, 36, 0.2);
@@ -2833,58 +2863,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -2931,18 +3009,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2956,11 +3043,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2971,7 +3061,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3069,8 +3159,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3126,10 +3216,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3205,7 +3295,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3259,24 +3349,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3345,10 +3435,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3456,7 +3546,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3476,11 +3566,11 @@
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3510,14 +3600,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3545,14 +3638,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3569,18 +3662,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3588,25 +3690,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3616,7 +3727,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3625,7 +3736,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(251, 191, 36, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3647,9 +3758,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3660,7 +3774,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3677,7 +3791,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3718,16 +3832,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3773,7 +3899,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3787,11 +3916,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3804,7 +3936,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3820,8 +3952,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3834,10 +3966,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3866,7 +3998,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3887,7 +4022,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3918,7 +4053,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3939,8 +4074,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3975,25 +4110,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4127,7 +4262,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4187,7 +4322,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4199,7 +4334,7 @@
     background-color: #fbbf24;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4208,23 +4343,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4242,13 +4386,13 @@
     color: #fbbf24;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4267,8 +4411,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4293,11 +4437,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4327,7 +4474,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4340,8 +4487,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4355,7 +4502,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4368,28 +4515,37 @@
     box-shadow: 0 0 0 0.2rem rgba(251, 191, 36, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4400,7 +4556,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4422,7 +4578,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #fcd34d;
@@ -4494,10 +4650,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4512,11 +4668,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4528,8 +4684,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #fbbf24;
@@ -4579,7 +4735,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4623,7 +4782,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4770,7 +4929,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4824,8 +4983,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4853,11 +5012,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4894,7 +5053,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4946,8 +5105,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -4962,9 +5121,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4991,11 +5150,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5023,7 +5182,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5122,11 +5281,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5138,33 +5300,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5184,10 +5352,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5203,8 +5371,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5218,10 +5386,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5241,7 +5409,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5283,14 +5451,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5325,7 +5496,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5406,9 +5577,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5450,7 +5621,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5459,7 +5630,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #fbbf24;
@@ -5470,28 +5644,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5509,10 +5689,10 @@
     color: #fbbf24;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5565,7 +5745,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5661,7 +5841,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5671,7 +5851,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5699,7 +5879,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5711,7 +5894,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5723,7 +5909,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5735,7 +5924,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5750,7 +5942,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5760,23 +5952,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5789,7 +5990,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5809,7 +6013,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5819,7 +6026,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5829,7 +6039,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5839,7 +6052,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5911,7 +6127,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5983,10 +6199,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6079,16 +6295,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6192,12 +6408,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6207,12 +6423,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6260,6 +6476,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #fbbf24;
@@ -6286,7 +6505,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-dark-blue/theme.css
+++ b/src/assets/components/themes/lara-dark-blue/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #60a5fa;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #60a5fa;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(96, 165, 250, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #60a5fa;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1051,15 +1057,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: rgba(96, 165, 250, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #424b57;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1661,7 +1670,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #60a5fa;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #424b57;
@@ -2047,24 +2056,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(96, 165, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(96, 165, 250, 0.2);
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(96, 165, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3950,10 +4082,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #60a5fa;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #60a5fa;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem rgba(96, 165, 250, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #93c5fd;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4628,11 +4784,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #60a5fa;
@@ -4695,7 +4851,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4940,8 +5099,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5062,8 +5221,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5399,14 +5567,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #60a5fa;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #60a5fa;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #60a5fa;
@@ -6450,7 +6681,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-dark-cyan/theme.css
+++ b/src/assets/components/themes/lara-dark-cyan/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #22d3ee;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #22d3ee;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(34, 211, 238, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #22d3ee;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1021,15 +1027,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: rgba(34, 211, 238, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1593,7 +1602,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #22d3ee;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2591,14 +2600,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2658,7 +2667,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2677,18 +2686,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2696,32 +2714,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2730,7 +2757,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(34, 211, 238, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2763,9 +2790,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2797,7 +2827,7 @@
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(34, 211, 238, 0.2);
@@ -2833,58 +2863,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -2931,18 +3009,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2956,11 +3043,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2971,7 +3061,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3069,8 +3159,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3126,10 +3216,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3205,7 +3295,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3259,24 +3349,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3345,10 +3435,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3456,7 +3546,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3476,11 +3566,11 @@
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3510,14 +3600,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3545,14 +3638,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3569,18 +3662,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3588,25 +3690,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3616,7 +3727,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3625,7 +3736,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(34, 211, 238, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3647,9 +3758,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3660,7 +3774,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3677,7 +3791,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3718,16 +3832,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3773,7 +3899,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3787,11 +3916,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3804,7 +3936,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3820,8 +3952,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3834,10 +3966,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3866,7 +3998,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3887,7 +4022,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3918,7 +4053,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3939,8 +4074,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3975,25 +4110,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4127,7 +4262,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4187,7 +4322,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4199,7 +4334,7 @@
     background-color: #22d3ee;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4208,23 +4343,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4242,13 +4386,13 @@
     color: #22d3ee;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4267,8 +4411,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4293,11 +4437,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4327,7 +4474,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4340,8 +4487,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4355,7 +4502,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4368,28 +4515,37 @@
     box-shadow: 0 0 0 0.2rem rgba(34, 211, 238, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4400,7 +4556,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4422,7 +4578,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #67e8f9;
@@ -4494,10 +4650,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4512,11 +4668,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4528,8 +4684,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #22d3ee;
@@ -4579,7 +4735,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4623,7 +4782,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4770,7 +4929,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4824,8 +4983,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4853,11 +5012,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4894,7 +5053,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4946,8 +5105,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -4962,9 +5121,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4991,11 +5150,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5023,7 +5182,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5122,11 +5281,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5138,33 +5300,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5184,10 +5352,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5203,8 +5371,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5218,10 +5386,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5241,7 +5409,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5283,14 +5451,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5325,7 +5496,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5406,9 +5577,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5450,7 +5621,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5459,7 +5630,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #22d3ee;
@@ -5470,28 +5644,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5509,10 +5689,10 @@
     color: #22d3ee;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5565,7 +5745,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5661,7 +5841,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5671,7 +5851,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5699,7 +5879,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5711,7 +5894,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5723,7 +5909,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5735,7 +5924,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5750,7 +5942,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5760,23 +5952,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5789,7 +5990,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5809,7 +6013,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5819,7 +6026,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5829,7 +6039,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5839,7 +6052,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5911,7 +6127,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5983,10 +6199,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6079,16 +6295,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6192,12 +6408,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6207,12 +6423,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6260,6 +6476,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #22d3ee;
@@ -6286,7 +6505,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-dark-green/theme.css
+++ b/src/assets/components/themes/lara-dark-green/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #34d399;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #34d399;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(52, 211, 153, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #34d399;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1021,15 +1027,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: rgba(52, 211, 153, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1593,7 +1602,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #34d399;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2591,14 +2600,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2658,7 +2667,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2677,18 +2686,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2696,32 +2714,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2730,7 +2757,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(52, 211, 153, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2763,9 +2790,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2797,7 +2827,7 @@
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(52, 211, 153, 0.2);
@@ -2833,58 +2863,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -2931,18 +3009,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2956,11 +3043,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2971,7 +3061,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3069,8 +3159,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3126,10 +3216,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3205,7 +3295,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3259,24 +3349,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3345,10 +3435,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3456,7 +3546,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3476,11 +3566,11 @@
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3510,14 +3600,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3545,14 +3638,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3569,18 +3662,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3588,25 +3690,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3616,7 +3727,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3625,7 +3736,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(52, 211, 153, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3647,9 +3758,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3660,7 +3774,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3677,7 +3791,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3718,16 +3832,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3773,7 +3899,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3787,11 +3916,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3804,7 +3936,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3820,8 +3952,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3834,10 +3966,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3866,7 +3998,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3887,7 +4022,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3918,7 +4053,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3939,8 +4074,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3975,25 +4110,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4127,7 +4262,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4187,7 +4322,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4199,7 +4334,7 @@
     background-color: #34d399;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4208,23 +4343,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4242,13 +4386,13 @@
     color: #34d399;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4267,8 +4411,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4293,11 +4437,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4327,7 +4474,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4340,8 +4487,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4355,7 +4502,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4368,28 +4515,37 @@
     box-shadow: 0 0 0 0.2rem rgba(52, 211, 153, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4400,7 +4556,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4422,7 +4578,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #6ee7b7;
@@ -4494,10 +4650,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4512,11 +4668,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4528,8 +4684,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #34d399;
@@ -4579,7 +4735,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4623,7 +4782,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4770,7 +4929,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4824,8 +4983,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4853,11 +5012,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4894,7 +5053,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4946,8 +5105,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -4962,9 +5121,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4991,11 +5150,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5023,7 +5182,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5122,11 +5281,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5138,33 +5300,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5184,10 +5352,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5203,8 +5371,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5218,10 +5386,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5241,7 +5409,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5283,14 +5451,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5325,7 +5496,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5406,9 +5577,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5450,7 +5621,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5459,7 +5630,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #34d399;
@@ -5470,28 +5644,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5509,10 +5689,10 @@
     color: #34d399;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5565,7 +5745,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5661,7 +5841,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5671,7 +5851,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5699,7 +5879,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5711,7 +5894,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5723,7 +5909,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5735,7 +5924,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5750,7 +5942,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5760,23 +5952,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5789,7 +5990,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5809,7 +6013,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5819,7 +6026,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5829,7 +6039,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5839,7 +6052,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5911,7 +6127,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5983,10 +6199,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6079,16 +6295,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6192,12 +6408,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6207,12 +6423,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6260,6 +6476,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #34d399;
@@ -6286,7 +6505,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-dark-indigo/theme.css
+++ b/src/assets/components/themes/lara-dark-indigo/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #818cf8;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #818cf8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(129, 140, 248, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #818cf8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1051,15 +1057,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: rgba(129, 140, 248, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #424b57;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1661,7 +1670,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #818cf8;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #424b57;
@@ -2047,24 +2056,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 140, 248, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(129, 140, 248, 0.2);
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 140, 248, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3950,10 +4082,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #818cf8;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #818cf8;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem rgba(129, 140, 248, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #a5b4fc;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4628,11 +4784,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #818cf8;
@@ -4695,7 +4851,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4940,8 +5099,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5062,8 +5221,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5399,14 +5567,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #818cf8;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #818cf8;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #818cf8;
@@ -6450,7 +6681,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-dark-pink/theme.css
+++ b/src/assets/components/themes/lara-dark-pink/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #f472b6;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #f472b6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(244, 114, 182, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #f472b6;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1021,15 +1027,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: rgba(244, 114, 182, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1593,7 +1602,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #f472b6;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2591,14 +2600,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2658,7 +2667,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2677,18 +2686,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2696,32 +2714,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2730,7 +2757,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(244, 114, 182, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2763,9 +2790,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2797,7 +2827,7 @@
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(244, 114, 182, 0.2);
@@ -2833,58 +2863,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -2931,18 +3009,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2956,11 +3043,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2971,7 +3061,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3069,8 +3159,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3126,10 +3216,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3205,7 +3295,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3259,24 +3349,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3345,10 +3435,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3456,7 +3546,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3476,11 +3566,11 @@
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3510,14 +3600,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3545,14 +3638,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3569,18 +3662,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3588,25 +3690,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3616,7 +3727,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3625,7 +3736,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(244, 114, 182, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3647,9 +3758,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3660,7 +3774,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3677,7 +3791,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3718,16 +3832,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3773,7 +3899,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3787,11 +3916,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3804,7 +3936,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3820,8 +3952,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3834,10 +3966,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3866,7 +3998,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3887,7 +4022,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3918,7 +4053,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3939,8 +4074,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3975,25 +4110,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4127,7 +4262,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4187,7 +4322,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4199,7 +4334,7 @@
     background-color: #f472b6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4208,23 +4343,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4242,13 +4386,13 @@
     color: #f472b6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4267,8 +4411,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4293,11 +4437,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4327,7 +4474,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4340,8 +4487,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4355,7 +4502,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4368,28 +4515,37 @@
     box-shadow: 0 0 0 0.2rem rgba(244, 114, 182, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4400,7 +4556,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4422,7 +4578,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #f9a8d4;
@@ -4494,10 +4650,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4512,11 +4668,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4528,8 +4684,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #f472b6;
@@ -4579,7 +4735,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4623,7 +4782,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4770,7 +4929,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4824,8 +4983,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4853,11 +5012,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4894,7 +5053,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4946,8 +5105,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -4962,9 +5121,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4991,11 +5150,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5023,7 +5182,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5122,11 +5281,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5138,33 +5300,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5184,10 +5352,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5203,8 +5371,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5218,10 +5386,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5241,7 +5409,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5283,14 +5451,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5325,7 +5496,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5406,9 +5577,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5450,7 +5621,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5459,7 +5630,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #f472b6;
@@ -5470,28 +5644,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5509,10 +5689,10 @@
     color: #f472b6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5565,7 +5745,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5661,7 +5841,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5671,7 +5851,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5699,7 +5879,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5711,7 +5894,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5723,7 +5909,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5735,7 +5924,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5750,7 +5942,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5760,23 +5952,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5789,7 +5990,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5809,7 +6013,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5819,7 +6026,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5829,7 +6039,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5839,7 +6052,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5911,7 +6127,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5983,10 +6199,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6079,16 +6295,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6192,12 +6408,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6207,12 +6423,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6260,6 +6476,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #f472b6;
@@ -6286,7 +6505,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-dark-purple/theme.css
+++ b/src/assets/components/themes/lara-dark-purple/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #a78bfa;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #a78bfa;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(167, 139, 250, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #a78bfa;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1051,15 +1057,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: rgba(167, 139, 250, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #424b57;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1661,7 +1670,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #a78bfa;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #424b57;
@@ -2047,24 +2056,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(167, 139, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(167, 139, 250, 0.2);
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(167, 139, 250, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3950,10 +4082,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #a78bfa;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #a78bfa;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem rgba(167, 139, 250, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #c4b5fd;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4628,11 +4784,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #a78bfa;
@@ -4695,7 +4851,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4940,8 +5099,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5062,8 +5221,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5399,14 +5567,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #a78bfa;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #a78bfa;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #a78bfa;
@@ -6450,7 +6681,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-dark-teal/theme.css
+++ b/src/assets/components/themes/lara-dark-teal/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2937;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #424b57;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #424b57;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #111827;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #2dd4bf;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #6b7280;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #424b57;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #2dd4bf;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: rgba(45, 212, 191, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #424b57;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #424b57;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #fca5a5;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #2dd4bf;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #fca5a5;
@@ -1051,15 +1057,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #424b57;
-    border-left: 1px solid #424b57;
+    border-inline-start: 1px solid #424b57;
     border-bottom: 1px solid #424b57;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: rgba(45, 212, 191, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #424b57;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1661,7 +1670,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #2dd4bf;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #424b57;
@@ -2047,24 +2056,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(45, 212, 191, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid rgba(45, 212, 191, 0.2);
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1c2532;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #424b57;
+    border-inline-end: 1px solid #424b57;
     border-color: #424b57;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2937;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(45, 212, 191, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #424b57;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #424b57;
@@ -3950,10 +4082,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #424b57;
+    border-inline-start: 1px #424b57;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #424b57;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #2dd4bf;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2937;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #2dd4bf;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem rgba(45, 212, 191, 0.2);
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #5eead4;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #424b57;
+    border-inline-end-color: #424b57;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #424b57;
+    border-inline-start-color: #424b57;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #424b57;
@@ -4628,11 +4784,11 @@
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #2dd4bf;
@@ -4695,7 +4851,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4940,8 +5099,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5062,8 +5221,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #374151;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #424b57;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #1f2937;
     border-color: #424b57;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #1f2937;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5399,14 +5567,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #424b57;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #424b57;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #2dd4bf;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #424b57;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #424b57 transparent;
     background: #1f2937;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #2dd4bf;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2937;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(59, 130, 246, 0.2);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #93c5fd;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(16, 185, 129, 0.2);
     border: solid #10b981;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6ee7b7;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(234, 179, 8, 0.2);
     border: solid #eab308;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fde047;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(239, 68, 68, 0.2);
     border: solid #ef4444;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #fca5a5;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #94a3b8;
     border: solid #94a3b8;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #020617;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid #ffffff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #111827;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #2dd4bf;
@@ -6450,7 +6681,7 @@
     color: #450a0a;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-amber/theme.css
+++ b/src/assets/components/themes/lara-light-amber/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #f59e0b;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #f59e0b;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #fffbeb;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #f59e0b;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1021,15 +1027,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: #fffbeb;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1593,7 +1602,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #f59e0b;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2542,14 +2551,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2609,7 +2618,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2628,18 +2637,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2647,32 +2665,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2681,7 +2708,7 @@
     line-height: 1.143rem;
     color: #b45309;
     background: #fffbeb;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2714,9 +2741,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2748,7 +2778,7 @@
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #fef08a;
@@ -2784,58 +2814,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -2882,18 +2960,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2907,11 +2994,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2922,7 +3012,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3020,8 +3110,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3077,10 +3167,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3156,7 +3246,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3210,24 +3300,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3296,10 +3386,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3407,7 +3497,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3427,11 +3517,11 @@
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3461,14 +3551,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3496,14 +3589,14 @@
     color: #b45309;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3520,18 +3613,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3539,25 +3641,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3567,7 +3678,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3576,7 +3687,7 @@
     line-height: 1.143rem;
     color: #b45309;
     background: #fffbeb;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3598,9 +3709,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3611,7 +3725,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3628,7 +3742,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3669,16 +3783,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3724,7 +3850,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3738,11 +3867,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3755,7 +3887,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3771,8 +3903,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3785,10 +3917,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3817,7 +3949,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3838,7 +3973,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3869,7 +4004,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3890,8 +4025,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3926,25 +4061,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4078,7 +4213,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4138,7 +4273,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4150,7 +4285,7 @@
     background-color: #f59e0b;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4159,23 +4294,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4193,13 +4337,13 @@
     color: #f59e0b;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4218,8 +4362,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4244,11 +4388,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4278,7 +4425,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4291,8 +4438,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4306,7 +4453,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4319,28 +4466,37 @@
     box-shadow: 0 0 0 0.2rem #fef08a;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4351,7 +4507,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4373,7 +4529,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #d97706;
@@ -4445,10 +4601,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4463,11 +4619,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4479,8 +4635,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #f59e0b;
@@ -4530,7 +4686,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4574,7 +4733,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4721,7 +4880,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4775,8 +4934,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4804,11 +4963,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4845,7 +5004,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4897,8 +5056,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -4913,9 +5072,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4942,11 +5101,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4974,7 +5133,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5073,11 +5232,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5089,33 +5251,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5135,10 +5303,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5154,8 +5322,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5169,10 +5337,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5192,7 +5360,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5234,14 +5402,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5276,7 +5447,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5357,9 +5528,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5401,7 +5572,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5410,7 +5581,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #f59e0b;
@@ -5421,28 +5595,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5460,10 +5640,10 @@
     color: #f59e0b;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5516,7 +5696,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5612,7 +5792,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5622,7 +5802,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5650,7 +5830,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5662,7 +5845,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5674,7 +5860,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5686,7 +5875,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5701,7 +5893,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5711,23 +5903,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5740,7 +5941,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5760,7 +5964,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5770,7 +5977,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5780,7 +5990,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5790,7 +6003,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5862,7 +6078,7 @@
     color: #b45309;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5934,10 +6150,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6030,16 +6246,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6143,12 +6359,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6158,12 +6374,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6211,6 +6427,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #f59e0b;
@@ -6237,7 +6456,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-blue/theme.css
+++ b/src/assets/components/themes/lara-light-blue/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #3B82F6;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #3B82F6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #EFF6FF;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #3B82F6;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1051,15 +1057,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: #EFF6FF;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f3f4f6;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1661,7 +1670,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #3B82F6;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f3f4f6;
@@ -2047,24 +2056,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: #1D4ED8;
     background: #EFF6FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #BFDBFE;
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: #1D4ED8;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: #1D4ED8;
     background: #EFF6FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3950,10 +4082,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #3B82F6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #3B82F6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem #BFDBFE;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #2563eb;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4628,11 +4784,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #3B82F6;
@@ -4695,7 +4851,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4940,8 +5099,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5062,8 +5221,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5399,14 +5567,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #3B82F6;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #3B82F6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: #1D4ED8;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #3B82F6;
@@ -6450,7 +6681,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-cyan/theme.css
+++ b/src/assets/components/themes/lara-light-cyan/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #06b6d4;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #06b6d4;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #ecfeff;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #06b6d4;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1021,15 +1027,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: #ecfeff;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1593,7 +1602,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #06b6d4;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2542,14 +2551,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2609,7 +2618,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2628,18 +2637,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2647,32 +2665,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2681,7 +2708,7 @@
     line-height: 1.143rem;
     color: #0e7490;
     background: #ecfeff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2714,9 +2741,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2748,7 +2778,7 @@
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #a5f3fc;
@@ -2784,58 +2814,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -2882,18 +2960,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2907,11 +2994,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2922,7 +3012,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3020,8 +3110,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3077,10 +3167,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3156,7 +3246,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3210,24 +3300,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3296,10 +3386,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3407,7 +3497,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3427,11 +3517,11 @@
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3461,14 +3551,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3496,14 +3589,14 @@
     color: #0e7490;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3520,18 +3613,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3539,25 +3641,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3567,7 +3678,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3576,7 +3687,7 @@
     line-height: 1.143rem;
     color: #0e7490;
     background: #ecfeff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3598,9 +3709,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3611,7 +3725,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3628,7 +3742,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3669,16 +3783,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3724,7 +3850,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3738,11 +3867,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3755,7 +3887,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3771,8 +3903,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3785,10 +3917,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3817,7 +3949,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3838,7 +3973,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3869,7 +4004,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3890,8 +4025,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3926,25 +4061,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4078,7 +4213,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4138,7 +4273,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4150,7 +4285,7 @@
     background-color: #06b6d4;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4159,23 +4294,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4193,13 +4337,13 @@
     color: #06b6d4;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4218,8 +4362,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4244,11 +4388,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4278,7 +4425,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4291,8 +4438,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4306,7 +4453,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4319,28 +4466,37 @@
     box-shadow: 0 0 0 0.2rem #a5f3fc;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4351,7 +4507,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4373,7 +4529,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0891b2;
@@ -4445,10 +4601,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4463,11 +4619,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4479,8 +4635,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #06b6d4;
@@ -4530,7 +4686,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4574,7 +4733,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4721,7 +4880,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4775,8 +4934,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4804,11 +4963,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4845,7 +5004,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4897,8 +5056,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -4913,9 +5072,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4942,11 +5101,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4974,7 +5133,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5073,11 +5232,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5089,33 +5251,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5135,10 +5303,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5154,8 +5322,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5169,10 +5337,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5192,7 +5360,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5234,14 +5402,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5276,7 +5447,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5357,9 +5528,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5401,7 +5572,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5410,7 +5581,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #06b6d4;
@@ -5421,28 +5595,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5460,10 +5640,10 @@
     color: #06b6d4;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5516,7 +5696,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5612,7 +5792,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5622,7 +5802,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5650,7 +5830,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5662,7 +5845,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5674,7 +5860,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5686,7 +5875,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5701,7 +5893,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5711,23 +5903,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5740,7 +5941,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5760,7 +5964,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5770,7 +5977,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5780,7 +5990,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5790,7 +6003,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5862,7 +6078,7 @@
     color: #0e7490;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5934,10 +6150,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6030,16 +6246,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6143,12 +6359,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6158,12 +6374,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6211,6 +6427,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #06b6d4;
@@ -6237,7 +6456,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-green/theme.css
+++ b/src/assets/components/themes/lara-light-green/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #10b981;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #10b981;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #F0FDFA;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #10b981;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1021,15 +1027,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: #F0FDFA;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1593,7 +1602,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #10b981;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2542,14 +2551,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2609,7 +2618,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2628,18 +2637,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2647,32 +2665,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2681,7 +2708,7 @@
     line-height: 1.143rem;
     color: #047857;
     background: #F0FDFA;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2714,9 +2741,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2748,7 +2778,7 @@
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #a7f3d0;
@@ -2784,58 +2814,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -2882,18 +2960,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2907,11 +2994,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2922,7 +3012,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3020,8 +3110,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3077,10 +3167,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3156,7 +3246,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3210,24 +3300,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3296,10 +3386,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3407,7 +3497,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3427,11 +3517,11 @@
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3461,14 +3551,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3496,14 +3589,14 @@
     color: #047857;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3520,18 +3613,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3539,25 +3641,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3567,7 +3678,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3576,7 +3687,7 @@
     line-height: 1.143rem;
     color: #047857;
     background: #F0FDFA;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3598,9 +3709,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3611,7 +3725,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3628,7 +3742,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3669,16 +3783,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3724,7 +3850,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3738,11 +3867,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3755,7 +3887,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3771,8 +3903,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3785,10 +3917,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3817,7 +3949,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3838,7 +3973,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3869,7 +4004,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3890,8 +4025,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3926,25 +4061,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4078,7 +4213,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4138,7 +4273,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4150,7 +4285,7 @@
     background-color: #10b981;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4159,23 +4294,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4193,13 +4337,13 @@
     color: #10b981;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4218,8 +4362,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4244,11 +4388,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4278,7 +4425,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4291,8 +4438,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4306,7 +4453,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4319,28 +4466,37 @@
     box-shadow: 0 0 0 0.2rem #a7f3d0;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4351,7 +4507,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4373,7 +4529,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #059669;
@@ -4445,10 +4601,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4463,11 +4619,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4479,8 +4635,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #10b981;
@@ -4530,7 +4686,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4574,7 +4733,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4721,7 +4880,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4775,8 +4934,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4804,11 +4963,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4845,7 +5004,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4897,8 +5056,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -4913,9 +5072,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4942,11 +5101,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4974,7 +5133,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5073,11 +5232,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5089,33 +5251,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5135,10 +5303,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5154,8 +5322,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5169,10 +5337,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5192,7 +5360,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5234,14 +5402,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5276,7 +5447,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5357,9 +5528,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5401,7 +5572,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5410,7 +5581,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #10b981;
@@ -5421,28 +5595,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5460,10 +5640,10 @@
     color: #10b981;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5516,7 +5696,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5612,7 +5792,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5622,7 +5802,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5650,7 +5830,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5662,7 +5845,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5674,7 +5860,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5686,7 +5875,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5701,7 +5893,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5711,23 +5903,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5740,7 +5941,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5760,7 +5964,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5770,7 +5977,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5780,7 +5990,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5790,7 +6003,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5862,7 +6078,7 @@
     color: #047857;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5934,10 +6150,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6030,16 +6246,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6143,12 +6359,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6158,12 +6374,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6211,6 +6427,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #10b981;
@@ -6237,7 +6456,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-indigo/theme.css
+++ b/src/assets/components/themes/lara-light-indigo/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #6366F1;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #6366F1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #EEF2FF;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #6366F1;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1051,15 +1057,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: #EEF2FF;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f3f4f6;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1661,7 +1670,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #6366F1;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f3f4f6;
@@ -2047,24 +2056,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: #4338CA;
     background: #EEF2FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #C7D2FE;
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: #4338CA;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: #4338CA;
     background: #EEF2FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3950,10 +4082,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #6366F1;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #6366F1;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem #C7D2FE;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #4F46E5;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4628,11 +4784,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #6366F1;
@@ -4695,7 +4851,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4940,8 +5099,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5062,8 +5221,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5399,14 +5567,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #6366F1;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #6366F1;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: #4338CA;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #6366F1;
@@ -6450,7 +6681,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-pink/theme.css
+++ b/src/assets/components/themes/lara-light-pink/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #ec4899;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #ec4899;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #fdf2f8;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -811,20 +811,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -887,7 +893,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -909,7 +915,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -919,7 +925,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -938,11 +944,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -980,7 +986,7 @@
     border-color: #ec4899;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -997,12 +1003,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1021,15 +1027,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1102,13 +1108,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1120,7 +1126,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1138,13 +1144,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1152,13 +1158,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1169,12 +1175,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1183,11 +1189,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.ng-dirty.ng-invalid > .p-inputnumber > .p-inputtext {
@@ -1195,18 +1201,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   .p-inputotp {
@@ -1233,13 +1239,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1297,7 +1306,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1308,38 +1317,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1391,18 +1400,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1424,7 +1433,7 @@
     background: #fdf2f8;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1488,20 +1497,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputwrapper-filled.p-multiselect.p-multiselect-chip .p-multiselect-label {
@@ -1509,11 +1518,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1529,21 +1538,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1593,7 +1602,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1649,19 +1658,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1721,7 +1730,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1813,13 +1822,13 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     width: 0.286rem;
   }
   .p-slider.p-slider-vertical .p-slider-handle {
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1843,7 +1852,7 @@
     border-color: #ec4899;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1921,7 +1930,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -1930,8 +1939,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   p-treeselect.ng-invalid.ng-dirty > .p-treeselect {
@@ -1955,24 +1964,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2013,11 +2022,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2102,10 +2111,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2114,7 +2123,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2154,10 +2163,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2542,14 +2551,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2609,7 +2618,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2628,18 +2637,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2647,32 +2665,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2681,7 +2708,7 @@
     line-height: 1.143rem;
     color: #be185d;
     background: #fdf2f8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2714,9 +2741,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2748,7 +2778,7 @@
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #fbcfe8;
@@ -2784,58 +2814,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -2882,18 +2960,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2907,11 +2994,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2922,7 +3012,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3020,8 +3110,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3077,10 +3167,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3156,7 +3246,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3210,24 +3300,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3296,10 +3386,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3407,7 +3497,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3427,11 +3517,11 @@
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3461,14 +3551,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3496,14 +3589,14 @@
     color: #be185d;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3520,18 +3613,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3539,25 +3641,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3567,7 +3678,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3576,7 +3687,7 @@
     line-height: 1.143rem;
     color: #be185d;
     background: #fdf2f8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3598,9 +3709,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3611,7 +3725,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3628,7 +3742,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3669,16 +3783,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3724,7 +3850,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3738,11 +3867,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3755,7 +3887,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3771,8 +3903,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3785,10 +3917,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3817,7 +3949,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3838,7 +3973,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3869,7 +4004,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3890,8 +4025,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -3926,25 +4061,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4078,7 +4213,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4138,7 +4273,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4150,7 +4285,7 @@
     background-color: #ec4899;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-tabview .p-tabview-nav-content {
@@ -4159,23 +4294,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4193,13 +4337,13 @@
     color: #ec4899;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4218,8 +4362,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4244,11 +4388,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4278,7 +4425,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4291,8 +4438,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4306,7 +4453,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4319,28 +4466,37 @@
     box-shadow: 0 0 0 0.2rem #fbcfe8;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4351,7 +4507,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4373,7 +4529,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #db2777;
@@ -4445,10 +4601,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4463,11 +4619,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4479,8 +4635,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #ec4899;
@@ -4530,7 +4686,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4574,7 +4733,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4721,7 +4880,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4775,8 +4934,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4804,11 +4963,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4845,7 +5004,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4897,8 +5056,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -4913,9 +5072,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -4942,11 +5101,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -4974,7 +5133,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5073,11 +5232,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5089,33 +5251,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5135,10 +5303,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5154,8 +5322,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5169,10 +5337,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5192,7 +5360,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5234,14 +5402,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5276,7 +5447,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5357,9 +5528,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5401,7 +5572,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5410,7 +5581,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #ec4899;
@@ -5421,28 +5595,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5460,10 +5640,10 @@
     color: #ec4899;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5516,7 +5696,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5612,7 +5792,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5622,7 +5802,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5650,7 +5830,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5662,7 +5845,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5674,7 +5860,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5686,7 +5875,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5701,7 +5893,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5711,23 +5903,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5740,7 +5941,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5760,7 +5964,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5770,7 +5977,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5780,7 +5990,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5790,7 +6003,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5862,7 +6078,7 @@
     color: #be185d;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -5934,10 +6150,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6030,16 +6246,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6143,12 +6359,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6158,12 +6374,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6211,6 +6427,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #ec4899;
@@ -6237,7 +6456,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-purple/theme.css
+++ b/src/assets/components/themes/lara-light-purple/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #8B5CF6;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #8B5CF6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #F5F3FF;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #8B5CF6;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1051,15 +1057,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: #F5F3FF;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f3f4f6;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1661,7 +1670,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #8B5CF6;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f3f4f6;
@@ -2047,24 +2056,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: #6D28D9;
     background: #F5F3FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #DDD6FE;
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: #6D28D9;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: #6D28D9;
     background: #F5F3FF;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3950,10 +4082,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #8B5CF6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #8B5CF6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem #DDD6FE;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #7C3AED;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4628,11 +4784,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #8B5CF6;
@@ -4695,7 +4851,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4940,8 +5099,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5062,8 +5221,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5399,14 +5567,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #8B5CF6;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #8B5CF6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: #6D28D9;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #8B5CF6;
@@ -6450,7 +6681,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/lara-light-teal/theme.css
+++ b/src/assets/components/themes/lara-light-teal/theme.css
@@ -192,8 +192,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f9fafb;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -244,8 +244,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -253,8 +253,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4b5563;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -365,10 +365,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #14b8a6;
@@ -401,7 +401,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d1d5db;
@@ -466,16 +466,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -511,8 +511,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -551,7 +551,7 @@
     color: #14b8a6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -659,18 +659,18 @@
     background: #f0fdfa;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e7eb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e7eb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f3f4f6;
@@ -698,16 +698,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6b7280;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -746,8 +746,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e24c4c;
@@ -820,20 +820,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -908,7 +914,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -930,7 +936,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -940,7 +946,7 @@
     color: #4b5563;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -959,11 +965,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1001,7 +1007,7 @@
     border-color: #14b8a6;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1018,12 +1024,12 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e24c4c;
@@ -1051,15 +1057,15 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1132,13 +1138,13 @@
     background: #f3f4f6;
     color: #6b7280;
     border-top: 1px solid #d1d5db;
-    border-left: 1px solid #d1d5db;
+    border-inline-start: 1px solid #d1d5db;
     border-bottom: 1px solid #d1d5db;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d1d5db;
+    border-inline-end: 1px solid #d1d5db;
   }
 
   .p-inputgroup > .p-component,
@@ -1150,7 +1156,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1168,13 +1174,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1182,13 +1188,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1199,12 +1205,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
@@ -1213,11 +1219,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1235,18 +1241,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1283,13 +1289,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1356,7 +1365,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
     transition-duration: 0.2s;
   }
@@ -1367,38 +1376,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1450,18 +1459,18 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1483,7 +1492,7 @@
     background: #f0fdfa;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1547,20 +1556,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f3f4f6;
@@ -1577,11 +1586,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1597,21 +1606,21 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -1661,7 +1670,7 @@
     background: #f3f4f6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1717,19 +1726,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6b7280;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6b7280;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1801,7 +1810,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1893,7 +1902,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1902,7 +1911,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1926,7 +1935,7 @@
     border-color: #14b8a6;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2004,7 +2013,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #4b5563;
     border-radius: 16px;
@@ -2013,8 +2022,8 @@
     background: transparent;
     color: #6b7280;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f3f4f6;
@@ -2047,24 +2056,24 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2105,11 +2114,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6b7280;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2194,10 +2203,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2206,7 +2215,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2246,10 +2255,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2683,14 +2692,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2750,7 +2759,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2769,18 +2778,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2788,32 +2806,41 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2822,7 +2849,7 @@
     line-height: 1.143rem;
     color: #0f766e;
     background: #f0fdfa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -2855,9 +2882,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2889,7 +2919,7 @@
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #99f6e4;
@@ -2925,58 +2955,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8fa;
@@ -3023,18 +3101,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3048,11 +3135,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3063,7 +3153,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3161,8 +3251,8 @@
     color: #374151;
     background: #f9fafb;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3218,10 +3308,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-orderlist .p-orderlist-list {
@@ -3297,7 +3387,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3351,24 +3441,24 @@
     color: #374151;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3437,10 +3527,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-picklist .p-picklist-list {
@@ -3548,7 +3638,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6b7280;
@@ -3568,11 +3658,11 @@
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6b7280;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3614,14 +3704,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #6b7280;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3649,14 +3742,14 @@
     color: #0f766e;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3673,18 +3766,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3692,25 +3794,34 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #374151;
     background: #f9fafb;
@@ -3720,7 +3831,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #374151;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3729,7 +3840,7 @@
     line-height: 1.143rem;
     color: #0f766e;
     background: #f0fdfa;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f3f4f6;
@@ -3751,9 +3862,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3764,7 +3878,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #374151;
@@ -3781,7 +3895,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4b5563;
@@ -3834,16 +3948,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3889,7 +4015,10 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3903,11 +4032,14 @@
     background: #f9fafb;
     color: #374151;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3920,7 +4052,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3936,8 +4068,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3950,10 +4082,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3982,7 +4114,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4003,7 +4138,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4034,7 +4169,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4055,8 +4190,8 @@
     padding: 1.25rem;
     background: #f9fafb;
     color: #374151;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4091,25 +4226,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4156,23 +4291,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4190,13 +4334,13 @@
     color: #14b8a6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4215,8 +4359,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4323,7 +4467,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6b7280;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4383,7 +4527,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4395,7 +4539,7 @@
     background-color: #14b8a6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4409,11 +4553,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4443,7 +4590,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4456,8 +4603,8 @@
     background: #ffffff;
     color: #374151;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4471,7 +4618,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #374151;
@@ -4484,28 +4631,37 @@
     box-shadow: 0 0 0 0.2rem #99f6e4;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4b5563;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4516,7 +4672,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4538,7 +4694,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0d9488;
@@ -4610,10 +4766,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4b5563;
+    border-inline-end-color: #4b5563;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4b5563;
+    border-inline-start-color: #4b5563;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4b5563;
@@ -4628,11 +4784,11 @@
     border: 1px solid #e5e7eb;
     color: #374151;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4644,8 +4800,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #4b5563;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #14b8a6;
@@ -4695,7 +4851,10 @@
     color: #6b7280;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4b5563;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4739,7 +4898,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4886,7 +5045,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -4940,8 +5099,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4969,11 +5128,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5010,7 +5169,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5062,8 +5221,8 @@
     color: #374151;
     background: #ffffff;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
@@ -5078,9 +5237,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5107,11 +5266,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4b5563;
@@ -5139,7 +5298,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5238,11 +5397,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5254,33 +5416,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5300,10 +5468,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5319,8 +5487,8 @@
     background: #f9fafb;
     border-color: #e5e7eb;
     color: #374151;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5334,10 +5502,10 @@
     background: #ffffff;
     color: #4b5563;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5357,7 +5525,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5399,14 +5567,17 @@
     color: #6b7280;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e7eb;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5441,7 +5612,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5522,9 +5693,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5566,7 +5737,7 @@
     border-top: 1px solid #e5e7eb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5575,7 +5746,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #14b8a6;
@@ -5586,28 +5760,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #6b7280;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5625,10 +5805,10 @@
     color: #14b8a6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5681,7 +5861,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6b7280;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6b7280;
@@ -5777,7 +5957,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5787,7 +5967,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5815,7 +5995,10 @@
   .p-message.p-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5827,7 +6010,10 @@
   .p-message.p-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5839,7 +6025,10 @@
   .p-message.p-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5851,7 +6040,10 @@
   .p-message.p-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5866,7 +6058,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5876,12 +6068,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5893,7 +6088,10 @@
   .p-message.p-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5907,16 +6105,25 @@
     opacity: 1;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5929,7 +6136,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5949,7 +6159,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: rgba(219, 234, 254, 0.7);
     border: solid #3b82f6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3b82f6;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5959,7 +6172,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: rgba(228, 248, 240, 0.7);
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5969,7 +6185,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: rgba(255, 242, 226, 0.7);
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5979,7 +6198,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: rgba(255, 231, 230, 0.7);
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5989,7 +6211,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #64748b;
     border: solid #64748b;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -5999,7 +6224,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #1f2937;
     border: solid #1f2937;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6071,7 +6299,7 @@
     color: #0f766e;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6143,10 +6371,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6243,16 +6471,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6356,12 +6584,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6371,12 +6599,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6424,6 +6652,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #14b8a6;
@@ -6450,7 +6681,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/luna-amber/theme.css
+++ b/src/assets/components/themes/luna-amber/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #191919;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #191919;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #191919;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #191919;
   color: #dedede;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #FFE082;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #FFE082;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #FFE082;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #4b4b4b;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #4b4b4b;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #FFE082;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #4b4b4b;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #4b4b4b;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #4c4c4c;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +929,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -927,7 +939,7 @@
     color: #dedede;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -946,11 +958,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +1000,7 @@
     border-color: #FFE082;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1017,12 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
@@ -1038,15 +1050,15 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1131,13 @@
     background: #252525;
     color: #888888;
     border-top: 1px solid #4b4b4b;
-    border-left: 1px solid #4b4b4b;
+    border-inline-start: 1px solid #4b4b4b;
     border-bottom: 1px solid #4b4b4b;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #4b4b4b;
+    border-inline-end: 1px solid #4b4b4b;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1149,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1167,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1181,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1198,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
@@ -1200,11 +1212,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1234,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1282,16 @@
     background: #323232;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1358,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
@@ -1354,38 +1369,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1452,18 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1470,7 +1485,7 @@
     background: #FFE082;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1549,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #4b4b4b;
@@ -1564,11 +1579,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1599,21 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -1648,7 +1663,7 @@
     background: #4c4c4c;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1719,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #888888;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1803,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1903,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1912,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1936,7 @@
     border-color: #FFE082;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1999,7 +2014,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -2008,8 +2023,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #4b4b4b;
@@ -2042,24 +2057,24 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2115,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2204,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2216,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2256,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2629,14 +2644,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2696,7 +2711,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2715,18 +2730,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2734,22 +2758,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -2759,7 +2789,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2768,7 +2798,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #FFE082;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -2801,7 +2831,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2835,7 +2865,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid white;
@@ -2871,58 +2901,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #323232;
@@ -2969,18 +3047,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2994,11 +3081,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3009,7 +3099,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3107,8 +3197,8 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3164,10 +3254,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-orderlist .p-orderlist-list {
@@ -3243,7 +3333,7 @@
     background: #191919;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #191919;
+    border-inline-end: 1px solid #191919;
     border-color: #191919;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3297,24 +3387,24 @@
     color: #4c4c4c;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3383,10 +3473,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-picklist .p-picklist-list {
@@ -3494,7 +3584,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -3514,11 +3604,11 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #888888;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3560,14 +3650,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3595,14 +3688,14 @@
     color: #212529;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #888888;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3619,18 +3712,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3638,22 +3740,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -3666,7 +3774,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3675,7 +3783,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #FFE082;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -3697,7 +3805,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3710,7 +3818,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #dedede;
@@ -3727,7 +3835,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3780,16 +3888,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3835,7 +3955,10 @@
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3849,11 +3972,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3866,7 +3992,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3882,8 +4008,8 @@
     background: #FFE082;
     border-color: #FFE082;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #FFCA28;
@@ -3896,10 +4022,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3928,7 +4054,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3949,7 +4078,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #4b4b4b;
+    border-inline-start: 1px #4b4b4b;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3980,7 +4109,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4001,8 +4130,8 @@
     padding: 0.857rem 1rem;
     background: #191919;
     color: #dedede;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4037,25 +4166,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     background: #323232;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4105,7 +4234,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #191919;
@@ -4115,10 +4244,13 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4136,13 +4268,13 @@
     color: #212529;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #FFE082;
@@ -4161,8 +4293,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4269,7 +4401,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #888888;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4329,7 +4461,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4341,7 +4473,7 @@
     background-color: #FFE082;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4355,11 +4487,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4389,7 +4524,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4402,8 +4537,8 @@
     background: #191919;
     color: #dedede;
     padding: 1rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4417,7 +4552,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #dedede;
@@ -4430,7 +4565,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #323232;
@@ -4438,20 +4573,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #191919;
     background: #323232;
     color: #dedede;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4462,7 +4600,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4484,7 +4622,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #FFD54F;
@@ -4556,10 +4694,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4c4c4c;
+    border-inline-end-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4c4c4c;
+    border-inline-start-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4c4c4c;
@@ -4574,11 +4712,11 @@
     border: 1px solid #191919;
     color: #dedede;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4590,8 +4728,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #FFE082;
@@ -4641,7 +4779,10 @@
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4685,7 +4826,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4832,7 +4973,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4886,8 +5027,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4915,11 +5056,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -4956,7 +5097,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5008,8 +5149,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
@@ -5024,9 +5165,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5053,11 +5194,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -5085,7 +5226,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5184,11 +5325,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5200,33 +5344,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5246,10 +5396,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5265,8 +5415,8 @@
     background: #FFE082;
     border-color: #FFE082;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5280,10 +5430,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5303,7 +5453,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5345,14 +5495,17 @@
     color: #dedede;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5387,7 +5540,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5468,9 +5621,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5512,7 +5665,7 @@
     border-top: 1px solid #4b4b4b;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5532,12 +5685,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #191919;
@@ -5547,13 +5700,16 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5571,10 +5727,10 @@
     color: #212529;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #FFE082;
@@ -5627,7 +5783,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5723,7 +5879,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5733,7 +5889,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5812,7 +5968,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5822,14 +5978,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 3px;
   }
@@ -5838,7 +5997,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5851,7 +6013,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5973,7 +6138,7 @@
     color: #212529;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6045,10 +6210,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6137,16 +6302,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6250,12 +6415,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6265,12 +6430,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6318,6 +6483,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #FFE082;
@@ -6344,7 +6512,7 @@
     color: #212529;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/luna-blue/theme.css
+++ b/src/assets/components/themes/luna-blue/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #191919;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #191919;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #191919;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #191919;
   color: #dedede;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #81D4FA;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #81D4FA;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #81D4FA;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #4b4b4b;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #4b4b4b;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #81D4FA;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #4b4b4b;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #4b4b4b;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #4c4c4c;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +929,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -927,7 +939,7 @@
     color: #dedede;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -946,11 +958,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +1000,7 @@
     border-color: #81D4FA;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1017,12 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
@@ -1038,15 +1050,15 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1131,13 @@
     background: #252525;
     color: #888888;
     border-top: 1px solid #4b4b4b;
-    border-left: 1px solid #4b4b4b;
+    border-inline-start: 1px solid #4b4b4b;
     border-bottom: 1px solid #4b4b4b;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #4b4b4b;
+    border-inline-end: 1px solid #4b4b4b;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1149,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1167,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1181,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1198,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
@@ -1200,11 +1212,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1234,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1282,16 @@
     background: #323232;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1358,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
@@ -1354,38 +1369,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1452,18 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1470,7 +1485,7 @@
     background: #81D4FA;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1549,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #4b4b4b;
@@ -1564,11 +1579,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1599,21 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -1648,7 +1663,7 @@
     background: #4c4c4c;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1719,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #888888;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1803,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1903,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1912,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1936,7 @@
     border-color: #81D4FA;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1999,7 +2014,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -2008,8 +2023,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #4b4b4b;
@@ -2042,24 +2057,24 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2115,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2204,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2216,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2256,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2629,14 +2644,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2696,7 +2711,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2715,18 +2730,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2734,22 +2758,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -2759,7 +2789,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2768,7 +2798,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #81D4FA;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -2801,7 +2831,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2835,7 +2865,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid white;
@@ -2871,58 +2901,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #323232;
@@ -2969,18 +3047,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2994,11 +3081,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3009,7 +3099,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3107,8 +3197,8 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3164,10 +3254,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-orderlist .p-orderlist-list {
@@ -3243,7 +3333,7 @@
     background: #191919;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #191919;
+    border-inline-end: 1px solid #191919;
     border-color: #191919;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3297,24 +3387,24 @@
     color: #4c4c4c;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3383,10 +3473,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-picklist .p-picklist-list {
@@ -3494,7 +3584,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -3514,11 +3604,11 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #888888;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3560,14 +3650,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3595,14 +3688,14 @@
     color: #212529;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #888888;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3619,18 +3712,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3638,22 +3740,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -3666,7 +3774,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3675,7 +3783,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #81D4FA;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -3697,7 +3805,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3710,7 +3818,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #dedede;
@@ -3727,7 +3835,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3780,16 +3888,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3835,7 +3955,10 @@
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3849,11 +3972,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3866,7 +3992,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3882,8 +4008,8 @@
     background: #81D4FA;
     border-color: #81D4FA;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #29B6F6;
@@ -3896,10 +4022,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3928,7 +4054,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3949,7 +4078,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #4b4b4b;
+    border-inline-start: 1px #4b4b4b;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3980,7 +4109,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4001,8 +4130,8 @@
     padding: 0.857rem 1rem;
     background: #191919;
     color: #dedede;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4037,25 +4166,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     background: #323232;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4105,7 +4234,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #191919;
@@ -4115,10 +4244,13 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4136,13 +4268,13 @@
     color: #212529;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #81D4FA;
@@ -4161,8 +4293,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4269,7 +4401,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #888888;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4329,7 +4461,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4341,7 +4473,7 @@
     background-color: #81D4FA;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4355,11 +4487,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4389,7 +4524,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4402,8 +4537,8 @@
     background: #191919;
     color: #dedede;
     padding: 1rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4417,7 +4552,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #dedede;
@@ -4430,7 +4565,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #323232;
@@ -4438,20 +4573,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #191919;
     background: #323232;
     color: #dedede;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4462,7 +4600,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4484,7 +4622,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #4FC3F7;
@@ -4556,10 +4694,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4c4c4c;
+    border-inline-end-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4c4c4c;
+    border-inline-start-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4c4c4c;
@@ -4574,11 +4712,11 @@
     border: 1px solid #191919;
     color: #dedede;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4590,8 +4728,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #81D4FA;
@@ -4641,7 +4779,10 @@
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4685,7 +4826,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4832,7 +4973,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4886,8 +5027,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4915,11 +5056,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -4956,7 +5097,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5008,8 +5149,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
@@ -5024,9 +5165,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5053,11 +5194,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -5085,7 +5226,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5184,11 +5325,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5200,33 +5344,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5246,10 +5396,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5265,8 +5415,8 @@
     background: #81D4FA;
     border-color: #81D4FA;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5280,10 +5430,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5303,7 +5453,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5345,14 +5495,17 @@
     color: #dedede;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5387,7 +5540,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5468,9 +5621,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5512,7 +5665,7 @@
     border-top: 1px solid #4b4b4b;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5532,12 +5685,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #191919;
@@ -5547,13 +5700,16 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5571,10 +5727,10 @@
     color: #212529;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #81D4FA;
@@ -5627,7 +5783,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5723,7 +5879,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5733,7 +5889,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5812,7 +5968,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5822,14 +5978,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 3px;
   }
@@ -5838,7 +5997,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5851,7 +6013,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5973,7 +6138,7 @@
     color: #212529;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6045,10 +6210,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6137,16 +6302,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6250,12 +6415,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6265,12 +6430,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6318,6 +6483,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #81D4FA;
@@ -6344,7 +6512,7 @@
     color: #212529;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/luna-green/theme.css
+++ b/src/assets/components/themes/luna-green/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #191919;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #191919;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #191919;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #191919;
   color: #dedede;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #C5E1A5;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #C5E1A5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #C5E1A5;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #4b4b4b;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #4b4b4b;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #C5E1A5;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #4b4b4b;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #4b4b4b;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #4c4c4c;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +929,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -927,7 +939,7 @@
     color: #dedede;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -946,11 +958,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +1000,7 @@
     border-color: #C5E1A5;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1017,12 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
@@ -1038,15 +1050,15 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1131,13 @@
     background: #252525;
     color: #888888;
     border-top: 1px solid #4b4b4b;
-    border-left: 1px solid #4b4b4b;
+    border-inline-start: 1px solid #4b4b4b;
     border-bottom: 1px solid #4b4b4b;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #4b4b4b;
+    border-inline-end: 1px solid #4b4b4b;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1149,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1167,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1181,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1198,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
@@ -1200,11 +1212,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1234,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1282,16 @@
     background: #323232;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1358,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
@@ -1354,38 +1369,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1452,18 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1470,7 +1485,7 @@
     background: #C5E1A5;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1549,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #4b4b4b;
@@ -1564,11 +1579,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1599,21 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -1648,7 +1663,7 @@
     background: #4c4c4c;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1719,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #888888;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1803,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1903,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1912,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1936,7 @@
     border-color: #C5E1A5;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1999,7 +2014,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -2008,8 +2023,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #4b4b4b;
@@ -2042,24 +2057,24 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2115,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2204,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2216,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2256,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2629,14 +2644,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2696,7 +2711,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2715,18 +2730,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2734,22 +2758,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -2759,7 +2789,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2768,7 +2798,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #C5E1A5;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -2801,7 +2831,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2835,7 +2865,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid white;
@@ -2871,58 +2901,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #323232;
@@ -2969,18 +3047,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2994,11 +3081,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3009,7 +3099,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3107,8 +3197,8 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3164,10 +3254,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-orderlist .p-orderlist-list {
@@ -3243,7 +3333,7 @@
     background: #191919;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #191919;
+    border-inline-end: 1px solid #191919;
     border-color: #191919;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3297,24 +3387,24 @@
     color: #4c4c4c;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3383,10 +3473,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-picklist .p-picklist-list {
@@ -3494,7 +3584,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -3514,11 +3604,11 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #888888;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3560,14 +3650,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3595,14 +3688,14 @@
     color: #212529;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #888888;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3619,18 +3712,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3638,22 +3740,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -3666,7 +3774,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3675,7 +3783,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #C5E1A5;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -3697,7 +3805,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3710,7 +3818,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #dedede;
@@ -3727,7 +3835,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3780,16 +3888,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3835,7 +3955,10 @@
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3849,11 +3972,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3866,7 +3992,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3882,8 +4008,8 @@
     background: #C5E1A5;
     border-color: #C5E1A5;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #9CCC65;
@@ -3896,10 +4022,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3928,7 +4054,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3949,7 +4078,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #4b4b4b;
+    border-inline-start: 1px #4b4b4b;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3980,7 +4109,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4001,8 +4130,8 @@
     padding: 0.857rem 1rem;
     background: #191919;
     color: #dedede;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4037,25 +4166,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     background: #323232;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4105,7 +4234,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #191919;
@@ -4115,10 +4244,13 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4136,13 +4268,13 @@
     color: #212529;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #C5E1A5;
@@ -4161,8 +4293,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4269,7 +4401,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #888888;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4329,7 +4461,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4341,7 +4473,7 @@
     background-color: #C5E1A5;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4355,11 +4487,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4389,7 +4524,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4402,8 +4537,8 @@
     background: #191919;
     color: #dedede;
     padding: 1rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4417,7 +4552,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #dedede;
@@ -4430,7 +4565,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #323232;
@@ -4438,20 +4573,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #191919;
     background: #323232;
     color: #dedede;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4462,7 +4600,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4484,7 +4622,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #AED581;
@@ -4556,10 +4694,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4c4c4c;
+    border-inline-end-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4c4c4c;
+    border-inline-start-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4c4c4c;
@@ -4574,11 +4712,11 @@
     border: 1px solid #191919;
     color: #dedede;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4590,8 +4728,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #C5E1A5;
@@ -4641,7 +4779,10 @@
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4685,7 +4826,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4832,7 +4973,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4886,8 +5027,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4915,11 +5056,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -4956,7 +5097,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5008,8 +5149,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
@@ -5024,9 +5165,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5053,11 +5194,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -5085,7 +5226,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5184,11 +5325,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5200,33 +5344,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5246,10 +5396,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5265,8 +5415,8 @@
     background: #C5E1A5;
     border-color: #C5E1A5;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5280,10 +5430,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5303,7 +5453,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5345,14 +5495,17 @@
     color: #dedede;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5387,7 +5540,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5468,9 +5621,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5512,7 +5665,7 @@
     border-top: 1px solid #4b4b4b;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5532,12 +5685,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #191919;
@@ -5547,13 +5700,16 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5571,10 +5727,10 @@
     color: #212529;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #C5E1A5;
@@ -5627,7 +5783,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5723,7 +5879,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5733,7 +5889,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5812,7 +5968,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5822,14 +5978,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 3px;
   }
@@ -5838,7 +5997,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5851,7 +6013,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5973,7 +6138,7 @@
     color: #212529;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6045,10 +6210,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6137,16 +6302,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6250,12 +6415,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6265,12 +6430,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6318,6 +6483,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #C5E1A5;
@@ -6344,7 +6512,7 @@
     color: #212529;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/luna-pink/theme.css
+++ b/src/assets/components/themes/luna-pink/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #191919;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #191919;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #191919;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #191919;
   color: #dedede;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #F48FB1;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #464646;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #F48FB1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #F48FB1;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #4b4b4b;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #4b4b4b;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #F48FB1;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #4b4b4b;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #4b4b4b;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #4c4c4c;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #888888;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e57373;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +929,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -927,7 +939,7 @@
     color: #dedede;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -946,11 +958,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +1000,7 @@
     border-color: #F48FB1;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1017,12 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e57373;
@@ -1038,15 +1050,15 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1131,13 @@
     background: #252525;
     color: #888888;
     border-top: 1px solid #4b4b4b;
-    border-left: 1px solid #4b4b4b;
+    border-inline-start: 1px solid #4b4b4b;
     border-bottom: 1px solid #4b4b4b;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #4b4b4b;
+    border-inline-end: 1px solid #4b4b4b;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1149,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1167,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1181,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1198,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
@@ -1200,11 +1212,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1234,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1282,16 @@
     background: #323232;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1358,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #9b9b9b;
     transition-duration: 0.2s;
   }
@@ -1354,38 +1369,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1452,18 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1470,7 +1485,7 @@
     background: #F48FB1;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1549,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #4b4b4b;
@@ -1564,11 +1579,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1599,21 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -1648,7 +1663,7 @@
     background: #4c4c4c;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1719,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #888888;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #888888;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1803,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1903,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1912,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1936,7 @@
     border-color: #F48FB1;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1999,7 +2014,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #4b4b4b;
     color: #dedede;
     border-radius: 16px;
@@ -2008,8 +2023,8 @@
     background: transparent;
     color: #888888;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #4b4b4b;
@@ -2042,24 +2057,24 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2115,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #888888;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2204,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2216,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2256,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2629,14 +2644,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2696,7 +2711,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2715,18 +2730,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2734,22 +2758,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -2759,7 +2789,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2768,7 +2798,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #F48FB1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -2801,7 +2831,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2835,7 +2865,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid white;
@@ -2871,58 +2901,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #323232;
@@ -2969,18 +3047,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2994,11 +3081,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3009,7 +3099,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3107,8 +3197,8 @@
     color: #dedede;
     background: #252525;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3164,10 +3254,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-orderlist .p-orderlist-list {
@@ -3243,7 +3333,7 @@
     background: #191919;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #191919;
+    border-inline-end: 1px solid #191919;
     border-color: #191919;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3297,24 +3387,24 @@
     color: #4c4c4c;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3383,10 +3473,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-picklist .p-picklist-list {
@@ -3494,7 +3584,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #8888;
@@ -3514,11 +3604,11 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #888888;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3560,14 +3650,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #888888;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3595,14 +3688,14 @@
     color: #212529;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #888888;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3619,18 +3712,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3638,22 +3740,28 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #dedede;
     background: #252525;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #191919;
     border-width: 1px;
@@ -3666,7 +3774,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #888888;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3675,7 +3783,7 @@
     line-height: 1.143rem;
     color: #212529;
     background: #F48FB1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #4c4c4c;
@@ -3697,7 +3805,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #191919;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3710,7 +3818,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #dedede;
@@ -3727,7 +3835,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #dedede;
@@ -3780,16 +3888,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3835,7 +3955,10 @@
     background: #191919;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3849,11 +3972,14 @@
     background: #323232;
     color: #dedede;
     border: 1px solid #191919;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3866,7 +3992,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3882,8 +4008,8 @@
     background: #F48FB1;
     border-color: #F48FB1;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #EC407A;
@@ -3896,10 +4022,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3928,7 +4054,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3949,7 +4078,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #4b4b4b;
+    border-inline-start: 1px #4b4b4b;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3980,7 +4109,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4001,8 +4130,8 @@
     padding: 0.857rem 1rem;
     background: #191919;
     color: #dedede;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4037,25 +4166,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     background: #323232;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4105,7 +4234,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #191919;
@@ -4115,10 +4244,13 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4136,13 +4268,13 @@
     color: #212529;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #F48FB1;
@@ -4161,8 +4293,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4269,7 +4401,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #888888;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4329,7 +4461,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4341,7 +4473,7 @@
     background-color: #F48FB1;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4355,11 +4487,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4389,7 +4524,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4402,8 +4537,8 @@
     background: #191919;
     color: #dedede;
     padding: 1rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4417,7 +4552,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #dedede;
@@ -4430,7 +4565,7 @@
     box-shadow: 0 0 0 0.1rem white;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #323232;
@@ -4438,20 +4573,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #191919;
     background: #323232;
     color: #dedede;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4462,7 +4600,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4484,7 +4622,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #F06292;
@@ -4556,10 +4694,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4c4c4c;
+    border-inline-end-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4c4c4c;
+    border-inline-start-color: #4c4c4c;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4c4c4c;
@@ -4574,11 +4712,11 @@
     border: 1px solid #191919;
     color: #dedede;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4590,8 +4728,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #191919;
     color: #dedede;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #F48FB1;
@@ -4641,7 +4779,10 @@
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #dedede;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4685,7 +4826,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4832,7 +4973,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -4886,8 +5027,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4915,11 +5056,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -4956,7 +5097,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5008,8 +5149,8 @@
     color: #dedede;
     background: #191919;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
@@ -5024,9 +5165,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5053,11 +5194,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #dedede;
@@ -5085,7 +5226,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5184,11 +5325,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5200,33 +5344,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5246,10 +5396,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5265,8 +5415,8 @@
     background: #F48FB1;
     border-color: #F48FB1;
     color: #212529;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5280,10 +5430,10 @@
     background: #323232;
     color: #dedede;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5303,7 +5453,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5345,14 +5495,17 @@
     color: #dedede;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #4b4b4b;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5387,7 +5540,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5468,9 +5621,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5512,7 +5665,7 @@
     border-top: 1px solid #4b4b4b;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5532,12 +5685,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #191919;
@@ -5547,13 +5700,16 @@
     color: #dedede;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5571,10 +5727,10 @@
     color: #212529;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #F48FB1;
@@ -5627,7 +5783,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #dedede;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #dedede;
@@ -5723,7 +5879,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5733,7 +5889,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5812,7 +5968,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5822,14 +5978,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 3px;
   }
@@ -5838,7 +5997,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5851,7 +6013,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5973,7 +6138,7 @@
     color: #212529;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6045,10 +6210,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6137,16 +6302,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6250,12 +6415,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6265,12 +6430,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6318,6 +6483,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #F48FB1;
@@ -6344,7 +6512,7 @@
     color: #212529;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/md-dark-deeppurple/theme.css
+++ b/src/assets/components/themes/md-dark-deeppurple/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -250,8 +250,8 @@
   padding: 1rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #1e1e1e;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(255, 255, 255, 0.6);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(255, 255, 255, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #CE93D8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(206, 147, 216, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 1rem;
+    padding-inline-end: 1rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.5rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #CE93D8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
@@ -1057,15 +1063,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 2rem;
-    margin-right: -2rem;
+    padding-inline-end: 2rem;
+    margin-inline-end: -2rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.3);
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
     padding: 1rem 1rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.3);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #bdbdbd;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(206, 147, 216, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: rgba(255, 255, 255, 0.06);
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(255, 255, 255, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 5rem;
+    padding-inline-end: 5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: rgba(255, 255, 255, 0.06);
@@ -2053,24 +2062,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 4rem;
+    padding-inline-end: 4rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2.5rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #222222;
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid rgba(255, 255, 255, 0.12);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.12);
     border-color: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #CE93D8;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-inline-start: 1px rgba(255, 255, 255, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 1rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 1rem 1rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #CE93D8;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: transparent;
@@ -4245,8 +4389,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #CE93D8;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 1rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 1rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1.25rem;
-    right: -1.25rem;
+    inset-inline-end: -1.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(206, 147, 216, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #444444;
+    border-inline-end-color: #444444;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #444444;
+    border-inline-start-color: #444444;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #444444;
@@ -4658,11 +4811,11 @@
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #CE93D8;
@@ -4725,7 +4878,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3rem;
+      padding-inline-start: 3rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5rem;
+      padding-inline-start: 5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7rem;
+      padding-inline-start: 7rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9rem;
+      padding-inline-start: 9rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 11rem;
+      padding-inline-start: 11rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #CE93D8;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #CE93D8;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: transparent;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #A5D6A7;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.5rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #A5D6A7;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #CE93D8;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.5rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.5rem;
     height: 2.5rem;
-    margin-left: -1rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -1rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #CE93D8;
@@ -6504,7 +6732,7 @@
     color: #212121;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(255, 255, 255, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #121212;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #121212;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(255, 255, 255, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(3rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/md-dark-indigo/theme.css
+++ b/src/assets/components/themes/md-dark-indigo/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -250,8 +250,8 @@
   padding: 1rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #1e1e1e;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(255, 255, 255, 0.6);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(255, 255, 255, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #9FA8DA;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(159, 168, 218, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 1rem;
+    padding-inline-end: 1rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.5rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #9FA8DA;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
@@ -1057,15 +1063,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 2rem;
-    margin-right: -2rem;
+    padding-inline-end: 2rem;
+    margin-inline-end: -2rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.3);
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
     padding: 1rem 1rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.3);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #bdbdbd;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(159, 168, 218, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: rgba(255, 255, 255, 0.06);
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(255, 255, 255, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 5rem;
+    padding-inline-end: 5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: rgba(255, 255, 255, 0.06);
@@ -2053,24 +2062,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 4rem;
+    padding-inline-end: 4rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2.5rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #222222;
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid rgba(255, 255, 255, 0.12);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.12);
     border-color: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #9FA8DA;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-inline-start: 1px rgba(255, 255, 255, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 1rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 1rem 1rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #9FA8DA;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: transparent;
@@ -4245,8 +4389,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #9FA8DA;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 1rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 1rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1.25rem;
-    right: -1.25rem;
+    inset-inline-end: -1.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(159, 168, 218, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #444444;
+    border-inline-end-color: #444444;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #444444;
+    border-inline-start-color: #444444;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #444444;
@@ -4658,11 +4811,11 @@
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #9FA8DA;
@@ -4725,7 +4878,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3rem;
+      padding-inline-start: 3rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5rem;
+      padding-inline-start: 5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7rem;
+      padding-inline-start: 7rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9rem;
+      padding-inline-start: 9rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 11rem;
+      padding-inline-start: 11rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #9FA8DA;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #9FA8DA;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: transparent;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #F48FB1;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.5rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #F48FB1;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #9FA8DA;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.5rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.5rem;
     height: 2.5rem;
-    margin-left: -1rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -1rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #9FA8DA;
@@ -6504,7 +6732,7 @@
     color: #212121;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(255, 255, 255, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #121212;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #121212;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(255, 255, 255, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(3rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/md-light-deeppurple/theme.css
+++ b/src/assets/components/themes/md-light-deeppurple/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e0e0e0;
@@ -250,8 +250,8 @@
   padding: 1rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e0e0e0;
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: rgba(0, 0, 0, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(0, 0, 0, 0.87);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(0, 0, 0, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #673AB7;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(103, 58, 183, 0.12);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(0, 0, 0, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #b00020;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 1rem;
+    padding-inline-end: 1rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.5rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #673AB7;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #b00020;
@@ -1057,15 +1063,15 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 2rem;
-    margin-right: -2rem;
+    padding-inline-end: 2rem;
+    margin-inline-end: -2rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     border-top: 1px solid rgba(0, 0, 0, 0.38);
-    border-left: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.38);
     border-bottom: 1px solid rgba(0, 0, 0, 0.38);
     padding: 1rem 1rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-end: 1px solid rgba(0, 0, 0, 0.38);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #ffffff;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(103, 58, 183, 0.12);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #f5f5f5;
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(0, 0, 0, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 5rem;
+    padding-inline-end: 5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f5f5f5;
@@ -2053,24 +2062,24 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 4rem;
+    padding-inline-end: 4rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2.5rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: rgba(0, 0, 0, 0.02);
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e0e0e0;
+    border-inline-end: 1px solid #e0e0e0;
     border-color: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #673AB7;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(0, 0, 0, 0.12);
+    border-inline-start: 1px rgba(0, 0, 0, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 1rem;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 1rem 1rem;
     border: 1px solid #e0e0e0;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #673AB7;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4245,8 +4389,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #673AB7;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 1rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 1rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1.25rem;
-    right: -1.25rem;
+    inset-inline-end: -1.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(103, 58, 183, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: rgba(97, 97, 97, 0.9);
+    border-inline-end-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: rgba(97, 97, 97, 0.9);
+    border-inline-start-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: rgba(97, 97, 97, 0.9);
@@ -4658,11 +4811,11 @@
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #673AB7;
@@ -4725,7 +4878,10 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3rem;
+      padding-inline-start: 3rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5rem;
+      padding-inline-start: 5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7rem;
+      padding-inline-start: 7rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9rem;
+      padding-inline-start: 9rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 11rem;
+      padding-inline-start: 11rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #673AB7;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #673AB7;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #4CAF50;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.5rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #4CAF50;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #673AB7;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.5rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.5rem;
     height: 2.5rem;
-    margin-left: -1rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -1rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #673AB7;
@@ -6504,7 +6732,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(0, 0, 0, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #ffffff;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #ffffff;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(0, 0, 0, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(3rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/md-light-indigo/theme.css
+++ b/src/assets/components/themes/md-light-indigo/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e0e0e0;
@@ -250,8 +250,8 @@
   padding: 1rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e0e0e0;
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: rgba(0, 0, 0, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(0, 0, 0, 0.87);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(0, 0, 0, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #3F51B5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(63, 81, 181, 0.12);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(0, 0, 0, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #b00020;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 1rem;
+    padding-inline-end: 1rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.5rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #3F51B5;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #b00020;
@@ -1057,15 +1063,15 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 2rem;
-    margin-right: -2rem;
+    padding-inline-end: 2rem;
+    margin-inline-end: -2rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     border-top: 1px solid rgba(0, 0, 0, 0.38);
-    border-left: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.38);
     border-bottom: 1px solid rgba(0, 0, 0, 0.38);
     padding: 1rem 1rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-end: 1px solid rgba(0, 0, 0, 0.38);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 4rem;
+    inset-inline-end: 4rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #ffffff;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 1rem;
+    inset-inline-start: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 3rem;
+    inset-inline-start: 3rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(63, 81, 181, 0.12);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #f5f5f5;
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(0, 0, 0, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 1rem;
+    inset-inline-end: 1rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 5rem;
+    padding-inline-end: 5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.5rem 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f5f5f5;
@@ -2053,24 +2062,24 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 4rem;
+    padding-inline-end: 4rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2.5rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: rgba(0, 0, 0, 0.02);
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e0e0e0;
+    border-inline-end: 1px solid #e0e0e0;
     border-color: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2.5rem;
     height: 2.5rem;
     color: rgba(0, 0, 0, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 1rem;
+    inset-inline-end: 1rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #3F51B5;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(0, 0, 0, 0.12);
+    border-inline-start: 1px rgba(0, 0, 0, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 1rem;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 1rem 1rem;
     border: 1px solid #e0e0e0;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #3F51B5;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4245,8 +4389,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #3F51B5;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 1rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 1rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1.25rem;
-    right: -1.25rem;
+    inset-inline-end: -1.25rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(63, 81, 181, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: rgba(97, 97, 97, 0.9);
+    border-inline-end-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: rgba(97, 97, 97, 0.9);
+    border-inline-start-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: rgba(97, 97, 97, 0.9);
@@ -4658,11 +4811,11 @@
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #3F51B5;
@@ -4725,7 +4878,10 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3rem;
+      padding-inline-start: 3rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5rem;
+      padding-inline-start: 5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7rem;
+      padding-inline-start: 7rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9rem;
+      padding-inline-start: 9rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 11rem;
+      padding-inline-start: 11rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #3F51B5;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 1rem 1.5rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #3F51B5;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #ff4081;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.5rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #ff4081;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #3F51B5;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.5rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.5rem;
     height: 2.5rem;
-    margin-left: -1rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -1rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #3F51B5;
@@ -6504,7 +6732,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(0, 0, 0, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #ffffff;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #ffffff;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(0, 0, 0, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(3rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/mdc-dark-deeppurple/theme.css
+++ b/src/assets/components/themes/mdc-dark-deeppurple/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -250,8 +250,8 @@
   padding: 0.75rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #1e1e1e;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(255, 255, 255, 0.6);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(255, 255, 255, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #CE93D8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(206, 147, 216, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #CE93D8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
@@ -1057,15 +1063,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.3);
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
     padding: 0.75rem 0.75rem;
     min-width: 2.75rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.3);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #bdbdbd;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(206, 147, 216, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: rgba(255, 255, 255, 0.06);
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(255, 255, 255, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: rgba(255, 255, 255, 0.06);
@@ -2053,24 +2062,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #222222;
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.75rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid rgba(255, 255, 255, 0.12);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.12);
     border-color: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.25rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #CE93D8;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #CE93D8;
     background: rgba(206, 147, 216, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 0.75rem 0;
   }
   .p-card .p-card-footer {
-    padding: 0.75rem 0 0 0;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-inline-start: 1px rgba(255, 255, 255, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 0.75rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 0.75rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #CE93D8;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: transparent;
@@ -4245,8 +4389,8 @@
     padding: 0.75rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #CE93D8;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.25rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.25rem 1.25rem 1.25rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.25rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1.25rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 0.75rem 1.25rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(206, 147, 216, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #444444;
+    border-inline-end-color: #444444;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #444444;
+    border-inline-start-color: #444444;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #444444;
@@ -4658,11 +4811,11 @@
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #CE93D8;
@@ -4725,7 +4878,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #CE93D8;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #CE93D8;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: transparent;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #A5D6A7;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.25rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #A5D6A7;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #CE93D8;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #CE93D8;
@@ -6504,7 +6732,7 @@
     color: #212121;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(255, 255, 255, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #121212;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #121212;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8, inset 0 0 0 1px #CE93D8;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(255, 255, 255, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #CE93D8, #CE93D8), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(2.75rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/mdc-dark-indigo/theme.css
+++ b/src/assets/components/themes/mdc-dark-indigo/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1e1e1e;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -250,8 +250,8 @@
   padding: 0.75rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid rgba(255, 255, 255, 0.12);
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #1e1e1e;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(255, 255, 255, 0.6);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(255, 255, 255, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #9FA8DA;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(159, 168, 218, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(255, 255, 255, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44435;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #9FA8DA;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44435;
@@ -1057,15 +1063,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid rgba(255, 255, 255, 0.3);
-    border-left: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-start: 1px solid rgba(255, 255, 255, 0.3);
     border-bottom: 1px solid rgba(255, 255, 255, 0.3);
     padding: 0.75rem 0.75rem;
     min-width: 2.75rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(255, 255, 255, 0.3);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.3);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #bdbdbd;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(159, 168, 218, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: rgba(255, 255, 255, 0.06);
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(255, 255, 255, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: rgba(255, 255, 255, 0.06);
@@ -2053,24 +2062,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #222222;
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #2b2b2b;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.75rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid rgba(255, 255, 255, 0.12);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.12);
     border-color: rgba(255, 255, 255, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.25rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #9FA8DA;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.87);
     background: #1e1e1e;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #9FA8DA;
     background: rgba(159, 168, 218, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #404040;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 0.75rem 0;
   }
   .p-card .p-card-footer {
-    padding: 0.75rem 0 0 0;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(255, 255, 255, 0.12);
+    border-inline-start: 1px rgba(255, 255, 255, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 0.75rem;
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 0.75rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #9FA8DA;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: transparent;
@@ -4245,8 +4389,8 @@
     padding: 0.75rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #9FA8DA;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.25rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.25rem 1.25rem 1.25rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.25rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1.25rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #262626;
     color: rgba(255, 255, 255, 0.87);
     padding: 0.75rem 1.25rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(159, 168, 218, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #444444;
+    border-inline-end-color: #444444;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #444444;
+    border-inline-start-color: #444444;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #444444;
@@ -4658,11 +4811,11 @@
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid rgba(255, 255, 255, 0.12);
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #9FA8DA;
@@ -4725,7 +4878,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(255, 255, 255, 0.6);
     background: transparent;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #1e1e1e;
     border-color: transparent;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #1e1e1e;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(255, 255, 255, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #9FA8DA;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(255, 255, 255, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(255, 255, 255, 0.12) transparent;
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #9FA8DA;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: transparent;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #F48FB1;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.25rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #F48FB1;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #ffffff;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #121212;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #9FA8DA;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #9FA8DA;
@@ -6504,7 +6732,7 @@
     color: #212121;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(255, 255, 255, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #121212;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #121212;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA, inset 0 0 0 1px #9FA8DA;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #1e1e1e;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(255, 255, 255, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: rgba(255, 255, 255, 0.06) no-repeat;
     background-image: linear-gradient(to bottom, #9FA8DA, #9FA8DA), linear-gradient(to bottom, rgba(255, 255, 255, 0.3), rgba(255, 255, 255, 0.3));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(2.75rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/mdc-light-deeppurple/theme.css
+++ b/src/assets/components/themes/mdc-light-deeppurple/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e0e0e0;
@@ -250,8 +250,8 @@
   padding: 0.75rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e0e0e0;
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: rgba(0, 0, 0, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(0, 0, 0, 0.87);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(0, 0, 0, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #673AB7;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(103, 58, 183, 0.12);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(0, 0, 0, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #b00020;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #673AB7;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #b00020;
@@ -1057,15 +1063,15 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     border-top: 1px solid rgba(0, 0, 0, 0.38);
-    border-left: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.38);
     border-bottom: 1px solid rgba(0, 0, 0, 0.38);
     padding: 0.75rem 0.75rem;
     min-width: 2.75rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-end: 1px solid rgba(0, 0, 0, 0.38);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #ffffff;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(103, 58, 183, 0.12);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #f5f5f5;
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(0, 0, 0, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f5f5f5;
@@ -2053,24 +2062,24 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: rgba(0, 0, 0, 0.02);
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.75rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e0e0e0;
+    border-inline-end: 1px solid #e0e0e0;
     border-color: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.25rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #673AB7;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #673AB7;
     background: rgba(103, 58, 183, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 0.75rem 0;
   }
   .p-card .p-card-footer {
-    padding: 0.75rem 0 0 0;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(0, 0, 0, 0.12);
+    border-inline-start: 1px rgba(0, 0, 0, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 0.75rem;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 0.75rem;
     border: 1px solid #e0e0e0;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #673AB7;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4245,8 +4389,8 @@
     padding: 0.75rem;
     border: 0 none;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #673AB7;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 1.25rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    padding: 0 1.25rem 1.25rem 1.25rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.25rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1.25rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 0.75rem 1.25rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(103, 58, 183, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: rgba(97, 97, 97, 0.9);
+    border-inline-end-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: rgba(97, 97, 97, 0.9);
+    border-inline-start-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: rgba(97, 97, 97, 0.9);
@@ -4658,11 +4811,11 @@
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #673AB7;
@@ -4725,7 +4878,10 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #673AB7;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #673AB7;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #4CAF50;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.25rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #4CAF50;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #673AB7;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #673AB7;
@@ -6504,7 +6732,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(0, 0, 0, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #ffffff;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #ffffff;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7, inset 0 0 0 1px #673AB7;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(0, 0, 0, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #673AB7, #673AB7), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(2.75rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/mdc-light-indigo/theme.css
+++ b/src/assets/components/themes/mdc-light-indigo/theme.css
@@ -198,8 +198,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e0e0e0;
@@ -250,8 +250,8 @@
   padding: 0.75rem 0.75rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e0e0e0;
@@ -259,8 +259,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: rgba(0, 0, 0, 0.87);
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -371,10 +371,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: rgba(0, 0, 0, 0.87);
@@ -407,7 +407,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: rgba(0, 0, 0, 0.24);
@@ -472,16 +472,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -517,8 +517,8 @@
     font-weight: 500;
     margin: 0;
     border-bottom: 1px solid rgba(0, 0, 0, 0.12);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -557,7 +557,7 @@
     color: #3F51B5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -665,18 +665,18 @@
     background: rgba(63, 81, 181, 0.12);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid rgba(0, 0, 0, 0.12);
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.12);
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -704,16 +704,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -752,8 +752,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #b00020;
@@ -826,20 +826,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -914,7 +920,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -936,7 +942,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -946,7 +952,7 @@
     color: rgba(0, 0, 0, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -965,11 +971,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1007,7 +1013,7 @@
     border-color: #3F51B5;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1024,12 +1030,12 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #b00020;
@@ -1057,15 +1063,15 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1138,13 +1144,13 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     border-top: 1px solid rgba(0, 0, 0, 0.38);
-    border-left: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-start: 1px solid rgba(0, 0, 0, 0.38);
     border-bottom: 1px solid rgba(0, 0, 0, 0.38);
     padding: 0.75rem 0.75rem;
     min-width: 2.75rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid rgba(0, 0, 0, 0.38);
+    border-inline-end: 1px solid rgba(0, 0, 0, 0.38);
   }
 
   .p-inputgroup > .p-component,
@@ -1156,7 +1162,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1174,13 +1180,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1188,13 +1194,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1205,12 +1211,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
@@ -1219,11 +1225,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1241,18 +1247,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.5rem;
+    inset-inline-end: 3.5rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1289,13 +1295,16 @@
     background: #ffffff;
     width: 1.5rem;
     height: 1.5rem;
-    left: -1px;
+    inset-inline-start: -1px;
     margin-top: -0.75rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.5rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.5rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1362,7 +1371,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
     transition-duration: 0.2s;
   }
@@ -1373,38 +1382,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1456,18 +1465,18 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1489,7 +1498,7 @@
     background: rgba(63, 81, 181, 0.12);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1553,20 +1562,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #f5f5f5;
@@ -1583,11 +1592,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-multiselect-panel {
@@ -1603,21 +1612,21 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -1667,7 +1676,7 @@
     background: rgba(0, 0, 0, 0.04);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1723,19 +1732,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1807,7 +1816,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1899,7 +1908,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -10px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1908,7 +1917,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 20px;
     width: 20px;
-    margin-left: -10px;
+    margin-inline-start: -10px;
     margin-bottom: -10px;
   }
   .p-slider .p-slider-handle {
@@ -1932,7 +1941,7 @@
     border-color: 0 none;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), left 0.2s;
+    transition: background-color 0.2s, border-color 0.2s, color 0.2s, box-shadow 0.2s, background-size 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2010,7 +2019,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: rgba(0, 0, 0, 0.12);
     color: rgba(0, 0, 0, 0.87);
     border-radius: 16px;
@@ -2019,8 +2028,8 @@
     background: transparent;
     color: rgba(0, 0, 0, 0.6);
     width: 2.75rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f5f5f5;
@@ -2053,24 +2062,24 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2111,11 +2120,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(0, 0, 0, 0.6);
-    right: 2.75rem;
+    inset-inline-end: 2.75rem;
   }
 
   .p-button {
@@ -2200,10 +2209,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2212,7 +2221,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2252,10 +2261,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2689,14 +2698,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2756,7 +2765,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2775,18 +2784,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -2794,32 +2812,41 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2828,7 +2855,7 @@
     line-height: 1.143rem;
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -2861,9 +2888,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2895,7 +2925,7 @@
     box-shadow: none;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid transparent;
@@ -2931,58 +2961,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: rgba(0, 0, 0, 0.02);
@@ -3029,18 +3107,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3054,11 +3141,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3069,7 +3159,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3167,8 +3257,8 @@
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.75rem;
@@ -3224,10 +3314,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3303,7 +3393,7 @@
     background: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e0e0e0;
+    border-inline-end: 1px solid #e0e0e0;
     border-color: rgba(0, 0, 0, 0.12);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3357,24 +3447,24 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3443,10 +3533,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3554,7 +3644,7 @@
     padding: 0.25rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(0, 0, 0, 0.6);
@@ -3574,11 +3664,11 @@
     box-shadow: none;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3620,14 +3710,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3655,14 +3748,14 @@
     color: #3F51B5;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3679,18 +3772,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3698,25 +3800,34 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 0.75rem;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
     background: #ffffff;
@@ -3726,7 +3837,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3735,7 +3846,7 @@
     line-height: 1.143rem;
     color: #3F51B5;
     background: rgba(63, 81, 181, 0.12);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(0, 0, 0, 0.04);
@@ -3757,9 +3868,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3770,7 +3884,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -3787,7 +3901,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(0, 0, 0, 0.87);
@@ -3840,16 +3954,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3895,7 +4021,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
   }
@@ -3909,11 +4038,14 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border: 1px solid #e4e4e4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 0.75rem;
     font-weight: 500;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3926,7 +4058,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3942,8 +4074,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: transparent;
@@ -3956,10 +4088,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3977,16 +4109,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -4012,7 +4144,10 @@
     padding: 0.75rem 0;
   }
   .p-card .p-card-footer {
-    padding: 0.75rem 0 0 0;
+    padding-block-start: 0.75rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -4033,7 +4168,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px rgba(0, 0, 0, 0.12);
+    border-inline-start: 1px rgba(0, 0, 0, 0.12);
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4064,7 +4199,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4085,8 +4220,8 @@
     padding: 0.75rem;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 500;
@@ -4121,25 +4256,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 0.75rem;
     border: 1px solid #e0e0e0;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4186,23 +4321,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4220,13 +4364,13 @@
     color: #3F51B5;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4245,8 +4389,8 @@
     padding: 0.75rem;
     border: 0 none;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4353,7 +4497,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.87);
     font-weight: 500;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4413,7 +4557,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4425,7 +4569,7 @@
     background-color: #3F51B5;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4439,11 +4583,14 @@
     padding: 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 0.75rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4473,7 +4620,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4486,8 +4633,8 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 1.25rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 500;
@@ -4501,7 +4648,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(0, 0, 0, 0.6);
@@ -4514,28 +4661,34 @@
     box-shadow: none;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
-    padding: 0 1.25rem 1.25rem 1.25rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.25rem;
+    padding-block-end: 1.25rem;
+    padding-inline-start: 1.25rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     padding: 0.75rem 1.25rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4546,7 +4699,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4568,7 +4721,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: rgba(63, 81, 181, 0.92);
@@ -4640,10 +4793,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: rgba(97, 97, 97, 0.9);
+    border-inline-end-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: rgba(97, 97, 97, 0.9);
+    border-inline-start-color: rgba(97, 97, 97, 0.9);
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: rgba(97, 97, 97, 0.9);
@@ -4658,11 +4811,11 @@
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4674,8 +4827,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e0e0e0;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #3F51B5;
@@ -4725,7 +4878,10 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(0, 0, 0, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4769,7 +4925,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4916,7 +5072,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -4970,8 +5126,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0;
@@ -4999,11 +5155,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5040,7 +5196,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5092,8 +5248,8 @@
     color: rgba(0, 0, 0, 0.6);
     background: #ffffff;
     font-weight: 400;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
@@ -5108,9 +5264,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5137,11 +5293,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(0, 0, 0, 0.87);
@@ -5169,7 +5325,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5268,11 +5424,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5284,33 +5443,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5330,10 +5495,10 @@
     font-weight: 400;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5349,8 +5514,8 @@
     background: #ffffff;
     border-color: transparent;
     color: rgba(0, 0, 0, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5364,10 +5529,10 @@
     background: #ffffff;
     color: rgba(0, 0, 0, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5387,7 +5552,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5429,14 +5594,17 @@
     color: rgba(0, 0, 0, 0.6);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     margin: 0.5rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5454,16 +5622,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5495,7 +5663,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5576,9 +5744,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5620,7 +5788,7 @@
     border-top: 1px solid rgba(0, 0, 0, 0.12);
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5629,7 +5797,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #3F51B5;
@@ -5640,28 +5811,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid rgba(0, 0, 0, 0.12);
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-color: transparent transparent rgba(0, 0, 0, 0.12) transparent;
     background: #ffffff;
     color: rgba(0, 0, 0, 0.6);
     padding: 0.75rem 1.25rem;
     font-weight: 500;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5679,10 +5856,10 @@
     color: #3F51B5;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5735,7 +5912,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(0, 0, 0, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(0, 0, 0, 0.6);
@@ -5831,7 +6008,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5841,7 +6018,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5869,7 +6046,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5881,7 +6061,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5893,7 +6076,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5905,7 +6091,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5920,7 +6109,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5930,12 +6119,15 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-message.p-message-secondary {
     background: #ff4081;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-secondary .p-message-icon {
@@ -5947,7 +6139,10 @@
   .p-message.p-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-message.p-message-contrast .p-message-icon {
@@ -5961,16 +6156,25 @@
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1.25rem;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5983,7 +6187,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -6003,7 +6210,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #01579b;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -6013,7 +6223,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #1b5e20;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -6023,7 +6236,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #7f6003;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -6033,7 +6249,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #b71c1c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6043,7 +6262,10 @@
   .p-toast .p-toast-message.p-toast-message-secondary {
     background: #ff4081;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-secondary .p-toast-message-icon,
@@ -6053,7 +6275,10 @@
   .p-toast .p-toast-message.p-toast-message-contrast {
     background: #212121;
     border: solid transparent;
-    border-width: 0 0 0 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 0;
     color: #ffffff;
   }
   .p-toast .p-toast-message.p-toast-message-contrast .p-toast-message-icon,
@@ -6125,7 +6350,7 @@
     color: #3F51B5;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6197,10 +6422,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6297,16 +6522,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6410,12 +6635,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6425,12 +6650,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6478,6 +6703,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #3F51B5;
@@ -6504,7 +6732,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6541,16 +6769,16 @@
     transition: margin-bottom 225ms;
   }
   .p-accordion .p-accordion-tab:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion .p-accordion-tab:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-accordion .p-accordion-tab .p-accordion-toggle-icon {
     order: 1;
-    margin-left: auto;
+    margin-inline-end: auto;
     transition: transform 0.2s;
   }
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-header-link:focus {
@@ -6559,11 +6787,17 @@
   .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon {
     transform: rotate(-270deg);
   }
+  .p-accordion .p-accordion-tab:not(.p-accordion-tab-active) .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(270deg);
+  }
   .p-accordion .p-accordion-tab.p-accordion-tab-active {
     margin-bottom: 1rem;
   }
   .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon {
     transform: rotate(-180deg);
+  }
+  .p-accordion .p-accordion-tab.p-accordion-tab-active .p-accordion-toggle-icon:dir(rtl) {
+    transform: rotate(180deg);
   }
   .p-accordion .p-accordion-tab .p-accordion-header.p-disabled {
     opacity: 1;
@@ -6577,8 +6811,8 @@
   }
 
   .p-input-filled .p-autocomplete .p-autocomplete-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6885,7 +7119,10 @@
     border-bottom: 0 none;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title {
-    margin: 0 auto 0 0;
+    margin-block-start: 0;
+    margin-inline-end: auto;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     order: 1;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev {
@@ -6921,8 +7158,8 @@
   }
 
   .p-input-filled .p-calendar-w-btn {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -6992,8 +7229,8 @@
   }
 
   .p-input-filled .p-cascadeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7090,12 +7327,17 @@
     content: "";
     position: absolute;
     top: 6px;
-    left: 1px;
-    border-right: 2px solid transparent;
+    inset-inline-start: 1px;
+    border-inline-end: 2px solid transparent;
     border-bottom: 2px solid transparent;
     transform: rotate(45deg);
     transform-origin: 0% 100%;
     animation: checkbox-check 125ms 50ms linear forwards;
+  }
+  .p-checkbox .p-checkbox-box.p-highlight .p-checkbox-icon.pi-check:dir(rtl):before {
+    transform: rotate(-45deg);
+    transform-origin: 100% 100%;
+    animation-name: checkbox-check-rtl;
   }
   .p-checkbox:not(.p-checkbox-disabled):hover {
     box-shadow: 0 0 1px 10px rgba(0, 0, 0, 0.04);
@@ -7135,13 +7377,32 @@
       transform: translate3d(0, -10px, 0) rotate(45deg);
     }
   }
+  @keyframes checkbox-check-rtl {
+    0% {
+      width: 0;
+      height: 0;
+      border-color: #ffffff;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    33% {
+      width: 4px;
+      height: 0;
+      transform: translate3d(0, 0, 0) rotate(-45deg);
+    }
+    100% {
+      width: 4px;
+      height: 10px;
+      border-color: #ffffff;
+      transform: translate3d(0, -10px, 0) rotate(-45deg);
+    }
+  }
   .p-chips .p-chips-multiple-container:not(.p-disabled).p-focus {
     box-shadow: inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5, inset 0 0 0 1px #3F51B5;
   }
 
   .p-input-filled .p-chips-multiple-container {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7247,8 +7508,8 @@
   }
 
   .p-input-filled .p-dropdown {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7314,8 +7575,8 @@
   }
 
   .p-input-filled .p-inputtext {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7344,8 +7605,8 @@
   }
 
   .p-input-filled .p-inputgroup .p-inputgroup-addon {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7354,23 +7615,23 @@
     background-origin: border-box;
   }
   .p-input-filled .p-inputgroup .p-inputgroup-addon:last-child {
-    border-right-color: transparent;
+    border-inline-end-color: transparent;
   }
   .p-input-filled .p-inputgroup-addon:first-child,
 .p-input-filled .p-inputgroup button:first-child,
 .p-input-filled .p-inputgroup input:first-child {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:first-child input {
-    border-bottom-left-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-input-filled .p-inputgroup-addon:last-child,
 .p-input-filled .p-inputgroup button:last-child,
 .p-input-filled .p-inputgroup input:last-child {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-input-filled .p-inputgroup .p-float-label:last-child input {
-    border-bottom-right-radius: 0;
+    border-end-end-radius: 0;
   }
 
   p-inputmask.ng-dirty.ng-invalid .p-inputtext:enabled:focus {
@@ -7432,7 +7693,7 @@
     top: -0.5rem !important;
     background-color: #ffffff;
     padding: 2px 4px;
-    margin-left: -4px;
+    margin-inline-end: -4px;
     margin-top: 0;
   }
 
@@ -7513,8 +7774,8 @@
   }
 
   .p-input-filled .p-multiselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -7633,17 +7894,17 @@
     transition: margin-bottom 225ms;
   }
   .p-panelmenu .p-panelmenu-panel:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header .p-panelmenu-icon {
     order: 1;
-    margin-left: auto;
-    margin-right: 0;
+    margin-inline-end: auto;
+    margin-inline-end: 0;
   }
   .p-panelmenu .p-panelmenu-panel .p-panelmenu-header.p-disabled {
     opacity: 1;
@@ -7769,7 +8030,7 @@
   }
   .p-steps .p-steps-item:before {
     position: static;
-    left: auto;
+    inset-inline-start: auto;
     top: auto;
     margin-top: 0;
   }
@@ -7795,7 +8056,7 @@
   }
   .p-steps .p-steps-item .p-menuitem-link .p-steps-title {
     margin: 0;
-    padding-left: 0.5rem;
+    padding-inline-start: 0.5rem;
   }
   .p-steps .p-steps-item .p-menuitem-link:not(.p-disabled):focus {
     background: rgba(0, 0, 0, 0.12);
@@ -7870,8 +8131,8 @@
   }
 
   .p-input-filled .p-treeselect {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
     border: 1px solid transparent;
     background: #f5f5f5 no-repeat;
     background-image: linear-gradient(to bottom, #3F51B5, #3F51B5), linear-gradient(to bottom, rgba(0, 0, 0, 0.38), rgba(0, 0, 0, 0.38));
@@ -8022,7 +8283,7 @@
     box-shadow: inset 0 0 0 1px;
   }
   .p-splitbutton.p-button-outlined > .p-button.p-splitbutton-menubutton {
-    margin-left: -1px;
+    margin-inline-end: -1px;
     width: calc(2.75rem + 1px);
   }
   .p-splitbutton.p-disabled.p-button-text > .p-button {

--- a/src/assets/components/themes/mira/theme.css
+++ b/src/assets/components/themes/mira/theme.css
@@ -201,8 +201,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 4px;
-  border-top-left-radius: 4px;
+  border-start-end-radius: 4px;
+  border-start-start-radius: 4px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e9f0;
@@ -253,8 +253,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e9f0;
@@ -262,8 +262,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #4c566a;
-  border-bottom-right-radius: 4px;
-  border-bottom-left-radius: 4px;
+  border-end-end-radius: 4px;
+  border-end-start-radius: 4px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -374,10 +374,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #81a1c1;
@@ -410,7 +410,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d8dee9;
@@ -475,16 +475,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #81a1c1;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #81a1c1;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -520,8 +520,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e9f0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -560,7 +560,7 @@
     color: #5e81ac;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -668,18 +668,18 @@
     background: #d8dee9;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #e5e9f0;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #e5e9f0;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #d8dee9;
@@ -707,16 +707,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #81a1c1;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #81a1c1;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -755,8 +755,8 @@
     background: transparent;
     color: #81a1c1;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #bf616a;
@@ -829,20 +829,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #81a1c1;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -917,7 +923,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -939,7 +945,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e9f0;
     color: #4c566a;
     border-radius: 16px;
@@ -949,7 +955,7 @@
     color: #4c566a;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -968,11 +974,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #81a1c1;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -1010,7 +1016,7 @@
     border-color: #81a1c1;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1027,12 +1033,12 @@
     background: transparent;
     color: #81a1c1;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #81a1c1;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #bf616a;
@@ -1060,15 +1066,15 @@
     color: #4c566a;
     background: #eceff4;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1141,13 +1147,13 @@
     background: #ffffff;
     color: #81a1c1;
     border-top: 1px solid #d8dee9;
-    border-left: 1px solid #d8dee9;
+    border-inline-start: 1px solid #d8dee9;
     border-bottom: 1px solid #d8dee9;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d8dee9;
+    border-inline-end: 1px solid #d8dee9;
   }
 
   .p-inputgroup > .p-component,
@@ -1159,7 +1165,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1177,13 +1183,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1191,13 +1197,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1208,12 +1214,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #81a1c1;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
 
@@ -1222,11 +1228,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #81a1c1;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1244,18 +1250,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #81a1c1;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1292,13 +1298,16 @@
     background: #5e81ac;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1365,7 +1374,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #4c566a;
     transition-duration: 0.2s;
   }
@@ -1376,38 +1385,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #81a1c1;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1459,18 +1468,18 @@
     color: #4c566a;
     background: #eceff4;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1492,7 +1501,7 @@
     background: #d8dee9;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1556,20 +1565,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e9f0;
     color: #4c566a;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #81a1c1;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-multiselect.p-variant-filled {
     background: #eceff4;
@@ -1586,11 +1595,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #81a1c1;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1606,21 +1615,21 @@
     color: #4c566a;
     background: #eceff4;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #81a1c1;
@@ -1670,7 +1679,7 @@
     background: transparent;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1726,19 +1735,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #81a1c1;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #81a1c1;
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1810,7 +1819,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1902,7 +1911,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1911,7 +1920,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1935,7 +1944,7 @@
     border-color: #5e81ac;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2013,7 +2022,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e9f0;
     color: #4c566a;
     border-radius: 16px;
@@ -2022,8 +2031,8 @@
     background: transparent;
     color: #81a1c1;
     width: 2.357rem;
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #eceff4;
@@ -2056,24 +2065,24 @@
     color: #4c566a;
     background: #eceff4;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2114,11 +2123,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #81a1c1;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2203,10 +2212,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2215,7 +2224,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2255,10 +2264,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2643,14 +2652,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2710,7 +2719,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2729,18 +2738,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2748,32 +2766,41 @@
     background: #eceff4;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #4c566a;
     background: #eceff4;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #4c566a;
     background: #eceff4;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #81a1c1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2782,7 +2809,7 @@
     line-height: 1.143rem;
     color: #2e3440;
     background: #d8dee9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #ffffff;
@@ -2815,9 +2842,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #eceff4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2849,7 +2879,7 @@
     box-shadow: 0 0 0 0.2rem #c0d0e0;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #c0d0e0;
@@ -2885,58 +2915,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f6f7fa;
@@ -2983,18 +3061,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3008,11 +3095,14 @@
     background: #eceff4;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3023,7 +3113,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3121,8 +3211,8 @@
     color: #4c566a;
     background: #eceff4;
     margin: 0;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3178,10 +3268,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-orderlist .p-orderlist-list {
@@ -3257,7 +3347,7 @@
     background: #e5e9f0;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e9f0;
+    border-inline-end: 1px solid #e5e9f0;
     border-color: #e5e9f0;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3311,24 +3401,24 @@
     color: #4c566a;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3397,10 +3487,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-picklist .p-picklist-list {
@@ -3508,7 +3598,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #81a1c1;
@@ -3528,11 +3618,11 @@
     box-shadow: 0 0 0 0.2rem #c0d0e0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4c566a;
@@ -3574,14 +3664,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #81a1c1;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3609,14 +3702,14 @@
     color: #2e3440;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3633,18 +3726,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3652,25 +3754,34 @@
     background: #eceff4;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #4c566a;
     background: #eceff4;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #4c566a;
     background: #eceff4;
@@ -3680,7 +3791,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #81a1c1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3689,7 +3800,7 @@
     line-height: 1.143rem;
     color: #2e3440;
     background: #d8dee9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #ffffff;
@@ -3711,9 +3822,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #eceff4;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3724,7 +3838,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #4c566a;
@@ -3741,7 +3855,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #4c566a;
@@ -3794,16 +3908,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3849,7 +3975,10 @@
     background: #ffffff;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3863,11 +3992,14 @@
     background: #eceff4;
     color: #4c566a;
     border: 1px solid #ffffff;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3880,7 +4012,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3896,8 +4028,8 @@
     background: #ffffff;
     border-color: #e5e9f0;
     color: #4c566a;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e9f0;
@@ -3910,10 +4042,10 @@
     background: #ffffff;
     color: #4c566a;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3931,16 +4063,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-card {
@@ -3966,7 +4098,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3987,7 +4122,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e9f0;
+    border-inline-start: 1px #e5e9f0;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4018,7 +4153,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4039,8 +4174,8 @@
     padding: 1rem;
     background: #ffffff;
     color: #4c566a;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4075,25 +4210,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #e5e9f0;
     background: #ffffff;
     color: #4c566a;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4140,23 +4275,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 2px solid #e5e9f0;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e9f0;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e9f0 transparent;
     background: #ffffff;
     color: #4c566a;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4174,13 +4318,13 @@
     color: #4c566a;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4199,8 +4343,8 @@
     padding: 1rem;
     border: 0 none;
     color: #4c566a;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-toolbar {
@@ -4307,7 +4451,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #81a1c1;
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4367,7 +4511,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4379,7 +4523,7 @@
     background-color: #5e81ac;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4393,11 +4537,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4427,7 +4574,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4440,8 +4587,8 @@
     background: #ffffff;
     color: #4c566a;
     padding: 1.5rem;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4455,7 +4602,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #4c566a;
@@ -4468,28 +4615,37 @@
     box-shadow: 0 0 0 0.2rem #c0d0e0;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #4c566a;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #4c566a;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4500,7 +4656,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4522,7 +4678,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #81a1c1;
@@ -4594,10 +4750,10 @@
     border-radius: 4px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #4c566a;
+    border-inline-end-color: #4c566a;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #4c566a;
+    border-inline-start-color: #4c566a;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #4c566a;
@@ -4612,11 +4768,11 @@
     border: 1px solid #e5e9f0;
     color: #4c566a;
     border-bottom: 0 none;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4628,8 +4784,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e9f0;
     color: #4c566a;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #5e81ac;
@@ -4679,7 +4835,10 @@
     color: #81a1c1;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #4c566a;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4723,7 +4882,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
@@ -4870,7 +5029,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
@@ -4924,8 +5083,8 @@
     color: #4c566a;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4953,11 +5112,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4c566a;
@@ -4994,7 +5153,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
@@ -5046,8 +5205,8 @@
     color: #4c566a;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #e5e9f0;
@@ -5062,9 +5221,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5091,11 +5250,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #4c566a;
@@ -5123,7 +5282,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
@@ -5222,11 +5381,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5238,33 +5400,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5284,10 +5452,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5303,8 +5471,8 @@
     background: #ffffff;
     border-color: #e5e9f0;
     color: #4c566a;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5318,10 +5486,10 @@
     background: #ffffff;
     color: #4c566a;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5341,7 +5509,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
@@ -5383,14 +5551,17 @@
     color: #81a1c1;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #e5e9f0;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5408,16 +5579,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-end-end-radius: 4px;
+    border-end-start-radius: 4px;
   }
 
   .p-slidemenu {
@@ -5449,7 +5620,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
@@ -5530,9 +5701,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5574,7 +5745,7 @@
     border-top: 1px solid #e5e9f0;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5583,7 +5754,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 2px solid #e5e9f0;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #5e81ac;
@@ -5594,28 +5768,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 4px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e9f0;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e9f0 transparent;
     background: #ffffff;
     color: #4c566a;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 4px;
-    border-top-left-radius: 4px;
+    border-start-end-radius: 4px;
+    border-start-start-radius: 4px;
     transition: none;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5633,10 +5813,10 @@
     color: #4c566a;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5689,7 +5869,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #81a1c1;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #81a1c1;
@@ -5785,7 +5965,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5795,7 +5975,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5823,7 +6003,10 @@
   .p-message.p-message-info {
     background: #b8d9e3;
     border: solid #2e4f5d;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #2e4f5d;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5835,7 +6018,10 @@
   .p-message.p-message-success {
     background: #c8d8ba;
     border: solid #3f5332;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #202919;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5847,7 +6033,10 @@
   .p-message.p-message-warn {
     background: #f1d6ca;
     border: solid #783b28;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3c1d14;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5859,7 +6048,10 @@
   .p-message.p-message-error {
     background: #e8b8b8;
     border: solid #662a2f;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #331518;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5874,7 +6066,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5884,23 +6076,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 4px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5913,7 +6114,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5933,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b8d9e3;
     border: solid #2e4f5d;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #2e4f5d;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5943,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8d8ba;
     border: solid #3f5332;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #202919;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5953,7 +6163,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #f1d6ca;
     border: solid #783b28;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #3c1d14;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5963,7 +6176,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #e8b8b8;
     border: solid #662a2f;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #331518;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6035,7 +6251,7 @@
     color: #2e3440;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6107,10 +6323,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6199,16 +6415,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 4px;
@@ -6312,12 +6528,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-bottom-left-radius: 4px;
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6327,12 +6543,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 4px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
+    border-end-start-radius: 4px;
+    border-end-end-radius: 4px;
   }
 
   .p-progressbar {
@@ -6380,6 +6596,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #5e81ac;
@@ -6406,7 +6625,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/nano/theme.css
+++ b/src/assets/components/themes/nano/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f2f4f8;
-  border-top-right-radius: 1px;
-  border-top-left-radius: 1px;
+  border-start-end-radius: 1px;
+  border-start-start-radius: 1px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dee2e6;
@@ -227,8 +227,8 @@
   padding: 0.25rem 0.5rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 1px;
-  border-bottom-left-radius: 1px;
+  border-end-end-radius: 1px;
+  border-end-start-radius: 1px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dee2e6;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #343a3f;
-  border-bottom-right-radius: 1px;
-  border-bottom-left-radius: 1px;
+  border-end-end-radius: 1px;
+  border-end-start-radius: 1px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.607rem;
+    inset-inline-end: 2.607rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #1174c0;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #c8cbcf;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #697077;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #697077;
-    right: 2.607rem;
+    inset-inline-end: 2.607rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #dee2e6;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #1174c0;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #44a1d9;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dee2e6;
-    padding-right: 0.25rem;
-    padding-left: 0.25rem;
+    border-inline-start: 1px solid #dee2e6;
+    padding-inline-end: 0.25rem;
+    padding-inline-start: 0.25rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #dde1e6;
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #697077;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #697077;
-    right: 2.607rem;
+    inset-inline-end: 2.607rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: #697077;
     width: 2.357rem;
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #d8222f;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.25rem;
+    padding-inline-end: 0.25rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #697077;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.125rem 0.25rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #343a3f;
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: #343a3f;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.125rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #697077;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #1174c0;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: #697077;
     width: 2.357rem;
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #697077;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #d8222f;
@@ -1034,15 +1040,15 @@
     color: #343a3f;
     background: #f2f4f8;
     margin: 0;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.25rem;
-    margin-right: -1.25rem;
+    padding-inline-end: 1.25rem;
+    margin-inline-end: -1.25rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #dde1e6;
     color: #697077;
     border-top: 1px solid #a5acb3;
-    border-left: 1px solid #a5acb3;
+    border-inline-start: 1px solid #a5acb3;
     border-bottom: 1px solid #a5acb3;
     padding: 0.25rem 0.25rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #a5acb3;
+    border-inline-end: 1px solid #a5acb3;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-start-start-radius: 1px;
+    border-end-start-radius: 1px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-start-start-radius: 1px;
+    border-end-start-radius: 1px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     color: #697077;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #697077;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #697077;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.607rem;
+    inset-inline-end: 2.607rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.607rem;
+    inset-inline-end: 2.607rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: #ffffff;
     width: 0.825rem;
     height: 0.825rem;
-    left: 0.165rem;
+    inset-inline-start: 0.165rem;
     margin-top: -0.4125rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(0.825rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-0.825rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     color: #697077;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     color: #697077;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.5rem;
+    inset-inline-start: 1.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.5rem;
+    inset-inline-start: 1.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: #343a3f;
     background: #f2f4f8;
     margin: 0;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0;
@@ -1466,7 +1475,7 @@
     background: #44a1d9;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.125rem 0.25rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #343a3f;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #697077;
     width: 2.357rem;
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
   .p-multiselect.p-variant-filled {
     background: #f2f4f8;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #697077;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: #343a3f;
     background: #f2f4f8;
     margin: 0;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 1rem;
     height: 1rem;
     color: #878d96;
@@ -1644,7 +1653,7 @@
     background: #dde1e6;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #697077;
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 2.75rem;
+    padding-inline-end: 2.75rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #697077;
-    right: 1.5rem;
+    inset-inline-end: 1.5rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #1174c0;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.125rem 0.25rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #343a3f;
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: #697077;
     width: 2.357rem;
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f2f4f8;
@@ -2030,24 +2039,24 @@
     color: #343a3f;
     background: #f2f4f8;
     margin: 0;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.5rem;
+    inset-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 1rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #697077;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.25rem 1rem;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #343a3f;
     background: #f2f4f8;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.25rem 1rem;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #343a3f;
     background: #f2f4f8;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #697077;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #44a1d9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #dde1e6;
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #90c9f5;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-end-start-radius: 1px;
+    border-end-end-radius: 1px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: #343a3f;
     background: #f2f4f8;
     margin: 0;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.5rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dee2e6;
+    border-inline-end: 1px solid #dee2e6;
     border-color: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: #343a3f;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-start-start-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0.25rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 1rem;
     height: 1rem;
     color: #878d96;
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #697077;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #343a3f;
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.25rem;
+    padding-inline-end: 1.25rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.25rem;
+    inset-inline-end: 0.25rem;
     color: #697077;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: #ffffff;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.25rem 1rem;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #343a3f;
     background: #f2f4f8;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.25rem 1rem;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #343a3f;
     background: #f2f4f8;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #697077;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #44a1d9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #dde1e6;
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #343a3f;
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #343a3f;
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #f2f4f8;
     color: #343a3f;
     border: 1px solid #dde1e6;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.25rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-end-start-radius: 1px;
+    border-end-end-radius: 1px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #f2f4f8;
     border-color: #dee2e6;
     color: #343a3f;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dee2e6;
@@ -3884,10 +4016,10 @@
     background: #ffffff;
     color: #343a3f;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 0.5rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dee2e6;
+    border-inline-start: 1px #dee2e6;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 0.75rem;
     background: #f2f4f8;
     color: #343a3f;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #dee2e6;
     background: #ffffff;
     color: #343a3f;
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #697077;
     padding: 0.75rem;
     font-weight: 600;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #1174c0;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4173,8 +4317,8 @@
     padding: 0.5rem;
     border: 0 none;
     color: #343a3f;
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #697077;
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #1174c0;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 0.5rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #ffffff;
     color: #343a3f;
     padding: 0.75rem;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #343a3f;
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 0.2rem #90c9f5;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #343a3f;
-    padding: 0 0.75rem 1rem 0.75rem;
+    padding-block-start: 0;
+    padding-inline-end: 0.75rem;
+    padding-block-end: 1rem;
+    padding-inline-start: 0.75rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #343a3f;
-    padding: 0 0.75rem 0.75rem 0.75rem;
-    text-align: right;
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    padding-block-start: 0;
+    padding-inline-end: 0.75rem;
+    padding-block-end: 0.75rem;
+    padding-inline-start: 0.75rem;
+    text-align: end;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -0.5rem;
-    right: -0.5rem;
+    inset-inline-end: -0.5rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0f68ad;
@@ -4568,10 +4724,10 @@
     border-radius: 1px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #343a3f;
+    border-inline-end-color: #343a3f;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #343a3f;
+    border-inline-start-color: #343a3f;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #343a3f;
@@ -4586,11 +4742,11 @@
     border: 1px solid #dee2e6;
     color: #343a3f;
     border-bottom: 0 none;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dee2e6;
     color: #343a3f;
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #1174c0;
@@ -4653,7 +4809,10 @@
     color: #697077;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #343a3f;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
@@ -4898,8 +5057,8 @@
     color: #343a3f;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #343a3f;
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
@@ -5020,8 +5179,8 @@
     color: #343a3f;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 1px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #343a3f;
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 1.5rem;
+      padding-inline-start: 1.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.5rem;
+      padding-inline-start: 2.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.5rem;
+      padding-inline-start: 3.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.5rem;
+      padding-inline-start: 4.5rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.5rem;
+      padding-inline-start: 5.5rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #f2f4f8;
     border-color: #dee2e6;
     color: #343a3f;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #ffffff;
     color: #343a3f;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
@@ -5357,14 +5525,17 @@
     color: #697077;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-end-end-radius: 1px;
+    border-end-start-radius: 1px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 1px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #dee2e6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #1174c0;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 1px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #697077;
     padding: 0.75rem;
     font-weight: 600;
-    border-top-right-radius: 1px;
-    border-top-left-radius: 1px;
+    border-start-end-radius: 1px;
+    border-start-start-radius: 1px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #1174c0;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #697077;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #697077;
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #cdf2fb;
     border: solid #11add3;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #08576a;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #d7f8d3;
     border: solid #32c620;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #196310;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #fef8d6;
     border: solid #e4c306;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #726203;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #fdded2;
     border: solid #de450a;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6f2205;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 1px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #cdf2fb;
     border: solid #11add3;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #08576a;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #d7f8d3;
     border: solid #32c620;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #196310;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #fef8d6;
     border: solid #e4c306;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #726203;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #fdded2;
     border: solid #de450a;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6f2205;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: #ffffff;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.125rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.75rem;
     height: 1.75rem;
-    margin-left: -0.25rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.25rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 1px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 1px;
-    border-bottom-left-radius: 1px;
+    border-start-start-radius: 1px;
+    border-end-start-radius: 1px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-start-end-radius: 1px;
+    border-end-end-radius: 1px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 1px;
-    border-top-right-radius: 1px;
+    border-start-start-radius: 1px;
+    border-start-end-radius: 1px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 1px;
-    border-bottom-right-radius: 1px;
+    border-end-start-radius: 1px;
+    border-end-end-radius: 1px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #1174c0;
@@ -6380,7 +6599,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/nova-accent/theme.css
+++ b/src/assets/components/themes/nova-accent/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #007ad9;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #007ad9;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #c8c8c8;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #333333;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #212121;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #bababa;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #848484;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #007ad9;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #e02365;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #d8dae2;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #d8dae2;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #e02365;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #d8dae2;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #d8dae2;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #eaeaea;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #848484;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a80000;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +925,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
@@ -923,7 +935,7 @@
     color: #333333;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -942,11 +954,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +996,7 @@
     border-color: #007ad9;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1013,12 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #a80000;
@@ -1034,15 +1046,15 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1127,13 @@
     background: #eaeaea;
     color: #848484;
     border-top: 1px solid #a6a6a6;
-    border-left: 1px solid #a6a6a6;
+    border-inline-start: 1px solid #a6a6a6;
     border-bottom: 1px solid #a6a6a6;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #a6a6a6;
+    border-inline-end: 1px solid #a6a6a6;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1145,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1163,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1177,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1194,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #848484;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
 
@@ -1196,11 +1208,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1230,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1278,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1354,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #666666;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1365,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #848484;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1448,18 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1466,7 +1481,7 @@
     background: #e02365;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1545,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #f4f4f4;
@@ -1560,11 +1575,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1595,21 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -1644,7 +1659,7 @@
     background: #eaeaea;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1715,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #848484;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1799,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1891,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1900,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1924,7 @@
     border-color: #007ad9;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +2002,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
@@ -1996,8 +2011,8 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f4f4f4;
@@ -2030,24 +2045,24 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2103,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2192,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2204,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2244,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2632,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2699,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2718,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #007ad9;
     color: #ffffff;
     border: 1px solid #007ad9;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2722,22 +2746,28 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #333333;
     background: #f4f4f4;
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
     border-width: 1px;
@@ -2747,7 +2777,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #848484;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2786,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #e02365;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e0e0e0;
@@ -2789,7 +2819,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #c8c8c8;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #8dcdff;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f9f9f9;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #007ad9;
     color: #ffffff;
     border: 1px solid #007ad9;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2982,11 +3069,14 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #c8c8c8;
+    border-inline-end: 1px solid #c8c8c8;
     border-color: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: #333333;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #848484;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #333333;
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: #ffffff;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #848484;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #007ad9;
     color: #ffffff;
     border: 1px solid #007ad9;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3626,22 +3728,28 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #333333;
     background: #f4f4f4;
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
     border-width: 1px;
@@ -3654,7 +3762,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #848484;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3771,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #e02365;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e0e0e0;
@@ -3685,7 +3793,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #c8c8c8;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3698,7 +3806,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #007ad9;
@@ -3715,7 +3823,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #333333;
@@ -3768,16 +3876,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3943,10 @@
     background: #007ad9;
     color: #ffffff;
     border: 1px solid #007ad9;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3837,11 +3960,14 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3980,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +3996,8 @@
     background: #007ad9;
     border-color: #007ad9;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #005b9f;
@@ -3884,10 +4010,10 @@
     background: #ffffff;
     color: #333333;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3916,7 +4042,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3937,7 +4066,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #c8c8c8;
+    border-inline-start: 1px #c8c8c8;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3968,7 +4097,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3989,8 +4118,8 @@
     padding: 0.857rem 1rem;
     background: #007ad9;
     color: #ffffff;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4025,25 +4154,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     background: #ffffff;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4093,7 +4222,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #007ad9;
@@ -4103,10 +4232,13 @@
     color: #ffffff;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4124,13 +4256,13 @@
     color: #ffffff;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #007ad9;
@@ -4149,8 +4281,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4257,7 +4389,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #848484;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4317,7 +4449,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4329,7 +4461,7 @@
     background-color: #007ad9;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4343,11 +4475,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4377,7 +4512,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4390,8 +4525,8 @@
     background: #007ad9;
     color: #ffffff;
     padding: 1rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4405,7 +4540,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #007ad9;
@@ -4418,7 +4553,7 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
@@ -4426,20 +4561,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #c8c8c8;
     background: #ffffff;
     color: #333333;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4450,7 +4588,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4472,7 +4610,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #116fbf;
@@ -4544,10 +4682,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #333333;
+    border-inline-end-color: #333333;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #333333;
+    border-inline-start-color: #333333;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #333333;
@@ -4562,11 +4700,11 @@
     border: 1px solid #007ad9;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4578,8 +4716,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #007ad9;
@@ -4629,7 +4767,10 @@
     color: #333333;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #333333;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4673,7 +4814,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -4820,7 +4961,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -4874,8 +5015,8 @@
     color: #333333;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4903,11 +5044,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #333333;
@@ -4944,7 +5085,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -4996,8 +5137,8 @@
     color: #333333;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #d8dae2;
@@ -5012,9 +5153,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5041,11 +5182,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #333333;
@@ -5073,7 +5214,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5172,11 +5313,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5188,33 +5332,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5234,10 +5384,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5253,8 +5403,8 @@
     background: #007ad9;
     border-color: #007ad9;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5268,10 +5418,10 @@
     background: #ffffff;
     color: #333333;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5291,7 +5441,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5333,14 +5483,17 @@
     color: #333333;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5375,7 +5528,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5456,9 +5609,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5500,7 +5653,7 @@
     border-top: 1px solid #d8dae2;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5520,12 +5673,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #007ad9;
@@ -5535,13 +5688,16 @@
     color: #ffffff;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5559,10 +5715,10 @@
     color: #ffffff;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #007ad9;
@@ -5615,7 +5771,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5711,7 +5867,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5721,7 +5877,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5800,7 +5956,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5810,14 +5966,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 3px;
   }
@@ -5826,7 +5985,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5839,7 +6001,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5961,7 +6126,7 @@
     color: #ffffff;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6033,10 +6198,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6125,16 +6290,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6238,12 +6403,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6253,12 +6418,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6306,6 +6471,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #007ad9;
@@ -6332,7 +6500,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/nova-alt/theme.css
+++ b/src/assets/components/themes/nova-alt/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #333333;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #333333;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #c8c8c8;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #333333;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #212121;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #bababa;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #848484;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #007ad9;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #007ad9;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #d8dae2;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #d8dae2;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #007ad9;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #d8dae2;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #d8dae2;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #eaeaea;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #848484;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a80000;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +929,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
@@ -927,7 +939,7 @@
     color: #333333;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -946,11 +958,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +1000,7 @@
     border-color: #007ad9;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1017,12 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #a80000;
@@ -1038,15 +1050,15 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1131,13 @@
     background: #eaeaea;
     color: #848484;
     border-top: 1px solid #a6a6a6;
-    border-left: 1px solid #a6a6a6;
+    border-inline-start: 1px solid #a6a6a6;
     border-bottom: 1px solid #a6a6a6;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #a6a6a6;
+    border-inline-end: 1px solid #a6a6a6;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1149,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1167,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1181,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1198,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #848484;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
 
@@ -1200,11 +1212,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1234,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1282,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1358,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #666666;
     transition-duration: 0.2s;
   }
@@ -1354,38 +1369,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #848484;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1452,18 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1470,7 +1485,7 @@
     background: #007ad9;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1549,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #f4f4f4;
@@ -1564,11 +1579,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1599,21 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -1648,7 +1663,7 @@
     background: #eaeaea;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1719,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #848484;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1803,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1903,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1912,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1936,7 @@
     border-color: #007ad9;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1999,7 +2014,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
@@ -2008,8 +2023,8 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f4f4f4;
@@ -2042,24 +2057,24 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2115,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2204,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2216,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2256,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2629,14 +2644,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2696,7 +2711,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2715,18 +2730,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #333333;
     color: #ffffff;
     border: 1px solid #333333;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2734,22 +2758,28 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #333333;
     background: #f4f4f4;
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
     border-width: 1px;
@@ -2759,7 +2789,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #848484;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2768,7 +2798,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #007ad9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e0e0e0;
@@ -2801,7 +2831,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #c8c8c8;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2835,7 +2865,7 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #8dcdff;
@@ -2871,58 +2901,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f9f9f9;
@@ -2969,18 +3047,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #333333;
     color: #ffffff;
     border: 1px solid #333333;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2994,11 +3081,14 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3009,7 +3099,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3107,8 +3197,8 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3164,10 +3254,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-orderlist .p-orderlist-list {
@@ -3243,7 +3333,7 @@
     background: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #c8c8c8;
+    border-inline-end: 1px solid #c8c8c8;
     border-color: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3297,24 +3387,24 @@
     color: #333333;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3383,10 +3473,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-picklist .p-picklist-list {
@@ -3494,7 +3584,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -3514,11 +3604,11 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #848484;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #333333;
@@ -3560,14 +3650,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3595,14 +3688,14 @@
     color: #ffffff;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #848484;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3619,18 +3712,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #333333;
     color: #ffffff;
     border: 1px solid #333333;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3638,22 +3740,28 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #333333;
     background: #f4f4f4;
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
     border-width: 1px;
@@ -3666,7 +3774,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #848484;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3675,7 +3783,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #007ad9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e0e0e0;
@@ -3697,7 +3805,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #c8c8c8;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3710,7 +3818,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #007ad9;
@@ -3727,7 +3835,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #333333;
@@ -3780,16 +3888,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3835,7 +3955,10 @@
     background: #333333;
     color: #ffffff;
     border: 1px solid #333333;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3849,11 +3972,14 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3866,7 +3992,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3882,8 +4008,8 @@
     background: #007ad9;
     border-color: #007ad9;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #005b9f;
@@ -3896,10 +4022,10 @@
     background: #ffffff;
     color: #333333;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3928,7 +4054,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3949,7 +4078,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #c8c8c8;
+    border-inline-start: 1px #c8c8c8;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3980,7 +4109,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4001,8 +4130,8 @@
     padding: 0.857rem 1rem;
     background: #333333;
     color: #ffffff;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4037,25 +4166,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     background: #ffffff;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4105,7 +4234,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #333333;
@@ -4115,10 +4244,13 @@
     color: #ffffff;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4136,13 +4268,13 @@
     color: #ffffff;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #007ad9;
@@ -4161,8 +4293,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4269,7 +4401,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #848484;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4329,7 +4461,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4341,7 +4473,7 @@
     background-color: #007ad9;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4355,11 +4487,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4389,7 +4524,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4402,8 +4537,8 @@
     background: #333333;
     color: #ffffff;
     padding: 1rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4417,7 +4552,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #007ad9;
@@ -4430,7 +4565,7 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
@@ -4438,20 +4573,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #c8c8c8;
     background: #ffffff;
     color: #333333;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4462,7 +4600,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4484,7 +4622,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #116fbf;
@@ -4556,10 +4694,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #333333;
+    border-inline-end-color: #333333;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #333333;
+    border-inline-start-color: #333333;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #333333;
@@ -4574,11 +4712,11 @@
     border: 1px solid #333333;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4590,8 +4728,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #007ad9;
@@ -4641,7 +4779,10 @@
     color: #333333;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #333333;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4685,7 +4826,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -4832,7 +4973,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -4886,8 +5027,8 @@
     color: #333333;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4915,11 +5056,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #333333;
@@ -4956,7 +5097,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5008,8 +5149,8 @@
     color: #333333;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #d8dae2;
@@ -5024,9 +5165,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5053,11 +5194,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #333333;
@@ -5085,7 +5226,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5184,11 +5325,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5200,33 +5344,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5246,10 +5396,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5265,8 +5415,8 @@
     background: #007ad9;
     border-color: #007ad9;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5280,10 +5430,10 @@
     background: #ffffff;
     color: #333333;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5303,7 +5453,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5345,14 +5495,17 @@
     color: #333333;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5387,7 +5540,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5468,9 +5621,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5512,7 +5665,7 @@
     border-top: 1px solid #d8dae2;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5532,12 +5685,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #333333;
@@ -5547,13 +5700,16 @@
     color: #ffffff;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5571,10 +5727,10 @@
     color: #ffffff;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #007ad9;
@@ -5627,7 +5783,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5723,7 +5879,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5733,7 +5889,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5812,7 +5968,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5822,14 +5978,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 3px;
   }
@@ -5838,7 +5997,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5851,7 +6013,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5973,7 +6138,7 @@
     color: #ffffff;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6045,10 +6210,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6137,16 +6302,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6250,12 +6415,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6265,12 +6430,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6318,6 +6483,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #007ad9;
@@ -6344,7 +6512,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/nova/theme.css
+++ b/src/assets/components/themes/nova/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f4f4f4;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #c8c8c8;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #c8c8c8;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #333333;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #212121;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #bababa;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #848484;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #007ad9;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #007ad9;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #d8dae2;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #d8dae2;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #007ad9;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #d8dae2;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #d8dae2;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #eaeaea;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #848484;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #a80000;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-checkbox .p-checkbox-box {
@@ -917,7 +929,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
@@ -927,7 +939,7 @@
     color: #333333;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -946,11 +958,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -988,7 +1000,7 @@
     border-color: #007ad9;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1005,12 +1017,12 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #a80000;
@@ -1038,15 +1050,15 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1119,13 +1131,13 @@
     background: #eaeaea;
     color: #848484;
     border-top: 1px solid #a6a6a6;
-    border-left: 1px solid #a6a6a6;
+    border-inline-start: 1px solid #a6a6a6;
     border-bottom: 1px solid #a6a6a6;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #a6a6a6;
+    border-inline-end: 1px solid #a6a6a6;
   }
 
   .p-inputgroup > .p-component,
@@ -1137,7 +1149,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1155,13 +1167,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1169,13 +1181,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1186,12 +1198,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #848484;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
 
@@ -1200,11 +1212,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1222,18 +1234,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1270,13 +1282,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1343,7 +1358,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #666666;
     transition-duration: 0.2s;
   }
@@ -1354,38 +1369,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #848484;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1437,18 +1452,18 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1470,7 +1485,7 @@
     background: #007ad9;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1534,20 +1549,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #f4f4f4;
@@ -1564,11 +1579,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1584,21 +1599,21 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -1648,7 +1663,7 @@
     background: #eaeaea;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1704,19 +1719,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #848484;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #848484;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1788,7 +1803,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-highlight .p-radiobutton .p-radiobutton-box {
@@ -1888,7 +1903,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1897,7 +1912,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1921,7 +1936,7 @@
     border-color: #007ad9;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1999,7 +2014,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #c8c8c8;
     color: #333333;
     border-radius: 16px;
@@ -2008,8 +2023,8 @@
     background: transparent;
     color: #848484;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f4f4f4;
@@ -2042,24 +2057,24 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2100,11 +2115,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #848484;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2189,10 +2204,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2201,7 +2216,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2241,10 +2256,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2629,14 +2644,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2696,7 +2711,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2715,18 +2730,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f4f4f4;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2734,22 +2758,28 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #333333;
     background: #f4f4f4;
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
     border-width: 1px;
@@ -2759,7 +2789,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #848484;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2768,7 +2798,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #007ad9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e0e0e0;
@@ -2801,7 +2831,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #c8c8c8;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2835,7 +2865,7 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #8dcdff;
@@ -2871,58 +2901,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f9f9f9;
@@ -2969,18 +3047,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f4f4f4;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2994,11 +3081,14 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3009,7 +3099,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3107,8 +3197,8 @@
     color: #333333;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3164,10 +3254,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-orderlist .p-orderlist-list {
@@ -3243,7 +3333,7 @@
     background: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #c8c8c8;
+    border-inline-end: 1px solid #c8c8c8;
     border-color: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3297,24 +3387,24 @@
     color: #333333;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3383,10 +3473,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-picklist .p-picklist-list {
@@ -3494,7 +3584,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -3514,11 +3604,11 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #848484;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #333333;
@@ -3560,14 +3650,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #848484;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3595,14 +3688,14 @@
     color: #ffffff;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #848484;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3619,18 +3712,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f4f4f4;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3638,22 +3740,28 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #333333;
     background: #f4f4f4;
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #c8c8c8;
     border-width: 1px;
@@ -3666,7 +3774,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #848484;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3675,7 +3783,7 @@
     line-height: 1.143rem;
     color: #ffffff;
     background: #007ad9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e0e0e0;
@@ -3697,7 +3805,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #c8c8c8;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3710,7 +3818,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #007ad9;
@@ -3727,7 +3835,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #333333;
@@ -3780,16 +3888,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3835,7 +3955,10 @@
     background: #f4f4f4;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3849,11 +3972,14 @@
     background: #ffffff;
     color: #333333;
     border: 1px solid #c8c8c8;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3866,7 +3992,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3882,8 +4008,8 @@
     background: #007ad9;
     border-color: #007ad9;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #005b9f;
@@ -3896,10 +4022,10 @@
     background: #ffffff;
     color: #333333;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3928,7 +4054,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3949,7 +4078,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #c8c8c8;
+    border-inline-start: 1px #c8c8c8;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3980,7 +4109,7 @@
     transition: background-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4001,8 +4130,8 @@
     padding: 0.857rem 1rem;
     background: #f4f4f4;
     color: #333333;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4037,25 +4166,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     background: #ffffff;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4105,7 +4234,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #c8c8c8;
@@ -4115,10 +4244,13 @@
     color: #333333;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4136,13 +4268,13 @@
     color: #ffffff;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #007ad9;
@@ -4161,8 +4293,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4269,7 +4401,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #848484;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4329,7 +4461,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4341,7 +4473,7 @@
     background-color: #007ad9;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4355,11 +4487,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4389,7 +4524,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4402,8 +4537,8 @@
     background: #f4f4f4;
     color: #333333;
     padding: 1rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4417,7 +4552,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #007ad9;
@@ -4430,7 +4565,7 @@
     box-shadow: 0 0 0 0.2rem #8dcdff;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
@@ -4438,20 +4573,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #c8c8c8;
     background: #ffffff;
     color: #333333;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4462,7 +4600,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4484,7 +4622,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #116fbf;
@@ -4556,10 +4694,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #333333;
+    border-inline-end-color: #333333;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #333333;
+    border-inline-start-color: #333333;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #333333;
@@ -4574,11 +4712,11 @@
     border: 1px solid #c8c8c8;
     color: #333333;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4590,8 +4728,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #c8c8c8;
     color: #333333;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #007ad9;
@@ -4641,7 +4779,10 @@
     color: #333333;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #333333;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4685,7 +4826,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -4832,7 +4973,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -4886,8 +5027,8 @@
     color: #333333;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4915,11 +5056,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #333333;
@@ -4956,7 +5097,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5008,8 +5149,8 @@
     color: #333333;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #d8dae2;
@@ -5024,9 +5165,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5053,11 +5194,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #333333;
@@ -5085,7 +5226,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5184,11 +5325,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5200,33 +5344,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5246,10 +5396,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5265,8 +5415,8 @@
     background: #007ad9;
     border-color: #007ad9;
     color: #ffffff;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5280,10 +5430,10 @@
     background: #ffffff;
     color: #333333;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5303,7 +5453,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5345,14 +5495,17 @@
     color: #333333;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #d8dae2;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5387,7 +5540,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5468,9 +5621,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5512,7 +5665,7 @@
     border-top: 1px solid #d8dae2;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5532,12 +5685,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #c8c8c8;
@@ -5547,13 +5700,16 @@
     color: #333333;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: background-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5571,10 +5727,10 @@
     color: #ffffff;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #007ad9;
@@ -5627,7 +5783,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #333333;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #333333;
@@ -5723,7 +5879,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5733,7 +5889,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5812,7 +5968,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5822,14 +5978,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 3px;
   }
@@ -5838,7 +5997,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5851,7 +6013,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5973,7 +6138,7 @@
     color: #ffffff;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6045,10 +6210,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6137,16 +6302,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6250,12 +6415,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6265,12 +6430,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6318,6 +6483,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #007ad9;
@@ -6344,7 +6512,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/rhea/theme.css
+++ b/src/assets/components/themes/rhea/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #7b95a3;
-  border-top-right-radius: 2px;
-  border-top-left-radius: 2px;
+  border-start-end-radius: 2px;
+  border-start-start-radius: 2px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #7b95a3;
@@ -227,8 +227,8 @@
   padding: 0.429rem 0.857rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 2px;
-  border-bottom-left-radius: 2px;
+  border-end-end-radius: 2px;
+  border-end-start-radius: 2px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dadada;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #666666;
-  border-bottom-right-radius: 2px;
-  border-bottom-left-radius: 2px;
+  border-end-end-radius: 2px;
+  border-end-start-radius: 2px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #a6a6a6;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #cbcbcb;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #a6a6a6;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #a6a6a6;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 0 none;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #7b95a3;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -576,7 +576,10 @@
     background: #afd3c8;
   }
   .p-datepicker .p-datepicker-buttonbar {
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
     border-top: 1px solid #dadada;
   }
   .p-datepicker .p-datepicker-buttonbar .p-button {
@@ -584,7 +587,10 @@
   }
   .p-datepicker .p-timepicker {
     border-top: 1px solid #dadada;
-    padding: 0.857rem 0 0.429rem 0;
+    padding-block-start: 0.857rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.429rem;
+    padding-inline-start: 0;
   }
   .p-datepicker .p-timepicker button {
     width: 2rem;
@@ -642,18 +648,18 @@
     background: #afd3c8;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dadada;
-    padding-right: 0.857rem;
-    padding-left: 0.857rem;
+    border-inline-start: 1px solid #dadada;
+    padding-inline-end: 0.857rem;
+    padding-inline-start: 0.857rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f4f4f4;
@@ -681,16 +687,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #a6a6a6;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #a6a6a6;
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +735,8 @@
     background: transparent;
     color: #a6a6a6;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #e7a3a3;
@@ -803,20 +809,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.429rem;
+    padding-inline-end: 0.429rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #a6a6a6;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +903,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +925,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dadada;
     color: #666666;
     border-radius: 16px;
@@ -923,7 +935,7 @@
     color: #666666;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.2145rem 0;
@@ -942,11 +954,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #a6a6a6;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +996,7 @@
     border-color: #7b95a3;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1013,12 @@
     background: transparent;
     color: #a6a6a6;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #a6a6a6;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #e7a3a3;
@@ -1034,15 +1046,15 @@
     color: #666666;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.429rem;
-    margin-right: -1.429rem;
+    padding-inline-end: 1.429rem;
+    margin-inline-end: -1.429rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1127,13 @@
     background: #dbdbdb;
     color: #666666;
     border-top: 1px solid #dadada;
-    border-left: 1px solid #dadada;
+    border-inline-start: 1px solid #dadada;
     border-bottom: 1px solid #dadada;
     padding: 0.429rem 0.429rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #dadada;
+    border-inline-end: 1px solid #dadada;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1145,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1163,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-start-radius: 2px;
+    border-end-start-radius: 2px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-start-radius: 2px;
+    border-end-start-radius: 2px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1177,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1194,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #a6a6a6;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
 
@@ -1196,11 +1208,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #a6a6a6;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1230,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #a6a6a6;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.786rem;
+    inset-inline-end: 2.786rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1278,16 @@
     background: #7b95a3;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1354,7 @@
   }
 
   .p-float-label > label {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #a6a6a6;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1365,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.429rem;
+    inset-inline-start: 0.429rem;
     color: #a6a6a6;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 1.858rem;
+    padding-inline-start: 1.858rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 1.858rem;
+    inset-inline-start: 1.858rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1448,18 @@
     color: #666666;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0;
@@ -1466,7 +1481,7 @@
     background: #afd3c8;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1545,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dadada;
     color: #666666;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #a6a6a6;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-multiselect.p-variant-filled {
     background: #f4f4f4;
@@ -1560,11 +1575,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #a6a6a6;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1595,21 @@
     color: #666666;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -1644,7 +1659,7 @@
     background: #f4f4f4;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1715,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 1.858rem;
+    padding-inline-end: 1.858rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #a6a6a6;
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.287rem;
+    padding-inline-end: 3.287rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #a6a6a6;
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1799,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1891,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.7145rem;
-    margin-left: -0.7145rem;
+    margin-inline-start: -0.7145rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1900,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.429rem;
     width: 1.429rem;
-    margin-left: -0.7145rem;
+    margin-inline-start: -0.7145rem;
     margin-bottom: -0.7145rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1924,7 @@
     border-color: #7b95a3;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +2002,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.2145rem 0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dadada;
     color: #666666;
     border-radius: 16px;
@@ -1996,8 +2011,8 @@
     background: transparent;
     color: #a6a6a6;
     width: 2.357rem;
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f4f4f4;
@@ -2030,24 +2045,24 @@
     color: #666666;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 2.858rem;
+    padding-inline-end: 2.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 1.858rem;
+    inset-inline-end: 1.858rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2103,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #a6a6a6;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2192,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2204,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2244,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2632,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2699,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2718,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #7b95a3;
     color: #ffffff;
     border: 1px solid #7b95a3;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2722,22 +2746,28 @@
     background: #ffffff;
     color: #666666;
     border: 1px solid #dadada;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #dadada;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #666666;
     background: #ffffff;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #dadada;
     border-width: 1px;
@@ -2747,7 +2777,7 @@
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #666666;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2786,7 @@
     line-height: 1.143rem;
     color: #385048;
     background: #afd3c8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #eaeaea;
@@ -2789,7 +2819,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dadada;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #e4e9ec;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #f8f8f8;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #7b95a3;
     color: #ffffff;
     border: 1px solid #7b95a3;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -2982,11 +3069,14 @@
     background: #ffffff;
     color: #666666;
     border: 1px solid #dadada;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-end-start-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: #666666;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 0.571rem 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dadada;
+    border-inline-end: 1px solid #dadada;
     border-color: #c8c8c8;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: #666666;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #a6a6a6;
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #a6a6a6;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #666666;
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.429rem;
+    padding-inline-end: 1.429rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.429rem;
+    inset-inline-end: 0.429rem;
     color: #a6a6a6;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: #385048;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #a6a6a6;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #7b95a3;
     color: #ffffff;
     border: 1px solid #7b95a3;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3626,22 +3728,28 @@
     background: #ffffff;
     color: #666666;
     border: 1px solid #dadada;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #dadada;
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     font-weight: 700;
     color: #666666;
     background: #ffffff;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 0.571rem 0.857rem;
     border: 1px solid #dadada;
     border-width: 1px;
@@ -3654,7 +3762,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #666666;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3771,7 @@
     line-height: 1.143rem;
     color: #385048;
     background: #afd3c8;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #eaeaea;
@@ -3685,7 +3793,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dadada;
     border-width: 1px;
     padding: 0.571rem 0.857rem;
@@ -3698,7 +3806,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #666666;
@@ -3715,7 +3823,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #666666;
@@ -3768,16 +3876,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3943,10 @@
     background: #7b95a3;
     color: #ffffff;
     border: 1px solid #7b95a3;
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
     padding: 0.857rem 1rem;
     font-weight: 700;
   }
@@ -3837,11 +3960,14 @@
     background: #ffffff;
     color: #666666;
     border: 1px solid #dadada;
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
     padding: 0.571rem 1rem;
     font-weight: normal;
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-end-start-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3980,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +3996,8 @@
     background: #afd3c8;
     border-color: #dadada;
     color: #385048;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #8dc8b5;
@@ -3884,10 +4010,10 @@
     background: #ffffff;
     color: #666666;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 2px;
@@ -3916,7 +4042,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3937,7 +4066,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dadada;
+    border-inline-start: 1px #dadada;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3968,7 +4097,7 @@
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -3989,8 +4118,8 @@
     padding: 0.857rem 1rem;
     background: #7b95a3;
     color: #ffffff;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4025,25 +4154,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-panel .p-panel-footer {
     padding: 0.571rem 1rem;
     border: 1px solid #dadada;
     background: #ffffff;
     color: #666666;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4093,7 +4222,7 @@
     border-width: 1px;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: 1px solid #7b95a3;
@@ -4103,10 +4232,13 @@
     color: #ffffff;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4124,13 +4256,13 @@
     color: #385048;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #afd3c8;
@@ -4149,8 +4281,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #dadada;
     color: #666666;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
 
   .p-toolbar {
@@ -4257,7 +4389,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #a6a6a6;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4317,7 +4449,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4329,7 +4461,7 @@
     background-color: #7b95a3;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4343,11 +4475,14 @@
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.571rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4377,7 +4512,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4390,8 +4525,8 @@
     background: #7b95a3;
     color: #ffffff;
     padding: 1rem;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4405,7 +4540,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #666666;
@@ -4418,7 +4553,7 @@
     box-shadow: 0 0 0 0.2rem #e4e9ec;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
@@ -4426,20 +4561,23 @@
     padding: 1rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 1px solid #dadada;
     background: #ffffff;
     color: #666666;
     padding: 0.571rem 1rem;
-    text-align: right;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    text-align: end;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4450,7 +4588,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4472,7 +4610,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #6c8999;
@@ -4544,10 +4682,10 @@
     border-radius: 2px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #afd3c8;
+    border-inline-end-color: #afd3c8;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #afd3c8;
+    border-inline-start-color: #afd3c8;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #afd3c8;
@@ -4562,11 +4700,11 @@
     border: 1px solid #7b95a3;
     color: #ffffff;
     border-bottom: 0 none;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4578,8 +4716,8 @@
     padding: 0.571rem 1rem;
     border: 1px solid #dadada;
     color: #666666;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #7b95a3;
@@ -4629,7 +4767,10 @@
     color: #666666;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #666666;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4673,7 +4814,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
@@ -4820,7 +4961,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
@@ -4874,8 +5015,8 @@
     color: #666666;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0;
@@ -4903,11 +5044,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #666666;
@@ -4944,7 +5085,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
@@ -4996,8 +5137,8 @@
     color: #666666;
     background: #f4f4f4;
     font-weight: 700;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dadada;
@@ -5012,9 +5153,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 2px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5041,11 +5182,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #666666;
@@ -5073,7 +5214,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
@@ -5172,11 +5313,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5188,33 +5332,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.571rem;
+      padding-inline-start: 2.571rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 4.285rem;
+      padding-inline-start: 4.285rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.999rem;
+      padding-inline-start: 5.999rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 7.713rem;
+      padding-inline-start: 7.713rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 9.427rem;
+      padding-inline-start: 9.427rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5234,10 +5384,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5253,8 +5403,8 @@
     background: #afd3c8;
     border-color: #dadada;
     color: #385048;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5268,10 +5418,10 @@
     background: #ffffff;
     color: #666666;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5291,7 +5441,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
@@ -5333,14 +5483,17 @@
     color: #666666;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dadada;
     margin: 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 2px;
@@ -5375,7 +5528,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
@@ -5456,9 +5609,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 2px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5500,7 +5653,7 @@
     border-top: 1px solid #dadada;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5520,12 +5673,12 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 2px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 2px;
+    margin-inline-end: 2px;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: 1px solid #7b95a3;
@@ -5535,13 +5688,16 @@
     color: #ffffff;
     padding: 0.857rem 1rem;
     font-weight: 700;
-    border-top-right-radius: 2px;
-    border-top-left-radius: 2px;
+    border-start-end-radius: 2px;
+    border-start-start-radius: 2px;
     transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
-    margin: 0 0 -1px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -1px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5559,10 +5715,10 @@
     color: #385048;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #afd3c8;
@@ -5615,7 +5771,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #666666;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #666666;
@@ -5711,7 +5867,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5721,7 +5877,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5800,7 +5956,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5810,14 +5966,17 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 3px 6px 0 rgba(0, 0, 0, 0.16);
     border-radius: 2px;
   }
@@ -5826,7 +5985,10 @@
     border-width: 0;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5839,7 +6001,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5961,7 +6126,7 @@
     color: #385048;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6033,10 +6198,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6125,16 +6290,16 @@
     margin-bottom: 0.2145rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 1.929rem;
     height: 1.929rem;
-    margin-left: -0.429rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.429rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 2px;
@@ -6238,12 +6403,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 2px;
-    border-bottom-left-radius: 2px;
+    border-start-start-radius: 2px;
+    border-end-start-radius: 2px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-start-end-radius: 2px;
+    border-end-end-radius: 2px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6253,12 +6418,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 2px;
-    border-top-right-radius: 2px;
+    border-start-start-radius: 2px;
+    border-start-end-radius: 2px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 2px;
-    border-bottom-right-radius: 2px;
+    border-end-start-radius: 2px;
+    border-end-end-radius: 2px;
   }
 
   .p-progressbar {
@@ -6306,6 +6471,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #7b95a3;
@@ -6332,7 +6500,7 @@
     color: #262222;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/saga-blue/theme.css
+++ b/src/assets/components/themes/saga-blue/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f8f9fa;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dee2e6;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dee2e6;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #495057;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #2196F3;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #ced4da;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #dee2e6;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #2196F3;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #E3F2FD;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dee2e6;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #dee2e6;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #e9ecef;
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: #495057;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #2196F3;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
@@ -1034,15 +1040,15 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #e9ecef;
     color: #6c757d;
     border-top: 1px solid #ced4da;
-    border-left: 1px solid #ced4da;
+    border-inline-start: 1px solid #ced4da;
     border-bottom: 1px solid #ced4da;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #ced4da;
+    border-inline-end: 1px solid #ced4da;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: #E3F2FD;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8f9fa;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -1644,7 +1653,7 @@
     background: #e9ecef;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6c757d;
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #2196F3;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8f9fa;
@@ -2030,24 +2039,24 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #E3F2FD;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #a6d5fa;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dee2e6;
+    border-inline-end: 1px solid #dee2e6;
     border-color: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: #495057;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: #495057;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #E3F2FD;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #495057;
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dee2e6;
@@ -3884,10 +4016,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dee2e6;
+    border-inline-start: 1px #dee2e6;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #f8f9fa;
     color: #495057;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #dee2e6;
     background: #ffffff;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #2196F3;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #2196F3;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #ffffff;
     color: #495057;
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #495057;
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 0.2rem #a6d5fa;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #0d89ec;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #495057;
+    border-inline-end-color: #495057;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #495057;
+    border-inline-start-color: #495057;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #495057;
@@ -4586,11 +4742,11 @@
     border: 1px solid #dee2e6;
     color: #495057;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #2196F3;
@@ -4653,7 +4809,10 @@
     color: #6c757d;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #495057;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4898,8 +5057,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5020,8 +5179,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5357,14 +5525,17 @@
     color: #6c757d;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #dee2e6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #2196F3;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #2196F3;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: #495057;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #2196F3;
@@ -6380,7 +6599,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/saga-green/theme.css
+++ b/src/assets/components/themes/saga-green/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f8f9fa;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dee2e6;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dee2e6;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #495057;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #4CAF50;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #ced4da;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #dee2e6;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #4CAF50;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #E8F5E9;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dee2e6;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #dee2e6;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #e9ecef;
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: #495057;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #4CAF50;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
@@ -1034,15 +1040,15 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #e9ecef;
     color: #6c757d;
     border-top: 1px solid #ced4da;
-    border-left: 1px solid #ced4da;
+    border-inline-start: 1px solid #ced4da;
     border-bottom: 1px solid #ced4da;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #ced4da;
+    border-inline-end: 1px solid #ced4da;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: #E8F5E9;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8f9fa;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -1644,7 +1653,7 @@
     background: #e9ecef;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6c757d;
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #4CAF50;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8f9fa;
@@ -2030,24 +2039,24 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #E8F5E9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #b7e0b8;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dee2e6;
+    border-inline-end: 1px solid #dee2e6;
     border-color: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: #495057;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: #495057;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #E8F5E9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #495057;
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dee2e6;
@@ -3884,10 +4016,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dee2e6;
+    border-inline-start: 1px #dee2e6;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #f8f9fa;
     color: #495057;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #dee2e6;
     background: #ffffff;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #4CAF50;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #4CAF50;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #ffffff;
     color: #495057;
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #495057;
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 0.2rem #b7e0b8;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #449e48;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #495057;
+    border-inline-end-color: #495057;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #495057;
+    border-inline-start-color: #495057;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #495057;
@@ -4586,11 +4742,11 @@
     border: 1px solid #dee2e6;
     color: #495057;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #4CAF50;
@@ -4653,7 +4809,10 @@
     color: #6c757d;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #495057;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4898,8 +5057,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5020,8 +5179,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5357,14 +5525,17 @@
     color: #6c757d;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #dee2e6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #4CAF50;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #4CAF50;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: #495057;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #4CAF50;
@@ -6380,7 +6599,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/saga-orange/theme.css
+++ b/src/assets/components/themes/saga-orange/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f8f9fa;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dee2e6;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dee2e6;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #495057;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #FFC107;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #ced4da;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #dee2e6;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #FFC107;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #FFF3E0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dee2e6;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #dee2e6;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #e9ecef;
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: #495057;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #FFC107;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
@@ -1034,15 +1040,15 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #e9ecef;
     color: #6c757d;
     border-top: 1px solid #ced4da;
-    border-left: 1px solid #ced4da;
+    border-inline-start: 1px solid #ced4da;
     border-bottom: 1px solid #ced4da;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #ced4da;
+    border-inline-end: 1px solid #ced4da;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: #FFF3E0;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8f9fa;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -1644,7 +1653,7 @@
     background: #e9ecef;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6c757d;
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #FFC107;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8f9fa;
@@ -2030,24 +2039,24 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #FFF3E0;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #ffe69c;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dee2e6;
+    border-inline-end: 1px solid #dee2e6;
     border-color: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: #495057;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: #495057;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #FFF3E0;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #495057;
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dee2e6;
@@ -3884,10 +4016,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dee2e6;
+    border-inline-start: 1px #dee2e6;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #f8f9fa;
     color: #495057;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #dee2e6;
     background: #ffffff;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #FFC107;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #FFC107;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #ffffff;
     color: #495057;
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #495057;
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 0.2rem #ffe69c;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #ecb100;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #495057;
+    border-inline-end-color: #495057;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #495057;
+    border-inline-start-color: #495057;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #495057;
@@ -4586,11 +4742,11 @@
     border: 1px solid #dee2e6;
     color: #495057;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #FFC107;
@@ -4653,7 +4809,10 @@
     color: #6c757d;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #495057;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4898,8 +5057,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5020,8 +5179,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5357,14 +5525,17 @@
     color: #6c757d;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #dee2e6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #FFC107;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #FFC107;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: #495057;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #FFC107;
@@ -6380,7 +6599,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/saga-purple/theme.css
+++ b/src/assets/components/themes/saga-purple/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #f8f9fa;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dee2e6;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dee2e6;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #495057;
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #9C27B0;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #ced4da;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #dee2e6;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #9C27B0;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: #F3E5F5;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dee2e6;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #dee2e6;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #e9ecef;
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #6c757d;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f44336;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: #495057;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #9C27B0;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f44336;
@@ -1034,15 +1040,15 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #e9ecef;
     color: #6c757d;
     border-top: 1px solid #ced4da;
-    border-left: 1px solid #ced4da;
+    border-inline-start: 1px solid #ced4da;
     border-bottom: 1px solid #ced4da;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #ced4da;
+    border-inline-end: 1px solid #ced4da;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: #F3E5F5;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #f8f9fa;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -1644,7 +1653,7 @@
     background: #e9ecef;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #6c757d;
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #6c757d;
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #9C27B0;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dee2e6;
     color: #495057;
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: #6c757d;
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f8f9fa;
@@ -2030,24 +2039,24 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #6c757d;
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #F3E5F5;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #df9eea;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: #495057;
     background: #f8f9fa;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dee2e6;
+    border-inline-end: 1px solid #dee2e6;
     border-color: #dee2e6;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: #495057;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.357rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.357rem;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #6c757d;
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: #6c757d;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: #495057;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #495057;
     background: #f8f9fa;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: #495057;
     background: #F3E5F5;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #e9ecef;
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #495057;
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #495057;
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #f8f9fa;
     color: #495057;
     border: 1px solid #e9ecef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dee2e6;
@@ -3884,10 +4016,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dee2e6;
+    border-inline-start: 1px #dee2e6;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #f8f9fa;
     color: #495057;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #dee2e6;
     background: #ffffff;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #9C27B0;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #6c757d;
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #9C27B0;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #ffffff;
     color: #495057;
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #495057;
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 0.2rem #df9eea;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #495057;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #8c239e;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #495057;
+    border-inline-end-color: #495057;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #495057;
+    border-inline-start-color: #495057;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #495057;
@@ -4586,11 +4742,11 @@
     border: 1px solid #dee2e6;
     color: #495057;
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #9C27B0;
@@ -4653,7 +4809,10 @@
     color: #6c757d;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #495057;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -4898,8 +5057,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5020,8 +5179,8 @@
     color: #495057;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #495057;
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #f8f9fa;
     border-color: #dee2e6;
     color: #495057;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #ffffff;
     color: #495057;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5357,14 +5525,17 @@
     color: #6c757d;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dee2e6;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #dee2e6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #9C27B0;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #dee2e6;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dee2e6 transparent;
     background: #ffffff;
     color: #6c757d;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #9C27B0;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #6c757d;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #6c757d;
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: #495057;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #9C27B0;
@@ -6380,7 +6599,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/soho-dark/theme.css
+++ b/src/assets/components/themes/soho-dark/theme.css
@@ -197,8 +197,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #282936;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #3e4053;
@@ -249,8 +249,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #3e4053;
@@ -258,8 +258,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #1d1e27;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -370,10 +370,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #b19df7;
@@ -406,7 +406,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #4c4d5f;
@@ -471,16 +471,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -516,8 +516,8 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid #3e4053;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -556,7 +556,7 @@
     color: #b19df7;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -664,18 +664,18 @@
     background: rgba(177, 157, 247, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #3e4053;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #3e4053;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -703,16 +703,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -751,8 +751,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ff9a9a;
@@ -825,20 +825,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -913,7 +919,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -935,7 +941,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3e4053;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -945,7 +951,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -964,11 +970,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1006,7 +1012,7 @@
     border-color: #b19df7;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1023,12 +1029,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ff9a9a;
@@ -1056,15 +1062,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1137,13 +1143,13 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #3e4053;
-    border-left: 1px solid #3e4053;
+    border-inline-start: 1px solid #3e4053;
     border-bottom: 1px solid #3e4053;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #3e4053;
+    border-inline-end: 1px solid #3e4053;
   }
 
   .p-inputgroup > .p-component,
@@ -1155,7 +1161,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1173,13 +1179,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1187,13 +1193,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1204,12 +1210,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1218,11 +1224,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1240,18 +1246,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1288,13 +1294,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1361,7 +1370,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1372,38 +1381,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1455,18 +1464,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1488,7 +1497,7 @@
     background: rgba(177, 157, 247, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1552,20 +1561,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3e4053;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #3e4053;
@@ -1582,11 +1591,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1602,21 +1611,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1666,7 +1675,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1722,19 +1731,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1806,7 +1815,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1898,7 +1907,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1907,7 +1916,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1931,7 +1940,7 @@
     border-color: #b19df7;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2009,7 +2018,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #3e4053;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2018,8 +2027,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #3e4053;
@@ -2052,24 +2061,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2110,11 +2119,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2199,10 +2208,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2211,7 +2220,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2251,10 +2260,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2639,14 +2648,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2706,7 +2715,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2725,18 +2734,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2744,32 +2762,41 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2778,7 +2805,7 @@
     line-height: 1.143rem;
     color: #b19df7;
     background: rgba(177, 157, 247, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2811,9 +2838,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2845,7 +2875,7 @@
     box-shadow: 0 0 0 1px #e0d8fc;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #e0d8fc;
@@ -2881,58 +2911,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #2b2c38;
@@ -2979,18 +3057,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3004,11 +3091,14 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3019,7 +3109,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3117,8 +3207,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3174,10 +3264,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3253,7 +3343,7 @@
     background: #3e4053;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #3e4053;
+    border-inline-end: 1px solid #3e4053;
     border-color: #3e4053;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3307,24 +3397,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3393,10 +3483,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3504,7 +3594,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3524,11 +3614,11 @@
     box-shadow: 0 0 0 1px #e0d8fc;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3570,14 +3660,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3605,14 +3698,14 @@
     color: #b19df7;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3629,18 +3722,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3648,25 +3750,34 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: rgba(255, 255, 255, 0.87);
     background: #282936;
@@ -3676,7 +3787,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3685,7 +3796,7 @@
     line-height: 1.143rem;
     color: #b19df7;
     background: rgba(177, 157, 247, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3707,9 +3818,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3720,7 +3834,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3737,7 +3851,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3790,16 +3904,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3845,7 +3971,10 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3859,11 +3988,14 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #3e4053;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3876,7 +4008,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3892,8 +4024,8 @@
     background: #282936;
     border-color: #3e4053;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #3e4053;
@@ -3906,10 +4038,10 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3938,7 +4070,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3959,7 +4094,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #3e4053;
+    border-inline-start: 1px #3e4053;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3990,7 +4125,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4011,8 +4146,8 @@
     padding: 1.25rem;
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4047,25 +4182,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #3e4053;
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4112,23 +4247,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #3e4053;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #3e4053;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3e4053 transparent;
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4146,13 +4290,13 @@
     color: #b19df7;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #282936;
@@ -4171,8 +4315,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4279,7 +4423,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4339,7 +4483,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4351,7 +4495,7 @@
     background-color: #b19df7;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4365,11 +4509,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4399,7 +4546,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4412,8 +4559,8 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4427,7 +4574,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4440,28 +4587,37 @@
     box-shadow: 0 0 0 1px #e0d8fc;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4472,7 +4628,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4494,7 +4650,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #a28af5;
@@ -4566,10 +4722,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3e4053;
+    border-inline-end-color: #3e4053;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3e4053;
+    border-inline-start-color: #3e4053;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3e4053;
@@ -4584,11 +4740,11 @@
     border: 1px solid #3e4053;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4600,8 +4756,8 @@
     padding: 2rem 1rem;
     border: 1px solid #3e4053;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #b19df7;
@@ -4651,7 +4807,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4695,7 +4854,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4842,7 +5001,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4896,8 +5055,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #333544;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4925,11 +5084,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4966,7 +5125,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5018,8 +5177,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #333544;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #3e4053;
@@ -5034,9 +5193,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5063,11 +5222,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5095,7 +5254,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5194,11 +5353,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5210,33 +5372,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5256,10 +5424,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5275,8 +5443,8 @@
     background: #282936;
     border-color: #3e4053;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5290,10 +5458,10 @@
     background: #282936;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5313,7 +5481,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5355,14 +5523,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #3e4053;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5397,7 +5568,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5478,9 +5649,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5522,7 +5693,7 @@
     border-top: 1px solid #3e4053;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5531,7 +5702,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #3e4053;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #b19df7;
@@ -5542,28 +5716,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #3e4053;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #3e4053 transparent;
     background: #282936;
     color: rgba(255, 255, 255, 0.6);
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5581,10 +5761,10 @@
     color: #b19df7;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #282936;
@@ -5637,7 +5817,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5733,7 +5913,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5743,7 +5923,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5771,7 +5951,10 @@
   .p-message.p-message-info {
     background: #e9e9ff;
     border: solid #696cff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #696cff;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5783,7 +5966,10 @@
   .p-message.p-message-success {
     background: #e4f8f0;
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5795,7 +5981,10 @@
   .p-message.p-message-warn {
     background: #fff2e2;
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5807,7 +5996,10 @@
   .p-message.p-message-error {
     background: #ffe7e6;
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5822,7 +6014,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5832,23 +6024,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5861,7 +6062,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5881,7 +6085,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #e9e9ff;
     border: solid #696cff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #696cff;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5891,7 +6098,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #e4f8f0;
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5901,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #fff2e2;
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5911,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffe7e6;
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5983,7 +6199,7 @@
     color: #b19df7;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6055,10 +6271,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6147,16 +6363,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6260,12 +6476,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6275,12 +6491,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6328,6 +6544,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #b19df7;
@@ -6354,7 +6573,7 @@
     color: #1d1e27;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/soho-light/theme.css
+++ b/src/assets/components/themes/soho-light/theme.css
@@ -197,8 +197,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #eff3f8;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #dfe7ef;
@@ -249,8 +249,8 @@
   padding: 0.75rem 1.25rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #dfe7ef;
@@ -258,8 +258,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #043d75;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -370,10 +370,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #7254f3;
@@ -406,7 +406,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d3dbe3;
@@ -471,16 +471,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #708da9;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #708da9;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -501,10 +501,16 @@
     border: 0 none;
     border-radius: 6px;
   }
+  .p-datepicker:dir(rtl) {
+    background: linear-gradient(-90deg, #7254f3 0%, #9554f3 100%);
+  }
   .p-datepicker:not(.p-datepicker-inline) {
     background: linear-gradient(90deg, #7254f3 0%, #9554f3 100%);
     border: 0 none;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
+  }
+  .p-datepicker:not(.p-datepicker-inline):dir(rtl) {
+    background: linear-gradient(-90deg, #7254f3 0%, #9554f3 100%);
   }
   .p-datepicker:not(.p-datepicker-inline) .p-datepicker-header {
     background: transparent;
@@ -516,8 +522,11 @@
     font-weight: 700;
     margin: 0;
     border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
+  }
+  .p-datepicker .p-datepicker-header:dir(rtl) {
+    background: linear-gradient(-90deg, #7254f3 0%, #9554f3 100%);
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -556,7 +565,7 @@
     color: #7254f3;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -664,18 +673,18 @@
     background: #e2dcfc;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #dfe7ef;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #dfe7ef;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.2);
@@ -703,16 +712,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #708da9;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #708da9;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -751,8 +760,8 @@
     background: transparent;
     color: #708da9;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ff6767;
@@ -825,20 +834,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #708da9;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -913,7 +928,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -935,7 +950,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dfe7ef;
     color: #043d75;
     border-radius: 16px;
@@ -945,7 +960,7 @@
     color: #043d75;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -964,11 +979,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #708da9;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1006,7 +1021,7 @@
     border-color: #7254f3;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1023,12 +1038,12 @@
     background: transparent;
     color: #708da9;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #708da9;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ff6767;
@@ -1056,15 +1071,15 @@
     color: #708da9;
     background: #eff3f8;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1137,13 +1152,13 @@
     background: #f6f9fc;
     color: #708da9;
     border-top: 1px solid #d3dbe3;
-    border-left: 1px solid #d3dbe3;
+    border-inline-start: 1px solid #d3dbe3;
     border-bottom: 1px solid #d3dbe3;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d3dbe3;
+    border-inline-end: 1px solid #d3dbe3;
   }
 
   .p-inputgroup > .p-component,
@@ -1155,7 +1170,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1173,13 +1188,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1187,13 +1202,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1204,12 +1219,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #708da9;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
 
@@ -1218,11 +1233,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #708da9;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1240,18 +1255,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #708da9;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1288,13 +1303,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1361,7 +1379,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #708da9;
     transition-duration: 0.2s;
   }
@@ -1372,38 +1390,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #708da9;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1455,18 +1473,18 @@
     color: #708da9;
     background: #eff3f8;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.75rem 0;
@@ -1488,7 +1506,7 @@
     background: #e2dcfc;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1552,20 +1570,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dfe7ef;
     color: #043d75;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #708da9;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f6f9fc;
@@ -1582,11 +1600,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #708da9;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1602,21 +1620,21 @@
     color: #708da9;
     background: #eff3f8;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #708da9;
@@ -1666,7 +1684,7 @@
     background: #f6f9fc;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1722,19 +1740,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #708da9;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #708da9;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1806,7 +1824,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1898,7 +1916,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1907,7 +1925,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1931,7 +1949,7 @@
     border-color: #7254f3;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2009,7 +2027,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #dfe7ef;
     color: #043d75;
     border-radius: 16px;
@@ -2018,8 +2036,8 @@
     background: transparent;
     color: #708da9;
     width: 3rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f6f9fc;
@@ -2052,24 +2070,24 @@
     color: #708da9;
     background: #eff3f8;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2110,11 +2128,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #708da9;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2199,10 +2217,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2211,7 +2229,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2251,10 +2269,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2639,14 +2657,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2706,7 +2724,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2725,18 +2743,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -2744,32 +2771,41 @@
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #708da9;
     background: #eff3f8;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #708da9;
     background: #eff3f8;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #708da9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2778,7 +2814,7 @@
     line-height: 1.143rem;
     color: #7254f3;
     background: #e2dcfc;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f6f9fc;
@@ -2811,9 +2847,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2845,7 +2884,7 @@
     box-shadow: 0 0 0 1px #c7bbfa;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #c7bbfa;
@@ -2881,58 +2920,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2979,18 +3066,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3004,11 +3100,14 @@
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3019,7 +3118,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3117,8 +3216,8 @@
     color: #708da9;
     background: #eff3f8;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3174,10 +3273,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
   .p-orderlist .p-orderlist-list {
@@ -3253,7 +3352,7 @@
     background: #dfe7ef;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #dfe7ef;
+    border-inline-end: 1px solid #dfe7ef;
     border-color: #dfe7ef;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3307,24 +3406,24 @@
     color: #043d75;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 50%;
-    border-bottom-left-radius: 50%;
+    border-start-start-radius: 50%;
+    border-end-start-radius: 50%;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 50%;
-    border-bottom-right-radius: 50%;
+    border-start-end-radius: 50%;
+    border-end-end-radius: 50%;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3393,10 +3492,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
   .p-picklist .p-picklist-list {
@@ -3504,7 +3603,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #708da9;
@@ -3524,11 +3623,11 @@
     box-shadow: 0 0 0 1px #c7bbfa;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #708da9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #043d75;
@@ -3570,14 +3669,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #708da9;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3605,14 +3707,14 @@
     color: #7254f3;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3629,18 +3731,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3648,25 +3759,34 @@
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #708da9;
     background: #eff3f8;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 700;
     color: #708da9;
     background: #eff3f8;
@@ -3676,7 +3796,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #708da9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3685,7 +3805,7 @@
     line-height: 1.143rem;
     color: #7254f3;
     background: #e2dcfc;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f6f9fc;
@@ -3707,9 +3827,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3720,7 +3843,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #043d75;
@@ -3737,7 +3860,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #043d75;
@@ -3790,16 +3913,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3845,7 +3980,10 @@
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
   }
@@ -3859,11 +3997,14 @@
     background: #eff3f8;
     color: #708da9;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 700;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3876,7 +4017,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3892,8 +4033,8 @@
     background: #eff3f8;
     border-color: #dfe7ef;
     color: #043d75;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #dfe7ef;
@@ -3906,10 +4047,10 @@
     background: #ffffff;
     color: #043d75;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 4px;
@@ -3938,7 +4079,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3959,7 +4103,7 @@
     padding: 1.25rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #dfe7ef;
+    border-inline-start: 1px #dfe7ef;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3990,7 +4134,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4011,8 +4155,8 @@
     padding: 1.25rem;
     background: #eff3f8;
     color: #708da9;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4047,25 +4191,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #dfe7ef;
     background: #ffffff;
     color: #043d75;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4112,23 +4256,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #dfe7ef;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dfe7ef transparent;
     background: #ffffff;
     color: #708da9;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4146,13 +4299,13 @@
     color: #7254f3;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4171,8 +4324,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #043d75;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4279,7 +4432,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #708da9;
     font-weight: 700;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4339,7 +4492,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4351,7 +4504,7 @@
     background-color: #7254f3;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4365,11 +4518,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4399,7 +4555,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4412,8 +4568,8 @@
     background: #ffffff;
     color: #708da9;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 700;
@@ -4427,7 +4583,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #043d75;
@@ -4440,28 +4596,37 @@
     box-shadow: 0 0 0 1px #c7bbfa;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #043d75;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #043d75;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4472,7 +4637,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4494,7 +4659,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #6545f2;
@@ -4566,10 +4731,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #043d75;
+    border-inline-end-color: #043d75;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #043d75;
+    border-inline-start-color: #043d75;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #043d75;
@@ -4584,11 +4749,11 @@
     border: 1px solid #dfe7ef;
     color: #708da9;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4600,8 +4765,8 @@
     padding: 2rem 1rem;
     border: 1px solid #dfe7ef;
     color: #043d75;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #7254f3;
@@ -4651,7 +4816,10 @@
     color: #708da9;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #043d75;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4695,7 +4863,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
@@ -4842,7 +5010,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
@@ -4896,8 +5064,8 @@
     color: #708da9;
     background: #eff3f8;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4925,11 +5093,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #043d75;
@@ -4966,7 +5134,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
@@ -5018,8 +5186,8 @@
     color: #708da9;
     background: #eff3f8;
     font-weight: 700;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #dfe7ef;
@@ -5034,9 +5202,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5063,11 +5231,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #043d75;
@@ -5095,7 +5263,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
@@ -5194,11 +5362,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5210,33 +5381,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5256,10 +5433,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5275,8 +5452,8 @@
     background: #eff3f8;
     border-color: #dfe7ef;
     color: #043d75;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5290,10 +5467,10 @@
     background: #ffffff;
     color: #043d75;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5313,7 +5490,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
@@ -5355,14 +5532,17 @@
     color: #708da9;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #dfe7ef;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 4px;
@@ -5397,7 +5577,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
@@ -5478,9 +5658,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5522,7 +5702,7 @@
     border-top: 1px solid #dfe7ef;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5531,7 +5711,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #dfe7ef;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #7254f3;
@@ -5542,28 +5725,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #dfe7ef;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #dfe7ef transparent;
     background: #ffffff;
     color: #708da9;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5581,10 +5770,10 @@
     color: #7254f3;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5637,7 +5826,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #708da9;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #708da9;
@@ -5733,7 +5922,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5743,7 +5932,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5771,7 +5960,10 @@
   .p-message.p-message-info {
     background: #e9e9ff;
     border: solid #696cff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #696cff;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5783,7 +5975,10 @@
   .p-message.p-message-success {
     background: #e4f8f0;
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5795,7 +5990,10 @@
   .p-message.p-message-warn {
     background: #fff2e2;
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5807,7 +6005,10 @@
   .p-message.p-message-error {
     background: #ffe7e6;
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5822,7 +6023,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5832,23 +6033,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5861,7 +6071,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5881,7 +6094,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #e9e9ff;
     border: solid #696cff;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #696cff;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5891,7 +6107,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #e4f8f0;
     border: solid #1ea97c;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #1ea97c;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5901,7 +6120,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #fff2e2;
     border: solid #cc8925;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #cc8925;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5911,7 +6133,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffe7e6;
     border: solid #ff5757;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #ff5757;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -5983,7 +6208,7 @@
     color: #7254f3;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6055,10 +6280,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6147,16 +6372,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6260,12 +6485,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6275,12 +6500,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6328,6 +6553,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #7254f3;
@@ -6354,7 +6582,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6386,7 +6614,7 @@
     background-color: rgba(255, 255, 255, 0.2);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-right: 1px solid rgba(255, 255, 255, 0.2);
+    border-inline-end: 1px solid rgba(255, 255, 255, 0.2);
   }
   .p-datepicker .p-datepicker-buttonbar {
     border-top: 1px solid rgba(255, 255, 255, 0.2);

--- a/src/assets/components/themes/tailwind-light/theme.css
+++ b/src/assets/components/themes/tailwind-light/theme.css
@@ -211,8 +211,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #fafafa;
-  border-top-right-radius: 0.375rem;
-  border-top-left-radius: 0.375rem;
+  border-start-end-radius: 0.375rem;
+  border-start-start-radius: 0.375rem;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #e5e7eb;
@@ -263,8 +263,8 @@
   padding: 0.75rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 0.375rem;
-  border-bottom-left-radius: 0.375rem;
+  border-end-end-radius: 0.375rem;
+  border-end-start-radius: 0.375rem;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #e5e7eb;
@@ -272,8 +272,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #3f3f46;
-  border-bottom-right-radius: 0.375rem;
-  border-bottom-left-radius: 0.375rem;
+  border-end-end-radius: 0.375rem;
+  border-end-start-radius: 0.375rem;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -384,10 +384,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #d4d4d8;
@@ -420,7 +420,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #d4d4d8;
@@ -485,16 +485,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #71717a;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #71717a;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -530,8 +530,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #e5e7eb;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -570,7 +570,7 @@
     color: #4f46e5;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -678,18 +678,18 @@
     background: #eef2ff;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #f3f4f6;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #f3f4f6;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #f4f4f5;
@@ -717,16 +717,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #71717a;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #71717a;
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -765,8 +765,8 @@
     background: transparent;
     color: #71717a;
     width: 3rem;
-    border-top-right-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f0a9a7;
@@ -839,20 +839,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #71717a;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -927,7 +933,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -949,7 +955,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #3f3f46;
     border-radius: 16px;
@@ -959,7 +965,7 @@
     color: #3f3f46;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.375rem 0;
@@ -978,11 +984,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #71717a;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1020,7 +1026,7 @@
     border-color: #4f46e5;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1037,12 +1043,12 @@
     background: transparent;
     color: #71717a;
     width: 3rem;
-    border-top-right-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #71717a;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f0a9a7;
@@ -1070,15 +1076,15 @@
     color: #3f3f46;
     background: #fafafa;
     margin: 0;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1151,13 +1157,13 @@
     background: #fafafa;
     color: #71717a;
     border-top: 1px solid #d4d4d8;
-    border-left: 1px solid #d4d4d8;
+    border-inline-start: 1px solid #d4d4d8;
     border-bottom: 1px solid #d4d4d8;
     padding: 0.75rem 0.75rem;
     min-width: 3rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #d4d4d8;
+    border-inline-end: 1px solid #d4d4d8;
   }
 
   .p-inputgroup > .p-component,
@@ -1169,7 +1175,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1187,13 +1193,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1201,13 +1207,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1218,12 +1224,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #71717a;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
 
@@ -1232,11 +1238,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #71717a;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1254,18 +1260,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #71717a;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.75rem;
+    inset-inline-end: 3.75rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1302,13 +1308,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1375,7 +1384,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #71717a;
     transition-duration: 0.2s;
   }
@@ -1386,38 +1395,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #71717a;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1469,18 +1478,18 @@
     color: #3f3f46;
     background: #fafafa;
     margin: 0;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.25rem 0;
@@ -1502,7 +1511,7 @@
     background: #eef2ff;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1566,20 +1575,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #3f3f46;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #71717a;
     width: 3rem;
-    border-top-right-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
   .p-multiselect.p-variant-filled {
     background: #fafafa;
@@ -1596,11 +1605,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #71717a;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-multiselect-panel {
@@ -1616,21 +1625,21 @@
     color: #3f3f46;
     background: #fafafa;
     margin: 0;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #71717a;
@@ -1680,7 +1689,7 @@
     background: #f4f4f5;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1736,19 +1745,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #71717a;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #71717a;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1820,7 +1829,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1912,7 +1921,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1921,7 +1930,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1945,7 +1954,7 @@
     border-color: #4f46e5;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: none, left 0.2s;
+    transition: none, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -2023,7 +2032,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.375rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #e5e7eb;
     color: #3f3f46;
     border-radius: 16px;
@@ -2032,8 +2041,8 @@
     background: transparent;
     color: #71717a;
     width: 3rem;
-    border-top-right-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
   .p-treeselect.p-variant-filled {
     background-color: #fafafa;
@@ -2066,24 +2075,24 @@
     color: #3f3f46;
     background: #fafafa;
     margin: 0;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2124,11 +2133,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #71717a;
-    right: 3rem;
+    inset-inline-end: 3rem;
   }
 
   .p-button {
@@ -2213,10 +2222,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2225,7 +2234,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2265,10 +2274,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2653,14 +2662,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2720,7 +2729,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2739,18 +2748,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1.25rem 1.25rem;
     font-weight: 600;
   }
@@ -2758,32 +2776,41 @@
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1.5rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1.5rem;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: #6b7280;
     background: #fafafa;
     transition: none;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #3f3f46;
     background: #fafafa;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2792,7 +2819,7 @@
     line-height: 1.143rem;
     color: #312e81;
     background: #eef2ff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #f4f4f5;
@@ -2825,9 +2852,12 @@
     transition: none;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1.5rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2859,7 +2889,7 @@
     box-shadow: 0 0 0 1px #6366f1;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #6366f1;
@@ -2895,58 +2925,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2993,18 +3071,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1.25rem 1.25rem;
     font-weight: 600;
   }
@@ -3018,11 +3105,14 @@
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1.5rem;
     font-weight: 600;
-    border-bottom-left-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3033,7 +3123,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3131,8 +3221,8 @@
     color: #3f3f46;
     background: #fafafa;
     margin: 0;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1.25rem;
@@ -3188,10 +3278,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
   .p-orderlist .p-orderlist-list {
@@ -3267,7 +3357,7 @@
     background: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #e5e7eb;
+    border-inline-end: 1px solid #e5e7eb;
     border-color: #e5e7eb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3308,7 +3398,10 @@
     color: #71717a;
     min-width: 3rem;
     height: 3rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: none;
     border-radius: 0;
   }
@@ -3321,24 +3414,24 @@
     color: #3f3f46;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 3rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 3rem;
@@ -3349,7 +3442,10 @@
     color: #71717a;
     min-width: 3rem;
     height: 3rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     padding: 0 0.5rem;
   }
   .p-paginator .p-paginator-pages .p-paginator-page {
@@ -3358,7 +3454,10 @@
     color: #71717a;
     min-width: 3rem;
     height: 3rem;
-    margin: 0 0 0 -1px;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: -1px;
     transition: none;
     border-radius: 0;
   }
@@ -3407,10 +3506,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
   .p-picklist .p-picklist-list {
@@ -3518,7 +3617,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #71717a;
@@ -3538,11 +3637,11 @@
     box-shadow: 0 0 0 1px #6366f1;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #71717a;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #3f3f46;
@@ -3584,14 +3683,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #71717a;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3619,14 +3721,14 @@
     color: #312e81;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3643,18 +3745,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1.25rem 1.25rem;
     font-weight: 600;
   }
@@ -3662,25 +3773,34 @@
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1.5rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 0.75rem 1.5rem;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 500;
     color: #6b7280;
     background: #fafafa;
     transition: none;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #3f3f46;
     background: #fafafa;
@@ -3690,7 +3810,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3699,7 +3819,7 @@
     line-height: 1.143rem;
     color: #312e81;
     background: #eef2ff;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #f4f4f5;
@@ -3721,9 +3841,12 @@
     transition: none;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3734,7 +3857,7 @@
     background: transparent;
     border-radius: 50%;
     transition: none;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #18181b;
@@ -3751,7 +3874,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #3f3f46;
@@ -3804,16 +3927,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3859,7 +3994,10 @@
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1.25rem 1.25rem;
     font-weight: 600;
   }
@@ -3873,11 +4011,14 @@
     background: #fafafa;
     color: #3f3f46;
     border: 1px solid #f4f4f5;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 0.75rem 1.5rem;
     font-weight: 600;
-    border-bottom-left-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3890,7 +4031,7 @@
     transition: none;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3906,8 +4047,8 @@
     background: #fafafa;
     border-color: #e5e7eb;
     color: #3f3f46;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #e5e7eb;
@@ -3920,10 +4061,10 @@
     background: #ffffff;
     color: #3f3f46;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3941,16 +4082,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
 
   .p-card {
@@ -3976,7 +4117,10 @@
     padding: 1.25rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1.25rem 0 0 0;
+    padding-block-start: 1.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3997,7 +4141,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #e5e7eb;
+    border-inline-start: 1px #e5e7eb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4028,7 +4172,7 @@
     transition: none;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4049,8 +4193,8 @@
     padding: 1.25rem;
     background: #fafafa;
     color: #3f3f46;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 700;
@@ -4085,25 +4229,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-panel .p-panel-footer {
     padding: 0.75rem 1.25rem;
     border: 1px solid #e5e7eb;
     background: #ffffff;
     color: #3f3f46;
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4150,23 +4294,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #71717a;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
     transition: none;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4184,13 +4337,13 @@
     color: #4f46e5;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4209,8 +4362,8 @@
     padding: 1.25rem;
     border: 0 none;
     color: #3f3f46;
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
 
   .p-toolbar {
@@ -4317,7 +4470,7 @@
     transition: none;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #71717a;
     font-weight: 600;
     transition: none;
@@ -4377,7 +4530,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4389,7 +4542,7 @@
     background-color: #4f46e5;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4403,11 +4556,14 @@
     padding: 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.75rem 1.25rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4437,7 +4593,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4450,8 +4606,8 @@
     background: #ffffff;
     color: #3f3f46;
     padding: 1.5rem;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4465,7 +4621,7 @@
     background: transparent;
     border-radius: 50%;
     transition: none;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #18181b;
@@ -4478,28 +4634,37 @@
     box-shadow: 0 0 0 1px #6366f1;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #3f3f46;
-    padding: 0 1.5rem 1.5rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #3f3f46;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4510,7 +4675,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4532,7 +4697,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #4338ca;
@@ -4604,10 +4769,10 @@
     border-radius: 0.375rem;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #3f3f46;
+    border-inline-end-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #3f3f46;
+    border-inline-start-color: #3f3f46;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #3f3f46;
@@ -4622,11 +4787,11 @@
     border: 1px solid #e5e7eb;
     color: #3f3f46;
     border-bottom: 0 none;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4638,8 +4803,8 @@
     padding: 2rem 1rem;
     border: 1px solid #e5e7eb;
     color: #3f3f46;
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #4f46e5;
@@ -4689,7 +4854,10 @@
     color: #71717a;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #3f3f46;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4733,7 +4901,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4880,7 +5048,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -4934,8 +5102,8 @@
     color: #3f3f46;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4963,11 +5131,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #18181b;
@@ -5004,7 +5172,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5056,8 +5224,8 @@
     color: #3f3f46;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #f3f4f6;
@@ -5072,9 +5240,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 0.375rem;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5101,11 +5269,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #18181b;
@@ -5133,7 +5301,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5232,11 +5400,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5248,33 +5419,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5294,10 +5471,10 @@
     font-weight: 700;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5313,8 +5490,8 @@
     background: #fafafa;
     border-color: #e5e7eb;
     color: #3f3f46;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5328,10 +5505,10 @@
     background: #ffffff;
     color: #3f3f46;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5351,7 +5528,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5393,14 +5570,17 @@
     color: #71717a;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #f3f4f6;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5418,16 +5598,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
 
   .p-slidemenu {
@@ -5459,7 +5639,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5540,9 +5720,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 0.375rem;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5584,7 +5764,7 @@
     border-top: 1px solid #f3f4f6;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5593,7 +5773,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #4f46e5;
@@ -5604,28 +5787,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 0.375rem;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #e5e7eb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #e5e7eb transparent;
     background: #ffffff;
     color: #71717a;
     padding: 1.25rem;
     font-weight: 700;
-    border-top-right-radius: 0.375rem;
-    border-top-left-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
     transition: none;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5643,10 +5832,10 @@
     color: #4f46e5;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5699,7 +5888,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #71717a;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #71717a;
@@ -5795,7 +5984,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5805,7 +5994,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-info {
     background: #eff6ff;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #2563eb;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5845,7 +6037,10 @@
   .p-message.p-message-success {
     background: #ecfdf5;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #059669;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5857,7 +6052,10 @@
   .p-message.p-message-warn {
     background: #fef3c7;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #d97706;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5869,7 +6067,10 @@
   .p-message.p-message-error {
     background: #fef3c7;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #dc2626;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5884,7 +6085,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5894,23 +6095,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
     border-radius: 0.375rem;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5923,7 +6133,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5943,7 +6156,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #eff6ff;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #2563eb;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5953,7 +6169,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #ecfdf5;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #059669;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5963,7 +6182,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #fef3c7;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #d97706;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5973,7 +6195,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #fef3c7;
     border: none;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #dc2626;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6045,7 +6270,7 @@
     color: #312e81;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6117,10 +6342,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: none;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6209,16 +6434,16 @@
     margin-bottom: 0.375rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2.25rem;
     height: 2.25rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 0.375rem;
@@ -6322,12 +6547,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 0.375rem;
-    border-bottom-left-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6337,12 +6562,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 0.375rem;
-    border-top-right-radius: 0.375rem;
+    border-start-start-radius: 0.375rem;
+    border-start-end-radius: 0.375rem;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 0.375rem;
-    border-bottom-right-radius: 0.375rem;
+    border-end-start-radius: 0.375rem;
+    border-end-end-radius: 0.375rem;
   }
 
   .p-progressbar {
@@ -6390,6 +6615,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #4f46e5;
@@ -6416,7 +6644,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6463,11 +6691,11 @@
   }
 
   .p-paginator .p-paginator-pages .p-paginator-page {
-    margin-left: -1px;
+    margin-inline-end: -1px;
   }
   .p-paginator .p-paginator-pages .p-paginator-page.p-highlight {
     border-color: #4f46e5;
-    margin-right: 1px;
+    margin-inline-end: 1px;
   }
   .p-paginator .p-paginator-current {
     border: 0 none;

--- a/src/assets/components/themes/vela-blue/theme.css
+++ b/src/assets/components/themes/vela-blue/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2d40;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #304562;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #304562;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #17212f;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #64B5F6;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3e526d;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #304562;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #64B5F6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(100, 181, 246, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #304562;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #304562;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #64B5F6;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #304562;
-    border-left: 1px solid #304562;
+    border-inline-start: 1px solid #304562;
     border-bottom: 1px solid #304562;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(100, 181, 246, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #304562;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #64B5F6;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #304562;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #93cbf9;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #93cbf9;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #253144;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
     border-color: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #93cbf9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(100, 181, 246, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #304562;
@@ -3884,10 +4016,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #304562;
+    border-inline-start: 1px #304562;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #304562;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #64B5F6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2d40;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #64B5F6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #93cbf9;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #43a5f4;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #304562;
+    border-inline-end-color: #304562;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #304562;
+    border-inline-start-color: #304562;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #304562;
@@ -4586,11 +4742,11 @@
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #64B5F6;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #304562;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #304562;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #64B5F6;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #64B5F6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2d40;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #64B5F6;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/vela-green/theme.css
+++ b/src/assets/components/themes/vela-green/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2d40;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #304562;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #304562;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #17212f;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #81C784;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3e526d;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #304562;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #81C784;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(129, 199, 132, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #304562;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #304562;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #81C784;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #304562;
-    border-left: 1px solid #304562;
+    border-inline-start: 1px solid #304562;
     border-bottom: 1px solid #304562;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(129, 199, 132, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #304562;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #81C784;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #304562;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #a7d8a9;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #a7d8a9;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #253144;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
     border-color: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #a7d8a9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(129, 199, 132, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #304562;
@@ -3884,10 +4016,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #304562;
+    border-inline-start: 1px #304562;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #304562;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #81C784;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2d40;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #81C784;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #a7d8a9;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #6abd6e;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #304562;
+    border-inline-end-color: #304562;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #304562;
+    border-inline-start-color: #304562;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #304562;
@@ -4586,11 +4742,11 @@
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #81C784;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #304562;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #304562;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #81C784;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #81C784;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2d40;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #81C784;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/vela-orange/theme.css
+++ b/src/assets/components/themes/vela-orange/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2d40;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #304562;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #304562;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #17212f;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #FFD54F;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3e526d;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #304562;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #FFD54F;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(255, 213, 79, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #304562;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #304562;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #FFD54F;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #304562;
-    border-left: 1px solid #304562;
+    border-inline-start: 1px solid #304562;
     border-bottom: 1px solid #304562;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(255, 213, 79, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #304562;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #FFD54F;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #304562;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #ffe284;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #ffe284;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #253144;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
     border-color: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #ffe284;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(255, 213, 79, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #304562;
@@ -3884,10 +4016,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #304562;
+    border-inline-start: 1px #304562;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #304562;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #FFD54F;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2d40;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #FFD54F;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #ffe284;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #ffcd2e;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #304562;
+    border-inline-end-color: #304562;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #304562;
+    border-inline-start-color: #304562;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #304562;
@@ -4586,11 +4742,11 @@
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #FFD54F;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #304562;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #304562;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #FFD54F;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #FFD54F;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2d40;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #FFD54F;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/vela-purple/theme.css
+++ b/src/assets/components/themes/vela-purple/theme.css
@@ -175,8 +175,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #1f2d40;
-  border-top-right-radius: 3px;
-  border-top-left-radius: 3px;
+  border-start-end-radius: 3px;
+  border-start-start-radius: 3px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 1px solid #304562;
@@ -227,8 +227,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 1px solid #304562;
@@ -236,8 +236,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #17212f;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-end-end-radius: 3px;
+  border-end-start-radius: 3px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -348,10 +348,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #BA68C8;
@@ -384,7 +384,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #3e526d;
@@ -449,16 +449,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -494,8 +494,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #304562;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -534,7 +534,7 @@
     color: #BA68C8;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -642,18 +642,18 @@
     background: rgba(186, 104, 200, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #304562;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #304562;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -681,16 +681,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -729,8 +729,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -803,20 +803,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -891,7 +897,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -913,7 +919,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -923,7 +929,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -942,11 +948,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-colorpicker-preview,
@@ -984,7 +990,7 @@
     border-color: #BA68C8;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1001,12 +1007,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #ef9a9a;
@@ -1034,15 +1040,15 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.5rem;
-    margin-right: -1.5rem;
+    padding-inline-end: 1.5rem;
+    margin-inline-end: -1.5rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
@@ -1115,13 +1121,13 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border-top: 1px solid #304562;
-    border-left: 1px solid #304562;
+    border-inline-start: 1px solid #304562;
     border-bottom: 1px solid #304562;
     padding: 0.5rem 0.5rem;
     min-width: 2.357rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
   }
 
   .p-inputgroup > .p-component,
@@ -1133,7 +1139,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1151,13 +1157,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1165,13 +1171,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1182,12 +1188,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1196,11 +1202,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1218,18 +1224,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1266,13 +1272,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 50%;
     transition-duration: 0.2s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1339,7 +1348,7 @@
   }
 
   .p-float-label > label {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.2s;
   }
@@ -1350,38 +1359,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.5rem;
+    inset-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2rem;
+    padding-inline-start: 2rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2rem;
+    inset-inline-start: 2rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1433,18 +1442,18 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0;
@@ -1466,7 +1475,7 @@
     background: rgba(186, 104, 200, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1530,20 +1539,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-multiselect.p-variant-filled {
     background: #304562;
@@ -1560,11 +1569,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-multiselect-panel {
@@ -1580,21 +1589,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1644,7 +1653,7 @@
     background: rgba(255, 255, 255, 0.03);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1700,19 +1709,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2rem;
+    padding-inline-end: 2rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
 
   .p-radiobutton {
@@ -1784,7 +1793,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1876,7 +1885,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1885,7 +1894,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1909,7 +1918,7 @@
     border-color: #BA68C8;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, left 0.2s;
+    transition: background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s, inset-inline-start 0.2s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.2s;
@@ -1987,7 +1996,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #304562;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -1996,8 +2005,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.357rem;
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #304562;
@@ -2030,24 +2039,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3rem;
+    padding-inline-end: 3rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2rem;
+    inset-inline-end: 2rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2088,11 +2097,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.357rem;
+    inset-inline-end: 2.357rem;
   }
 
   .p-button {
@@ -2177,10 +2186,10 @@
     transition-duration: 0.2s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2189,7 +2198,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2229,10 +2238,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2617,14 +2626,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2684,7 +2693,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2703,18 +2712,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2722,32 +2740,41 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2756,7 +2783,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -2789,9 +2816,12 @@
     transition: box-shadow 0.2s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2823,7 +2853,7 @@
     box-shadow: 0 0 0 1px #cf95d9;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #cf95d9;
@@ -2859,58 +2889,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #253144;
@@ -2957,18 +3035,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2982,11 +3069,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -2997,7 +3087,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3095,8 +3185,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     margin: 0;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3152,10 +3242,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3231,7 +3321,7 @@
     background: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 1px solid #304562;
+    border-inline-end: 1px solid #304562;
     border-color: rgba(255, 255, 255, 0.6);
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3285,24 +3375,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.286em;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.286em;
@@ -3371,10 +3461,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3482,7 +3572,7 @@
     padding: 0;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3502,11 +3592,11 @@
     box-shadow: 0 0 0 1px #cf95d9;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3548,14 +3638,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.5rem;
+    padding-inline-end: 1.5rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.5rem;
+    inset-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3583,14 +3676,14 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3607,18 +3700,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 1px 0 1px 0;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3626,25 +3728,34 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
@@ -3654,7 +3765,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3663,7 +3774,7 @@
     line-height: 1.143rem;
     color: rgba(255, 255, 255, 0.87);
     background: rgba(186, 104, 200, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(255, 255, 255, 0.03);
@@ -3685,9 +3796,12 @@
     transition: box-shadow 0.2s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3698,7 +3812,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3715,7 +3829,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3768,16 +3882,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3823,7 +3949,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3837,11 +3966,14 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border: 1px solid #304562;
-    border-width: 0 0 1px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3854,7 +3986,7 @@
     transition: box-shadow 0.2s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3870,8 +4002,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #304562;
@@ -3884,10 +4016,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3905,16 +4037,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-card {
@@ -3940,7 +4072,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3961,7 +4096,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #304562;
+    border-inline-start: 1px #304562;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -3992,7 +4127,7 @@
     transition: box-shadow 0.2s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4013,8 +4148,8 @@
     padding: 1rem;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4049,25 +4184,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 1px solid #304562;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4114,23 +4249,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4148,13 +4292,13 @@
     color: #BA68C8;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #1f2d40;
@@ -4173,8 +4317,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-toolbar {
@@ -4281,7 +4425,7 @@
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
@@ -4341,7 +4485,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4353,7 +4497,7 @@
     background-color: #BA68C8;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4367,11 +4511,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4401,7 +4548,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4414,8 +4561,8 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4429,7 +4576,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4442,28 +4589,37 @@
     box-shadow: 0 0 0 1px #cf95d9;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4474,7 +4630,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4496,7 +4652,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #b052c0;
@@ -4568,10 +4724,10 @@
     border-radius: 3px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #304562;
+    border-inline-end-color: #304562;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #304562;
+    border-inline-start-color: #304562;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #304562;
@@ -4586,11 +4742,11 @@
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4602,8 +4758,8 @@
     padding: 2rem 1rem;
     border: 1px solid #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 1px dashed #BA68C8;
@@ -4653,7 +4809,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4697,7 +4856,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4844,7 +5003,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4898,8 +5057,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.25rem 0;
@@ -4927,11 +5086,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4968,7 +5127,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5020,8 +5179,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #1f2d40;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #304562;
@@ -5036,9 +5195,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5065,11 +5224,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5097,7 +5256,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5196,11 +5355,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.2s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5212,33 +5374,39 @@
       transition: transform 0.2s;
       transform: rotate(90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-submenu-icon:dir(rtl) {
+      transform: rotate(-90deg);
+    }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
+    }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
     }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5258,10 +5426,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5277,8 +5445,8 @@
     background: #1f2d40;
     border-color: #304562;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5292,10 +5460,10 @@
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5315,7 +5483,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5357,14 +5525,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #304562;
     margin: 0.25rem 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5382,16 +5553,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-end-end-radius: 3px;
+    border-end-start-radius: 3px;
   }
 
   .p-slidemenu {
@@ -5423,7 +5594,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5504,9 +5675,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5548,7 +5719,7 @@
     border-top: 1px solid #304562;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5557,7 +5728,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #BA68C8;
@@ -5568,28 +5742,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 3px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #304562;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #304562 transparent;
     background: #1f2d40;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 3px;
-    border-top-left-radius: 3px;
+    border-start-end-radius: 3px;
+    border-start-start-radius: 3px;
     transition: box-shadow 0.2s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5607,10 +5787,10 @@
     color: #BA68C8;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #1f2d40;
@@ -5663,7 +5843,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5759,7 +5939,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5769,7 +5949,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5797,7 +5977,10 @@
   .p-message.p-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5809,7 +5992,10 @@
   .p-message.p-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5821,7 +6007,10 @@
   .p-message.p-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5833,7 +6022,10 @@
   .p-message.p-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5848,7 +6040,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5858,23 +6050,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 3px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5887,7 +6088,10 @@
     font-weight: 700;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5907,7 +6111,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #b3e5fc;
     border: solid #0891cf;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #044868;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5917,7 +6124,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #c8e6c9;
     border: solid #439446;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #224a23;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5927,7 +6137,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecb3;
     border: solid #d9a300;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #6d5100;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5937,7 +6150,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #ffcdd2;
     border: solid #e60017;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #73000c;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6009,7 +6225,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6081,10 +6297,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6173,16 +6389,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 3px;
@@ -6286,12 +6502,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-bottom-left-radius: 3px;
+    border-start-start-radius: 3px;
+    border-end-start-radius: 3px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-start-end-radius: 3px;
+    border-end-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6301,12 +6517,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
+    border-start-start-radius: 3px;
+    border-start-end-radius: 3px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 3px;
-    border-bottom-right-radius: 3px;
+    border-end-start-radius: 3px;
+    border-end-end-radius: 3px;
   }
 
   .p-progressbar {
@@ -6354,6 +6570,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #BA68C8;
@@ -6380,7 +6599,7 @@
     color: #121212;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {

--- a/src/assets/components/themes/viva-dark/theme.css
+++ b/src/assets/components/themes/viva-dark/theme.css
@@ -205,8 +205,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #161d21;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 2px solid #263238;
@@ -257,8 +257,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 2px solid #263238;
@@ -266,8 +266,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #0e1315;
   color: rgba(255, 255, 255, 0.87);
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -378,10 +378,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #2d3e44;
@@ -414,7 +414,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #2d3e44;
@@ -435,7 +435,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
@@ -479,16 +482,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -524,8 +527,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #263238;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -564,7 +567,7 @@
     color: #9eade6;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -672,18 +675,18 @@
     background: rgba(158, 173, 230, 0.16);
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #263238;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #263238;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: rgba(158, 173, 230, 0.08);
@@ -711,16 +714,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -759,8 +762,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f78c79;
@@ -786,7 +789,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
@@ -833,20 +839,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -921,7 +933,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -943,7 +955,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #263238;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -953,7 +965,7 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -972,11 +984,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1014,7 +1026,7 @@
     border-color: #9eade6;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1031,12 +1043,12 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f78c79;
@@ -1064,22 +1076,25 @@
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-dropdown-panel .p-dropdown-items {
     padding: 0.5rem 0.5rem;
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
@@ -1145,13 +1160,13 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
     border-top: 2px solid #263238;
-    border-left: 2px solid #263238;
+    border-inline-start: 2px solid #263238;
     border-bottom: 2px solid #263238;
     padding: 0.5rem 0.75rem;
     min-width: 2.857rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 2px solid #263238;
+    border-inline-end: 2px solid #263238;
   }
 
   .p-inputgroup > .p-component,
@@ -1163,7 +1178,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1181,13 +1196,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1195,13 +1210,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1212,12 +1227,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
@@ -1226,11 +1241,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1248,18 +1263,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1296,13 +1311,16 @@
     background: rgba(255, 255, 255, 0.6);
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 6px;
     transition-duration: 0.3s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1369,7 +1387,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
     transition-duration: 0.3s;
   }
@@ -1380,38 +1398,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1463,25 +1481,28 @@
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0.5rem;
     outline: 0 none;
   }
   .p-listbox .p-listbox-list .p-listbox-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
@@ -1496,7 +1517,7 @@
     background: rgba(158, 173, 230, 0.16);
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1560,20 +1581,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #263238;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #263238;
@@ -1590,11 +1611,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   .p-multiselect-panel {
@@ -1610,21 +1631,21 @@
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -1647,7 +1668,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
@@ -1674,7 +1698,7 @@
     background: rgba(158, 173, 230, 0.08);
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1730,19 +1754,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1814,7 +1838,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1906,7 +1930,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1915,7 +1939,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1939,7 +1963,7 @@
     border-color: #9eade6;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s, left 0.3s;
+    transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s, inset-inline-start 0.3s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.3s;
@@ -2017,7 +2041,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #263238;
     color: rgba(255, 255, 255, 0.87);
     border-radius: 16px;
@@ -2026,8 +2050,8 @@
     background: transparent;
     color: rgba(255, 255, 255, 0.6);
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #263238;
@@ -2060,24 +2084,24 @@
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2118,11 +2142,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: rgba(255, 255, 255, 0.6);
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   .p-button {
@@ -2207,10 +2231,10 @@
     transition-duration: 0.3s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2219,7 +2243,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2259,10 +2283,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2647,14 +2671,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2714,7 +2738,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2733,18 +2757,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2752,32 +2785,41 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     transition: box-shadow 0.3s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2786,7 +2828,7 @@
     line-height: 1.143rem;
     color: #9eade6;
     background: rgba(158, 173, 230, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(158, 173, 230, 0.08);
@@ -2819,9 +2861,12 @@
     transition: box-shadow 0.3s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2853,7 +2898,7 @@
     box-shadow: 0 0 0 1px #9eade6;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #9eade6;
@@ -2889,58 +2934,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #1b2327;
@@ -2987,18 +3080,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3012,11 +3114,14 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3027,7 +3132,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3090,7 +3195,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
@@ -3125,8 +3233,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3182,10 +3290,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-orderlist .p-orderlist-list {
@@ -3198,7 +3306,10 @@
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     padding: 0.5rem 1rem;
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
@@ -3261,7 +3372,7 @@
     background: #263238;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 2px solid #263238;
+    border-inline-end: 2px solid #263238;
     border-color: #263238;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3315,24 +3426,24 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.857rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.857rem;
@@ -3401,10 +3512,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-picklist .p-picklist-list {
@@ -3417,7 +3528,10 @@
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     padding: 0.5rem 1rem;
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
     background: transparent;
@@ -3512,7 +3626,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: rgba(255, 255, 255, 0.6);
@@ -3532,11 +3646,11 @@
     box-shadow: 0 0 0 1px #9eade6;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3578,14 +3692,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: rgba(255, 255, 255, 0.6);
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3613,14 +3730,14 @@
     color: #9eade6;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3637,18 +3754,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3656,25 +3782,34 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     transition: box-shadow 0.3s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
@@ -3684,7 +3819,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3693,7 +3828,7 @@
     line-height: 1.143rem;
     color: #9eade6;
     background: rgba(158, 173, 230, 0.16);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: rgba(158, 173, 230, 0.08);
@@ -3715,9 +3850,12 @@
     transition: box-shadow 0.3s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3728,7 +3866,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -3745,7 +3883,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: rgba(255, 255, 255, 0.87);
@@ -3798,16 +3936,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3853,7 +4003,10 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3867,11 +4020,14 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
     border: 2px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3884,7 +4040,7 @@
     transition: box-shadow 0.3s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3900,8 +4056,8 @@
     background: #161d21;
     border-color: #263238;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #263238;
@@ -3914,10 +4070,10 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3935,16 +4091,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -3970,7 +4126,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3991,7 +4150,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #263238;
+    border-inline-start: 1px #263238;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4022,7 +4181,7 @@
     transition: box-shadow 0.3s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4043,8 +4202,8 @@
     padding: 1rem;
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4079,25 +4238,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 2px solid #263238;
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4144,23 +4303,32 @@
   .p-tabview .p-tabview-nav {
     background: transparent;
     border: 1px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #263238 transparent;
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.3s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4178,13 +4346,13 @@
     color: #9eade6;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #161d21;
@@ -4203,8 +4371,8 @@
     padding: 1rem;
     border: 0 none;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4311,7 +4479,7 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.6);
     font-weight: 600;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
@@ -4371,7 +4539,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4383,7 +4551,7 @@
     background-color: #9eade6;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4397,11 +4565,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4431,7 +4602,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4444,8 +4615,8 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4459,7 +4630,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4472,28 +4643,37 @@
     box-shadow: 0 0 0 1px #9eade6;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4504,7 +4684,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4526,7 +4706,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #8fa0e2;
@@ -4598,10 +4778,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #263238;
+    border-inline-end-color: #263238;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #263238;
+    border-inline-start-color: #263238;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #263238;
@@ -4616,11 +4796,11 @@
     border: 2px solid #263238;
     color: rgba(255, 255, 255, 0.87);
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4632,8 +4812,8 @@
     padding: 2rem 1rem;
     border: 2px solid #263238;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 2px solid #263238 dashed #9eade6;
@@ -4683,7 +4863,10 @@
     color: rgba(255, 255, 255, 0.6);
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: rgba(255, 255, 255, 0.87);
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4727,7 +4910,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4874,7 +5057,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -4928,8 +5111,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0.5rem;
@@ -4957,11 +5140,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -4998,7 +5181,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5050,8 +5233,8 @@
     color: rgba(255, 255, 255, 0.87);
     background: #161d21;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #263238;
@@ -5066,9 +5249,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5095,11 +5278,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: rgba(255, 255, 255, 0.87);
@@ -5127,7 +5310,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5226,11 +5409,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.3s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5245,30 +5431,33 @@
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
+    }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5288,10 +5477,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5307,8 +5496,8 @@
     background: #161d21;
     border-color: #263238;
     color: rgba(255, 255, 255, 0.87);
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5322,10 +5511,10 @@
     background: #161d21;
     color: rgba(255, 255, 255, 0.87);
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5345,7 +5534,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5387,14 +5576,17 @@
     color: rgba(255, 255, 255, 0.87);
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #263238;
     margin: 4px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5412,16 +5604,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5453,7 +5645,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5534,9 +5726,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5578,7 +5770,7 @@
     border-top: 1px solid #263238;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5587,7 +5779,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: transparent;
     border: 1px solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #9eade6;
@@ -5598,28 +5793,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #263238;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #263238 transparent;
     background: #161d21;
     color: rgba(255, 255, 255, 0.6);
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.3s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5637,10 +5838,10 @@
     color: #9eade6;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #161d21;
@@ -5693,7 +5894,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: rgba(255, 255, 255, 0.6);
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: rgba(255, 255, 255, 0.6);
@@ -5789,7 +5990,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5799,7 +6000,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5827,7 +6028,10 @@
   .p-message.p-message-info {
     background: #a3d7e6;
     border: 4px solid #65bcd6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5839,7 +6043,10 @@
   .p-message.p-message-success {
     background: #bfd47f;
     border: 4px solid #a2c044;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5851,7 +6058,10 @@
   .p-message.p-message-warn {
     background: #ff9c3e;
     border: 4px solid #ff8817;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5863,7 +6073,10 @@
   .p-message.p-message-error {
     background: #e6a3b2;
     border: 4px solid #de8499;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5878,7 +6091,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5888,23 +6101,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: none;
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5917,7 +6139,10 @@
     font-weight: 600;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5937,7 +6162,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #a3d7e6;
     border: 4px solid #65bcd6;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5947,7 +6175,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #bfd47f;
     border: 4px solid #a2c044;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5957,7 +6188,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ff9c3e;
     border: 4px solid #ff8817;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5967,7 +6201,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #e6a3b2;
     border: 4px solid #de8499;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #0e1315;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6039,7 +6276,7 @@
     color: #9eade6;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6111,10 +6348,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6203,16 +6440,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6316,12 +6553,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6331,12 +6568,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6384,6 +6621,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #9eade6;
@@ -6410,7 +6650,7 @@
     color: #0e1315;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6467,9 +6707,9 @@
 
   .p-accordion .p-accordion-toggle-icon {
     order: 10;
-    margin-left: auto;
+    margin-inline-end: auto;
   }
-  .p-accordion .p-accordion-toggle-icon.pi-chevron-right::before {
+  .p-accordion .p-accordion-toggle-icon.pi-chevron-inset-inline-end::before {
     content: "\e90d";
   }
   .p-accordion .p-accordion-toggle-icon.pi-chevron-down::before {
@@ -6530,9 +6770,9 @@
 
   .p-panelmenu .p-panelmenu-icon.pi-chevron-right, .p-panelmenu .p-panelmenu-icon.pi-chevron-down {
     order: 10;
-    margin-left: auto;
+    margin-inline-end: auto;
   }
-  .p-panelmenu .p-panelmenu-icon.pi-chevron-right::before {
+  .p-panelmenu .p-panelmenu-icon.pi-chevron-inset-inline-end::before {
     content: "\e90d";
   }
   .p-panelmenu .p-panelmenu-icon.pi-chevron-down::before {

--- a/src/assets/components/themes/viva-light/theme.css
+++ b/src/assets/components/themes/viva-light/theme.css
@@ -206,8 +206,8 @@
 
 .p-editor-container .p-editor-toolbar {
   background: #ffffff;
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
+  border-start-end-radius: 6px;
+  border-start-start-radius: 6px;
 }
 .p-editor-container .p-editor-toolbar.ql-snow {
   border: 2px solid #ebebeb;
@@ -258,8 +258,8 @@
   padding: 0.5rem 1rem;
 }
 .p-editor-container .p-editor-content {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .p-editor-content.ql-snow {
   border: 2px solid #ebebeb;
@@ -267,8 +267,8 @@
 .p-editor-container .p-editor-content .ql-editor {
   background: #ffffff;
   color: #6c6c6c;
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
+  border-end-end-radius: 6px;
+  border-end-start-radius: 6px;
 }
 .p-editor-container .ql-snow.ql-toolbar button:hover,
 .p-editor-container .ql-snow.ql-toolbar button:focus {
@@ -379,10 +379,10 @@
   }
 
   .p-autocomplete .p-autocomplete-loader {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
   .p-autocomplete.p-autocomplete-dd .p-autocomplete-loader {
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
   .p-autocomplete:not(.p-disabled):hover .p-autocomplete-multiple-container {
     border-color: #cecece;
@@ -415,7 +415,7 @@
     border-radius: 16px;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token .p-autocomplete-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-autocomplete .p-autocomplete-multiple-container .p-autocomplete-token.p-focus {
     background: #e1e1e1;
@@ -436,7 +436,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-autocomplete-panel .p-autocomplete-items .p-autocomplete-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: #6c6c6c;
@@ -480,16 +483,16 @@
   }
 
   p-autocomplete.p-autocomplete-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-clear-icon {
     color: #898989;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-autocomplete.p-autocomplete-clearable .p-autocomplete-dd .p-autocomplete-clear-icon {
     color: #898989;
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
 
   p-calendar.ng-dirty.ng-invalid > .p-calendar > .p-inputtext {
@@ -525,8 +528,8 @@
     font-weight: 600;
     margin: 0;
     border-bottom: 1px solid #ebebeb;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-prev,
 .p-datepicker .p-datepicker-header .p-datepicker-next {
@@ -565,7 +568,7 @@
     color: #5472d4;
   }
   .p-datepicker .p-datepicker-header .p-datepicker-title .p-datepicker-month {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datepicker table {
     font-size: 1rem;
@@ -673,18 +676,18 @@
     background: #ced6f1;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group {
-    border-left: 1px solid #ebebeb;
-    padding-right: 0.5rem;
-    padding-left: 0.5rem;
+    border-inline-start: 1px solid #ebebeb;
+    padding-inline-end: 0.5rem;
+    padding-inline-start: 0.5rem;
     padding-top: 0;
     padding-bottom: 0;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:first-child {
-    padding-left: 0;
-    border-left: 0 none;
+    padding-inline-start: 0;
+    border-inline-start: 0 none;
   }
   .p-datepicker.p-datepicker-multiple-month .p-datepicker-group:last-child {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-datepicker:not(.p-disabled) table td span:not(.p-highlight):not(.p-disabled):hover {
     background: #edf0fa;
@@ -712,16 +715,16 @@
   }
 
   p-calendar.p-calendar-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-calendar.p-calendar-clearable .p-calendar-clear-icon {
     color: #898989;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-calendar.p-calendar-clearable .p-calendar-w-btn .p-calendar-clear-icon {
     color: #898989;
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
 
   @media screen and (max-width: 769px) {
@@ -760,8 +763,8 @@
     background: transparent;
     color: #898989;
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-cascadeselect.p-invalid.p-component {
     border-color: #f88c79;
@@ -787,7 +790,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-cascadeselect-panel .p-cascadeselect-items .p-cascadeselect-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     border: 0 none;
     color: #6c6c6c;
     background: transparent;
@@ -834,20 +840,26 @@
   }
 
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-label {
-    padding-right: 0.75rem;
+    padding-inline-end: 0.75rem;
   }
   p-cascadeselect.p-cascadeselect-clearable .p-cascadeselect-clear-icon {
     color: #898989;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   .p-overlay-modal .p-cascadeselect-sublist .p-cascadeselect-panel {
     box-shadow: none;
     border-radius: 0;
-    padding: 0.25rem 0 0.25rem 0.5rem;
+    padding-block-start: 0.25rem;
+    padding-inline-end: 0;
+    padding-block-end: 0.25rem;
+    padding-inline-start: 0.5rem;
   }
   .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon {
     transform: rotate(90deg);
+  }
+  .p-overlay-modal .p-cascadeselect-item-active > .p-cascadeselect-item-content .p-cascadeselect-group-icon:dir(rtl) {
+    transform: rotate(-90deg);
   }
 
   .p-checkbox {
@@ -922,7 +934,7 @@
   }
 
   .p-checkbox-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   p-tristatecheckbox.ng-dirty.ng-invalid > .p-checkbox > .p-checkbox-box {
@@ -944,7 +956,7 @@
   }
   .p-chips .p-chips-multiple-container .p-chips-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #ebebeb;
     color: #6c6c6c;
     border-radius: 16px;
@@ -954,7 +966,7 @@
     color: #6c6c6c;
   }
   .p-chips .p-chips-multiple-container .p-chips-token .p-chips-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chips .p-chips-multiple-container .p-chips-input-token {
     padding: 0.25rem 0;
@@ -973,11 +985,11 @@
   }
 
   p-chips.p-chips-clearable .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-chips.p-chips-clearable .p-chips-clear-icon {
     color: #898989;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-colorpicker-preview,
@@ -1015,7 +1027,7 @@
     border-color: #91a4e3;
   }
   .p-dropdown.p-dropdown-clearable .p-dropdown-label {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-dropdown .p-dropdown-label {
     background: transparent;
@@ -1032,12 +1044,12 @@
     background: transparent;
     color: #898989;
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dropdown .p-dropdown-clear-icon {
     color: #898989;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
   .p-dropdown.p-invalid.p-component {
     border-color: #f88c79;
@@ -1065,22 +1077,25 @@
     color: #6c6c6c;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter {
-    padding-right: 1.75rem;
-    margin-right: -1.75rem;
+    padding-inline-end: 1.75rem;
+    margin-inline-end: -1.75rem;
   }
   .p-dropdown-panel .p-dropdown-header .p-dropdown-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
   .p-dropdown-panel .p-dropdown-items {
     padding: 0.5rem 0.5rem;
   }
   .p-dropdown-panel .p-dropdown-items .p-dropdown-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: #6c6c6c;
@@ -1146,13 +1161,13 @@
     background: #f5f5f5;
     color: #898989;
     border-top: 2px solid #e1e1e1;
-    border-left: 2px solid #e1e1e1;
+    border-inline-start: 2px solid #e1e1e1;
     border-bottom: 2px solid #e1e1e1;
     padding: 0.5rem 0.75rem;
     min-width: 2.857rem;
   }
   .p-inputgroup-addon:last-child {
-    border-right: 2px solid #e1e1e1;
+    border-inline-end: 2px solid #e1e1e1;
   }
 
   .p-inputgroup > .p-component,
@@ -1164,7 +1179,7 @@
   .p-inputgroup > .p-component + .p-inputgroup-addon,
 .p-inputgroup > .p-inputwrapper > .p-inputtext + .p-inputgroup-addon,
 .p-inputgroup > .p-float-label > .p-component + .p-inputgroup-addon {
-    border-left: 0 none;
+    border-inline-start: 0 none;
   }
   .p-inputgroup > .p-component:focus,
 .p-inputgroup > .p-inputwrapper > .p-inputtext:focus,
@@ -1182,13 +1197,13 @@
 .p-inputgroup input:first-child,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component,
 .p-inputgroup > .p-inputwrapper:first-child > .p-component > .p-inputtext {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:first-child input {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-inputgroup-addon:last-child,
@@ -1196,13 +1211,13 @@
 .p-inputgroup input:last-child,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component,
 .p-inputgroup > .p-inputwrapper:last-child > .p-component > .p-inputtext {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-inputgroup .p-float-label:last-child input {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-fluid .p-inputgroup .p-button {
@@ -1213,12 +1228,12 @@
   }
 
   .p-icon-field-left .p-input-icon:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #898989;
   }
 
   .p-icon-field-right .p-input-icon:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
 
@@ -1227,11 +1242,11 @@
   }
 
   p-inputmask.p-inputmask-clearable .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputmask.p-inputmask-clearable .p-inputmask-clear-icon {
     color: #898989;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   .p-inputmask.p-variant-filled {
@@ -1249,18 +1264,18 @@
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-clear-icon {
     color: #898989;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-stacked .p-inputnumber-clear-icon {
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
   p-inputnumber.p-inputnumber-clearable .p-inputnumber-buttons-horizontal .p-inputnumber-clear-icon {
-    right: 3.607rem;
+    inset-inline-end: 3.607rem;
   }
 
   p-inputnumber.p-inputnumber.p-variant-filled > .p-inputnumber-input {
@@ -1297,13 +1312,16 @@
     background: #ffffff;
     width: 1.25rem;
     height: 1.25rem;
-    left: 0.25rem;
+    inset-inline-start: 0.25rem;
     margin-top: -0.625rem;
     border-radius: 6px;
     transition-duration: 0.3s;
   }
   .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:before {
     transform: translateX(1.25rem);
+  }
+  .p-inputswitch.p-inputswitch-checked .p-inputswitch-slider:dir(rtl):before {
+    transform: translateX(-1.25rem);
   }
   .p-inputswitch.p-focus .p-inputswitch-slider {
     outline: 0 none;
@@ -1370,7 +1388,7 @@
   }
 
   .p-float-label > label {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #898989;
     transition-duration: 0.3s;
   }
@@ -1381,38 +1399,38 @@
 
   .p-input-icon-left > .p-icon-wrapper.p-icon,
 .p-input-icon-left > i:first-of-type {
-    left: 0.75rem;
+    inset-inline-start: 0.75rem;
     color: #898989;
   }
 
   .p-input-icon-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-input-icon-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-input-icon-right > .p-icon-wrapper,
 .p-input-icon-right > i:last-of-type {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
 
   .p-input-icon-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   .p-icon-field-left > .p-inputtext {
-    padding-left: 2.5rem;
+    padding-inline-start: 2.5rem;
   }
 
   .p-icon-field-left.p-float-label > label {
-    left: 2.5rem;
+    inset-inline-start: 2.5rem;
   }
 
   .p-icon-field-right > .p-inputtext {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
 
   ::-webkit-input-placeholder {
@@ -1464,25 +1482,28 @@
     color: #6c6c6c;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-listbox .p-listbox-header .p-listbox-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-listbox .p-listbox-header .p-listbox-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
   .p-listbox .p-listbox-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list {
     padding: 0.5rem 0.5rem;
     outline: 0 none;
   }
   .p-listbox .p-listbox-list .p-listbox-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: #6c6c6c;
@@ -1497,7 +1518,7 @@
     background: #ced6f1;
   }
   .p-listbox .p-listbox-list .p-listbox-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-listbox .p-listbox-list .p-listbox-item-group {
     margin: 0;
@@ -1561,20 +1582,20 @@
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #ebebeb;
     color: #6c6c6c;
     border-radius: 16px;
   }
   .p-multiselect.p-multiselect-chip .p-multiselect-token .p-multiselect-token-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-multiselect .p-multiselect-trigger {
     background: transparent;
     color: #898989;
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-multiselect.p-variant-filled {
     background: #f2f2f2;
@@ -1591,11 +1612,11 @@
   }
 
   .p-multiselect-clearable .p-multiselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-clearable .p-multiselect-clear-icon {
     color: #898989;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   .p-multiselect-panel {
@@ -1611,21 +1632,21 @@
     color: #6c6c6c;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-inputtext {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-filter-container .p-multiselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
   .p-multiselect-panel .p-multiselect-header .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-header .p-multiselect-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #898989;
@@ -1648,7 +1669,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: #6c6c6c;
@@ -1675,7 +1699,7 @@
     background: #edf0fa;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-multiselect-panel .p-multiselect-items .p-multiselect-item-group {
     margin: 0;
@@ -1731,19 +1755,19 @@
   }
 
   p-password.p-password-clearable .p-password-input {
-    padding-right: 2.5rem;
+    padding-inline-end: 2.5rem;
   }
   p-password.p-password-clearable .p-password-clear-icon {
     color: #898989;
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
   }
 
   p-password.p-password-clearable.p-password-mask .p-password-input {
-    padding-right: 4.25rem;
+    padding-inline-end: 4.25rem;
   }
   p-password.p-password-clearable.p-password-mask .p-password-clear-icon {
     color: #898989;
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
 
   .p-radiobutton {
@@ -1815,7 +1839,7 @@
   }
 
   .p-radiobutton-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-rating {
@@ -1907,7 +1931,7 @@
   }
   .p-slider.p-slider-horizontal .p-slider-handle {
     margin-top: -0.5715rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
   }
   .p-slider.p-slider-vertical {
     height: 100%;
@@ -1916,7 +1940,7 @@
   .p-slider.p-slider-vertical .p-slider-handle {
     height: 1.143rem;
     width: 1.143rem;
-    margin-left: -0.5715rem;
+    margin-inline-start: -0.5715rem;
     margin-bottom: -0.5715rem;
   }
   .p-slider .p-slider-handle {
@@ -1940,7 +1964,7 @@
     border-color: #5472d4;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-handle {
-    transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s, left 0.3s;
+    transition: background-color 0.3s, color 0.3s, border-color 0.3s, box-shadow 0.3s, inset-inline-start 0.3s;
   }
   .p-slider.p-slider-animate.p-slider-horizontal .p-slider-range {
     transition: width 0.3s;
@@ -2018,7 +2042,7 @@
   }
   .p-treeselect.p-treeselect-chip .p-treeselect-token {
     padding: 0.25rem 0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     background: #ebebeb;
     color: #6c6c6c;
     border-radius: 16px;
@@ -2027,8 +2051,8 @@
     background: transparent;
     color: #898989;
     width: 2.857rem;
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-treeselect.p-variant-filled {
     background-color: #f2f2f2;
@@ -2061,24 +2085,24 @@
     color: #6c6c6c;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container .p-treeselect-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter {
-    padding-right: 3.5rem;
+    padding-inline-end: 3.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-filter-container.p-treeselect-clearable-filter .p-treeselect-filter-clear-icon {
-    right: 2.5rem;
+    inset-inline-end: 2.5rem;
   }
   .p-treeselect-panel .p-treeselect-header .p-treeselect-close {
     width: 2rem;
@@ -2119,11 +2143,11 @@
   }
 
   p-treeselect.p-treeselect-clearable .p-treeselect-label-container {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   p-treeselect.p-treeselect-clearable .p-treeselect-clear-icon {
     color: #898989;
-    right: 2.857rem;
+    inset-inline-end: 2.857rem;
   }
 
   .p-button {
@@ -2208,10 +2232,10 @@
     transition-duration: 0.3s;
   }
   .p-button .p-button-icon-left {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-button .p-button-icon-right {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button .p-button-icon-bottom {
     margin-top: 0.5rem;
@@ -2220,7 +2244,7 @@
     margin-bottom: 0.5rem;
   }
   .p-button .p-badge {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     min-width: 1rem;
     height: 1rem;
     line-height: 1rem;
@@ -2260,10 +2284,10 @@
     font-size: 1.25rem;
   }
   .p-button.p-button-loading-label-only .p-button-label {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-button.p-button-loading-label-only .p-button-loading-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-fluid .p-button {
@@ -2648,14 +2672,14 @@
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-left .p-speeddial-item:first-child {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
 
   .p-speeddial-direction-right .p-speeddial-item {
     margin: 0 0.25rem;
   }
   .p-speeddial-direction-right .p-speeddial-item:first-child {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-speeddial-circle .p-speeddial-item,
@@ -2715,7 +2739,7 @@
     padding: 1rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     margin-bottom: 0.5rem;
   }
   .p-carousel .p-carousel-indicators .p-carousel-indicator button {
@@ -2734,18 +2758,27 @@
   }
 
   .p-datatable .p-paginator-top {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-paginator-bottom {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-datatable .p-datatable-header {
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -2753,32 +2786,41 @@
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-datatable .p-datatable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #6c6c6c;
     background: #ffffff;
     transition: box-shadow 0.3s;
   }
   .p-datatable .p-datatable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #6c6c6c;
     background: #ffffff;
   }
   .p-datatable .p-sortable-column .p-sortable-column-icon {
     color: #898989;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -2787,7 +2829,7 @@
     line-height: 1.143rem;
     color: #585858;
     background: #ced6f1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-datatable .p-sortable-column:not(.p-highlight):hover {
     background: #edf0fa;
@@ -2820,9 +2862,12 @@
     transition: box-shadow 0.3s;
   }
   .p-datatable .p-datatable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-toggler,
@@ -2854,7 +2899,7 @@
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
   .p-datatable .p-datatable-tbody > tr > td .p-row-editor-save {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-datatable .p-datatable-tbody > tr:focus-visible {
     outline: 0.15rem solid #bbc7ee;
@@ -2890,58 +2935,106 @@
     font-size: 2rem;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-paginator-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead > tr > th:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td {
-    border-width: 1px 0 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr > td:last-child {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tbody > tr:last-child > td:last-child {
     border-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td {
-    border-width: 1px 0 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-tfoot > tr > td:last-child {
-    border-width: 1px 1px 1px 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines .p-datatable-thead + .p-datatable-tfoot > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td {
-    border-width: 0 0 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-thead):has(.p-datatable-tbody) .p-datatable-tbody > tr > td:last-child {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td {
-    border-width: 0 0 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-gridlines:has(.p-datatable-tbody):has(.p-datatable-tfoot) .p-datatable-tbody > tr:last-child > td:last-child {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-datatable.p-datatable-striped .p-datatable-tbody > tr:nth-child(even) {
     background: #fcfcfc;
@@ -2988,18 +3081,27 @@
   }
 
   .p-dataview .p-paginator-top {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-paginator-bottom {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-dataview .p-dataview-header {
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3013,11 +3115,14 @@
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-dataview .p-dataview-loading-icon {
     font-size: 2rem;
@@ -3028,7 +3133,7 @@
 
   .p-column-filter-row .p-column-filter-menu-button,
 .p-column-filter-row .p-column-filter-clear-button {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-column-filter-menu-button {
@@ -3091,7 +3196,10 @@
     padding: 0.5rem 0.5rem;
   }
   .p-column-filter-overlay .p-column-filter-row-items .p-column-filter-row-item {
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     padding: 0.5rem 1rem;
     border: 0 none;
     color: #6c6c6c;
@@ -3126,8 +3234,8 @@
     color: #6c6c6c;
     background: #ffffff;
     margin: 0;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-column-filter-overlay-menu .p-column-filter-constraint {
     padding: 1rem;
@@ -3183,10 +3291,10 @@
     border-bottom: 0 none;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-orderlist .p-orderlist-filter-container .p-orderlist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
   .p-orderlist .p-orderlist-list {
@@ -3199,7 +3307,10 @@
   }
   .p-orderlist .p-orderlist-list .p-orderlist-item {
     padding: 0.5rem 1rem;
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     border: 0 none;
     color: #6c6c6c;
     background: transparent;
@@ -3262,7 +3373,7 @@
     background: #ebebeb;
   }
   .p-organizationchart .p-organizationchart-line-left {
-    border-right: 2px solid #ebebeb;
+    border-inline-end: 2px solid #ebebeb;
     border-color: #ebebeb;
   }
   .p-organizationchart .p-organizationchart-line-top {
@@ -3316,24 +3427,24 @@
     color: #6c6c6c;
   }
   .p-paginator .p-paginator-first {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-paginator .p-paginator-last {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-paginator .p-dropdown {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
     height: 2.857rem;
   }
   .p-paginator .p-dropdown .p-dropdown-label {
-    padding-right: 0;
+    padding-inline-end: 0;
   }
   .p-paginator .p-paginator-page-input {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-paginator .p-paginator-page-input .p-inputtext {
     max-width: 2.857rem;
@@ -3402,10 +3513,10 @@
     border-bottom: 0 none;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-input {
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-picklist .p-picklist-filter-container .p-picklist-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
   .p-picklist .p-picklist-list {
@@ -3418,7 +3529,10 @@
   }
   .p-picklist .p-picklist-list .p-picklist-item {
     padding: 0.5rem 1rem;
-    margin: 0 0 4px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 4px;
+    margin-inline-start: 0;
     border: 0 none;
     color: #6c6c6c;
     background: transparent;
@@ -3513,7 +3627,7 @@
     padding: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     width: 2rem;
     height: 2rem;
     color: #898989;
@@ -3533,11 +3647,11 @@
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-treenode-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
     color: #898989;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree .p-tree-container .p-treenode .p-treenode-content .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #6c6c6c;
@@ -3579,14 +3693,17 @@
   }
   .p-tree .p-tree-filter-container .p-tree-filter {
     width: 100%;
-    padding-right: 1.75rem;
+    padding-inline-end: 1.75rem;
   }
   .p-tree .p-tree-filter-container .p-tree-filter-icon {
-    right: 0.75rem;
+    inset-inline-end: 0.75rem;
     color: #898989;
   }
   .p-tree .p-treenode-children {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-tree .p-tree-loading-icon {
     font-size: 2rem;
@@ -3614,14 +3731,14 @@
     color: #585858;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-tree-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tree.p-tree-horizontal .p-treenode .p-treenode-content .p-treenode-label:not(.p-highlight):hover {
     background-color: inherit;
@@ -3638,18 +3755,27 @@
   }
 
   .p-treetable .p-paginator-top {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-paginator-bottom {
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-radius: 0;
   }
   .p-treetable .p-treetable-header {
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3657,25 +3783,34 @@
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
   .p-treetable .p-treetable-thead > tr > th {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #6c6c6c;
     background: #ffffff;
     transition: box-shadow 0.3s;
   }
   .p-treetable .p-treetable-tfoot > tr > td {
-    text-align: left;
+    text-align: start;
     padding: 1rem 1rem;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     font-weight: 600;
     color: #6c6c6c;
     background: #ffffff;
@@ -3685,7 +3820,7 @@
   }
   .p-treetable .p-sortable-column .p-sortable-column-icon {
     color: #898989;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column .p-sortable-column-badge {
     border-radius: 50%;
@@ -3694,7 +3829,7 @@
     line-height: 1.143rem;
     color: #585858;
     background: #ced6f1;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-treetable .p-sortable-column:not(.p-highlight):hover {
     background: #edf0fa;
@@ -3716,9 +3851,12 @@
     transition: box-shadow 0.3s;
   }
   .p-treetable .p-treetable-tbody > tr > td {
-    text-align: left;
+    text-align: start;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler {
@@ -3729,7 +3867,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td .p-treetable-toggler:enabled:hover {
     color: #6c6c6c;
@@ -3746,7 +3884,7 @@
     height: 2rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-treetable .p-treetable-tbody > tr > td p-treetablecheckbox .p-checkbox .p-indeterminate .p-checkbox-icon {
     color: #6c6c6c;
@@ -3799,16 +3937,28 @@
     height: 2rem;
   }
   .p-treetable.p-treetable-gridlines .p-datatable-header {
-    border-width: 1px 1px 0 1px;
+    border-block-start-width: 1px;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-footer {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-top {
-    border-width: 0 1px 0 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 0;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-bottom {
-    border-width: 0 1px 1px 1px;
+    border-block-start-width: 0;
+    border-inline-end-width: 1px;
+    border-block-end-width: 1px;
+    border-inline-start-width: 1px;
   }
   .p-treetable.p-treetable-gridlines .p-treetable-thead > tr > th {
     border-width: 1px;
@@ -3854,7 +4004,10 @@
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
   }
@@ -3868,11 +4021,14 @@
     background: #ffffff;
     color: #6c6c6c;
     border: 2px solid #f5f5f5;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     padding: 1rem 1rem;
     font-weight: 600;
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-accordion .p-accordion-header .p-accordion-header-link {
@@ -3885,7 +4041,7 @@
     transition: box-shadow 0.3s;
   }
   .p-accordion .p-accordion-header .p-accordion-header-link .p-accordion-toggle-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-accordion .p-accordion-header:not(.p-disabled) .p-accordion-header-link:focus-visible {
     outline: 0 none;
@@ -3901,8 +4057,8 @@
     background: #ffffff;
     border-color: #ebebeb;
     color: #6c6c6c;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
   }
   .p-accordion .p-accordion-header:not(.p-disabled).p-highlight:hover .p-accordion-header-link {
     border-color: #ebebeb;
@@ -3915,10 +4071,10 @@
     background: #ffffff;
     color: #6c6c6c;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab .p-accordion-tab {
     margin-bottom: 0;
@@ -3936,16 +4092,16 @@
     border-top: 0 none;
   }
   .p-accordion p-accordiontab:first-child .p-accordion-header .p-accordion-header-link {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-header:not(.p-highlight) .p-accordion-header-link {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-accordion p-accordiontab:last-child .p-accordion-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-card {
@@ -3971,7 +4127,10 @@
     padding: 1rem 0;
   }
   .p-card .p-card-footer {
-    padding: 1rem 0 0 0;
+    padding-block-start: 1rem;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 0;
   }
 
   .p-divider .p-divider-content {
@@ -3992,7 +4151,7 @@
     padding: 1rem 0;
   }
   .p-divider.p-divider-vertical:before {
-    border-left: 1px #ebebeb;
+    border-inline-start: 1px #ebebeb;
   }
   .p-divider.p-divider-vertical .p-divider-content {
     padding: 0.5rem 0;
@@ -4023,7 +4182,7 @@
     transition: box-shadow 0.3s;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a .p-fieldset-toggler {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fieldset.p-fieldset-toggleable .p-fieldset-legend a:focus-visible {
     outline: 0 none;
@@ -4044,8 +4203,8 @@
     padding: 1rem;
     background: #ffffff;
     color: #6c6c6c;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panel .p-panel-header .p-panel-title {
     font-weight: 600;
@@ -4080,25 +4239,25 @@
     border-top: 0 none;
   }
   .p-panel .p-panel-content:last-child {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panel .p-panel-footer {
     padding: 0.5rem 1rem;
     border: 2px solid #ebebeb;
     background: #ffffff;
     color: #6c6c6c;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
     border-top: 0 none;
   }
   .p-panel .p-panel-icons-end {
     order: 2;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
   .p-panel .p-panel-icons-start {
     order: 0;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panel .p-panel-icons-center {
     order: 2;
@@ -4145,23 +4304,32 @@
   .p-tabview .p-tabview-nav {
     background: #ffffff;
     border: 1px solid #ebebeb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabview .p-tabview-nav li {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link {
     border: solid #ebebeb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #ebebeb transparent;
     background: #ffffff;
     color: #898989;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.3s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabview .p-tabview-nav li .p-tabview-nav-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -4179,13 +4347,13 @@
     color: #5472d4;
   }
   .p-tabview .p-tabview-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabview .p-tabview-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-close {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabview .p-tabview-nav-btn.p-link {
     background: #ffffff;
@@ -4204,8 +4372,8 @@
     padding: 1rem;
     border: 0 none;
     color: #6c6c6c;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-toolbar {
@@ -4312,7 +4480,7 @@
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
   }
   .p-stepper .p-stepper-header .p-stepper-action .p-stepper-title {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
     color: #898989;
     font-weight: 600;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
@@ -4372,7 +4540,7 @@
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-content {
     width: 100%;
-    padding-left: 1rem;
+    padding-inline-start: 1rem;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel .p-stepper-separator {
     flex: 0 0 auto;
@@ -4384,7 +4552,7 @@
     background-color: #5472d4;
   }
   .p-stepper.p-stepper-vertical .p-stepper-panel:last-of-type .p-stepper-content {
-    padding-left: 3rem;
+    padding-inline-start: 3rem;
   }
 
   .p-confirm-popup {
@@ -4398,11 +4566,14 @@
     padding: 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer {
-    text-align: right;
+    text-align: end;
     padding: 0.5rem 1rem;
   }
   .p-confirm-popup .p-confirm-popup-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-confirm-popup .p-confirm-popup-footer button:last-child {
@@ -4432,7 +4603,7 @@
     height: 1.5rem;
   }
   .p-confirm-popup .p-confirm-popup-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-dialog {
@@ -4445,8 +4616,8 @@
     background: #ffffff;
     color: #6c6c6c;
     padding: 1.5rem;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-dialog .p-dialog-header .p-dialog-title {
     font-weight: 600;
@@ -4460,7 +4631,7 @@
     background: transparent;
     border-radius: 50%;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:enabled:hover {
     color: #6c6c6c;
@@ -4473,28 +4644,37 @@
     box-shadow: 0 0 0 0.1rem #bbc7ee;
   }
   .p-dialog .p-dialog-header .p-dialog-header-icon:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-dialog .p-dialog-content {
     background: #ffffff;
     color: #6c6c6c;
-    padding: 0 1.5rem 2rem 1.5rem;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 2rem;
+    padding-inline-start: 1.5rem;
   }
   .p-dialog .p-dialog-content:last-of-type {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer {
     border-top: 0 none;
     background: #ffffff;
     color: #6c6c6c;
-    padding: 0 1.5rem 1.5rem 1.5rem;
-    text-align: right;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    padding-block-start: 0;
+    padding-inline-end: 1.5rem;
+    padding-block-end: 1.5rem;
+    padding-inline-start: 1.5rem;
+    text-align: end;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-dialog .p-dialog-footer button {
-    margin: 0 0.5rem 0 0;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0;
     width: auto;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-icon {
@@ -4505,7 +4685,7 @@
     height: 2rem;
   }
   .p-dialog.p-confirm-dialog .p-confirm-dialog-message {
-    margin-left: 1rem;
+    margin-inline-start: 1rem;
   }
 
   .p-overlaypanel {
@@ -4527,7 +4707,7 @@
     border-radius: 50%;
     position: absolute;
     top: -1rem;
-    right: -1rem;
+    inset-inline-end: -1rem;
   }
   .p-overlaypanel .p-overlaypanel-close:enabled:hover {
     background: #4868d1;
@@ -4599,10 +4779,10 @@
     border-radius: 6px;
   }
   .p-tooltip.p-tooltip-right .p-tooltip-arrow {
-    border-right-color: #585858;
+    border-inline-end-color: #585858;
   }
   .p-tooltip.p-tooltip-left .p-tooltip-arrow {
-    border-left-color: #585858;
+    border-inline-start-color: #585858;
   }
   .p-tooltip.p-tooltip-top .p-tooltip-arrow {
     border-top-color: #585858;
@@ -4617,11 +4797,11 @@
     border: 2px solid #ebebeb;
     color: #6c6c6c;
     border-bottom: 0 none;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-fileupload .p-fileupload-buttonbar .p-button.p-fileupload-choose.p-focus {
     outline: 0 none;
@@ -4633,8 +4813,8 @@
     padding: 2rem 1rem;
     border: 2px solid #ebebeb;
     color: #6c6c6c;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-fileupload .p-fileupload-content.p-fileupload-highlight {
     border-color: 2px solid #ebebeb dashed #5472d4;
@@ -4684,7 +4864,10 @@
     color: #898989;
   }
   .p-breadcrumb .p-breadcrumb-list li.p-menuitem-separator {
-    margin: 0 0.5rem 0 0.5rem;
+    margin-block-start: 0;
+    margin-inline-end: 0.5rem;
+    margin-block-end: 0;
+    margin-inline-start: 0.5rem;
     color: #6c6c6c;
   }
   .p-breadcrumb .p-breadcrumb-list li:last-child .p-menuitem-text {
@@ -4728,7 +4911,7 @@
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-contextmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
@@ -4875,7 +5058,7 @@
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
@@ -4929,8 +5112,8 @@
     color: #6c6c6c;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-megamenu .p-submenu-list {
     padding: 0.5rem 0.5rem;
@@ -4958,11 +5141,11 @@
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-megamenu.p-megamenu-horizontal .p-megamenu-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #6c6c6c;
@@ -4999,7 +5182,7 @@
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
@@ -5051,8 +5234,8 @@
     color: #6c6c6c;
     background: #ffffff;
     font-weight: 600;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
   }
   .p-menu .p-menuitem-separator {
     border-top: 1px solid #ebebeb;
@@ -5067,9 +5250,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-menubar {
@@ -5096,11 +5279,11 @@
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-menubar .p-menubar-root-list > .p-menuitem:not(.p-highlight):not(.p-disabled) > .p-menuitem-content:hover {
     color: #6c6c6c;
@@ -5128,7 +5311,7 @@
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-menubar .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
@@ -5227,11 +5410,14 @@
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-      margin-left: auto;
+      margin-inline-start: auto;
       transition: transform 0.3s;
     }
     .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-180deg);
+    }
+    .p-menubar .p-menubar-root-list .p-menuitem.p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(180deg);
     }
     .p-menubar .p-menubar-root-list .p-submenu-list {
       width: 100%;
@@ -5246,30 +5432,33 @@
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon {
       transform: rotate(-90deg);
     }
+    .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem-active > .p-menuitem-content > .p-menuitem-link > .p-submenu-icon:dir(rtl) {
+      transform: rotate(90deg);
+    }
     .p-menubar .p-menubar-root-list .p-menuitem {
       width: 100%;
       position: static;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 2.25rem;
+      padding-inline-start: 2.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 3.75rem;
+      padding-inline-start: 3.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 5.25rem;
+      padding-inline-start: 5.25rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 6.75rem;
+      padding-inline-start: 6.75rem;
     }
     .p-menubar .p-menubar-root-list .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-submenu-list .p-menuitem .p-menuitem-content .p-menuitem-link {
-      padding-left: 8.25rem;
+      padding-inline-start: 8.25rem;
     }
     .p-menubar.p-menubar-mobile-active .p-menubar-root-list {
       display: flex;
       flex-direction: column;
       top: 100%;
-      left: 0;
+      inset-inline-start: 0;
       z-index: 1;
     }
   }
@@ -5289,10 +5478,10 @@
     font-weight: 600;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header .p-panelmenu-header-content .p-panelmenu-header-action .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled):focus-visible .p-panelmenu-header-content {
     outline: 0 none;
@@ -5308,8 +5497,8 @@
     background: #ffffff;
     border-color: #ebebeb;
     color: #6c6c6c;
-    border-bottom-right-radius: 0;
-    border-bottom-left-radius: 0;
+    border-end-end-radius: 0;
+    border-end-start-radius: 0;
     margin-bottom: 0;
   }
   .p-panelmenu .p-panelmenu-header:not(.p-disabled).p-highlight:hover .p-panelmenu-header-content {
@@ -5323,10 +5512,10 @@
     background: #ffffff;
     color: #6c6c6c;
     border-top: 0;
-    border-top-right-radius: 0;
-    border-top-left-radius: 0;
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-end-radius: 0;
+    border-start-start-radius: 0;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-content .p-panelmenu-root-list {
     outline: 0 none;
@@ -5346,7 +5535,7 @@
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
@@ -5388,14 +5577,17 @@
     color: #898989;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem .p-menuitem-content .p-menuitem-link .p-submenu-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-panelmenu .p-panelmenu-content .p-menuitem-separator {
     border-top: 1px solid #ebebeb;
     margin: 4px 0;
   }
   .p-panelmenu .p-panelmenu-content .p-submenu-list:not(.p-panelmenu-root-list) {
-    padding: 0 0 0 1rem;
+    padding-block-start: 0;
+    padding-inline-end: 0;
+    padding-block-end: 0;
+    padding-inline-start: 1rem;
   }
   .p-panelmenu .p-panelmenu-panel {
     margin-bottom: 0;
@@ -5413,16 +5605,16 @@
     border-top: 0 none;
   }
   .p-panelmenu .p-panelmenu-panel:first-child .p-panelmenu-header .p-panelmenu-header-content {
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-header:not(.p-highlight) .p-panelmenu-header-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-panelmenu .p-panelmenu-panel:last-child .p-panelmenu-content {
-    border-bottom-right-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-end-end-radius: 6px;
+    border-end-start-radius: 6px;
   }
 
   .p-slidemenu {
@@ -5454,7 +5646,7 @@
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-slidemenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
@@ -5535,9 +5727,9 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
 
   .p-steps .p-steps-item .p-menuitem-link {
@@ -5579,7 +5771,7 @@
     border-top: 1px solid #ebebeb;
     width: 100%;
     top: 50%;
-    left: 0;
+    inset-inline-start: 0;
     display: block;
     position: absolute;
     margin-top: -1rem;
@@ -5588,7 +5780,10 @@
   .p-tabmenu .p-tabmenu-nav {
     background: #ffffff;
     border: 1px solid #ebebeb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-menuitem-badge {
     background: #5472d4;
@@ -5599,28 +5794,34 @@
     height: 1.5rem;
     line-height: 1.5rem;
     border-radius: 6px;
-    margin-left: 0.5rem;
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
+    margin-inline-start: 0.5rem;
+    padding-inline-start: 0.5rem;
+    padding-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link {
     border: solid #ebebeb;
-    border-width: 0 0 2px 0;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 2px;
+    border-inline-start-width: 0;
     border-color: transparent transparent #ebebeb transparent;
     background: #ffffff;
     color: #898989;
     padding: 1rem;
     font-weight: 600;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
+    border-start-end-radius: 6px;
+    border-start-start-radius: 6px;
     transition: box-shadow 0.3s;
-    margin: 0 0 -2px 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: -2px;
+    margin-inline-start: 0;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link .p-menuitem-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav .p-tabmenuitem .p-menuitem-link:not(.p-disabled):focus-visible {
     outline: 0 none;
@@ -5638,10 +5839,10 @@
     color: #5472d4;
   }
   .p-tabmenu .p-tabmenu-left-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-right-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-tabmenu .p-tabmenu-nav-btn.p-link {
     background: #ffffff;
@@ -5694,7 +5895,7 @@
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-menuitem-icon {
     color: #898989;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-tieredmenu .p-menuitem > .p-menuitem-content .p-menuitem-link .p-submenu-icon {
     color: #898989;
@@ -5790,7 +5991,7 @@
   }
   .p-inline-message .p-inline-message-icon {
     font-size: 1rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-inline-message .p-icon {
     width: 1rem;
@@ -5800,7 +6001,7 @@
     font-size: 1rem;
   }
   .p-inline-message.p-inline-message-icon-only .p-inline-message-icon {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .p-message {
@@ -5828,7 +6029,10 @@
   .p-message.p-message-info {
     background: #e1f2f7;
     border: 4px solid #83c7e0;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-message.p-message-info .p-message-icon {
@@ -5840,7 +6044,10 @@
   .p-message.p-message-success {
     background: #f2f8e1;
     border: 4px solid #c7e084;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-message.p-message-success .p-message-icon {
@@ -5852,7 +6059,10 @@
   .p-message.p-message-warn {
     background: #ffecdb;
     border: 4px solid #ffb065;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-message.p-message-warn .p-message-icon {
@@ -5864,7 +6074,10 @@
   .p-message.p-message-error {
     background: #f7e1e6;
     border: 4px solid #de8499;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-message.p-message-error .p-message-icon {
@@ -5879,7 +6092,7 @@
   }
   .p-message .p-message-icon {
     font-size: 1.5rem;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-message .p-icon {
     width: 1.5rem;
@@ -5889,23 +6102,32 @@
     font-weight: 700;
   }
   .p-message .p-message-detail {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
 
   .p-toast {
     opacity: 0.9;
   }
   .p-toast .p-toast-message {
-    margin: 0 0 1rem 0;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 1rem;
+    margin-inline-start: 0;
     box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
     border-radius: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content {
     padding: 1rem;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-text {
-    margin: 0 0 0 1rem;
+    margin-block-start: 0;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 1rem;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-message-icon {
     font-size: 2rem;
@@ -5918,7 +6140,10 @@
     font-weight: 600;
   }
   .p-toast .p-toast-message .p-toast-message-content .p-toast-detail {
-    margin: 0.5rem 0 0 0;
+    margin-block-start: 0.5rem;
+    margin-inline-end: 0;
+    margin-block-end: 0;
+    margin-inline-start: 0;
   }
   .p-toast .p-toast-message .p-toast-icon-close {
     width: 2rem;
@@ -5938,7 +6163,10 @@
   .p-toast .p-toast-message.p-toast-message-info {
     background: #e1f2f7;
     border: 4px solid #83c7e0;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-info .p-toast-message-icon,
@@ -5948,7 +6176,10 @@
   .p-toast .p-toast-message.p-toast-message-success {
     background: #f2f8e1;
     border: 4px solid #c7e084;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-success .p-toast-message-icon,
@@ -5958,7 +6189,10 @@
   .p-toast .p-toast-message.p-toast-message-warn {
     background: #ffecdb;
     border: 4px solid #ffb065;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-warn .p-toast-message-icon,
@@ -5968,7 +6202,10 @@
   .p-toast .p-toast-message.p-toast-message-error {
     background: #f7e1e6;
     border: 4px solid #de8499;
-    border-width: 0 0 0 6px;
+    border-block-start-width: 0;
+    border-inline-end-width: 0;
+    border-block-end-width: 0;
+    border-inline-start-width: 6px;
     color: #585858;
   }
   .p-toast .p-toast-message.p-toast-message-error .p-toast-message-icon,
@@ -6040,7 +6277,7 @@
     color: #585858;
   }
   .p-galleria.p-galleria-indicators-bottom .p-galleria-indicator, .p-galleria.p-galleria-indicators-top .p-galleria-indicator {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-galleria.p-galleria-indicators-left .p-galleria-indicator, .p-galleria.p-galleria-indicators-right .p-galleria-indicator {
     margin-bottom: 0.5rem;
@@ -6112,10 +6349,10 @@
     height: 3rem;
     border-radius: 50%;
     transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-image-action.p-link:last-child {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
   .p-image-action.p-link:hover {
     color: #f8f9fa;
@@ -6204,16 +6441,16 @@
     margin-bottom: 0.25rem;
   }
   .p-chip .p-chip-icon {
-    margin-right: 0.5rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
-    margin-left: 0.5rem;
+    margin-inline-start: 0.5rem;
   }
   .p-chip img {
     width: 2rem;
     height: 2rem;
-    margin-left: -0.75rem;
-    margin-right: 0.5rem;
+    margin-inline-start: -0.75rem;
+    margin-inline-end: 0.5rem;
   }
   .p-chip .pi-chip-remove-icon {
     border-radius: 6px;
@@ -6317,12 +6554,12 @@
     height: 0.5rem;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-bottom-left-radius: 6px;
+    border-start-start-radius: 6px;
+    border-end-start-radius: 6px;
   }
   .p-metergroup.p-metergroup-horizontal .p-metergroup-meter:last-of-type {
-    border-top-right-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-start-end-radius: 6px;
+    border-end-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical {
     flex-direction: row;
@@ -6332,12 +6569,12 @@
     height: 100%;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:first-of-type {
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-start-start-radius: 6px;
+    border-start-end-radius: 6px;
   }
   .p-metergroup.p-metergroup-vertical .p-metergroup-meter:last-of-type {
-    border-bottom-left-radius: 6px;
-    border-bottom-right-radius: 6px;
+    border-end-start-radius: 6px;
+    border-end-end-radius: 6px;
   }
 
   .p-progressbar {
@@ -6385,6 +6622,9 @@
   .p-skeleton:after {
     background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
   }
+  .p-skeleton:dir(rtl):after {
+    background: linear-gradient(-90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0));
+  }
 
   .p-tag {
     background: #5472d4;
@@ -6411,7 +6651,7 @@
     color: #ffffff;
   }
   .p-tag .p-tag-icon {
-    margin-right: 0.25rem;
+    margin-inline-end: 0.25rem;
     font-size: 0.75rem;
   }
   .p-tag .p-icon {
@@ -6468,9 +6708,9 @@
 
   .p-accordion .p-accordion-toggle-icon {
     order: 10;
-    margin-left: auto;
+    margin-inline-end: auto;
   }
-  .p-accordion .p-accordion-toggle-icon.pi-chevron-right::before {
+  .p-accordion .p-accordion-toggle-icon.pi-chevron-inset-inline-end::before {
     content: "\e90d";
   }
   .p-accordion .p-accordion-toggle-icon.pi-chevron-down::before {
@@ -6531,9 +6771,9 @@
 
   .p-panelmenu .p-panelmenu-icon.pi-chevron-right, .p-panelmenu .p-panelmenu-icon.pi-chevron-down {
     order: 10;
-    margin-left: auto;
+    margin-inline-end: auto;
   }
-  .p-panelmenu .p-panelmenu-icon.pi-chevron-right::before {
+  .p-panelmenu .p-panelmenu-icon.pi-chevron-inset-inline-end::before {
     content: "\e90d";
   }
   .p-panelmenu .p-panelmenu-icon.pi-chevron-down::before {


### PR DESCRIPTION
Hey,

We've forked PrimeNG 17.18.11 and added RTL support there. It's clear you guys won't merge this directly, but you might want to base your implementation on ours.

Please note that not only the styles are updated to use the [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values/Basic_concepts_of_logical_properties_and_values) where possible, but also the code-behind is fixed so that offset values like `clientX` are reported correctly in the RTL mode -- check the `DomHandler` class changes.

Detection of the mode is done via the `Directionality` class of the Angular CDK so switching to the RTL mode is done via `<html lang="..." dir="...">`.