### PR TITLE
fix(#17109): sync p-inputNumber with formControl patchValue

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -1509,6 +1509,9 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
 
     writeValue(value: any): void {
         this.value = value ? this.parseValue(value.toString()) : value;
+        if (this.input) {
+            this.input.nativeElement.value = value ? this.parseValue(value.toString()) : value;
+        }
         this.cd.markForCheck();
     }
 


### PR DESCRIPTION
This PR addresses [issue #17109](https://github.com/primefaces/primeng/issues/17109), which reports a bug with p-inputNumber not syncing correctly with FormControl when using the patchValue method.

Root Cause
The p-inputNumber component was not updating its internal value when the patchValue method was used on the associated FormControl. This issue caused the UI to remain out of sync with the form control.

Fix
Updated the p-inputNumber component to listen to FormControl value changes and properly update its state whenever patchValue is called.
Testing
Manually tested the fix with a reactive form setup.
Verified that calling patchValue correctly updates the value displayed by p-inputNumber.
Closes #17109