### PR TITLE
add glob flag to rimraf call in clean command for windows compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     },
     "scripts": {
         "setup": "pnpm run clean && pnpm run init",
-        "clean": "npx rimraf **/node_modules **/dist **/.angular ./pnpm-lock.yaml",
+        "clean": "npx rimraf --glob **/node_modules **/dist **/.angular ./pnpm-lock.yaml",
         "init": "pnpm install && husky",
         "link": "pnpm --filter './packages/*' dev:link",
         "release": "pnpm run build && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary",


### PR DESCRIPTION
### Defect Fixes
Fixes error thrown by rimraf during repository setup with `npm run setup` in Windows environments #17186 

add `--glob` flag to rimraf call, as suggested by https://stackoverflow.com/questions/75281066/error-illegal-characters-in-path-in-npm-rimraf and documented at https://www.npmjs.com/package/rimraf