### PR TITLE
#17888: Fixed range date-picker showing wrong date as selected date

### DIFF
--- a/packages/primeng/src/datepicker/style/datepickerstyle.ts
+++ b/packages/primeng/src/datepicker/style/datepickerstyle.ts
@@ -458,7 +458,7 @@ const classes = {
         let selectedDayClass = '';
 
         if (instance.isRangeSelection() && instance.isSelected(date) && date.selectable) {
-            selectedDayClass = date.day === instance.value[0].getDate() || date.day === instance.value[1].getDate() ? 'p-datepicker-day-selected' : 'p-datepicker-day-selected-range';
+            selectedDayClass = (date.day === instance.value[0].getDate() && date.month === instance.value[0].getMonth()) || (date.day === instance.value[1].getDate() && date.month === instance.value[1].getMonth()) ? 'p-datepicker-day-selected' : 'p-datepicker-day-selected-range';
         }
 
         return {


### PR DESCRIPTION
Fixes #17888: Range datepicker showing wrong selected date fixed

**Steps to reproduce the behavior:**
1) Select a date in a given month as first date.
2) Select a date in the following month as second date.

**Bug:** `.p-datepicker-day-selected` class was applied if the date matches, so as a result if I select 12 Jan 2025 as my start date and 15 Feb 2025 as my end date then 12 and 15 date will be shown as selected in Jan and Feb both

**Expected behavior:** Coloured date should ONLY reflect the selected date. All dates in between should be light-coloured like the ones working correctly (even the ones from the previous month that get rendered in the current month template)

**Solution:** `.p-datepicker-day-selected` class should only be applied if date and month matches

**Screenshots before fix:**
![image](https://github.com/user-attachments/assets/30667082-971f-4ee2-917a-d013508649e7)
![image](https://github.com/user-attachments/assets/0b39150c-a7e0-47a8-b3c0-4b492386b354)


**Screenshots after fix:**
![image](https://github.com/user-attachments/assets/4ab72666-e96a-4149-8d1e-702d6db2a522)
![image](https://github.com/user-attachments/assets/94fad333-97f6-4d35-93b2-0e470f84696d)

_Note:_ I have used Aura as my based theme and Emerald as primary color, I have tested my solution with different combination of selection has all looks good as expected :)





