### PR TITLE
Fix docs for selecteditems template in multiselect

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.interface.ts
+++ b/packages/primeng/src/multiselect/multiselect.interface.ts
@@ -127,7 +127,7 @@ export interface MultiSelectTemplates {
      * Custom selected item template.
      * @param {Object} context - selected items data.
      */
-    selectedItems(context: {
+    selecteditems(context: {
         /**
          * Selected option value.
          */


### PR DESCRIPTION
Fixes #17892 - `selectedItems` template has incorrect casing in the docs.
