### PR TITLE
Fix: Tab[(16768): disabled input is not disabling tab

### DIFF
--- a/packages/primeng/src/tabs/tab.ts
+++ b/packages/primeng/src/tabs/tab.ts
@@ -21,6 +21,7 @@ import { Tabs } from './tabs';
     host: {
         '[class.p-tab]': 'true',
         '[class.p-tab-active]': 'active()',
+        '[class.p-disabled]': 'disabled()',
         '[class.p-component]': 'true',
         '[attr.data-pc-name]': '"tab"',
         '[attr.id]': 'id()',


### PR DESCRIPTION
Fix for #16768 

**Solution Implemented**: added `p-disabled` to host class mapping.
