### PR TITLE
fix: datepicker when its disabled

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -2142,6 +2142,10 @@ export class DatePicker extends BaseComponent implements OnInit, AfterContentIni
     }
 
     onButtonClick(event: Event, inputfield: any = this.inputfieldViewChild?.nativeElement) {
+        if (this.disabled) {
+            return;
+        }
+
         if (!this.overlayVisible) {
             inputfield.focus();
             this.showOverlay();


### PR DESCRIPTION
When the datepicker it's disabled and you click the icon, open the calendar.

## BEFORE

![image](https://github.com/user-attachments/assets/10975038-073d-49e0-b9e0-e44639456fa8)

## AFTER

![image](https://github.com/user-attachments/assets/1351d012-1277-4ae5-bfe0-322ad017a60a)
