### PR TITLE
Fix: Dropdown(#17112) Autoscroll Bug

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -2023,7 +2023,9 @@ export class Select extends BaseComponent implements OnInit, AfterViewInit, Afte
         }
 
         if (optionIndex !== -1) {
-            this.changeFocusedOptionIndex(event, optionIndex);
+            setTimeout(() => {
+                this.changeFocusedOptionIndex(event, optionIndex);
+            });
         }
 
         if (this.searchTimeout) {


### PR DESCRIPTION
Closes #17112

Problem: `changeFocusedOptionIndex()` was not triggered properly if overlay is still in animation state.