### PR TITLE
fix: Update textarea docs to import TextareaModule

### DIFF
--- a/src/app/showcase/doc/table/productsdoc.ts
+++ b/src/app/showcase/doc/table/productsdoc.ts
@@ -676,7 +676,7 @@ import { ToastModule } from 'primeng/toast';
 import { ToolbarModule } from 'primeng/toolbar';
 import { ConfirmDialog } from 'primeng/confirmdialog';
 import { InputTextModule } from 'primeng/inputtext';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { CommonModule } from '@angular/common';
 import { FileUpload } from 'primeng/fileupload';
 import { DropdownModule } from 'primeng/dropdown';
@@ -690,7 +690,7 @@ import { InputNumber } from 'primeng/inputnumber';
     selector: 'table-products-demo',
     templateUrl: 'table-products-demo.html',
     standalone: true,
-    imports: [TableModule, Dialog, Ripple, ButtonModule, ToastModule, ToolbarModule, ConfirmDialog, InputTextModule, Textarea, CommonModule, FileUpload, DropdownModule, Tag, RadioButton, Rating, InputTextModule, FormsModule, InputNumber],
+    imports: [TableModule, Dialog, Ripple, ButtonModule, ToastModule, ToolbarModule, ConfirmDialog, InputTextModule, TextareaModule, CommonModule, FileUpload, DropdownModule, Tag, RadioButton, Rating, InputTextModule, FormsModule, InputNumber],
     providers: [MessageService, ConfirmationService, ProductService],
     styles: [
         \`:host ::ng-deep .p-dialog .product-image {

--- a/src/app/showcase/doc/textarea/autoresizedoc.ts
+++ b/src/app/showcase/doc/textarea/autoresizedoc.ts
@@ -22,14 +22,14 @@ export class AutoResizeDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { FormsModule } from '@angular/forms';
 
 @Component({
     selector: 'input-textarea-auto-resize-demo',
     templateUrl: './input-textarea-auto-resize-demo.html',
     standalone: true,
-    imports: [FormsModule, Textarea]
+    imports: [FormsModule, TextareaModule]
 })
 export class InputTextareaAutoResizeDemo {
 }`,

--- a/src/app/showcase/doc/textarea/basicdoc.ts
+++ b/src/app/showcase/doc/textarea/basicdoc.ts
@@ -24,14 +24,14 @@ export class BasicDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { FormsModule } from '@angular/forms';
 
 @Component({
     selector: 'input-textarea-basic-demo',
     templateUrl: './input-textarea-basic-demo.html',
     standalone: true,
-    imports: [FormsModule, Textarea]
+    imports: [FormsModule, TextareaModule]
 })
 
 export class InputTextareaBasicDemo {

--- a/src/app/showcase/doc/textarea/disableddoc.ts
+++ b/src/app/showcase/doc/textarea/disableddoc.ts
@@ -22,14 +22,14 @@ export class DisabledDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { FormsModule } from '@angular/forms';
 
 @Component({
     selector: 'input-textarea-disabled-demo',
     templateUrl: './input-textarea-disabled-demo.html',
     standalone: true,
-    imports: [FormsModule, Textarea]
+    imports: [FormsModule, TextareaModule]
 })
 export class InputTextareaDisabledDemo {
 }`,

--- a/src/app/showcase/doc/textarea/filleddoc.ts
+++ b/src/app/showcase/doc/textarea/filleddoc.ts
@@ -27,14 +27,14 @@ export class FilledDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { FormsModule } from '@angular/forms';
 
 @Component({
     selector: 'input-textarea-filled-demo',
     templateUrl: './input-textarea-filled-demo.html',
     standalone: true,
-    imports: [FormsModule, Textarea]
+    imports: [FormsModule, TextareaModule]
 })
 
 export class InputTextareaFilledDemo {

--- a/src/app/showcase/doc/textarea/floatlabeldoc.ts
+++ b/src/app/showcase/doc/textarea/floatlabeldoc.ts
@@ -70,7 +70,7 @@ export class FloatlabelDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { FormsModule } from '@angular/forms';
 import { FloatLabel } from 'primeng/floatlabel';
 
@@ -78,7 +78,7 @@ import { FloatLabel } from 'primeng/floatlabel';
     selector: ': 'input-textarea-floatlabel-demo',
     templateUrl: './: 'input-textarea-floatlabel-demo.html',
     standalone: true,
-    imports: [FormsModule, Textarea, FloatLabel]
+    imports: [FormsModule, TextareaModule, FloatLabel]
 })
 export class TextareaFloatlabelDemo {
     value1: string = '';

--- a/src/app/showcase/doc/textarea/importdoc.ts
+++ b/src/app/showcase/doc/textarea/importdoc.ts
@@ -7,6 +7,6 @@ import { Code } from '@domain/code';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { Textarea } from 'primeng/textearea';;`,
+        typescript: `import { TextareaModule } from 'primeng/textarea;`,
     };
 }

--- a/src/app/showcase/doc/textarea/invaliddoc.ts
+++ b/src/app/showcase/doc/textarea/invaliddoc.ts
@@ -24,14 +24,14 @@ export class InvalidDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { FormsModule } from '@angular/forms';
 
 @Component({
     selector: 'input-textarea-invalid-demo',
     templateUrl: './input-textarea-invalid-demo.html',
     standalone: true,
-    imports: [FormsModule, Textarea]
+    imports: [FormsModule, TextareaModule]
 })
 export class InputTextareaInvalidDemo {
     value!: string;

--- a/src/app/showcase/doc/textarea/keyfilterdoc.ts
+++ b/src/app/showcase/doc/textarea/keyfilterdoc.ts
@@ -35,14 +35,14 @@ export class KeyfilterDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 import { FormsModule } from '@angular/forms';
 
 @Component({
     selector:'input-textarea-key-filter-demo',
     templateUrl: './input-textarea-key-filter-demo.html',
     standalone: true,
-    imports: [FormsModule, Textarea]
+    imports: [FormsModule, TextareaModule]
 })
 export class InputTextareaKeyFilterDemo {
 }`,

--- a/src/app/showcase/doc/textarea/reactiveformsdoc.ts
+++ b/src/app/showcase/doc/textarea/reactiveformsdoc.ts
@@ -41,13 +41,13 @@ export class ReactiveFormsDoc implements OnInit {
 
         typescript: `import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { Textarea } from 'primeng/textearea';;
+import { TextareaModule } from 'primeng/textarea;
 
 @Component({
     selector: 'input-textarea-reactive-forms-demo',
     templateUrl: './input-textarea-reactive-forms-demo.html',
     standalone: true,
-    imports: [ReactiveFormsModule, Textarea],
+    imports: [ReactiveFormsModule, TextareaModule],
 })
 export class InputTextareaReactiveFormsDemo implements OnInit {
     formGroup!: FormGroup;

--- a/src/app/showcase/layout/doc/codeeditor/templates.ts
+++ b/src/app/showcase/layout/doc/codeeditor/templates.ts
@@ -437,7 +437,7 @@ const getAngularApp = (props: Props = {}) => {
     import { ToggleSwitch } from 'primeng/toggleswitch';
     import { InputTextModule } from 'primeng/inputtext';
     import { InputNumber } from 'primeng/inputnumber';
-    import { Textarea } from 'primeng/textearea';;
+    import { TextareaModule } from 'primeng/textarea;
     import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
     import { InputGroup } from 'primeng/inputgroup';
     import { InputOtp } from 'primeng/inputotp';
@@ -554,7 +554,7 @@ const getAngularApp = (props: Props = {}) => {
         InputMask,
         InputSwitchModule,
         InputTextModule,
-        Textarea,
+        TextareaModule,
         InputNumber,
         InputGroup,
         InputGroupAddonModule,
@@ -664,7 +664,7 @@ const getAngularApp = (props: Props = {}) => {
         InputMask,
         InputSwitchModule,
         InputTextModule,
-        Textarea,
+        TextareaModule,
         InputNumber,
         InputGroup,
         InputGroupAddonModule,


### PR DESCRIPTION
### Defect Fixes
Fixes issue https://github.com/primefaces/primeng/issues/16678
The import `InputTextareaModule` from docs v18.0.0-beta.3 doesn't work and fixes the typo in the v18 branch.

![image](https://github.com/user-attachments/assets/9fe044d4-110b-4fbc-ba89-3ab3fe0dc87b)
