### PR TITLE
Fix: InputNumber(#17169) InputNumber marked dirty on blur

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -1508,7 +1508,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
     }
 
     writeValue(value: any): void {
-        this.value = value;
+        this.value = value ? this.parseValue(value.toString()) : value;
         this.cd.markForCheck();
     }
 


### PR DESCRIPTION
Closes #17169

**Problem:** Input is marked dirty on blur. This is caused by `writeValue()` writing `this.value` as `string`.

**Solution:** Parsed value first before overwriting.