### PR TITLE
Fix detection of pDroppableDisabled change after ngAfterViewInit

### DIFF
--- a/packages/primeng/src/dragdrop/dragdrop.ts
+++ b/packages/primeng/src/dragdrop/dragdrop.ts
@@ -174,7 +174,20 @@ export class Droppable implements AfterViewInit, OnDestroy {
      * Whether the element is droppable, useful for conditional cases.
      * @group Props
      */
-    @Input({ transform: booleanAttribute }) pDroppableDisabled: boolean = false;
+    _pDroppableDisabled: boolean = false;
+
+    @Input() get pDroppableDisabled(): boolean {
+        return this._pDroppableDisabled;
+    }
+    set pDroppableDisabled(_pDroppableDisabled: boolean) {
+        this._pDroppableDisabled = _pDroppableDisabled;
+
+        if (this._pDroppableDisabled) {
+            this.unbindDragOverListener();
+        } else {
+            this.bindDragOverListener();
+        }
+    }
     /**
      * Defines the cursor style, valid values are none, copy, move, link, copyMove, copyLink, linkMove and all.
      * @group Props


### PR DESCRIPTION
Changing the value of pDroppableDisabled after ngAfterViewInit has no effect. This commit replicates the behaviour of pDraggableDisabled to bind and unbind the listeners on value change

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
