### PR TITLE
fix( #16695): missing '}', better formatting in themedoc

### DIFF
--- a/src/app/showcase/doc/theming/themedoc.ts
+++ b/src/app/showcase/doc/theming/themedoc.ts
@@ -21,11 +21,12 @@ export class AppComponent {
     constructor(private config: PrimeNGConfig) {
         // Default theme configuration
         this.config.theme.set({
-        preset: Aura,
-        options: {
-            prefix: 'p',
-            darkModeSelector: 'system',
-            cssLayer: false
+            preset: Aura,
+            options: {
+                prefix: 'p',
+                darkModeSelector: 'system',
+                cssLayer: false    
+            }
         });
     }
 }`,


### PR DESCRIPTION
fix for #16695 

This pull request adds missing '}' and puts better formatting in themedoc.
