### PR TITLE
Fixes primefaces#16595 - CSS Layers for example with Tailwind CSS fail when appending styles to header and SSR enabled

### DIFF
--- a/src/app/components/usestyle/usestyle.ts
+++ b/src/app/components/usestyle/usestyle.ts
@@ -38,7 +38,12 @@ export class UseStyle {
                 nonce,
             });
 
-            first ? this.document.head.prepend(styleRef) : this.document.head.appendChild(styleRef);
+            const head = this.document.head || this.document.getElementsByTagName('head')[0];
+            if (first) {
+                head.insertBefore(styleRef, head.firstChild);
+            } else {
+                head.appendChild(styleRef);
+            }
             DomHandler.setAttribute(styleRef, 'data-primeng-style-id', name);
         }
 


### PR DESCRIPTION
fix primefaces#16595

Using custom implementation of prepend instead of the normal one that is not known by SSR