### PR TITLE
feat(tree): Pass node.loading to togglerIconTemplate context

### DIFF
--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -111,7 +111,7 @@ import {
                             </ng-container>
                         </ng-container>
                         <span *ngIf="tree.togglerIconTemplate || tree._togglerIconTemplate" class="p-tree-node-toggle-icon">
-                            <ng-template *ngTemplateOutlet="tree.togglerIconTemplate || tree._togglerIconTemplate; context: { $implicit: node.expanded }"></ng-template>
+                            <ng-template *ngTemplateOutlet="tree.togglerIconTemplate || tree._togglerIconTemplate; context: { $implicit: node.expanded, loading: node.loading }"></ng-template>
                         </span>
                     </button>
 


### PR DESCRIPTION
# feat(tree): Pass `node.loading` to `togglerIconTemplate` context  

## Description  
This PR extends the `togglerIconTemplate` context to include `node.loading`, in addition to `node.expanded`.  

## Changes  
- Updated `*ngTemplateOutlet` context to:  
  ```ts
  context: { $implicit: node.expanded, loading: node.loading }
  ```

## Why?

Currently, custom toggler templates can determine whether a node is expanded but not whether it is loading. This addition allows developers to show a spinner or other indicators when nodes are asynchronously loading.

## Linked Issue
Closes #17851 