### PR TITLE
Update Stackblitz URL to Directly Open `app.component.html`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,7 +30,7 @@ body:
       placeholder: https://stackblitz.com/github/primefaces/primeng-issue-template
       description: |
         Please fork one of the issue template
-        [PrimeNG Issue Template](https://stackblitz.com/github/primefaces/primeng-issue-template)
+        [PrimeNG Issue Template](https://stackblitz.com/github/primefaces/primeng-issue-template?file=src%2Fapp%2Fapp.component.html)
         and create a case demonstrating your bug report. Issues **without** a StackBlitz example have much less possibility to be reviewed.
     validations:
       required: false


### PR DESCRIPTION
Providing a direct link to the `app.component.html` file ensures users can easily navigate to the key part of the template when creating or reproducing issues, reducing confusion and saving time.