### PR TITLE
fix: Set the opacity to `1` for disabled autocomplete inputs

### DIFF
--- a/packages/primeng/src/autocomplete/style/autocompletestyle.ts
+++ b/packages/primeng/src/autocomplete/style/autocompletestyle.ts
@@ -179,6 +179,10 @@ const theme = ({ dt }) => `
     background: ${dt('autocomplete.filled.focus.background')};
 }
 
+.p-autocomplete.p-disabled {
+    opacity: 1;
+}
+
 .p-autocomplete.p-disabled .p-autocomplete-input-multiple {
     opacity: 1;
     background: ${dt('autocomplete.disabled.background')};


### PR DESCRIPTION
Fixes #17685