### PR TITLE
SelectedItemGroup type as generic

### DIFF
--- a/src/app/components/api/selectitemgroup.ts
+++ b/src/app/components/api/selectitemgroup.ts
@@ -3,8 +3,8 @@ import { SelectItem } from './selectitem';
  * Represents a group of select items.
  * @group Interface
  */
-export interface SelectItemGroup {
+export interface SelectItemGroup<T = any> {
     label: string;
     value?: any;
-    items: SelectItem[];
+    items: SelectItem<T>[];
 }


### PR DESCRIPTION
Make `SelectedItemGroup` a generic, passing the type to `SelectItem`.

```ts
export interface SelectItemGroup<T = any> {
    label: string;
    value?: any;
    items: SelectItem<T>[];
}
```

Fixes #16561
