### PR TITLE
Update basestyle.ts with avoid global 'box-sizing:border-box'

### DIFF
--- a/packages/primeng/src/base/style/basestyle.ts
+++ b/packages/primeng/src/base/style/basestyle.ts
@@ -4,9 +4,12 @@ import { minifyCSS, resolve } from '@primeuix/utils';
 import { UseStyle } from 'primeng/usestyle';
 
 const theme = ({ dt }) => `
-*,
-::before,
-::after {
+*[class^="p-"],
+*[class*=" p-"],
+*[class^="p-"]::before,
+*[class*=" p-"]::before
+*[class^="p-"]::after,
+*[class*=" p-"]::after {
     box-sizing: border-box;
 }
 


### PR DESCRIPTION
### Defect Fixes
https://github.com/primefaces/primeng/issues/7383
We have a global `box-sizing: border-box` which break default browser behavior.
Overriding this style locally to default, except "PrimeNG", breaks other local libraries.
This PR add "box-sizing: border-box" just for "PrimeNG" name space

### Feature Requests
Apply `box-sizing: border-box` for "PrimeNG" name space avoid to apply "box-sizing: border-box" globally
