### PR TITLE
feat(inputnumber): add anyDecimalKey option

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -336,6 +336,11 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
      */
     @Input() mode: string | any = 'decimal';
     /**
+     * Determines whether any decimal key on the keyboard can be used for adding decimals.
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) anyDecimalKey: boolean = false;
+    /**
      * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. There is no default value; if the style is "currency", the currency property must be provided.
      * @group Props
      */
@@ -1042,11 +1047,12 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
         let char = String.fromCharCode(code);
         let isDecimalSign = this.isDecimalSign(char);
         const isMinusSign = this.isMinusSign(char);
+        const isAnyDecimalKey = event.code === 'NumpadDecimal' || (this.anyDecimalKey && (event.code === 'Comma' || event.code === 'Period'));
 
         if (code != 13) {
             event.preventDefault();
         }
-        if (!isDecimalSign && event.code === 'NumpadDecimal') {
+        if (!isDecimalSign && isAnyDecimalKey) {
             isDecimalSign = true;
             char = this._decimalChar;
             code = char.charCodeAt(0);


### PR DESCRIPTION
We ran into the issue where the user can't use their desired decimal key on their keyboard due to the `inputNumber`'s locale being set differently than the users' browser locale.

This PR adds an attribute, `anyDecimalKey`, to `inputNumber` to allow any decimal key to be used for adding a decimal mark, regardless of locale.