### PR TITLE
Fix accessibility issues in Carousel component (issue #16552)

### DIFF
--- a/src/app/components/carousel/carousel.ts
+++ b/src/app/components/carousel/carousel.ts
@@ -149,6 +149,25 @@ import { DomHandler } from 'primeng/dom';
     }
 })
 export class Carousel implements AfterContentInit {
+
+    private updateSlideAccessibility(slide: HTMLElement, isActive: boolean): void {
+        const focusableElements = slide.querySelectorAll<HTMLElement>('a, button, input, select, textarea, [tabindex]');
+        focusableElements.forEach((element) => {
+            element.tabIndex = isActive ? 0 : -1;
+        });
+    }
+    
+    private updateCarouselItemsAccessibility(): void {
+        const slides = this.el.nativeElement.querySelectorAll('.p-carousel-item');
+        slides.forEach((slide, index) => {
+            const isActive = index === this._page;
+            slide.setAttribute('aria-hidden', !isActive ? 'true' : 'false');
+            this.updateSlideAccessibility(slide as HTMLElement, isActive);
+        });
+    }
+    
+    
+    
     /**
      * Index of the first item.
      * @defaultValue 0
@@ -815,6 +834,7 @@ export class Carousel implements AfterContentInit {
             page: this.page
         });
         this.cd.markForCheck();
+        this.updateCarouselItemsAccessibility();
     }
 
     startAutoplay() {


### PR DESCRIPTION
Fixes #16552
This PR addresses an accessibility issue in the p-carousel component, where interactive elements within hidden slides were focusable, triggering warnings in tools like Axe DevTools. The fix ensures that only active slides have tabindex="0", while inactive slides are set with aria-hidden="true" and tabindex="-1" to meet accessibility standards.
