### PR TITLE
fix: In autocomplete dropdown, the item’s event has been changed from click to mousedown

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -242,7 +242,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                                         [attr.data-p-focused]="focusedOptionIndex() === getOptionIndex(i, scrollerOptions)"
                                         [attr.aria-setsize]="ariaSetSize"
                                         [attr.aria-posinset]="getAriaPosInset(getOptionIndex(i, scrollerOptions))"
-                                        (click)="onOptionSelect($event, option)"
+                                        (mousedown)="onOptionSelect($event, option)"
                                         (mouseenter)="onOptionMouseEnter($event, getOptionIndex(i, scrollerOptions))"
                                     >
                                         <span *ngIf="!itemTemplate">{{ getOptionLabel(option) }}</span>


### PR DESCRIPTION
#16625
In an autocomplete input component, events can often lead to unintended order of execution, particularly when handling change and click events. When a user types in the input and then selects an item from the dropdown list, the change event fires first because it’s triggered as soon as the input field loses focus or updates its content. Then, the click event on the dropdown item is executed.

Problem:
change Event: This triggers first when the input value changes, such as when the user clicks outside the input or the dropdown, updating the internal value.
click Event on Dropdown Item: This triggers after the change event, potentially overriding or undoing the intended selection behavior.
Solution with mousedown Event:
To change the order and have the dropdown selection (click) execute before the change event, you can replace click with the mousedown event on the dropdown items. This way:

mousedown Event on Dropdown Item: Fires when the user presses the mouse button down on the dropdown item, executing before the input loses focus.
change Event: Now, the change event fires after mousedown, updating the input field only after the item is selected.




