### PR TITLE
fix: dt styles not loading for drawer set to [modal]="false"

### DIFF
--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -358,6 +358,8 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
     }
 
     show() {
+        this.container.setAttribute(this.attrSelector, '');
+
         if (this.autoZIndex) {
             ZIndexUtils.set('modal', this.container, this.baseZIndex || this.config.zIndex.modal);
         }
@@ -390,7 +392,6 @@ export class Drawer extends BaseComponent implements AfterViewInit, AfterContent
         const activeDrawers = this.document.querySelectorAll('.p-drawer-active');
         const activeDrawersLength = activeDrawers.length;
         const zIndex = activeDrawersLength == 1 ? String(parseInt((this.container as HTMLDivElement).style.zIndex) - 1) : String(parseInt((activeDrawers[activeDrawersLength - 1] as HTMLElement).style.zIndex) - 1);
-        this.container.setAttribute(this.attrSelector, '');
 
         if (!this.mask) {
             this.mask = this.renderer.createElement('div');


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/17840

It appears this line was being set to solve a similar issue that was run into before with the drawer but only when the overlay mask was being applied. Moved this line out into the show handler so it covers both modal/non-modal cases.
