### PR TITLE
Fix: PanelMenu(15403) - Submenu displays angledownicon when submenu is collapsed

### DIFF
--- a/src/app/components/panelmenu/panelmenu.ts
+++ b/src/app/components/panelmenu/panelmenu.ts
@@ -357,7 +357,17 @@ export class PanelMenuList implements OnChanges {
     constructor(private el: ElementRef) {}
 
     ngOnChanges(changes: SimpleChanges) {
-        this.processedItems.set(this.createProcessedItems(changes?.items?.currentValue || this.items || []));
+        const hasItems = !!changes?.items?.currentValue;
+
+        if (hasItems) {
+            this.processedItems.set(this.createProcessedItems(changes?.items?.currentValue || this.items || []));
+            return;
+        }
+
+        // Update and keep `expanded` property from previous data
+        else {
+            this.processedItems.update(prev => prev.map(i => ({...i, expanded: i.expanded})))
+        }
     }
 
     getItemProp(processedItem, name) {

--- a/src/app/components/panelmenu/panelmenu.ts
+++ b/src/app/components/panelmenu/panelmenu.ts
@@ -366,7 +366,7 @@ export class PanelMenuList implements OnChanges {
 
         // Update and keep `expanded` property from previous data
         else {
-            this.processedItems.update(prev => prev.map(i => ({...i, expanded: i.expanded})))
+            this.processedItems.update((prev) => prev.map((i) => ({ ...i, expanded: i.expanded })));
         }
     }
 


### PR DESCRIPTION
Resolves #15403

**Problem:**: The logic from `ngOnChanges()` forces the component to create new `processedItems` with `expanded: undefined`.

**Solution**: Added check to keep `expanded` properties.


_This is a possible solution for #16781 too, but I created another PR(#16791) with the fix for the `hide` animation._