### PR TITLE
Fix autocomplete updateOn blur on select (#16805)

### DIFF
--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -1209,7 +1209,11 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
         this.dirty = false;
         this.focused = false;
         this.focusedOptionIndex.set(-1);
-        this.onModelTouched();
+        /** triggered only if user can input freely text
+         * Later on it must set touched also onSelect */
+        if(!this.forceSelection){
+            this.onModelTouched();
+        }
         this.onBlur.emit(event);
     }
 
@@ -1446,6 +1450,9 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
             this.updateModel(value);
         }
 
+        /** triggers model touched to update FormControl
+         * value in case updateOn is set to "blur" */
+        this.onModelTouched();
         this.onSelect.emit({ originalEvent: event, value: option });
 
         isHide && this.hide(true);


### PR DESCRIPTION
## Related issue
Issue reported here #16805
## Changes rationale
To handle `updateOn` setup with `blur` value, the following changes have been made:
1. Adapting the `onInputBlur` conditionally calling `onModelTouched` only if `forceSelection` is `false`.
2. Adding `onModelTouched` call in the `onSelect` ( unconditionally ), which provides the `FormControl` / `FormGroup` the value selected by the user, without considering the text input the user is searching ( unless forceSelection is false ).

## Additional notes

This way was chosen because [NG_VALUE_ACCESSOR](https://angular.dev/api/forms/ControlValueAccessor#registerOnTouched) updates the ancestor calling `registerOnTouched` which by angular docs:

> When implementing registerOnTouched in your own value accessor, save the given function so your class calls it when the control should be considered blurred or "touched"

If `forceSelection` is set to `false` and `updateOn` is set as `blur`, upon  both user input text / search and when user selects an option, the `FormControl` and `FormGroup` will be updated.

