### PR TITLE
Use PrimeNG's interface in examples, instead of manually creating a duplicate (bad practice in documentation)

### DIFF
--- a/apps/showcase/doc/paginator/basicdoc.ts
+++ b/apps/showcase/doc/paginator/basicdoc.ts
@@ -1,12 +1,6 @@
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
+import { PaginatorState } from 'primeng/paginator';
 
 @Component({
     selector: 'basic-doc',
@@ -29,7 +23,7 @@ export class BasicDoc {
 
     rows: number = 10;
 
-    onPageChange(event: PageEvent) {
+    onPageChange(event: PaginatorState) {
         this.first = event.first;
         this.rows = event.rows;
     }
@@ -42,14 +36,7 @@ export class BasicDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { PaginatorModule } from 'primeng/paginator';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
+import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 
 @Component({
     selector: 'paginator-basic-demo',
@@ -62,7 +49,7 @@ export class PaginatorBasicDemo {
 
     rows: number = 10;
 
-    onPageChange(event: PageEvent) {
+    onPageChange(event: PaginatorState) {
         this.first = event.first;
         this.rows = event.rows;
     }

--- a/apps/showcase/doc/paginator/basicdoc.ts
+++ b/apps/showcase/doc/paginator/basicdoc.ts
@@ -24,8 +24,8 @@ export class BasicDoc {
     rows: number = 10;
 
     onPageChange(event: PaginatorState) {
-        this.first = event.first;
-        this.rows = event.rows;
+        this.first = event.first ?? 0;
+        this.rows = event.rows ?? 10;
     }
 
     code: Code = {
@@ -50,8 +50,8 @@ export class PaginatorBasicDemo {
     rows: number = 10;
 
     onPageChange(event: PaginatorState) {
-        this.first = event.first;
-        this.rows = event.rows;
+        this.first = event.first ?? 0;
+        this.rows = event.rows ?? 10;
     }
 }`
     };

--- a/apps/showcase/doc/paginator/currentpagereportdoc.ts
+++ b/apps/showcase/doc/paginator/currentpagereportdoc.ts
@@ -38,8 +38,8 @@ export class CurrentPageReportDoc {
     rows: number = 10;
 
     onPageChange(event: PaginatorState) {
-        this.first = event.first;
-        this.rows = event.rows;
+        this.first = event.first ?? 0;
+        this.rows = event.rows ?? 10;
     }
 
     code: Code = {
@@ -80,8 +80,8 @@ export class PaginatorCurrentPageReportDemo {
     rows: number = 10;
 
     onPageChange(event: PaginatorState) {
-        this.first = event.first;
-        this.rows = event.rows;
+        this.first = event.first ?? 0;
+        this.rows = event.rows ?? 10;
     }
 }`
     };

--- a/apps/showcase/doc/paginator/currentpagereportdoc.ts
+++ b/apps/showcase/doc/paginator/currentpagereportdoc.ts
@@ -1,12 +1,6 @@
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
+import { PaginatorState } from 'primeng/paginator';
 
 @Component({
     selector: 'current-page-report-doc',
@@ -43,7 +37,7 @@ export class CurrentPageReportDoc {
 
     rows: number = 10;
 
-    onPageChange(event: PageEvent) {
+    onPageChange(event: PaginatorState) {
         this.first = event.first;
         this.rows = event.rows;
     }
@@ -72,14 +66,7 @@ export class CurrentPageReportDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { PaginatorModule } from 'primeng/paginator';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
+import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 
 @Component({
     selector: 'paginator-current-page-report-demo',
@@ -92,7 +79,7 @@ export class PaginatorCurrentPageReportDemo {
 
     rows: number = 10;
 
-    onPageChange(event: PageEvent) {
+    onPageChange(event: PaginatorState) {
         this.first = event.first;
         this.rows = event.rows;
     }

--- a/apps/showcase/doc/paginator/imagesdoc.ts
+++ b/apps/showcase/doc/paginator/imagesdoc.ts
@@ -22,8 +22,8 @@ export class ImagesDoc {
     rows: number = 10;
 
     onPageChange(event: PaginatorState) {
-        this.first = event.first;
-        this.rows = event.rows;
+        this.first = event.first ?? 0;
+        this.rows = event.rows ?? 10;
     }
 
     code: Code = {
@@ -50,8 +50,8 @@ export class PaginatorImagesDemo {
     rows: number = 10;
 
     onPageChange(event: PaginatorState) {
-        this.first = event.first;
-        this.rows = event.rows;
+        this.first = event.first ?? 0;
+        this.rows = event.rows ?? 10;
     }
 }`
     };

--- a/apps/showcase/doc/paginator/imagesdoc.ts
+++ b/apps/showcase/doc/paginator/imagesdoc.ts
@@ -1,12 +1,6 @@
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
+import { PaginatorState } from 'primeng/paginator';
 
 @Component({
     selector: 'images-doc',
@@ -27,7 +21,7 @@ export class ImagesDoc {
 
     rows: number = 10;
 
-    onPageChange(event: PageEvent) {
+    onPageChange(event: PaginatorState) {
         this.first = event.first;
         this.rows = event.rows;
     }
@@ -44,13 +38,7 @@ export class ImagesDoc {
 
         typescript: `
 import { Component } from '@angular/core';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
+import { PaginatorState } from 'primeng/paginator';
 
 @Component({
     selector: 'paginator-images-demo',
@@ -61,7 +49,7 @@ export class PaginatorImagesDemo {
 
     rows: number = 10;
 
-    onPageChange(event: PageEvent) {
+    onPageChange(event: PaginatorState) {
         this.first = event.first;
         this.rows = event.rows;
     }

--- a/apps/showcase/doc/paginator/templatedoc.ts
+++ b/apps/showcase/doc/paginator/templatedoc.ts
@@ -79,18 +79,18 @@ export class TemplateDoc {
     ];
 
     onPageChange1(event: PaginatorState) {
-        this.first1 = event.first;
-        this.rows1 = event.rows;
+        this.first1 = event.first ?? 0;
+        this.rows1 = event.rows ?? 10;
     }
 
     onPageChange2(event: PaginatorState) {
-        this.first2 = event.first;
-        this.rows2 = event.rows;
+        this.first2 = event.first ?? 0;
+        this.rows2 = event.rows ?? 10;
     }
 
     onPageChange3(event: PaginatorState) {
-        this.first3 = event.first;
-        this.rows3 = event.rows;
+        this.first3 = event.first ?? 0;
+        this.rows3 = event.rows ?? 10;
     }
 
     code: Code = {
@@ -188,18 +188,18 @@ export class PaginatorTemplateDemo {
     ];
 
     onPageChange1(event: PaginatorState) {
-        this.first1 = event.first;
-        this.rows1 = event.rows;
+        this.first1 = event.first ?? 0;
+        this.rows1 = event.rows ?? 10;
     }
 
     onPageChange2(event: PaginatorState) {
-        this.first2 = event.first;
-        this.rows2 = event.rows;
+        this.first2 = event.first ?? 0;
+        this.rows2 = event.rows ?? 10;
     }
 
     onPageChange3(event: PaginatorState) {
-        this.first3 = event.first;
-        this.rows3 = event.rows;
+        this.first3 = event.first ?? 0;
+        this.rows3 = event.rows ?? 10;
     }
 }`
     };

--- a/apps/showcase/doc/paginator/templatedoc.ts
+++ b/apps/showcase/doc/paginator/templatedoc.ts
@@ -1,12 +1,6 @@
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
+import { PaginatorState } from 'primeng/paginator';
 
 @Component({
     selector: 'template-doc',
@@ -84,17 +78,17 @@ export class TemplateDoc {
         { label: 120, value: 120 }
     ];
 
-    onPageChange1(event: PageEvent) {
+    onPageChange1(event: PaginatorState) {
         this.first1 = event.first;
         this.rows1 = event.rows;
     }
 
-    onPageChange2(event: PageEvent) {
+    onPageChange2(event: PaginatorState) {
         this.first2 = event.first;
         this.rows2 = event.rows;
     }
 
-    onPageChange3(event: PageEvent) {
+    onPageChange3(event: PaginatorState) {
         this.first3 = event.first;
         this.rows3 = event.rows;
     }
@@ -159,18 +153,11 @@ export class TemplateDoc {
 </div>`,
 
         typescript: `import { Component } from '@angular/core';
-import { PaginatorModule } from 'primeng/paginator';
+import { PaginatorModule, PaginatorState } from 'primeng/paginator';
 import { ButtonModule } from 'primeng/button';
 import { DividerModule } from 'primeng/divider';
 import { Slider } from 'primeng/slider';
 import { FormsModule } from '@angular/forms';
-
-interface PageEvent {
-    first: number;
-    rows: number;
-    page: number;
-    pageCount: number;
-}
 
 @Component({
     selector: 'paginator-template-demo',
@@ -200,17 +187,17 @@ export class PaginatorTemplateDemo {
         { label: 120, value: 120 }
     ];
 
-    onPageChange1(event: PageEvent) {
+    onPageChange1(event: PaginatorState) {
         this.first1 = event.first;
         this.rows1 = event.rows;
     }
 
-    onPageChange2(event: PageEvent) {
+    onPageChange2(event: PaginatorState) {
         this.first2 = event.first;
         this.rows2 = event.rows;
     }
 
-    onPageChange3(event: PageEvent) {
+    onPageChange3(event: PaginatorState) {
         this.first3 = event.first;
         this.rows3 = event.rows;
     }


### PR DESCRIPTION
The current paginator documentation, shows the practice of manually defining a type interface in every example where the paginator is used, for the `onPageChange($event)` event emitter. In every example, the type of `$event` is manually defined like so:

```ts
interface PageEvent {
    first: number;
    rows: number;
    page: number;
    pageCount: number;
}

...

onPageChange(event: PageEvent) {
  this.first = event.first;
  this.rows = event.rows;
}
```

Since PrimeNG internally uses its own interface definition for this event, manually defining it in the users' project code could lead to errors in future updates where PrimeNG changes its internal interface for the `onPageChange($event)` event emitter. Having users use their own defined type would undo the benefits of typed javascript, as it would obscure potential issues or functionality.

In fact, the current duplicate definition of the interface you see above, is already unpaired/unsynchronised with PrimeNG's internal interface, which defines all properties as nullable. This already introduces possibilities for forgotten undefined-checks in the users code, as this is hidden by the use of the manually defined interface. This is a good example of why the current example could be considered a bad practice.

Therefore, I propose to remove the manual definition of the type `PageEvent` in the examples, and instead refer to the PrimeNG, which is available as `PaginatorState` in `primeng/paginator`.

Users could simply acquire this interface trough an import; and it would always be up to date with PrimeNG's functionality:
```ts
import { PaginatorState } from 'primeng/paginator';

...

onPageChange(event: PaginatorState) {
  this.first = event.first;
  this.rows = event.rows;
}
```

I hope this helps! With kind regards :)
