### PR TITLE
Fix: Dropdown/Select(#17178) Marked as dirty on start

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1367,7 +1367,7 @@ export class Select extends BaseComponent implements OnInit, AfterViewInit, Afte
     }
 
     allowModelChange() {
-        return this.autoDisplayFirst && !this.placeholder() && (this.modelValue() === undefined || this.modelValue() === null) && !this.editable && this.options && this.options.length;
+        return !!this.modelValue() && !this.placeholder() && (this.modelValue() === undefined || this.modelValue() === null) && !this.editable && this.options && this.options.length;
     }
 
     isSelected(option) {


### PR DESCRIPTION
Closes #17178

**Problem:** `onModelChange `triggered because of depricated `autoDisplayFirst`.

**Solution:** Replaced with initial value check.