### PR TITLE
Remove unsupported ARIA attribute from MenuBar Fixes #16451

### DIFF
--- a/packages/primeng/src/menubar/menubar.ts
+++ b/packages/primeng/src/menubar/menubar.ts
@@ -97,7 +97,6 @@ export class MenubarService {
                     [attr.aria-disabled]="isItemDisabled(processedItem) || undefined"
                     [attr.aria-haspopup]="isItemGroup(processedItem) && !getItemProp(processedItem, 'to') ? 'menu' : undefined"
                     [attr.aria-expanded]="isItemGroup(processedItem) ? isItemActive(processedItem) : undefined"
-                    [attr.aria-level]="level + 1"
                     [attr.aria-setsize]="getAriaSetSize()"
                     [attr.aria-posinset]="getAriaPosInset(index)"
                     [ngStyle]="getItemProp(processedItem, 'style')"


### PR DESCRIPTION
Fixes #16451

Remove unsupported `aria-level` attribute from MenuBar component.

* Remove `aria-level` attribute from `packages/primeng/src/menubar/menubar.ts` for items with `role="menuitem"`