### PR TITLE
fix: set correct aria-hidden value on carousel items

### DIFF
--- a/packages/primeng/src/carousel/carousel.ts
+++ b/packages/primeng/src/carousel/carousel.ts
@@ -87,7 +87,7 @@ import { CarouselStyle } from './style/carouselstyle';
                                     'p-carousel-item-start': firstIndex() === index,
                                     'p-carousel-item-end': lastIndex() === index
                                 }"
-                                [attr.aria-hidden]="!(totalShiftedItems * -1 === value.length)"
+                                [attr.aria-hidden]="!(firstIndex() <= index && lastIndex() >= index)"
                                 [attr.aria-label]="ariaSlideNumber(index)"
                                 [attr.aria-roledescription]="ariaSlideLabel()"
                             >


### PR DESCRIPTION
Sets the correct value for aria-hidden on carousel items depending on the visibility of the item.