### PR TITLE
fix (#17088): typo in input number component content child incrementbuttonicon

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -450,10 +450,10 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
      */
     @ContentChild('clearicon') clearicon: Nullable<TemplateRef<any>>;
     /**
-     * Template of the icrement button icon.
+     * Template of the increment button icon.
      * @group Templates
      */
-    @ContentChild('icrementbuttonicon') incrementbuttonicon: Nullable<TemplateRef<any>>;
+    @ContentChild('incrementbuttonicon') incrementbuttonicon: Nullable<TemplateRef<any>>;
 
     /**
      * Template of the decrement button icon.


### PR DESCRIPTION
The naming of the "incrementbuttonicon" content child has a typo:

Currently: "icrementbuttonicon"
Correct: "incrementbuttonicon"

edit: resolved conflicts with master