### PR TITLE
fix: #17171 Fix tree inline style overridde

### DIFF
--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -1295,7 +1295,9 @@ export class Tree extends BaseComponent implements OnInit, AfterContentInit, OnC
                 node.style = '--p-focus-ring-color: none;';
                 return;
             } else {
-                node.style = '--p-focus-ring-color: var(--primary-color)';
+                if (!node.style?.includes('--p-focus-ring-color')) {
+                    node.style = node.style ? `${node.style}--p-focus-ring-color: var(--primary-color)` : '--p-focus-ring-color: var(--primary-color)';
+                }
             }
 
             if (this.hasFilteredNodes()) {


### PR DESCRIPTION
#17171

The goal is to keep the provided style and add to it --p-focus-ring-color value only if it's not set before.