### PR TITLE
fix decade title logic, fixes #17326

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -214,7 +214,7 @@ export const DATEPICKER_VALUE_ACCESSOR: any = {
                                         {{ getYear(month) }}
                                     </button>
                                     <span class="p-datepicker-decade" *ngIf="currentView === 'year'">
-                                        <ng-container *ngIf="!decadeTemplate && _decadeTemplate">{{ yearPickerValues()[0] }} - {{ yearPickerValues()[yearPickerValues().length - 1] }}</ng-container>
+                                        <ng-container *ngIf="!decadeTemplate && !_decadeTemplate">{{ yearPickerValues()[0] }} - {{ yearPickerValues()[yearPickerValues().length - 1] }}</ng-container>
                                         <ng-container *ngTemplateOutlet="decadeTemplate || _decadeTemplate; context: { $implicit: yearPickerValues }"></ng-container>
                                     </span>
                                 </div>


### PR DESCRIPTION
fix #17326

changed *ngIf="!decadeTemplate && _decadeTemplate" to *ngIf="!decadeTemplate && !_decadeTemplate">

This video shows the v19 PrimeNG DatePicker Basic dem's Decade title  working correctly after the fix.


https://github.com/user-attachments/assets/0d637d1d-d979-4a09-9d87-29d8a5b02089
