### PR TITLE
Updates Loading Icon template reference variable

### DIFF
--- a/packages/primeng/src/dataview/dataview.ts
+++ b/packages/primeng/src/dataview/dataview.ts
@@ -359,7 +359,7 @@ export class DataView extends BaseComponent implements OnInit, OnDestroy, Blocka
      * Template for loading icon.
      * @group Templates
      */
-    @ContentChild('loadingIcon') loadingicon: TemplateRef<any>;
+    @ContentChild('loadingicon') loadingicon: TemplateRef<any>;
     /**
      * Template for list icon.
      * @group Templates


### PR DESCRIPTION
This update normalises the reference variable name of the loading icon template, which currently is "loadingIcon" but should be "loadingicon", following the same standard as other variable names.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
