### PR TITLE
Fixes #17866 - Emit correct index value when an AccordionHeader is clicked 

### DIFF
--- a/packages/primeng/src/accordion/accordion.ts
+++ b/packages/primeng/src/accordion/accordion.ts
@@ -183,9 +183,7 @@ export class AccordionHeader extends BaseComponent {
         this.changeActiveValue();
 
         const isActive = this.active();
-
-        const panels = this.pcAccordion.panelList ? this.pcAccordion.panelList.toArray() : [];
-        const index = panels.findIndex((panel) => panel === this.pcAccordionPanel);
+        const index = this.pcAccordionPanel.value();
 
         if (!wasActive && isActive) {
             this.pcAccordion.onOpen.emit({ originalEvent: event, index });


### PR DESCRIPTION
### Defect Fixes

Fixes [[Accordion] onOpen and onClose events emit wrong index value #17866](https://github.com/primefaces/primeng/issues/17866)
