### PR TITLE
fix(dialog): Ensure mask visibility state is consistent with dialog visibility

### DIFF
--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -1060,6 +1060,10 @@ export class Dialog extends BaseComponent implements OnInit, AfterContentInit, O
                 this.onContainerDestroy();
                 this.onHide.emit({});
                 this.cd.markForCheck();
+
+                if (this.maskVisible !== this.visible) {
+                    this.maskVisible = this.visible;
+                }
                 break;
             case 'visible':
                 this.onShow.emit({});


### PR DESCRIPTION
fix #17301

Animations if they are quickly changed between they lost sync because they are not done programatically. 
