### PR TITLE
Fix 17096: Updated examples to remove 'undefined' from `suggestions` type.

### DIFF
--- a/apps/showcase/doc/autocomplete/basicdoc.ts
+++ b/apps/showcase/doc/autocomplete/basicdoc.ts
@@ -21,7 +21,7 @@ interface AutoCompleteCompleteEvent {
         <app-code [code]="code" selector="autocomplete-basic-demo"></app-code>`
 })
 export class BasicDoc {
-    items: any[] | undefined;
+    items: any[] = [];
 
     value: any;
     code: Code = {
@@ -47,7 +47,7 @@ interface AutoCompleteCompleteEvent {
     standalone: true,
 })
 export class AutocompleteBasicDemo {
-    items: any[] | undefined;
+    items: any[] = [];
 
     value: any;
 


### PR DESCRIPTION
Fix #17096: **Since the 'suggestions' variable from the Autosuggest component has type `any[]`, the example code should reflect this.**

The documentation of [AutoComplete](https://primeng.org/autocomplete) contains this code in the example:
```ts
items: any[] | undefined;
```

However the [signature](https://primeng.org/autocomplete#api.autocomplete.props.suggestions) of the `suggestions`-property is `any[]`. This causes the following error in a TypeScript IDE:

```
Type 'any[] | undefined' is not assignable to type 'any[]'.
  Type 'undefined' is not assignable to type 'any[]'.ngtsc(2322)
```

Therefore, the example code should be corrected to:
```ts
items: any[] = [];
```