### PR TITLE
fix: setting display contents for icon avatar

### DIFF
--- a/packages/primeng/src/avatar/style/avatarstyle.ts
+++ b/packages/primeng/src/avatar/style/avatarstyle.ts
@@ -30,6 +30,7 @@ const theme = ({ dt }) => `
     font-size: ${dt('avatar.icon.size')};
     width: ${dt('avatar.icon.size')};
     height: ${dt('avatar.icon.size')};
+    display: contents;
 }
 
 .p-avatar img {


### PR DESCRIPTION
### Defect fixing 

Icon avatar is not displayed correctly

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/28097af5-01fe-49a5-b7b0-1e1b73e7b70f" />

After the fix:

<img width="1062" alt="image" src="https://github.com/user-attachments/assets/1ccf096f-e6f3-402b-bed9-b6f20112dd22" />
