### PR TITLE
Fixes #17204

### DIFF
--- a/packages/primeng/src/menu/menu.ts
+++ b/packages/primeng/src/menu/menu.ts
@@ -151,7 +151,7 @@ export class MenuItemContent {
             [ngClass]="{ 'p-menu p-component': true, 'p-menu-overlay': popup }"
             [class]="styleClass"
             [ngStyle]="style"
-            *ngIf="!popup || visible"
+            *ngIf="!popup || visible !== false"
             (click)="onOverlayClick($event)"
             [@overlayAnimation]="{
                 value: 'visible',
@@ -199,14 +199,13 @@ export class MenuItemContent {
                         <ng-container *ngTemplateOutlet="submenuHeaderTemplate ?? _submenuHeaderTemplate; context: { $implicit: submenu }"></ng-container>
                     </li>
                     <ng-template ngFor let-item let-j="index" [ngForOf]="submenu.items">
-                        <li class="p-menu-separator" *ngIf="item.separator" [ngClass]="{ 'p-hidden': item.visible === false || submenu.visible === false }" role="separator"></li>
+                        <li class="p-menu-separator" *ngIf="item.separator && item.visible && submenu.visibile" role="separator"></li>
                         <li
                             class="p-menu-item"
-                            *ngIf="!item.separator"
+                            *ngIf="!item.separator && item.visible !== false && submenu.visible"
                             [pMenuItemContent]="item"
                             [itemTemplate]="itemTemplate ?? _itemTemplate"
                             [ngClass]="{
-                                'p-hidden': item.visible === false || submenu.visible === false,
                                 'p-focus': focusedOptionId() && menuitemId(item, id, i, j) === focusedOptionId(),
                                 'p-disabled': disabled(item.disabled)
                             }"
@@ -226,14 +225,13 @@ export class MenuItemContent {
                     </ng-template>
                 </ng-template>
                 <ng-template ngFor let-item let-i="index" [ngForOf]="model" *ngIf="!hasSubMenu()">
-                    <li class="p-menu-separator" *ngIf="item.separator" [ngClass]="{ 'p-hidden': item.visible === false }" role="separator"></li>
+                    <li class="p-menu-separator" *ngIf="item.separator && item.visible !== false" role="separator"></li>
                     <li
                         class="p-menu-item"
-                        *ngIf="!item.separator"
+                        *ngIf="!item.separator && item.visible !== false"
                         [pMenuItemContent]="item"
                         [itemTemplate]="itemTemplate ?? _itemTemplate"
                         [ngClass]="{
-                            'p-hidden': item.visible === false,
                             'p-focus': focusedOptionId() && menuitemId(item, id, i) === focusedOptionId(),
                             'p-disabled': disabled(item.disabled)
                         }"


### PR DESCRIPTION
### Issue 
#17204

### Resolution
In accordance with the documentation, the description of the `visible` property states:

> Whether the DOM element of the menu item is created or not.

The previous implementation utilized the `p-hidden` class to control the visibility of the menu item. However, upon reviewing the codebase, I discovered that the styles associated with this class are only defined in `basestyle.ts`, which appears to be unused in the current code. Further investigation revealed that the `p-hidden` class is referenced in the `PanelMenu`, which employs the `*ngIf` directive to manage the visibility of menu items.

To ensure code consistency, I adopted the approach used in `PanelMenu` and modified the implementation accordingly. Instead of relying on the `p-hidden` class to show or hide the menu item, I now utilize the condition `visible !== false`. This decision was made to avoid using `visible === true`, as the default value of the `visible` key is `undefined`, necessitating an explicit check for falsy values.

With this update, the code now functions as intended, dynamically adding or removing the element from the DOM based on the state of the `visible` flag.