### PR TITLE
fix: #16404 InputOtp: Unclear behavior when editing the filled component

### DIFF
--- a/packages/primeng/src/inputotp/inputotp.ts
+++ b/packages/primeng/src/inputotp/inputotp.ts
@@ -378,7 +378,7 @@ export class InputOtp extends BaseComponent implements AfterContentInit {
                 break;
 
             default:
-                if ((this.integerOnly && !((event.code.startsWith('Digit') || event.code.startsWith('Numpad')) && Number(event.key) >= 0 && Number(event.key) <= 9)) || (this.tokens.join('').length >= this.length && event.code !== 'Delete')) {
+                if ((this.integerOnly && !((event.code.startsWith('Digit') || event.code.startsWith('Numpad')) && Number(event.key) >= 0 && Number(event.key) <= 9))) {
                     event.preventDefault();
                 }
 


### PR DESCRIPTION
This PR removes a line that previously prevented default input behavior when the input reached its maxLength. The restriction allowed only the "Backspace" button to function, requiring users to delete existing values before entering new ones. With this change, users can overwrite the value in each input slot directly, improving usability.

The change is very small and basically removes a line in the onKeyDown method. However if the change is too harsh, would love to learn more.

### Defect Fixes
Allow editing inputotp when maxLength is reached, as stated in Issue #16404 

