### PR TITLE
Fix: Tooltip[(16729): unresponsive browser if pressing ESC-key in combination with lots of tooltips or overlay panels

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -1,5 +1,5 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { AfterViewInit, Directive, ElementRef, HostListener, Inject, Input, NgModule, NgZone, OnDestroy, PLATFORM_ID, Renderer2, SimpleChanges, TemplateRef, ViewContainerRef, booleanAttribute, numberAttribute } from '@angular/core';
+import { AfterViewInit, Directive, ElementRef, Inject, Input, NgModule, NgZone, OnDestroy, PLATFORM_ID, Renderer2, SimpleChanges, TemplateRef, ViewContainerRef, booleanAttribute, numberAttribute } from '@angular/core';
 import { PrimeNGConfig, TooltipOptions } from 'primeng/api';
 import { ConnectedOverlayScrollHandler, DomHandler } from 'primeng/dom';
 import { Nullable } from 'primeng/ts-helpers';

--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -160,6 +160,8 @@ export class Tooltip implements AfterViewInit, OnDestroy {
 
     blurListener: Nullable<Function>;
 
+    documentEscapeListener: Nullable<Function>;
+
     scrollHandler: any;
 
     resizeListener: any;
@@ -333,13 +335,6 @@ export class Tooltip implements AfterViewInit, OnDestroy {
         this.deactivate();
     }
 
-    @HostListener('document:keydown.escape', ['$event'])
-    onPressEscape() {
-        if (this.hideOnEscape) {
-            this.deactivate();
-        }
-    }
-
     activate() {
         if (!this.interactionInProgress) {
             this.active = true;
@@ -357,6 +352,13 @@ export class Tooltip implements AfterViewInit, OnDestroy {
                     this.hide();
                 }, duration);
             }
+
+            if (this.getOption('hideOnEscape')) {
+                this.documentEscapeListener = this.renderer.listen('document', 'keydown.escape', () => {
+                    this.deactivate();
+                    this.documentEscapeListener();
+                });
+            }
         }
         this.interactionInProgress = true;
     }
@@ -373,6 +375,10 @@ export class Tooltip implements AfterViewInit, OnDestroy {
             }, this.getOption('hideDelay'));
         } else {
             this.hide();
+        }
+
+        if (this.documentEscapeListener) {
+            this.documentEscapeListener();
         }
     }
 
@@ -734,6 +740,10 @@ export class Tooltip implements AfterViewInit, OnDestroy {
         if (this.scrollHandler) {
             this.scrollHandler.destroy();
             this.scrollHandler = null;
+        }
+
+        if (this.documentEscapeListener) {
+            this.documentEscapeListener();
         }
     }
 }


### PR DESCRIPTION
Fix for #16729 

I modified the behavior so that the `document:keydown` event listener is only active when the Tooltip is in `interactionInProgress` state. This change significantly reduces the number of active `@HostListener`, improving overall performance and preventing browser freezes.
