### PR TITLE
Fix: Drawer(#17242) - Mask zIndex calculation bug

### DIFF
--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -389,7 +389,7 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
     enableModality() {
         const activeDrawers = this.document.querySelectorAll('.p-drawer-active');
         const activeDrawersLength = activeDrawers.length;
-        const zIndex = activeDrawersLength == 1 ? String(parseInt((this.container as HTMLDivElement).style.zIndex) - 1) : String(parseInt((activeDrawers[0] as HTMLElement).style.zIndex) - 1);
+        const zIndex = activeDrawersLength == 1 ? String(parseInt((this.container as HTMLDivElement).style.zIndex) - 1) : String(parseInt((activeDrawers[activeDrawersLength - 1] as HTMLElement).style.zIndex) - 1);
         this.container.setAttribute(this.attrSelector, '');
 
         if (!this.mask) {


### PR DESCRIPTION
Closes #17242 .

Fixed mask's `zIndex` calculation.
