### PR TITLE
fix(DatePicker): range selection incorrectly styles dates in range

### DIFF
--- a/packages/primeng/src/datepicker/style/datepickerstyle.ts
+++ b/packages/primeng/src/datepicker/style/datepickerstyle.ts
@@ -458,7 +458,13 @@ const classes = {
         let selectedDayClass = '';
 
         if (instance.isRangeSelection() && instance.isSelected(date) && date.selectable) {
-            selectedDayClass = date.day === instance.value[0].getDate() || date.day === instance.value[1].getDate() ? 'p-datepicker-day-selected' : 'p-datepicker-day-selected-range';
+            const startDate = instance.value[0];
+            const endDate = instance.value[1];
+            
+            const isStart = startDate && date.year === startDate.getFullYear() && date.month === startDate.getMonth() && date.day === startDate.getDate();
+            const isEnd = endDate && date.year === endDate.getFullYear() && date.month === endDate.getMonth() && date.day === endDate.getDate();
+            
+            selectedDayClass = isStart || isEnd ? 'p-datepicker-day-selected' : 'p-datepicker-day-selected-range';
         }
 
         return {


### PR DESCRIPTION
The DatePicker component using range type, when selecting a range spanning multiple months, the component styles the first and last selected days for each month.

Fixes [#17613](https://github.com/primefaces/primeng/issues/17613)