### PR TITLE
fix: rating keyboard navigation, fixes primefaces#17315

### DIFF
--- a/packages/primeng/src/rating/rating.ts
+++ b/packages/primeng/src/rating/rating.ts
@@ -238,12 +238,14 @@ export class Rating extends BaseComponent implements OnInit, ControlValueAccesso
     }
 
     onOptionSelect(event, value) {
-        if (this.focusedOptionIndex === value || value === this.value) {
-            this.focusedOptionIndex.set(-1);
-            this.updateModel(event, null);
-        } else {
-            this.focusedOptionIndex.set(value);
-            this.updateModel(event, value || null);
+        if (!this.readonly && !this.disabled) {
+            if (this.focusedOptionIndex() === value || value === this.value) {
+                this.focusedOptionIndex.set(-1);
+                this.updateModel(event, null);
+            } else {
+                this.focusedOptionIndex.set(value);
+                this.updateModel(event, value || null);
+            }
         }
     }
 
@@ -258,8 +260,10 @@ export class Rating extends BaseComponent implements OnInit, ControlValueAccesso
     }
 
     onInputFocus(event, value) {
-        this.focusedOptionIndex.set(value);
-        this.onFocus.emit(event);
+        if (!this.readonly && !this.disabled) {
+            this.focusedOptionIndex.set(value);
+            this.onFocus.emit(event);
+        }
     }
 
     updateModel(event, value) {

--- a/packages/primeng/src/rating/style/ratingstyle.ts
+++ b/packages/primeng/src/rating/style/ratingstyle.ts
@@ -61,7 +61,7 @@ const classes = {
         'p-rating-option',
         {
             'p-rating-option-active': value <= props.modelValue,
-            'p-focus-visible': value === instance.focusedOptionIndex && instance.isFocusVisibleItem
+            'p-focus-visible': value === instance.focusedOptionIndex() && instance.isFocusVisibleItem
         }
     ],
     onIcon: 'p-rating-icon p-rating-on-icon',


### PR DESCRIPTION
Fixes primefaces#17315

This fixes the keyboard navigation for the rating component.

Part of the fix is using the value of a signal instead of the signal itself for comparison purposes (`focusedOptionIndex`). I fear that similar problems exists in other components as well—at least in `dropdownstyle.ts` a quick search yields a similar situation.

