### PR TITLE
fix(TreeTable): Use margin-inline-start for proper RTL alignment

### DIFF
--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -3825,7 +3825,7 @@ export class TTRow {
             tabindex="-1"
             pRipple
             [style.visibility]="rowNode.node.leaf === false || (rowNode.node.children && rowNode.node.children.length) ? 'visible' : 'hidden'"
-            [style.marginLeft]="rowNode.level * 16 + 'px'"
+            [style.marginInlineStart]="rowNode.level * 16 + 'px'"
             [attr.data-pc-section]="'rowtoggler'"
             [attr.data-pc-group-section]="'rowactionbutton'"
             [attr.aria-label]="toggleButtonAriaLabel"


### PR DESCRIPTION
## Fix: TreeTable expand icon misalignment in RTL mode  

This PR fixes an issue where TreeTable expand icons were misaligned when using **RTL mode**. The issue was caused by a hardcoded `margin-left`, which didn't adapt to the text direction.

### Changes:  
- **Replaced** `[style.marginLeft]` with `[style.marginInlineStart]` in `p-treetable-toggler`.  
- **Ensures proper indentation** for child expand icons in **both LTR and RTL** modes.  
- Fixes incorrect alignment where child icons appeared **directly under parent icons** in RTL.

### Linked Issue  
Fixes #17780

### Notes  
- This change is **fully backward-compatible** with LTR behavior.  
- No breaking changes. 