### PR TITLE
Fix: Tag v19 (#17181): Remove deprecation warning from icon-property of TagComponent

### DIFF
--- a/packages/primeng/src/tag/tag.ts
+++ b/packages/primeng/src/tag/tag.ts
@@ -60,7 +60,6 @@ export class Tag extends BaseComponent implements AfterContentInit {
     /**
      * Icon of the tag to display next to the value.
      * @group Props
-     * @deprecated since 15.4.2. Use 'icon' template.
      */
     @Input() icon: string | undefined;
     /**


### PR DESCRIPTION
### Defect Fixes
Removes the deprecation warning from the icon property in TagComponent. Since it seems not to be deprecated (see #16220)

This is the fix for v19.
