### PR TITLE
Fix #17621: Removed duplicate class attribute in examples of DataView

### DIFF
--- a/apps/showcase/doc/dataview/basicdoc.ts
+++ b/apps/showcase/doc/dataview/basicdoc.ts
@@ -14,7 +14,7 @@ import { Component, inject, signal } from '@angular/core';
             <p-dataview #dv [value]="products()">
                 <ng-template #list let-items>
                     <div class="grid grid-cols-12 gap-4 grid-nogutter">
-                        <div class="col-span-12" *ngFor="let item of items; let first = first" class="col-span-12">
+                        <div class="col-span-12" *ngFor="let item of items; let first = first">
                             <div class="flex flex-col sm:flex-row sm:items-center p-6 gap-4" [ngClass]="{ 'border-t border-surface-200 dark:border-surface-700': !first }">
                                 <div class="md:w-40 relative">
                                     <img class="block xl:block mx-auto rounded-border w-full" [src]="'https://primefaces.org/cdn/primeng/images/demo/product/' + item.image" [alt]="item.name" />

--- a/apps/showcase/doc/dataview/paginationdoc.ts
+++ b/apps/showcase/doc/dataview/paginationdoc.ts
@@ -14,7 +14,7 @@ import { Component, signal } from '@angular/core';
             <p-dataview #dv [value]="products()" [rows]="5" [paginator]="true">
                 <ng-template #list let-items>
                     <div class="grid grid-cols-12 gap-4 grid-nogutter">
-                        <div class="col-span-12" *ngFor="let item of items; let first = first" class="col-span-12">
+                        <div class="col-span-12" *ngFor="let item of items; let first = first">
                             <div class="flex flex-col sm:flex-row sm:items-center p-6 gap-4" [ngClass]="{ 'border-t border-surface-200 dark:border-surface-700': !first }">
                                 <div class="md:w-40 relative">
                                     <img class="block xl:block mx-auto rounded-border w-full" [src]="'https://primefaces.org/cdn/primeng/images/demo/product/' + item.image" [alt]="item.name" />


### PR DESCRIPTION
Fix #17621: Two examples in the [DataView component](https://primeng.org/dataview) have double class attributes, likely a copy-paste error. This issue / bug report exists because it is required for the PR I am creating to fix this documentation error.

This is a line the current documentation:
```html
<div class="col-span-12" *ngFor="let item of items; let first = first" class="col-span-12">
```

This is my proposed fix:
```html
<div class="col-span-12" *ngFor="let item of items; let first = first">
```

With kind regards