### PR TITLE
#17132 Fix link would not work in Tree 

### DIFF
--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -122,6 +122,7 @@ import {
                         [variant]="tree?.config.inputStyle() === 'filled' ? 'filled' : 'outlined' || tree?.config.inputVariant() === 'filled' ? 'filled' : 'outlined'"
                         [attr.data-p-partialchecked]="node.partialSelected"
                         [tabindex]="-1"
+                        (click)="$event.preventDefault()" 
                     >
                         <ng-container *ngIf="tree.checkboxIconTemplate || tree._checkboxIconTemplate">
                             <ng-template #icon>
@@ -282,7 +283,6 @@ export class UITreeNode extends BaseComponent implements OnInit {
 
     onNodeClick(event: MouseEvent) {
         this.tree.onNodeClick(event, <TreeNode>this.node);
-        event.preventDefault();
     }
 
     onNodeKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
#17132 
Move prevent default closer to the event's origin (checkbox). 
Was added here: 
https://github.com/qwadrox/primeng/commit/0f615c4bb2879213404115d34ab50d5001eae8d7