### PR TITLE
Fix: Multiselect & Autocomplete(#16708 & #16727) - Scroller panel height bug

### DIFF
--- a/src/app/components/scroller/scroller.ts
+++ b/src/app/components/scroller/scroller.ts
@@ -834,6 +834,11 @@ export class Scroller implements OnInit, AfterContentInit, AfterViewChecked, OnD
                     this.contentEl.style.minHeight = this.contentEl.style.minWidth = '';
                     this.contentEl.style.position = '';
                     (<ElementRef>this.elementViewChild).nativeElement.style.contain = '';
+
+                    this.defaultWidth = width;
+                    this.defaultHeight = height;
+                    this.defaultContentWidth = contentWidth;
+                    this.defaultContentHeight = contentHeight;
                 }
             });
         }
@@ -1059,12 +1064,6 @@ export class Scroller implements OnInit, AfterContentInit, AfterViewChecked, OnD
                 reinit &&
                     this.zone.run(() => {
                         this.d_numToleratedItems = this._numToleratedItems;
-                        this.defaultWidth = width;
-                        this.defaultHeight = height;
-                        if (this.contentEl) {
-                            this.defaultContentWidth = DomHandler.getWidth(this.contentEl);
-                            this.defaultContentHeight = DomHandler.getHeight(this.contentEl);
-                        }
 
                         this.init();
                         this.calculateAutoSize();


### PR DESCRIPTION
Resolves #16708, resolves #16727

**Problem**: `onResize()` is triggered first before `calculateAutoSize()`. While `onResize()` sets the height and width of scroller, **it's job is not to calculate and update the height/width** but to just identify if update is needed. The proper calculations actually happens in `calculateAutoSize()`.

**Solution**: Transferred the height/width update job to `calculateAutoSize()` to eliminate errors in height/width updates.