### PR TITLE
fix: xlsx remove unused vulnerable dependency

### DIFF
--- a/apps/showcase/angular.json
+++ b/apps/showcase/angular.json
@@ -42,7 +42,6 @@
                         ],
                         "allowedCommonJsDependencies": [
                             "chart.js",
-                            "xlsx",
                             "jspdf-autotable",
                             "file-saver",
                             "jspdf",

--- a/apps/showcase/components/doc/codeeditor/templates.ts
+++ b/apps/showcase/components/doc/codeeditor/templates.ts
@@ -278,7 +278,6 @@ const angular_json = `{
               "scripts": [],
               "allowedCommonJsDependencies": [
                 "chart.js",
-                "xlsx",
                 "jspdf-autotable",
                 "file-saver",
                 "jspdf",

--- a/apps/showcase/package.json
+++ b/apps/showcase/package.json
@@ -49,7 +49,6 @@
         "ts-node": "~10.9.1",
         "tslib": "^2.5.0",
         "typedoc": "0.27.4",
-        "xlsx": "^0.18.5",
         "zone.js": "catalog:angular19"
     },
     "dependencies": {


### PR DESCRIPTION
### Defect Fixes
The dependency "xlsx" is vulnerable and not used in the project, therefor it should be removed.