### PR TITLE
Fix ConfirmDialog breakpoints

### DIFF
--- a/packages/primeng/src/confirmdialog/confirmdialog.ts
+++ b/packages/primeng/src/confirmdialog/confirmdialog.ts
@@ -24,7 +24,7 @@ import { findSingle, setAttribute, uuid } from '@primeuix/utils';
 import { Confirmation, ConfirmationService, ConfirmEventType, Footer, PrimeTemplate, SharedModule, TranslationKeys } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
 import { Button } from 'primeng/button';
-import { Dialog } from 'primeng/dialog';
+import { Dialog, DialogPosition } from 'primeng/dialog';
 import { Nullable } from 'primeng/ts-helpers';
 import { Subscription } from 'rxjs';
 import { ConfirmDialogStyle } from './style/confirmdialogstyle';
@@ -53,6 +53,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
             [blockScroll]="option('blockScroll')"
             [appendTo]="option('appendTo')"
             [position]="position"
+            [breakpoints]="breakpoints"
             [style]="style"
             [dismissableMask]="dismissableMask"
         >
@@ -308,10 +309,10 @@ export class ConfirmDialog extends BaseComponent implements OnInit, OnDestroy {
      *  Allows getting the position of the component.
      * @group Props
      */
-    @Input() get position(): string {
+    @Input() get position(): DialogPosition {
         return this._position;
     }
-    set position(value: string) {
+    set position(value: DialogPosition) {
         this._position = value;
 
         switch (value) {
@@ -395,7 +396,7 @@ export class ConfirmDialog extends BaseComponent implements OnInit, OnDestroy {
 
     preWidth: number | undefined;
 
-    _position: string = 'center';
+    _position: DialogPosition = 'center';
 
     transformOptions: any = 'scale(0.7)';
 
@@ -447,9 +448,6 @@ export class ConfirmDialog extends BaseComponent implements OnInit, OnDestroy {
 
     ngOnInit() {
         super.ngOnInit();
-        if (this.breakpoints) {
-            this.createStyle();
-        }
 
         this.translationSubscription = this.config.translationObserver.subscribe(() => {
             if (this.visible) {
@@ -532,27 +530,6 @@ export class ConfirmDialog extends BaseComponent implements OnInit, OnDestroy {
             //backward compatibility
             default:
                 return findSingle(this.dialog.el.nativeElement, '.p-confirm-dialog-accept');
-        }
-    }
-
-    createStyle() {
-        if (!this.styleElement) {
-            this.styleElement = this.document.createElement('style');
-            this.styleElement.type = 'text/css';
-            this.document.head.appendChild(this.styleElement);
-            let innerHTML = '';
-            for (let breakpoint in this.breakpoints) {
-                innerHTML += `
-                    @media screen and (max-width: ${breakpoint}) {
-                        .p-dialog[${this.id}] {
-                            width: ${this.breakpoints[breakpoint]} !important;
-                        }
-                    }
-                `;
-            }
-
-            this.styleElement.innerHTML = innerHTML;
-            setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
         }
     }
 

--- a/packages/primeng/src/dialog/dialog.interface.ts
+++ b/packages/primeng/src/dialog/dialog.interface.ts
@@ -1,5 +1,6 @@
 import { TemplateRef } from '@angular/core';
 
+export type DialogPosition = 'center' | 'top' | 'bottom' | 'left' | 'right' | 'topleft' | 'topright' | 'bottomleft' | 'bottomright';
 /**
  * Defines valid templates in Dialog.
  * @group Templates

--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -33,6 +33,7 @@ import { TimesIcon, WindowMaximizeIcon, WindowMinimizeIcon } from 'primeng/icons
 import { Nullable, VoidListener } from 'primeng/ts-helpers';
 import { ZIndexUtils } from 'primeng/utils';
 import { DialogStyle } from './style/dialogstyle';
+import { DialogPosition } from './dialog.interface';
 
 const showAnimation = animation([style({ transform: '{{transform}}', opacity: 0 }), animate('{{transition}}')]);
 
@@ -384,10 +385,10 @@ export class Dialog extends BaseComponent implements OnInit, AfterContentInit, O
      * Position of the dialog.
      * @group Props
      */
-    @Input() get position(): 'center' | 'top' | 'bottom' | 'left' | 'right' | 'topleft' | 'topright' | 'bottomleft' | 'bottomright' {
+    @Input() get position(): DialogPosition {
         return this._position;
     }
-    set position(value: 'center' | 'top' | 'bottom' | 'left' | 'right' | 'topleft' | 'topright' | 'bottomleft' | 'bottomright') {
+    set position(value: DialogPosition) {
         this._position = value;
 
         switch (value) {
@@ -560,7 +561,7 @@ export class Dialog extends BaseComponent implements OnInit, AfterContentInit, O
 
     _style: any = {};
 
-    _position: 'center' | 'top' | 'bottom' | 'left' | 'right' | 'topleft' | 'topright' | 'bottomleft' | 'bottomright' = 'center';
+    _position: DialogPosition = 'center';
 
     originalStyle: any;
 


### PR DESCRIPTION
**Bug:** The `ConfirmDialog` component receives the `breakpoints` input property and generates corresponding CSS `@media` classes for it. However, it assigns names in the format `.p-dialog[pn_id_<id>]`, where `<id>` is the identifier of the `ConfirmDialog` component itself, not the ID of the internal `p-dialog` component. As a result, the CSS classes do not work as intended. Meanwhile, the `p-dialog` component is capable of accepting the `breakpoints` property directly and correctly generates the appropriate class names.  

**Fix:** Pass the `breakpoints` property through to the internal `p-dialog` component.

**PS:** Also define separate type for dialog position 

#17753 
