### PR TITLE
fix: Multiselect option should have the p-multiselect-option-selected class if options is selected

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -85,7 +85,8 @@ export const MULTISELECT_VALUE_ACCESSOR: any = {
             [ngClass]="{
                 'p-multiselect-option': true,
                 'p-disabled': disabled,
-                'p-focus': focused
+                'p-focus': focused,
+                'p-multiselect-option-selected': selected
             }"
             [id]="id"
             [attr.aria-label]="label"


### PR DESCRIPTION
[17894](https://github.com/primefaces/primeng/issues/17894)