### PR TITLE
Fix: Inftalabel for other fields caused by PR#17755

### DIFF
--- a/packages/primeng/src/iftalabel/style/iftalabelstyle.ts
+++ b/packages/primeng/src/iftalabel/style/iftalabelstyle.ts
@@ -27,7 +27,13 @@ const theme = ({ dt }) => `
 .p-iftalabel .p-multiselect-label-container,
 .p-iftalabel .p-autocomplete-input-multiple,
 .p-iftalabel .p-cascadeselect-label,
-.p-iftalabel .p-treeselect-label {
+.p-iftalabel .p-treeselect-label,
+.p-iftalabel .p-datepicker-input,
+.p-iftalabel .p-inputmask,
+.p-iftalabel .p-autocomplete .p-inputtext,
+.p-iftalabel .p-inputnumber .p-inputtext,
+.p-iftalabel .p-password .p-inputtext,
+.p-iftalabel > .p-iconfield .p-inputtext {
     padding-top: ${dt('iftalabel.input.padding.top')};
 }
 
@@ -42,7 +48,7 @@ const theme = ({ dt }) => `
     color: ${dt('iftalabel.focus.color')};
 }
 
-.p-iftalabel > .p-inputicon {
+.p-iftalabel > .p-iconfield .p-inputicon {
     top: ${dt('iftalabel.input.padding.top')};
     transform: translateY(25%);
     margin-top: 0;


### PR DESCRIPTION
**Fix solution for:**
https://github.com/primefaces/primeng/issues/17841

Problem:
After correcting the iftalabel for the filter field in the multi-select select components, a side effect occurred in other components.

Solution:
It was necessary to style the individual components and in the iconfield component it was necessary to style only the next element, the same as with inputText.


Screens:

Autocomplete:
![image](https://github.com/user-attachments/assets/4bb52297-7844-46dc-be7f-eb0b058003e1)

CascadeSelect:
![image](https://github.com/user-attachments/assets/40384bfb-429b-4a5d-843d-8f2c931aff33)

Datepicker:
![image](https://github.com/user-attachments/assets/223d52cf-1c59-408e-b02c-8d73391a8e0a)

Iconfield:
![image](https://github.com/user-attachments/assets/f87d97b4-1b84-4105-bcd7-c9c1193cbdea)

InputGroup:
![image](https://github.com/user-attachments/assets/5f9010df-ce0c-4f45-b15f-8f2690196f41)

InputMask:
![image](https://github.com/user-attachments/assets/e9cb68a2-71c3-494c-b6ee-3fe99ec002cf)

InputNumber:
![image](https://github.com/user-attachments/assets/25a54424-f8d7-49be-8cfe-7cd31fbd3a66)

InputText:
![image](https://github.com/user-attachments/assets/d0216b9c-de44-4b7d-90d2-522a637b693b)

MultiSelect:
![image](https://github.com/user-attachments/assets/f7ccd24b-8894-4f4f-b698-4cb1d86368bf)

Password:
![image](https://github.com/user-attachments/assets/0387edde-3e92-40fa-b928-5f738c6cd962)

Select:
![image](https://github.com/user-attachments/assets/e6f510d3-c827-44ce-9db9-7c50f824f2ef)

TreeSelect:
![image](https://github.com/user-attachments/assets/3d0f57ab-db12-4bb2-bae8-9010bf2d2493)

