### PR TITLE
fixed #17193: fixed rendering of dynamic dialog content

### DIFF
--- a/packages/primeng/src/dialog/style/dialogstyle.ts
+++ b/packages/primeng/src/dialog/style/dialogstyle.ts
@@ -18,6 +18,7 @@ const theme = ({ dt }) => `
 .p-dialog-content {
     overflow-y: auto;
     padding: ${dt('dialog.content.padding')};
+    flex: 1 1 auto
 }
 
 .p-dialog-header {

--- a/packages/primeng/src/dialog/style/dialogstyle.ts
+++ b/packages/primeng/src/dialog/style/dialogstyle.ts
@@ -18,7 +18,7 @@ const theme = ({ dt }) => `
 .p-dialog-content {
     overflow-y: auto;
     padding: ${dt('dialog.content.padding')};
-    flex: 1 1 auto
+    flex-grow: 1;
 }
 
 .p-dialog-header {


### PR DESCRIPTION
This pull request fixes issue #17193

The video shows the pull request fixes the reproducer that demonstrated the bug.

https://github.com/user-attachments/assets/5b9d0aab-c4df-49e1-8605-5d83e7da881c


Note:  I manually verified that this pull request doesn't break  PrimeNG's dialog and dynamic dialog demos