### PR TITLE
Fix: Scroller(#16438 and #16564) - Scroll behavior bug

### DIFF
--- a/src/app/components/scroller/scroller.ts
+++ b/src/app/components/scroller/scroller.ts
@@ -882,7 +882,7 @@ export class Scroller implements OnInit, AfterContentInit, AfterViewChecked, OnD
                 setProp('height', numItems, this._itemSize[0]);
                 setProp('width', this._columns?.length || this._items[1]?.length, this._itemSize[1]);
             } else {
-                this.horizontal ? setProp('width', this._columns.length || this._items.length, this._itemSize) : setProp('height', numItems, this._itemSize);
+                this.horizontal ? setProp('width', this._columns?.length || this._items.length, this._itemSize) : setProp('height', numItems, this._itemSize);
             }
         }
     }


### PR DESCRIPTION
Resolves #16438, resolves #16564

**Problem**: Missing optional chaining that causes `undefined` read on scroll update.

**Solution**: Fixed.
