### PR TITLE
styleClass is missing from Tree component

### DIFF
--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -70,6 +70,7 @@ import {
             <li
                 [ngClass]="nodeClass"
                 [ngStyle]="{ height: itemSize + 'px' }"
+                [class]="node.styleClass"
                 [style]="node.style"
                 [attr.aria-label]="node.label"
                 [attr.aria-checked]="checked"


### PR DESCRIPTION
Added missing styleClass on Tree component

It appears that the styleClass property was omitted in versions 18 and 19 of the Tree component, despite still being documented in the [official documentation](https://primeng.org/tree#api.tree.interfaces.TreeNode.styleClass).

I kindly request that you consider restoring the styleClass property, as it is crucial for my use case, and I have not found an alternative solution to achieve the same functionality.
