### PR TITLE
Fix: InputNumber(16733): unsupported `getSelection()` causes input unwritable

### DIFF
--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -1015,10 +1015,14 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
             char = this._decimalChar;
             code = char.charCodeAt(0);
         }
-        const newValue = this.parseValue(this.input.nativeElement.value + char);
+        const { value, selectionStart, selectionEnd } = this.input.nativeElement;
+        const newValue = this.parseValue(value + char);
         const newValueStr = newValue != null ? newValue.toString() : '';
+        const selectedValue = value.substring(selectionStart, selectionEnd);
+        const selectedValueParsed = this.parseValue(selectedValue);
+        const selectedValueStr = selectedValueParsed != null ? selectedValueParsed.toString() : '';
 
-        if (this.maxlength && this.getSelectedText()?.length == this.maxlength) {
+        if (selectionStart !== selectionEnd && selectedValueStr.length > 0) {
             this.insert(event, char, { isDecimalSign, isMinusSign });
             return;
         }
@@ -1030,15 +1034,6 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
         if ((48 <= code && code <= 57) || isMinusSign || isDecimalSign) {
             this.insert(event, char, { isDecimalSign, isMinusSign });
         }
-    }
-
-    private getSelectedText() {
-        return (
-            window
-                ?.getSelection()
-                ?.toString()
-                .replaceAll(/[^0-9']/g, '') || ''
-        );
     }
 
     onPaste(event: ClipboardEvent) {


### PR DESCRIPTION
Fix for #16733

The component uses `getSelection()` which [is not supported](https://developer.mozilla.org/en-US/docs/Web/API/Window/getSelection#related_objects) in Firefox and Edge (Legacy). Does making `onInputKeyPress()` read `null` on selected texts.

Updated `onInputKeyPress()` for more browser agnostic approach.