### PR TITLE
fix(tabs): resolve ghost tab selection when collection changes (#17049)

### DIFF
--- a/packages/primeng/src/tabs/tablist.ts
+++ b/packages/primeng/src/tabs/tablist.ts
@@ -5,6 +5,7 @@ import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
 import { ChevronLeftIcon, ChevronRightIcon } from 'primeng/icons';
 import { RippleModule } from 'primeng/ripple';
+import { Tab } from './tab';
 import { Tabs } from './tabs';
 
 /**
@@ -89,10 +90,15 @@ export class TabList extends BaseComponent implements AfterViewInit, AfterConten
 
     scrollable = computed(() => this.pcTabs.scrollable());
 
+    @ContentChildren(Tab, { descendants: true }) tab: QueryList<Tab>;
+
+    tabCount = signal<number>(0);
+
     constructor() {
         super();
         effect(() => {
             this.pcTabs.value();
+            this.tabCount();
             if (isPlatformBrowser(this.platformId)) {
                 setTimeout(() => {
                     this.updateInkBar();
@@ -122,6 +128,9 @@ export class TabList extends BaseComponent implements AfterViewInit, AfterConten
     _nextIconTemplate: TemplateRef<any> | undefined;
 
     ngAfterContentInit() {
+        this.tab.changes.subscribe(() => {
+            this.tabCount.update(() => this.tab.length);
+        });
         this.templates.forEach((t) => {
             switch (t.getType()) {
                 case 'previcon':


### PR DESCRIPTION
fix(tabs): resolve ghost tab selection when collection changes (#17049)

Fixes an issue where the tab ink bar remains visible for a previously selected tab even after the underlying tab collection changes. 

- Ensured the `ContentChildren` query tracks changes to the `p-tab` components.
- Added signal-based tracking for the number of tabs to update the ink bar dynamically.
- Improved handling of tab rendering lifecycle to ensure consistency during dynamic updates.

Closes #17049.
