### PR TITLE
fix(  #16837):  fix: month selection issue in Calendar component

### DIFF
--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -1818,12 +1818,22 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
     }
 
     isMonthSelected(month: number) {
-        if (this.isComparable() && !this.isMultipleSelection()) {
-            const [start, end] = this.isRangeSelection() ? this.value : [this.value, this.value];
-            const selected = new Date(this.currentYear, month, 1);
-            return selected >= start && selected <= (end ?? start);
+        if (!this.isComparable() || this.isMultipleSelection()) {
+            return false;
         }
-        return false;
+
+        if (this.isRangeSelection()) {
+            const selected = new Date(this.currentYear, month, 1);
+            const start = this.value[0];
+            const end = this.value[1];
+
+            start.setDate(1);
+            end.setDate(1);
+            
+            return selected >= start && selected <= end;
+        }
+        return (this.value ? this.value.getMonth() === month : false) && 
+               (this.value.getFullYear() == this.currentYear);
     }
 
     isMonthDisabled(month: number, year?: number) {


### PR DESCRIPTION
fix for #16837 

This pull requests fixes two things in "isMonthSelected(month: number)" method:
1. Selected month in "Reactive Forms" is being highlighted.
2. Correct range of months in "Range" is being highlighted.


