### PR TITLE
fix: #17314 -  inputnumber model binding issue

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -1508,7 +1508,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
     }
 
     writeValue(value: any): void {
-        this.value = value ? this.parseValue(value.toString()) : value;
+        this.value = Number(value);
         this.cd.markForCheck();
     }
 


### PR DESCRIPTION
writeValue() must not parse the model value as it is expected to be a number already. Otherwise, all kinds of locale related issues may arise.