### PR TITLE
fix: Style the background according the design token for filled hovered text inputs

### DIFF
--- a/packages/primeng/src/inputtext/style/inputtextstyle.ts
+++ b/packages/primeng/src/inputtext/style/inputtextstyle.ts
@@ -43,6 +43,10 @@ const theme = ({ dt }) => `
     background: ${dt('inputtext.filled.background')};
 }
 
+.p-inputtext.p-variant-filled:enabled:hover {
+    background: ${dt('inputtext.filled.hover.background')};
+}
+
 .p-inputtext.p-variant-filled:enabled:focus {
     background: ${dt('inputtext.filled.focus.background')};
 }


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/17277