### PR TITLE
Fix: Issue#17751 - Inftalabel affected nested inputtext in Select Component.

### DIFF
--- a/packages/primeng/src/iftalabel/style/iftalabelstyle.ts
+++ b/packages/primeng/src/iftalabel/style/iftalabelstyle.ts
@@ -21,7 +21,7 @@ const theme = ({ dt }) => `
     transition-duration: ${dt('iftalabel.transition.duration')};
 }
 
-.p-iftalabel .p-inputtext,
+.p-iftalabel > .p-inputtext,
 .p-iftalabel .p-textarea,
 .p-iftalabel .p-select-label,
 .p-iftalabel .p-multiselect-label-container,
@@ -42,7 +42,7 @@ const theme = ({ dt }) => `
     color: ${dt('iftalabel.focus.color')};
 }
 
-.p-iftalabel .p-inputicon {
+.p-iftalabel > .p-inputicon {
     top: ${dt('iftalabel.input.padding.top')};
     transform: translateY(25%);
     margin-top: 0;


### PR DESCRIPTION
**Fix solution for issue:**
https://github.com/primefaces/primeng/issues/17751


**Problem:**
When using the Select component with a filter within an Iftalabel, the search field appears in the IftaLabel pattern with padding top without the label.

**Solution:**
CSS adjustment so padding affects only first child element.


---

![image](https://github.com/user-attachments/assets/6f5258f4-fe7a-4a81-9797-f845cce5c063)

