### PR TITLE
Fix: V18 Editable Dropdown(#17110) Placeholder bug

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1504,7 +1504,7 @@ export class Select extends BaseComponent implements OnInit, AfterViewInit, Afte
         !matched && this.focusedOptionIndex.set(-1);
 
         this.onModelChange(value);
-        this.updateModel(value, event);
+        this.updateModel(value || null, event);
         setTimeout(() => {
             this.onChange.emit({ originalEvent: event, value: value });
         }, 1);


### PR DESCRIPTION
Closes #17110
**Problem:**  Property `modelValue()` has empty string value on clear which prevents placeholder to show.
**Solution:**  Passed `null` to `updateModel()` when `value` is empty to properly update the input element.

A separate PR #17115 for V17 was created