### PR TITLE
fix(#16630): ensure aria-describedby is dynamically set and removed for tooltip

### DIFF
--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -206,6 +206,18 @@ export class Tooltip implements AfterViewInit, OnDestroy {
             });
         }
     }
+    
+    setAriaDescribedBy() {
+        const tooltipId = this.getOption('id');
+        if (tooltipId && this.active) {
+            this.renderer.setAttribute(this.el.nativeElement, 'aria-describedby', tooltipId);
+        }
+    }
+
+    removeAriaDescribedBy() {
+        this.renderer.removeAttribute(this.el.nativeElement, 'aria-describedby');
+    }
+
 
     ngOnChanges(simpleChange: SimpleChanges) {
         if (simpleChange.tooltipPosition) {
@@ -423,6 +435,8 @@ export class Tooltip implements AfterViewInit, OnDestroy {
             this.container.style.pointerEvents = 'unset';
             this.bindContainerMouseleaveListener();
         }
+
+        this.setAriaDescribedBy();
     }
 
     bindContainerMouseleaveListener() {
@@ -705,6 +719,7 @@ export class Tooltip implements AfterViewInit, OnDestroy {
         this.unbindScrollListener();
         this.unbindContainerMouseleaveListener();
         this.clearTimeouts();
+        this.removeAriaDescribedBy();
         this.container = null;
         this.scrollHandler = null;
     }


### PR DESCRIPTION
fixes #16630 

This fix improves accessibility by maintaining proper ARIA relationships for tooltips.

- Added `setAriaDescribedBy` to dynamically set `aria-describedby` attribute on the target element when the tooltip is created.
- Added `removeAriaDescribedBy` to remove the `aria-describedby` attribute when the tooltip is removed.
