### PR TITLE
Add new emitter in Tree component: onNodeDoubleClick

### DIFF
--- a/apps/showcase/doc/apidoc/index.json
+++ b/apps/showcase/doc/apidoc/index.json
@@ -34573,6 +34573,16 @@
                             "description": "Callback to invoke when a node is selected with right click."
                         },
                         {
+                            "name": "onNodeDoubleClick",
+                            "parameters": [
+                                {
+                                    "name": "event",
+                                    "type": "TreeNodeDoubleClickEvent"
+                                }
+                            ],
+                            "description": "Callback to invoke when a node is double clicked."
+                        },
+                        {
                             "name": "onNodeDrop",
                             "parameters": [
                                 {
@@ -34867,6 +34877,26 @@
                     {
                         "name": "TreeNodeContextMenuSelectEvent",
                         "description": "Custom context menu select event.",
+                        "props": [
+                            {
+                                "name": "originalEvent",
+                                "optional": false,
+                                "readonly": false,
+                                "type": "Event",
+                                "description": "Browser event"
+                            },
+                            {
+                                "name": "node",
+                                "optional": false,
+                                "readonly": false,
+                                "type": "TreeNode<any>",
+                                "description": "Node instance."
+                            }
+                        ]
+                    },
+                    {
+                        "name": "TreeNodeDoubleClickEvent",
+                        "description": "Custom node double click event.",
                         "props": [
                             {
                                 "name": "originalEvent",

--- a/packages/primeng/src/tree/tree.interface.ts
+++ b/packages/primeng/src/tree/tree.interface.ts
@@ -46,6 +46,13 @@ export interface TreeNodeCollapseEvent extends TreeNodeSelectEvent {}
  */
 export interface TreeNodeContextMenuSelectEvent extends TreeNodeSelectEvent {}
 /**
+ * Custom node double click event.
+ * @see {@link Tree.onNodeDoubleClick}
+ * @extends {TreeNodeSelectEvent}
+ * @group Events
+ */
+export interface TreeNodeDoubleClickEvent extends TreeNodeSelectEvent {}
+/**
  * Custom node drop event.
  * @see {@link Tree.onNodeDrop}
  * @group Events

--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -43,6 +43,7 @@ import {
     TreeLazyLoadEvent,
     TreeNodeCollapseEvent,
     TreeNodeContextMenuSelectEvent,
+    TreeNodeDoubleClickEvent,
     TreeNodeDropEvent,
     TreeNodeExpandEvent,
     TreeNodeSelectEvent,
@@ -88,6 +89,7 @@ import {
                     [style.paddingLeft]="level * indentation + 'rem'"
                     (click)="onNodeClick($event)"
                     (contextmenu)="onNodeRightClick($event)"
+                    (dblclick)="onNodeDblClick($event)"
                     (touchend)="onNodeTouchEnd()"
                     (drop)="onDropNode($event)"
                     (dragover)="onDropNodeDragOver($event)"
@@ -297,6 +299,10 @@ export class UITreeNode extends BaseComponent implements OnInit {
 
     onNodeRightClick(event: MouseEvent) {
         this.tree.onNodeRightClick(event, <TreeNode>this.node);
+    }
+
+    onNodeDblClick(event: MouseEvent) {
+        this.tree.onNodeDblClick(event, <TreeNode>this.node);
     }
 
     isSelected() {
@@ -1034,6 +1040,12 @@ export class Tree extends BaseComponent implements OnInit, AfterContentInit, OnC
      */
     @Output() onNodeContextMenuSelect: EventEmitter<TreeNodeContextMenuSelectEvent> = new EventEmitter<TreeNodeContextMenuSelectEvent>();
     /**
+     * Callback to invoke when a node is double clicked.
+     * @param {TreeNodeDoubleClickEvent} event - Node double click event.
+     * @group Emits
+     */
+    @Output() onNodeDoubleClick: EventEmitter<TreeNodeDoubleClickEvent> = new EventEmitter<TreeNodeDoubleClickEvent>();
+    /**
      * Callback to invoke when a node is dropped.
      * @param {TreeNodeDropEvent} event - Node drop event.
      * @group Emits
@@ -1412,6 +1424,10 @@ export class Tree extends BaseComponent implements OnInit, AfterContentInit, OnC
                 this.onNodeContextMenuSelect.emit({ originalEvent: event, node: node });
             }
         }
+    }
+
+    onNodeDblClick(event: MouseEvent, node: TreeNode<any>) {
+        this.onNodeDoubleClick.emit({ originalEvent: event, node: node });
     }
 
     findIndexInSelection(node: TreeNode) {


### PR DESCRIPTION
_Related to [https://github.com/orgs/primefaces/discussions/3313](https://github.com/orgs/primefaces/discussions/3313)._
_This PR fixes #17401._

- Created `onNodeDoubleClick` emitter in Tree component.
- Thus created `TreeNodeDoubleClickEvent`.