### PR TITLE
Fix 17016 Close dynamic dialog on escape also when autoZindex is set to false

### DIFF
--- a/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
@@ -61,7 +61,7 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      */
     baseZIndex?: number;
     /**
-     * Whether to automatically manage layering.
+     * Whether to re-enforce layering through applying zIndex.
      * @group Props
      */
     autoZIndex?: boolean = false;

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -1,6 +1,6 @@
 import { animate, animation, AnimationEvent, style, transition, trigger, useAnimation } from '@angular/animations';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, ComponentRef, ElementRef, inject, NgModule, NgZone, OnDestroy, Optional, Renderer2, SkipSelf, TemplateRef, Type, ViewChild, ViewEncapsulation, ViewRef } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, ComponentRef, ElementRef, inject, NgModule, NgZone, OnDestroy, Optional, Renderer2, SkipSelf, Type, ViewChild, ViewEncapsulation, ViewRef } from '@angular/core';
 import { addClass, getOuterHeight, getOuterWidth, getViewport, hasClass, removeClass, setAttribute, uuid } from '@primeuix/utils';
 import { SharedModule, TranslationKeys } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
@@ -288,6 +288,8 @@ export class DynamicDialogComponent extends BaseComponent implements AfterViewIn
         return this.attrSelector;
     }
 
+    private zIndexForLayering?: number;
+
     constructor(
         public renderer: Renderer2,
         public ddconfig: DynamicDialogConfig,
@@ -364,6 +366,8 @@ export class DynamicDialogComponent extends BaseComponent implements AfterViewIn
         if (this.ddconfig.autoZIndex !== false) {
             ZIndexUtils.set('modal', this.container, (this.ddconfig.baseZIndex || 0) + this.config.zIndex.modal);
             (this.wrapper as HTMLElement).style.zIndex = String(parseInt((this.container as HTMLDivElement).style.zIndex, 10) - 1);
+        } else {
+            this.zIndexForLayering = ZIndexUtils.generateZIndex('modal', (this.ddconfig.baseZIndex || 0) + this.config.zIndex.modal);
         }
     }
 
@@ -411,6 +415,9 @@ export class DynamicDialogComponent extends BaseComponent implements AfterViewIn
 
         if (this.container && this.ddconfig.autoZIndex !== false) {
             ZIndexUtils.clear(this.container);
+        }
+        if (this.zIndexForLayering) {
+            ZIndexUtils.revertZIndex(this.zIndexForLayering);
         }
 
         if (this.ddconfig.modal !== false) {
@@ -695,7 +702,8 @@ export class DynamicDialogComponent extends BaseComponent implements AfterViewIn
 
         this.documentEscapeListener = this.renderer.listen(documentTarget, 'keydown', (event) => {
             if (event.which == 27) {
-                if (parseInt((this.container as HTMLDivElement).style.zIndex) == ZIndexUtils.getCurrent()) {
+                const currentZIndex = ZIndexUtils.getCurrent();
+                if (parseInt((this.container as HTMLDivElement).style.zIndex) == currentZIndex || this.zIndexForLayering == currentZIndex) {
                     this.hide();
                 }
             }

--- a/packages/primeng/src/utils/zindexutils.ts
+++ b/packages/primeng/src/utils/zindexutils.ts
@@ -35,7 +35,9 @@ function ZIndexUtils() {
                 el.style.zIndex = '';
             }
         },
-        getCurrent: () => getCurrentZIndex()
+        getCurrent: () => getCurrentZIndex(),
+        generateZIndex,
+        revertZIndex
     };
 }
 


### PR DESCRIPTION
fixes #17016 

### How I tested it

I used the exampledoc.ts and added / toggled `autoZIndex: false` [here](https://github.com/primefaces/primeng/blob/master/apps/showcase/doc/dynamicdialog/exampledoc.ts#L124) to verify existing of bug and fix of bug.

### Implementation design

I used the `ZIndexUtils` as  a nice layer tracker. I exposed the generation and removale, so I have access to it, without having to apply `zIndex` to an element. That way, still only the most top layer gets closed on escape, no matter if zIndex was applied to the an element. I think my change is none-destructive.   

Please let me know, what you think.