### PR TITLE
fix: only check for maximized when setting p-dialog-maximized

### DIFF
--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -43,7 +43,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
             <div
                 *ngIf="visible"
                 #container
-                [ngClass]="{ 'p-dialog p-component': true, 'p-dialog-maximized': maximizable && maximized }"
+                [ngClass]="{ 'p-dialog p-component': true, 'p-dialog-maximized': maximized }"
                 [ngStyle]="{ display: 'flex', 'flex-direction': 'column', 'pointer-events': 'auto' }"
                 [style]="ddconfig.style"
                 [class]="ddconfig.styleClass"


### PR DESCRIPTION
This is a regression bug as it worked in <v18 versions. This solves the following problems:
- This allows to toggle the maximization from the outside without using the default icon  
- Adding "maximizable: true" to the config, adds the default icon
- Not adding "maximizable: true" makes it impossible to toggle maximization
- There is no reason to check if maximizable. Checking if maximized should be the only check
