### PR TITLE
fix(v18): Datepicker focus error #16590

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -2546,8 +2546,8 @@ export class DatePicker extends BaseComponent implements OnInit, OnDestroy, Cont
             if (this.navigationState.button) {
                 this.initFocusableCell();
 
-                if (this.navigationState.backward) (findSingle(this.contentViewChild.nativeElement, '.p-datepicker-prev') as any).focus();
-                else (findSingle(this.contentViewChild.nativeElement, '.p-datepicker-next') as any).focus();
+                if (this.navigationState.backward) (findSingle(this.contentViewChild.nativeElement, '.p-datepicker-prev-button') as any).focus();
+                else (findSingle(this.contentViewChild.nativeElement, '.p-datepicker-next-button') as any).focus();
             } else {
                 if (this.navigationState.backward) {
                     let cells;


### PR DESCRIPTION
### Resolves issue: #16590 DatePicker: "Cannot read properties of null" error when clicking on next/previous month button (18.0.0-beta.3).

When clicking on chevron buttons month (next / previous) an error is shown:
![error](https://github.com/user-attachments/assets/df5072c7-bbc3-4d56-a0a7-17a2d7b7d7cf)

This commit resolves the issue taking into account that theming mentions the new token with `-button` suffix for both prev and next.
![image](https://github.com/user-attachments/assets/027785db-bfb6-4cdf-91c3-7514294172b0)
