### PR TITLE
fix #17024: megamenu alignment overlay

### DIFF
--- a/packages/primeng/src/megamenu/megamenu.ts
+++ b/packages/primeng/src/megamenu/megamenu.ts
@@ -384,7 +384,8 @@ export class MegaMenuSub extends BaseComponent {
                 'p-megamenu-mobile': queryMatches,
                 'p-megamenu-mobile-active': mobileActive,
                 'p-megamenu-horizontal': orientation == 'horizontal',
-                'p-megamenu-vertical': orientation == 'vertical'
+                'p-megamenu-vertical': orientation == 'vertical',
+                'p-megamenu-align-overlay': alignOverlay
             }"
             [class]="styleClass"
             [style]="{ flexDirection: orientation == 'vertical' && queryMatches ? 'row' : '' }"
@@ -476,6 +477,11 @@ export class MegaMenu extends BaseComponent implements AfterContentInit, OnDestr
      * @group Props
      */
     @Input() orientation: 'horizontal' | 'vertical' | string = 'horizontal';
+    /**
+     * Defines whether or not the MegaMenu's popup overlay is aligned with the launching menu item. If false the popup overlay will have a minimum with equal to the width of the the MegaMenu.
+     * @group Props
+     */
+    @Input() alignOverlay: boolean = false;
     /**
      * Current id state as a string.
      * @group Props

--- a/packages/primeng/src/megamenu/style/megamenustyle.ts
+++ b/packages/primeng/src/megamenu/style/megamenustyle.ts
@@ -127,6 +127,21 @@ const theme = ({ dt }) => `
     box-shadow: ${dt('megamenu.overlay.shadow')};
 }
 
+.p-megamenu-overlay. {
+    display: none;
+    position: absolute;
+    width: auto;
+    z-index: 1;
+    left: 0;
+    min-width: 100%;
+    padding: ${dt('megamenu.overlay.padding')};
+    background: ${dt('megamenu.overlay.background')};
+    color: ${dt('megamenu.overlay.color')};
+    border: 1px solid ${dt('megamenu.overlay.border.color')};
+    border-radius: ${dt('megamenu.overlay.border.radius')};
+    box-shadow: ${dt('megamenu.overlay.shadow')};
+}
+
 .p-megamenu-root-list > .p-megamenu-item-active > .p-megamenu-overlay {
     display: block;
 }
@@ -164,6 +179,11 @@ const theme = ({ dt }) => `
     gap: ${dt('megamenu.horizontal.orientation.gap')};
 }
 
+.p-megamenu-horizontal.p-megamenu-align-overlay .p-megamenu-root-list .p-megamenu-overlay  {
+    left: unset;
+    min-width: unset;
+}
+
 .p-megamenu-horizontal .p-megamenu-end {
     margin-left: auto;
     align-self: center;
@@ -183,9 +203,17 @@ const theme = ({ dt }) => `
     gap: ${dt('megamenu.vertical.orientation.gap')};
 }
 
+.p-megamenu-vertical.p-megamenu-align-overlay .p-megamenu-root-list > .p-megamenu-item-active.p-megamenu-item {
+    display: grid;
+}
+
 .p-megamenu-vertical .p-megamenu-root-list > .p-megamenu-item-active > .p-megamenu-overlay {
     left: 100%;
     top: 0;
+}
+
+.p-megamenu-vertical.p-megamenu-align-overlay .p-megamenu-root-list > .p-megamenu-item-active > .p-megamenu-overlay {
+    top: unset;
 }
 
 .p-megamenu-vertical .p-megamenu-root-list > .p-megamenu-item-active >.p-megamenu-overlay:dir(rtl) {


### PR DESCRIPTION
This pull request fixes issue #17024.

Since I believe there is a use case for how the megamenu currently works in PrimeNG v19.0.1/v18.0.2 compared to how it works in v17 and earlier I have added a new property to the megamenu:  alignOverlay.

**alignOverlay=true** (default) results in megamenu behavior consistent with PrimeNG v17 and earlier.  This fixes issue #17024
**alignOverlay=false** results in megamenu behavior that is consistent withe the current PrimeNG v19.0.1

The first video shows the PrimeNG megamenu working with **alignOverlay=true**

https://github.com/user-attachments/assets/76a0086b-acd5-4f24-95fa-ab1b21403f7e

The second video shows the PrimeNG megamenu working with **alignOverlay=false**

https://github.com/user-attachments/assets/dab8b90e-e9ba-4cc6-ae65-823fc2f87449


