### PR TITLE
Fix: Dynamic Dialog not being properly destroyed on close

### DIFF
--- a/packages/primeng/src/dynamicdialog/dialogservice.ts
+++ b/packages/primeng/src/dynamicdialog/dialogservice.ts
@@ -90,6 +90,7 @@ export class DialogService {
         const dialogComponentRef = this.dialogComponentRefMap.get(dialogRef);
         this.appRef.detachView(dialogComponentRef.hostView);
         dialogComponentRef.destroy();
+        dialogComponentRef.changeDetectorRef.detectChanges();
         this.dialogComponentRefMap.delete(dialogRef);
     }
 


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/16402

I'm not 100% sure why this works considering the component ref gets destroyed before calling it's change detector, but as far as i can tell it just works.