### PR TITLE
Fix: Select(#17382) Clickable Empty Message Label

### DIFF
--- a/packages/primeng/src/select/style/selectstyle.ts
+++ b/packages/primeng/src/select/style/selectstyle.ts
@@ -113,6 +113,7 @@ input.p-select-label {
 }
 
 .p-select-overlay {
+    cursor: default;
     background: ${dt('select.overlay.background')};
     color: ${dt('select.overlay.color')};
     border: 1px solid ${dt('select.overlay.border.color')};


### PR DESCRIPTION
Closes #17382

**Problem:** `p-select-overlay` inherits `cursor: pointer` from `p-select`.

**Solution:** Added default cursor.