### PR TITLE
fix: #17507 accordion icon position

### DIFF
--- a/apps/showcase/doc/accordion/accordiondoc.module.ts
+++ b/apps/showcase/doc/accordion/accordiondoc.module.ts
@@ -13,6 +13,7 @@ import { BasicDoc } from './basicdoc';
 import { ControlledDoc } from './controlleddoc';
 import { DisabledDoc } from './disableddoc';
 import { DynamicDoc } from './dynamicdoc';
+import { IconposDoc } from './iconposdoc';
 import { ImportDoc } from './importdoc';
 import { MultipleDoc } from './multipledoc';
 import { StyleDoc } from './styledoc';
@@ -21,6 +22,6 @@ import { TemplateDoc } from './templatedoc';
 @NgModule({
     imports: [CommonModule, AppCodeModule, AppDocModule, AccordionModule, ButtonModule, RouterModule, AvatarModule, BadgeModule, FormsModule],
     exports: [AppDocModule],
-    declarations: [ImportDoc, BasicDoc, DynamicDoc, MultipleDoc, DisabledDoc, ControlledDoc, TemplateDoc, StyleDoc, AccessibilityDoc]
+    declarations: [ImportDoc, BasicDoc, IconposDoc, DynamicDoc, MultipleDoc, DisabledDoc, ControlledDoc, TemplateDoc, StyleDoc, AccessibilityDoc]
 })
 export class AccordionDocModule {}

--- a/apps/showcase/doc/accordion/iconposdoc.ts
+++ b/apps/showcase/doc/accordion/iconposdoc.ts
@@ -1,0 +1,138 @@
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'iconpos-doc',
+    standalone: false,
+    template: `
+        <app-docsectiontext>
+            <p>The toggle icon position can be set in <i>Accordion</i>. The <i>iconPos</i> property can be set to <i>start</i> or <i>end</i>. The default value is <i>end</i></p>
+        </app-docsectiontext>
+        <div class="card flex justify-center">
+            <p-accordion value="0" iconPos="start">
+                <p-accordion-panel value="0">
+                    <p-accordion-header>Header I</p-accordion-header>
+                    <p-accordion-content>
+                        <p class="m-0">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+                            laborum.
+                        </p>
+                    </p-accordion-content>
+                </p-accordion-panel>
+
+                <p-accordion-panel value="1">
+                    <p-accordion-header>Header II</p-accordion-header>
+                    <p-accordion-content>
+                        <p class="m-0">
+                            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo
+                            enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+                        </p>
+                    </p-accordion-content>
+                </p-accordion-panel>
+
+                <p-accordion-panel value="2">
+                    <p-accordion-header>Header III</p-accordion-header>
+                    <p-accordion-content>
+                        <p class="m-0">
+                            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo
+                            enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+                        </p>
+                    </p-accordion-content>
+                </p-accordion-panel>
+            </p-accordion>
+        </div>
+        <app-code [code]="code" selector="accordion-basic-demo"></app-code>
+    `
+})
+export class IconposDoc {
+    code: Code = {
+        basic: `<p-accordion value="0" iconPos="start">
+    <p-accordion-panel value="0">
+        <p-accordion-header>Header I</p-accordion-header>
+        <p-accordion-content>
+            <p class="m-0">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+                pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+                laborum.
+            </p>
+        </p-accordion-content>
+    </p-accordion-panel>
+
+    <p-accordion-panel value="1">
+        <p-accordion-header>Header II</p-accordion-header>
+        <p-accordion-content>
+            <p class="m-0">
+                Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+                aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo
+                enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos
+                qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+            </p>
+        </p-accordion-content>
+    </p-accordion-panel>
+
+    <p-accordion-panel value="2">
+        <p-accordion-header>Header III</p-accordion-header>
+        <p-accordion-content>
+            <p class="m-0">
+                Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+                aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo
+                enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos
+                qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+            </p>
+        </p-accordion-content>
+    </p-accordion-panel>
+</p-accordion>`,
+
+        html: `<div class="card flex justify-center">
+   <p-accordion value="0" iconPos="start">
+        <p-accordion-panel value="0">
+            <p-accordion-header>Header I</p-accordion-header>
+            <p-accordion-content>
+                <p class="m-0">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+                    magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+                    pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+                    laborum.
+                </p>
+            </p-accordion-content>
+        </p-accordion-panel>
+
+        <p-accordion-panel value="1">
+            <p-accordion-header>Header II</p-accordion-header>
+            <p-accordion-content>
+                <p class="m-0">
+                    Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+                    aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo
+                    enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos
+                    qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+                </p>
+            </p-accordion-content>
+        </p-accordion-panel>
+
+        <p-accordion-panel value="2">
+            <p-accordion-header>Header III</p-accordion-header>
+            <p-accordion-content>
+                <p class="m-0">
+At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
+                </p>
+            </p-accordion-content>
+        </p-accordion-panel>
+    </p-accordion>
+</div>`,
+
+        typescript: `import { Component } from '@angular/core';
+import { AccordionModule } from 'primeng/accordion';
+
+@Component({
+    selector: 'accordion-iconpos-demo',
+    templateUrl: './accordion-iconpos-demo.html',
+    standalone: true,
+    imports: [AccordionModule]
+})
+export class AccordionIconposDemo {}`
+    };
+}

--- a/apps/showcase/pages/accordion/index.ts
+++ b/apps/showcase/pages/accordion/index.ts
@@ -4,6 +4,7 @@ import { BasicDoc } from '@/doc/accordion/basicdoc';
 import { ControlledDoc } from '@/doc/accordion/controlleddoc';
 import { DisabledDoc } from '@/doc/accordion/disableddoc';
 import { DynamicDoc } from '@/doc/accordion/dynamicdoc';
+import { IconposDoc } from '@/doc/accordion/iconposdoc';
 import { ImportDoc } from '@/doc/accordion/importdoc';
 import { MultipleDoc } from '@/doc/accordion/multipledoc';
 import { TemplateDoc } from '@/doc/accordion/templatedoc';
@@ -32,6 +33,11 @@ export class AccordionDemo {
             id: 'basic',
             label: 'Basic',
             component: BasicDoc
+        },
+        {
+            id: 'iconPos',
+            label: 'Icon Position',
+            component: IconposDoc
         },
         {
             id: 'dynamic',

--- a/packages/primeng/src/accordion/accordion.ts
+++ b/packages/primeng/src/accordion/accordion.ts
@@ -720,6 +720,20 @@ export class Accordion extends BaseComponent implements BlockableUI, AfterConten
      */
     @Input() collapseIcon: string | undefined;
     /**
+     * Position of the icon. The default value is 'end'.
+     * @defaultValue 'end'
+     * @group Props
+     */
+    @Input() iconPos: 'end' | 'start' = 'end';
+
+    get iconClass() {
+        if (this.iconPos === 'end') {
+            return 'p-accordionheader-toggle-icon icon-end';
+        } else {
+            return 'p-accordionheader-toggle-icon icon-start';
+        }
+    }
+    /**
      * When enabled, the focused tab is activated.
      * @defaultValue false
      * @group Props


### PR DESCRIPTION
### New Feature
[#17507](https://github.com/primefaces/primeng/issues/17507)  accordion icon position

Allows to pass `iconPos` values `start` or `end` in `Accordion` component like in the deprecated `AccordionTab`.
The default value is `end`.

