### PR TITLE
docs: fix `rowexpansion` template name in showcase code

### DIFF
--- a/apps/showcase/doc/table/rowexpansiondoc.ts
+++ b/apps/showcase/doc/table/rowexpansiondoc.ts
@@ -219,7 +219,7 @@ export class RowExpansionDoc {
             </td>
         </tr>
     </ng-template>
-    <ng-template #expandedrow let-product>
+    <ng-template #rowexpansion let-product>
         <tr>
             <td colspan="7">
                 <div class="p-4">


### PR DESCRIPTION
Adjusting showcase code to use `rowexpansion` instead of `expandedrow`, according to the documentation.

> [...] To use this feature, add a template named **rowexpansion** and use [...]

### Defect Fixes
Not really a "fix" as one word change in the showcase.

<!-- When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar). -->

