### PR TITLE
fix: make build scripts cross platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "release": "pnpm run build && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary",
         "release:beta": "pnpm run build && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary --tag v19-beta",
         "release:rc": "pnpm run build && pnpm recursive publish --filter './packages/*' --no-git-checks --report-summary --tag v19-rc",
-        "build": "NODE_ENV=production pnpm run build:check && pnpm run build:packages",
+        "build": "cross-env NODE_ENV=production pnpm run build:check && pnpm run build:packages",
         "build:check": "pnpm run format:check && pnpm run security:check",
         "build:packages": "pnpm run build:lib && pnpm run build:themes && pnpm run build:showcase",
         "build:lib": "pnpm --filter primeng build",
@@ -54,6 +54,7 @@
         "@commitlint/cli": "^19.6.1",
         "@commitlint/config-conventional": "^19.6.0",
         "@typescript-eslint/eslint-plugin": "^8.13.0",
+        "cross-env": "^7.0.3",
         "eslint": "^9.14.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-import": "^2.31.0",
@@ -75,6 +76,8 @@
     },
     "packageManager": "pnpm@9.6.0",
     "lint-staged": {
-        "**/*.{js,mjs,ts,mts,d.ts,html}": ["prettier --write"]
+        "**/*.{js,mjs,ts,mts,d.ts,html}": [
+            "prettier --write"
+        ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -76,8 +76,6 @@
     },
     "packageManager": "pnpm@9.6.0",
     "lint-staged": {
-        "**/*.{js,mjs,ts,mts,d.ts,html}": [
-            "prettier --write"
-        ]
+        "**/*.{js,mjs,ts,mts,d.ts,html}": ["prettier --write"]
     }
 }

--- a/packages/primeng/package.json
+++ b/packages/primeng/package.json
@@ -29,7 +29,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "NODE_ENV=production INPUT_DIR=src/ OUTPUT_DIR=dist/ pnpm run build:package",
+        "build": "cross-env NODE_ENV=production INPUT_DIR=src/ OUTPUT_DIR=dist/ pnpm run build:package",
         "build:package": "pnpm run build:prebuild && ng build primeng && pnpm run build:postbuild",
         "build:prebuild": "node ./scripts/prebuild.mjs",
         "build:postbuild": "node ./scripts/postbuild.mjs",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -38,7 +38,7 @@
         "access": "public"
     },
     "scripts": {
-        "build": "NODE_ENV=production INPUT_DIR=src/ OUTPUT_DIR=dist/ pnpm run build:package",
+        "build": "cross-env NODE_ENV=production INPUT_DIR=src/ OUTPUT_DIR=dist/ pnpm run build:package",
         "build:package": "pnpm run build:prebuild && pnpm run build:tokens && tsup && pnpm run build:postbuild",
         "build:tokens": "node ./scripts/build-tokens.js",
         "build:prebuild": "node ./scripts/prebuild.mjs",


### PR DESCRIPTION
Some of the PrimeNG git repo's (p)npm scripts cannot be executed on Windows due to the way environment variables are used in the scripts.

The solution is to use the "cross-env" tool where required. Tested under Ubuntu and Windows.