### PR TITLE
Fixed unselectable p-tree when node keys are not provided (issue #16819)

### DIFF
--- a/src/app/components/tree/tree.spec.ts
+++ b/src/app/components/tree/tree.spec.ts
@@ -83,7 +83,7 @@ class TestTreeComponent implements OnInit {
                         data: 'De Niro Movies',
                         children: [
                             { label: 'Goodfellas', icon: 'pi pi-file-video-o', data: 'Goodfellas Movie' },
-                            { label: 'Untouchables', icon: 'pi pi-file-video-o', data: 'Untouchables Movie', selectable: false }
+                            { label: 'Untouchables', icon: 'pi pi-file-video-o', data: 'Untouchables Movie' }
                         ]
                     }
                 ]
@@ -195,12 +195,7 @@ describe('Tree', () => {
                         data: 'De Niro Movies',
                         children: [
                             { label: 'Goodfellas', icon: 'pi pi-file-video-o', data: 'Goodfellas Movie' },
-                            {
-                                label: 'Untouchables',
-                                icon: 'pi pi-file-video-o',
-                                data: 'Untouchables Movie',
-                                selectable: false
-                            }
+                            { label: 'Untouchables', icon: 'pi pi-file-video-o', data: 'Untouchables Movie' }
                         ]
                     }
                 ]

--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -1498,7 +1498,7 @@ export class Tree implements OnInit, AfterContentInit, OnChanges, OnDestroy, Blo
                 }
             }
 
-            if (select && selectedCount == node.children.length) {
+            if (select && selectedCount == node.children.length && node.selectable !== false) {
                 this.selection = [...(this.selection || []), node];
                 node.partialSelected = false;
             } else {
@@ -1526,7 +1526,7 @@ export class Tree implements OnInit, AfterContentInit, OnChanges, OnDestroy, Blo
         let index = this.findIndexInSelection(node);
 
         if (select && index == -1 && node.selectable !== false) {
-            this.selection = [...(this.selection || []), this.filterUnselectableChildren(node)];
+            this.selection = [...(this.selection || []), node];
         } else if (!select && index > -1) {
             this.selection = this.selection.filter((val: TreeNode, i: number) => i != index);
         }
@@ -1540,21 +1540,6 @@ export class Tree implements OnInit, AfterContentInit, OnChanges, OnDestroy, Blo
                 this.propagateDown(child, select);
             }
         }
-    }
-
-    filterUnselectableChildren(node: TreeNode): TreeNode {
-        let clonedNode = Object.assign({}, node);
-
-        if (clonedNode.children && clonedNode.children.length) {
-            for (let child of clonedNode.children) {
-                if (child.selectable === false) {
-                    clonedNode.children = clonedNode.children.filter((val: TreeNode) => val != child);
-                }
-                child = this.filterUnselectableChildren(child);
-            }
-        }
-
-        return clonedNode;
     }
 
     isSelected(node: TreeNode) {

--- a/src/app/showcase/layout/doc/codeeditor/services.ts
+++ b/src/app/showcase/layout/doc/codeeditor/services.ts
@@ -10638,7 +10638,7 @@ export class NodeService {
                         data: 'De Niro Movies',
                         children: [
                             { key: '2-1-0', label: 'Goodfellas', icon: 'pi pi-fw pi-video', data: 'Goodfellas Movie' },
-                            { key: '2-1-1', label: 'Untouchables', icon: 'pi pi-fw pi-video', data: 'Untouchables Movie', selectable: false  }
+                            { key: '2-1-1', label: 'Untouchables', icon: 'pi pi-fw pi-video', data: 'Untouchables Movie' }
                         ]
                     }
                 ]

--- a/src/app/showcase/service/nodeservice.ts
+++ b/src/app/showcase/service/nodeservice.ts
@@ -6,39 +6,35 @@ export class NodeService {
     getTreeNodesData() {
         return [
             {
-                key: '0',
                 label: 'Documents',
                 data: 'Documents Folder',
                 icon: 'pi pi-fw pi-inbox',
                 children: [
                     {
-                        key: '0-0',
                         label: 'Work',
                         data: 'Work Folder',
                         icon: 'pi pi-fw pi-cog',
                         children: [
-                            { key: '0-0-0', label: 'Expenses.doc', icon: 'pi pi-fw pi-file', data: 'Expenses Document' },
-                            { key: '0-0-1', label: 'Resume.doc', icon: 'pi pi-fw pi-file', data: 'Resume Document' }
+                            { label: 'Expenses.doc', icon: 'pi pi-fw pi-file', data: 'Expenses Document' },
+                            { label: 'Resume.doc', icon: 'pi pi-fw pi-file', data: 'Resume Document' }
                         ]
                     },
                     {
-                        key: '0-1',
                         label: 'Home',
                         data: 'Home Folder',
                         icon: 'pi pi-fw pi-home',
-                        children: [{ key: '0-1-0', label: 'Invoices.txt', icon: 'pi pi-fw pi-file', data: 'Invoices for this month' }]
+                        children: [{ label: 'Invoices.txt', icon: 'pi pi-fw pi-file', data: 'Invoices for this month' }]
                     }
                 ]
             },
             {
-                key: '1',
                 label: 'Events',
                 data: 'Events Folder',
                 icon: 'pi pi-fw pi-calendar',
                 children: [
-                    { key: '1-0', label: 'Meeting', icon: 'pi pi-fw pi-calendar-plus', data: 'Meeting' },
-                    { key: '1-1', label: 'Product Launch', icon: 'pi pi-fw pi-calendar-plus', data: 'Product Launch' },
-                    { key: '1-2', label: 'Report Review', icon: 'pi pi-fw pi-calendar-plus', data: 'Report Review' }
+                    { label: 'Meeting', icon: 'pi pi-fw pi-calendar-plus', data: 'Meeting' },
+                    { label: 'Product Launch', icon: 'pi pi-fw pi-calendar-plus', data: 'Product Launch' },
+                    { label: 'Report Review', icon: 'pi pi-fw pi-calendar-plus', data: 'Report Review' }
                 ]
             },
             {

--- a/src/assets/showcase/data/files.json
+++ b/src/assets/showcase/data/files.json
@@ -47,7 +47,7 @@
                 "label": "Robert De Niro",
                 "icon": "pi pi-fw pi-star-fill",
                 "data": "De Niro Movies",
-                "children": [{ "key": "2-1-0", "label": "Goodfellas", "icon": "pi pi-fw pi-video", "data": "Goodfellas Movie" }, { "key": "2-1-1", "label": "Untouchables", "icon": "pi pi-fw pi-video", "data": "Untouchables Movie", "selectable": false  }]
+                "children": [{ "key": "2-1-0", "label": "Goodfellas", "icon": "pi pi-fw pi-video", "data": "Goodfellas Movie" }, { "key": "2-1-1", "label": "Untouchables", "icon": "pi pi-fw pi-video", "data": "Untouchables Movie" }]
             }]
         }
     ]


### PR DESCRIPTION
Fix for #16819

This fix causes nodes to be unselectable when nodes do not have a key.

example:
https://stackblitz.com/edit/github-fos6jj-ljajyw?file=src%2Fapp%2Fapp.component.ts

Steps to reproduce the behavior:
Create a p-tree with checkboxes and TreeNodes without key
Click on a checkbox of the tree
https://stackblitz.com/edit/github-fos6jj-ljajyw?file=src%2Fapp%2Fapp.component.ts

Expected behavior:
The treenodes should be selectable even when they have no key as was the case before https://github.com/primefaces/primeng/issues/16430 was merged