### PR TITLE
update designer json-to-js regex to allow keys with dot notation

### DIFF
--- a/apps/showcase/components/layout/designer/app.designer.component.ts
+++ b/apps/showcase/components/layout/designer/app.designer.component.ts
@@ -471,7 +471,7 @@ export class AppDesignerComponent {
     }
     download() {
         const basePreset = this.configService.appState().preset;
-        const theme = JSON.stringify(this.preset, null, 4).replace(/"([^"]+)":/g, '$1:');
+        const theme = JSON.stringify(this.preset, null, 4).replace(/"((?!\w+\.\d+)[^"]+)":/g, '$1:');
         const textContent = `import { ApplicationConfig } from '@angular/core';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { providePrimeNG } from 'primeng/config';


### PR DESCRIPTION
### Defect Fixes
Fixes issue https://github.com/primefaces/primeng/issues/17285

### Explanation of Changes

1. Lookahead `(?!...)`:
    - `(?!\w+\.\d+)` ensures the key does not match the pattern word.number (e.g., color.1).
    - `\w+`: Matches one or more word characters (letters, digits, or underscores).
    - `\.`: Matches a literal period (.).
    - `\d+`: Matches one or more digits.

2. Adjusted Capturing Group:
    - `((?!\w+\.\d+)[^"]+)`:
        - Captures keys that do not match the \w+\.\d+ pattern.
        - Ensures only valid keys are captured and replaced.

3. Replacement:
    - `$1`: retains the captured group (key) and appends the colon.