### PR TITLE
fix: p-select not propagating tab keyboard event

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1970,7 +1970,6 @@ export class Select extends BaseComponent implements OnInit, AfterViewInit, Afte
                 this.overlayVisible && this.hide(this.filter);
             }
         }
-        event.stopPropagation();
     }
 
     onFirstHiddenFocus(event) {


### PR DESCRIPTION
In the Select component, `Tab` key press isn't propagating a keyboard event up.