### PR TITLE
fix(tabs): "lazy" property doesn't do anything

### DIFF
--- a/apps/showcase/doc/tabs/lazydoc.ts
+++ b/apps/showcase/doc/tabs/lazydoc.ts
@@ -1,0 +1,134 @@
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'lazy-doc',
+    standalone: false,
+    template: `
+        <app-docsectiontext>
+            <p>Enabling <i>lazy</i> property of a Tab removes the content from the DOM until the tab is activated.</p>
+        </app-docsectiontext>
+        <div class="card">
+            <p-tabs value="0" [lazy]="true">
+                <p-tablist>
+                    <p-tab value="0">Header I</p-tab>
+                    <p-tab value="1">Header II</p-tab>
+                    <p-tab value="2">Header III</p-tab>
+                </p-tablist>
+                <p-tabpanels>
+                    <p-tabpanel value="0">
+                        <p class="m-0">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est
+                            laborum.
+                        </p>
+                    </p-tabpanel>
+                    <p-tabpanel value="1">
+                        <p class="m-0">
+                            Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo
+                            enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius modi.
+                        </p>
+                    </p-tabpanel>
+                    <p-tabpanel value="2">
+                        <p class="m-0">
+                            At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique sunt in
+                            culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil impedit quo minus.
+                        </p>
+                    </p-tabpanel>
+                </p-tabpanels>
+            </p-tabs>
+        </div>
+        <app-code [code]="code" selector="tabs-lazy-demo"></app-code>
+    `
+})
+export class LazyDoc {
+    code: Code = {
+        basic: `<p-tabs value="0" [lazy]="true">
+    <p-tablist>
+        <p-tab value="0">Header I</p-tab>
+        <p-tab value="1">Header II</p-tab>
+        <p-tab value="2">Header III</p-tab>
+    </p-tablist>
+    <p-tabpanels>
+        <p-tabpanel value="0">
+            <p class="m-0">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+                ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+                nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+                anim id est laborum.
+            </p>
+        </p-tabpanel>
+        <p-tabpanel value="1">
+            <p class="m-0">
+                Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+                aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+                Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+                dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius
+                modi.
+            </p>
+        </p-tabpanel>
+        <p-tabpanel value="2">
+            <p class="m-0">
+                At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti
+                atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique
+                sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum
+                facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil
+                impedit quo minus.
+            </p>
+        </p-tabpanel>
+    </p-tabpanels>
+</p-tabs>`,
+
+        html: `<div class="card">
+    <p-tabs value="0" [lazy]="true">
+        <p-tablist>
+            <p-tab value="0">Header I</p-tab>
+            <p-tab value="1">Header II</p-tab>
+            <p-tab value="2">Header III</p-tab>
+        </p-tablist>
+        <p-tabpanels>
+            <p-tabpanel value="0">
+                <p class="m-0">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+                    dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
+                    ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
+                    nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
+                    anim id est laborum.
+                </p>
+            </p-tabpanel>
+            <p-tabpanel value="1">
+                <p class="m-0">
+                    Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem
+                    aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo.
+                    Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni
+                    dolores eos qui ratione voluptatem sequi nesciunt. Consectetur, adipisci velit, sed quia non numquam eius
+                    modi.
+                </p>
+            </p-tabpanel>
+            <p-tabpanel value="2">
+                <p class="m-0">
+                    At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti
+                    atque corrupti quos dolores et quas molestias excepturi sint occaecati cupiditate non provident, similique
+                    sunt in culpa qui officia deserunt mollitia animi, id est laborum et dolorum fuga. Et harum quidem rerum
+                    facilis est et expedita distinctio. Nam libero tempore, cum soluta nobis est eligendi optio cumque nihil
+                    impedit quo minus.
+                </p>
+            </p-tabpanel>
+        </p-tabpanels>
+    </p-tabs>
+</div>`,
+
+        typescript: `import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TabsModule } from 'primeng/tabs';
+
+@Component({
+    selector: 'tabs-lazy-demo',
+    templateUrl: './tabs-lazy-demo.html',
+    standalone: true,
+    imports: [CommonModule, TabsModule]
+})
+export class TabsLazyDemo {}`
+    };
+}

--- a/apps/showcase/doc/tabs/tabsdoc.module.ts
+++ b/apps/showcase/doc/tabs/tabsdoc.module.ts
@@ -14,12 +14,13 @@ import { TemplateDoc } from './customtemplatedoc';
 import { DisabledDoc } from './disableddoc';
 import { DynamicDoc } from './dynamicdoc';
 import { ImportDoc } from './importdoc';
+import { LazyDoc } from './lazydoc';
 import { ScrollableDoc } from './scrollabledoc';
 import { TabmenuDoc } from './tabmenudoc';
 
 @NgModule({
     imports: [CommonModule, AppCodeModule, AppDocModule, TabsModule, RouterModule, ButtonModule, AvatarModule, BadgeModule],
     exports: [AppDocModule],
-    declarations: [ImportDoc, BasicDoc, ControlledDoc, DynamicDoc, DisabledDoc, TemplateDoc, ScrollableDoc, TabmenuDoc, AccessibilityDoc]
+    declarations: [ImportDoc, BasicDoc, ControlledDoc, DynamicDoc, DisabledDoc, LazyDoc, TemplateDoc, ScrollableDoc, TabmenuDoc, AccessibilityDoc]
 })
 export class TabsDocModule {}

--- a/apps/showcase/pages/tabs/index.ts
+++ b/apps/showcase/pages/tabs/index.ts
@@ -5,6 +5,7 @@ import { TemplateDoc } from '@/doc/tabs/customtemplatedoc';
 import { DisabledDoc } from '@/doc/tabs/disableddoc';
 import { DynamicDoc } from '@/doc/tabs/dynamicdoc';
 import { ImportDoc } from '@/doc/tabs/importdoc';
+import { LazyDoc } from '@/doc/tabs/lazydoc';
 import { ScrollableDoc } from '@/doc/tabs/scrollabledoc';
 import { TabmenuDoc } from '@/doc/tabs/tabmenudoc';
 import { TabsDocModule } from '@/doc/tabs/tabsdoc.module';
@@ -41,6 +42,11 @@ export class TabsDemo {
             id: 'scrollable',
             label: 'Scrollable',
             component: ScrollableDoc
+        },
+        {
+            id: 'lazy',
+            label: 'Lazy',
+            component: LazyDoc
         },
         {
             id: 'disabled',

--- a/packages/primeng/src/tabs/tabpanel.ts
+++ b/packages/primeng/src/tabs/tabpanel.ts
@@ -12,9 +12,15 @@ import { Tabs } from './tabs';
     selector: 'p-tabpanel',
     standalone: true,
     imports: [CommonModule],
-    template: `@if (active()) {
-        <ng-content></ng-content>
-    }`,
+    template: `
+        <ng-template #content>
+            <ng-content></ng-content>
+        </ng-template>
+
+        @if (!lazy() || active()) {
+            <ng-container *ngTemplateOutlet="content"></ng-container>
+        }
+    `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
@@ -24,11 +30,12 @@ import { Tabs } from './tabs';
         '[attr.id]': 'id()',
         '[attr.role]': '"tabpanel"',
         '[attr.aria-labelledby]': 'ariaLabelledby()',
-        '[attr.data-p-active]': 'active()'
+        '[attr.data-p-active]': 'active()',
+        '[hidden]': '!active()'
     }
 })
 export class TabPanel extends BaseComponent {
-    pcTabs = inject(forwardRef(() => Tabs));
+    pcTabs: Tabs = inject(forwardRef(() => Tabs));
     /**
      * Value of the active tab.
      * @defaultValue undefined
@@ -41,4 +48,6 @@ export class TabPanel extends BaseComponent {
     ariaLabelledby = computed(() => `${this.pcTabs.id()}_tab_${this.value()}`);
 
     active = computed(() => equals(this.pcTabs.value(), this.value()));
+
+    lazy = computed(() => this.pcTabs.lazy());
 }


### PR DESCRIPTION
Fixes #16806 
There is already a PR that resolved that issue, however I kept the original [lazy] flag functionality so you can toggle it on and off (false by default as described in the docs).

