### PR TITLE
Fixes error when badge applied as directive do not work with custom css tokens from dt

### DIFF
--- a/packages/primeng/src/badge/badge.ts
+++ b/packages/primeng/src/badge/badge.ts
@@ -105,6 +105,7 @@ export class BadgeDirective extends BaseComponent implements OnChanges, AfterVie
     }
 
     public ngAfterViewInit(): void {
+        super.ngAfterViewInit();
         this.id = uuid('pn_id_') + '_badge';
         this.renderBadgeContent();
     }


### PR DESCRIPTION
### Defect Fixes
When badge is applied to element with directive and You use dt to add custom css tokens, they are not working because attribute from super method is not added to root element

### Feature Requests
Now badge applied as directive is working the same way as applied as component
