### PR TITLE
[FIX] add missing doc for active tab css selector

### DIFF
--- a/apps/showcase/doc/apidoc/index.json
+++ b/apps/showcase/doc/apidoc/index.json
@@ -32219,6 +32219,10 @@
                         "description": "Class name of the inkbar element"
                     },
                     {
+                        "class": "p-tab-active",
+                        "description": "Class name of the active tab element"
+                    },
+                    {
                         "class": "p-tablist-nav-button",
                         "description": "Class name of the navigation buttons"
                     },


### PR DESCRIPTION
The .json file was missing a part for selecting the active tab in css 