### PR TITLE
fix(themes): unresolved modules for wildcard subpath entrypoints

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -26,11 +26,13 @@
         "exports": {
             ".": {
                 "types": "./index.d.mts",
-                "import": "./index.mjs"
+                "import": "./index.mjs",
+                "default": "./index.mjs"
             },
             "./*": {
                 "types": "./*/index.d.ts",
-                "import": "./*/index.mjs"
+                "import": "./*/index.mjs",
+                "default": "./*/index.mjs"
             }
         },
         "directory": "dist",


### PR DESCRIPTION
### Defect Fixes
Fixes #17059 

### Explanation

Various node environments can't resolve [conditional exports](https://nodejs.org/api/packages.html#conditional-exports). For compatibility, conditional exports should include a `default` export entrypoint.

> "default" - the generic fallback that always matches. Can be a CommonJS or ES module file. This condition should always come last. - [Node.js exerpt](https://nodejs.org/api/packages.html#conditional-exports)

The [PrimeNg](https://github.com/primefaces/primeng/tree/master/packages/primeng) package relies on [ng-packagr](https://github.com/ng-packagr/ng-packagr) in the [build step](https://github.com/primefaces/primeng/blob/master/packages/primeng/package.json#L33) to fill in the [`default` entrypoint](https://github.com/ng-packagr/ng-packagr/blob/a2c97b3bf0c4cb3fd61faff432b8e951e52745ad/src/lib/ng-package/entry-point/write-package.transform.ts#L372-L373), but `@primeng/themes` does not use `ng-packagr`.  `@primeng/themes` relies on [`publishConfig`](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#publishconfig) configuration in the `package.json`, so the `default` property should be added manually.