### PR TITLE
added support for KeyboardEvent.key in inputnumber

### DIFF
--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -1003,7 +1003,7 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
         }
 
         let code = event.which || event.keyCode;
-        let char = String.fromCharCode(code);
+        let char = event.key ?? String.fromCharCode(code);
         let isDecimalSign = this.isDecimalSign(char);
         const isMinusSign = this.isMinusSign(char);
 


### PR DESCRIPTION
both UIEvent.which and KeyboardEvent.keyCode are deprecated.  Testing frameworks such as 'testing-library' (https://github.com/testing-library/user-event/releases/tag/v14.0.0) for example, explicitly do not support either of these when simulating user events.

https://github.com/primefaces/primeng/issues/14776
