### PR TITLE
Label display fix in Component: multiSelect (issue #16288)

### DIFF
--- a/.github/workflows/npm-grunt.yml
+++ b/.github/workflows/npm-grunt.yml
@@ -1,0 +1,28 @@
+name: NodeJS with Grunt
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Build
+      run: |
+        npm install
+        grunt

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+1.Component: RadioButton #16553
+https://github.com/primefaces/primeng/issues/16553
+
+Issue:The RadioButton component is not functioning correctly with screen readers. When navigating using only the keyboard, the screen reader does not announce when a radio button is checked
+
+Requirement: Radiobutton component should work correctly with the screen readers when navigating using only the keyboard.
+
+2.Component: Carousel accessibility issue #16552
+https://github.com/primefaces/primeng/issues/16552
+
+Issue: Aria-hidden element must not be focusable or contain focusable elements.
+
+Requirement: Aria-hidden should not display or contain is focusable element. The need to examine whether elements are hidden using CSS (e.g. display: none) or ARIA attributes such as aria-hidden to ensure that they are correctly blocked from access.
+
+3.table inappropriately displays p-column-title of span #16549
+https://github.com/primefaces/primeng/issues/16549
+
+Issue: The hidden p-column-title span data is being displayed.
+
+Requirement: Check the p-column-title span data shouldn't display.
+
+

--- a/index.html
+++ b/index.html
@@ -19,4 +19,10 @@ Issue: The hidden p-column-title span data is being displayed.
 
 Requirement: Check the p-column-title span data shouldn't display.
 
+4.Tab navigation not getting focussed on Eye icon in ToggleMask Mode
 
+https://github.com/primefaces/primeng/issues/16555
+
+Issue: Password: Tab navigation not getting focussed on Eye icon in ToggleMask Mode.
+
+Requirement: When user has the focus inside input field, and click tab, then the focus should be redirected to the eye-icon.

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -1168,15 +1168,10 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
             if (ObjectUtils.isNotEmpty(this.maxSelectedLabels) && modelValue.length > this.maxSelectedLabels) {
                 return this.getSelectedItemsLabel();
             } else {
-                label = '';
-
-                for (let i = 0; i < modelValue.length; i++) {
-                    if (i !== 0) {
-                        label += ', ';
-                    }
-
-                    label += this.getLabelByValue(modelValue[i]);
-                }
+                label = modelValue
+                    .map(modelValue => this.getLabelByValue(modelValue))
+                    .filter(labelByValue => labelByValue !== null)
+                    .join(", ")
             }
         } else {
             label = this.placeholder() || this.defaultLabel || '';


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/16288
This pull request makes so that in multiSelect component, no "null" for null label is displayed. It was achieved by filtering null values.
