### PR TITLE
fix(floatlabel): Prevent placeholder rendering on top of floatlabel

### DIFF
--- a/packages/primeng/src/floatlabel/style/floatlabelstyle.ts
+++ b/packages/primeng/src/floatlabel/style/floatlabelstyle.ts
@@ -7,6 +7,24 @@ const theme = ({ dt }) => `
     position: relative;
 }
 
+.p-floatlabel .p-component::placeholder,
+.p-floatlabel .p-placeholder {
+    opacity: 0;
+    transition-property: all;
+    transition-timing-function: ease;
+    transition-duration: 0.2s;
+}
+
+.p-floatlabel:has(input:focus) input::placeholder,
+.p-floatlabel:has(input:-webkit-autofill) input::placeholder,
+.p-floatlabel:has(textarea:focus) .p-component::placeholder,
+.p-floatlabel:has(.p-inputwrapper-focus) .p-placeholder {
+    opacity: 1;
+    transition-property: all;
+    transition-timing-function: ease;
+    transition-duration: 0.2s;
+}
+
 .p-floatlabel label {
     position: absolute;
     pointer-events: none;


### PR DESCRIPTION
Make the placeholder invisible (opacity=0)  in situations where the floatlabel would be rendered in the same location.

### Defect Fixes
https://github.com/primefaces/primeng/issues/17778