### PR TITLE
fix(docs): typo in theming#component

### DIFF
--- a/apps/showcase/doc/theming/componentdoc.ts
+++ b/apps/showcase/doc/theming/componentdoc.ts
@@ -5,12 +5,14 @@ import { Component } from '@angular/core';
     template: `
         <app-docsectiontext>
             <p>
-                The design tokens of a specific component is defined at <i>components</i> layer. Overriding components tokens is not the recommended approach if you are building our own style, building your own preset should be preferred instead.
-                This configuration is global and applies to all card components, in case you need to customize a particular component on a page locally, view the Scoped CSS section for an example.
+                The design tokens of a specific component is defined at <i>components</i> layer. Overriding components tokens is not the
+                recommended approach if you are building your own style, building your own preset should be preferred instead. This
+                configuration is global and applies to all card components, in case you need to customize a particular component on a page
+                locally, view the Scoped CSS section for an example.
             </p>
         </app-docsectiontext>
         <app-code [code]="code" selector="component-demo" [hideToggleCode]="true"></app-code>
-    `
+    `,
 })
 export class ComponentDoc {
     code = {
@@ -39,6 +41,6 @@ export class ComponentDoc {
             }
         }
     }
-});`
+});`,
     };
 }


### PR DESCRIPTION
This PR fixes a type in the Component section of the Theming documentation.
Changes "our" to "your" in the sentence "Overriding components tokens is not the recommended approach if you are building our own style, building your own preset should be preferred instead."