### PR TITLE
fix: p-select lacks "pc" prefixed attributes

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1385,6 +1385,7 @@ export class Select extends BaseComponent implements OnInit, AfterViewInit, Afte
     }
 
     ngAfterViewInit() {
+        super.ngAfterViewInit();
         if (this.editable) {
             this.updateEditableLabel();
         }


### PR DESCRIPTION
In the `Select` component, the `ngAfterViewInit` method does not call the parent class's `ngAfterViewInit`, resulting in the inability to add `pc` prefixed attributes and causing custom Scoped Tokens to fail.