### PR TITLE
Fix: Table(#17062) | Adding custom sorticon should replace default sorticon.

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -3692,7 +3692,7 @@ export class SortableColumn implements OnInit, OnDestroy {
     selector: 'p-sortIcon',
     standalone: false,
     template: `
-        <ng-container *ngIf="!(dt.sortIconTemplate && dt._sortIconTemplate)">
+        <ng-container *ngIf="!(dt.sortIconTemplate || dt._sortIconTemplate)">
             <SortAltIcon [styleClass]="'p-sortable-column-icon'" *ngIf="sortOrder === 0" />
             <SortAmountUpAltIcon [styleClass]="'p-sortable-column-icon'" *ngIf="sortOrder === 1" />
             <SortAmountDownIcon [styleClass]="'p-sortable-column-icon'" *ngIf="sortOrder === -1" />


### PR DESCRIPTION
### Fixes
Changed operator to hide default if ng-template with  `#sorticon` OR `pTemplate="sorticon"` templates are provided in the component.

This is an enhancement of the fix for issue #17062

As the previous fix requires the both the template ref and ptemplate to be provided in order to hide the default sort icons.

``` 
<ng-template #sorticon pTemplate="sorticon">
...
</ng-template>
```
