### PR TITLE
Fix: V17 Editable Dropdown(#17110) Placeholder bug

### DIFF
--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -1372,7 +1372,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
         !matched && this.focusedOptionIndex.set(-1);
 
         this.onModelChange(value);
-        this.updateModel(value, event);
+        this.updateModel(value || null, event);
         setTimeout(() => {
             this.onChange.emit({ originalEvent: event, value: value });
         }, 1);


### PR DESCRIPTION
Closes #17110
**Problem:**  Property `modelValue()` has empty string value on clear which prevents placeholder to show.
**Solution:**  Passed `null` to `updateModel()` when `value` is empty to properly update the input element.

A separate PR #17116 for V18 was created