### PR TITLE
fix: changed how tooltip identifies if is attached on primeng component

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -527,7 +527,7 @@ export class Tooltip extends BaseComponent implements AfterViewInit, OnDestroy {
     }
 
     private get activeElement(): HTMLElement {
-        return this.el.nativeElement.nodeName.includes('P-') ? findSingle(this.el.nativeElement, '.p-component') : this.el.nativeElement;
+        return this.el.nativeElement.nodeName.startsWith('P-') ? findSingle(this.el.nativeElement, '.p-component') : this.el.nativeElement;
     }
 
     alignRight() {


### PR DESCRIPTION
changed how tooltip identifies if is attached on primeng componentnt from includes("P-") to startsWith("P-") because even "app-component" is identified as primeng component.
That causes a wrong alignment on non-primeng components

#17980 
