### PR TITLE
Fixed #16846 | Autocomplete: dropdown arrow and clear icon overlap

### DIFF
--- a/packages/primeng/src/autocomplete/style/autocompletestyle.ts
+++ b/packages/primeng/src/autocomplete/style/autocompletestyle.ts
@@ -268,6 +268,10 @@ const theme = ({ dt }) => `
     color: ${dt('autocomplete.dropdown.color')};
 }
 
+.p-autocomplete:has(.p-autocomplete-dropdown) .p-autocomplete-clear-icon {
+    right: calc(${dt('autocomplete.padding.x')} + ${dt('autocomplete.dropdown.width')});
+}
+
 p-autocomplete.ng-invalid.ng-dirty .p-autocomplete-input,
 p-autocomplete.ng-invalid.ng-dirty .p-autocomplete-input-multiple {
     border-color: ${dt('autocomplete.invalid.border.color')};


### PR DESCRIPTION
Fixes #16846 
