### PR TITLE
v19.0.7+ Fixing issue #17759 where we are referencing classes that havent been defined yet

### DIFF
--- a/packages/primeng/src/splitter/splitter.ts
+++ b/packages/primeng/src/splitter/splitter.ts
@@ -1,5 +1,23 @@
 import { CommonModule, isPlatformBrowser } from '@angular/common';
-import { AfterContentInit, ChangeDetectionStrategy, Component, computed, contentChild, ContentChildren, ElementRef, EventEmitter, inject, Input, NgModule, numberAttribute, Output, QueryList, ViewChild, ViewEncapsulation } from '@angular/core';
+import {
+    AfterContentInit,
+    ChangeDetectionStrategy,
+    Component,
+    computed,
+    contentChild,
+    ContentChildren,
+    ElementRef,
+    EventEmitter,
+    forwardRef,
+    inject,
+    Input,
+    NgModule,
+    numberAttribute,
+    Output,
+    QueryList,
+    ViewChild,
+    ViewEncapsulation
+} from '@angular/core';
 import { addClass, getHeight, getOuterHeight, getOuterWidth, getWidth, hasClass, isRTL, removeClass } from '@primeuix/utils';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
@@ -18,7 +36,7 @@ import { SplitterStyle } from './style/splitterstyle';
     }
 })
 export class SplitterPanel extends BaseComponent {
-    splitter = contentChild(Splitter);
+    splitter = contentChild(forwardRef(() => Splitter));
 
     nestedState = computed(() => this.splitter());
 }

--- a/packages/primeng/src/stepper/stepper.ts
+++ b/packages/primeng/src/stepper/stepper.ts
@@ -69,7 +69,7 @@ export interface StepPanelContentTemplateContext {
     }
 })
 export class StepList extends BaseComponent {
-    steps = contentChildren(Step);
+    steps = contentChildren(forwardRef(() => Step));
 }
 
 @Component({
@@ -115,9 +115,9 @@ export class StepItem extends BaseComponent {
 
     isActive = computed(() => this.pcStepper.value() === this.value());
 
-    step = contentChild(Step);
+    step = contentChild(forwardRef(() => Step));
 
-    stepPanel = contentChild(StepPanel);
+    stepPanel = contentChild(forwardRef(() => StepPanel));
 
     constructor() {
         super();


### PR DESCRIPTION
I believe this will fix issue #17759 where we are referencing classes before they've been defined. This causes issues when running unit tests with jest and receiving the error:

```
ReferenceError: Cannot access 'Splitter' before initialization
```

and

```
ReferenceError: Cannot access 'Step' before initialization
````