### PR TITLE
feat(angular): allow/support Angular 19 with zone.js 0.15

### DIFF
--- a/src/app/components/package.json
+++ b/src/app/components/package.json
@@ -18,10 +18,10 @@
     "module": "primeng.js",
     "typings": "primeng.d.ts",
     "peerDependencies": {
-        "@angular/core": "^17.0.0 || ^18.0.0",
-        "@angular/common": "^17.0.0 || ^18.0.0",
-        "@angular/forms": "^17.0.0 || ^18.0.0",
+        "@angular/core": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@angular/common": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@angular/forms": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "rxjs": "^6.0.0 || ^7.8.1",
-        "zone.js": "~0.14.0"
+        "zone.js": "~0.14.0 || ~0.15.0"
     }
 }


### PR DESCRIPTION
Hi :)
Locally, I built a version and link it to a project and found out the current state of the lib is not fundamentally incompatible with Angular 19.
So I'm opening this PR so we can, if possible allow Angular 19 as a peer dependency, or at least have a place to discuss the issues encountered by those who have tried using PrimeNG with the latest version of Angular :)

I also posted a [message on Discord](https://discord.com/channels/787967399105134612/787967806367989790/1308595968182194270) about this

The first place I tried to look for information about Angular 19 support was in the Issues, 2nd was open PRs so if you think it's appropriate I can open an issue as well

Cheers