### PR TITLE
Fix: InputOtp[(16777): Length validation bypassed `onPaste`

### DIFF
--- a/src/app/components/inputotp/inputotp.ts
+++ b/src/app/components/inputotp/inputotp.ts
@@ -325,8 +325,8 @@ export class InputOtp implements AfterContentInit {
             let paste = event.clipboardData.getData('text');
 
             if (paste.length) {
-                let pastedCode = paste.substring(0, this.length + 1);
-
+                let pastedCode = paste.substring(0, this.length);
+                
                 if (!this.integerOnly || !isNaN(pastedCode)) {
                     this.tokens = pastedCode.split('');
                     this.updateModel(event);


### PR DESCRIPTION
Resolves #16777 

Updated `length` validation for `onPaste()`.
