### PR TITLE
Add missing ng-invalid css rules for alternative component selectors

### DIFF
--- a/packages/primeng/src/calendar/style/calendarstyle.ts
+++ b/packages/primeng/src/calendar/style/calendarstyle.ts
@@ -377,7 +377,9 @@ p-calendar.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext{
     border-color: ${dt('inputtext.invalid.border.color')};
 }
 
-p-datepicker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext{
+p-datePicker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext,
+p-date-picker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext,
+p-datepicker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext {
     border-color: ${dt('inputtext.invalid.border.color')};
 }
 `;

--- a/packages/primeng/src/cascadeselect/style/cascadeselectstyle.ts
+++ b/packages/primeng/src/cascadeselect/style/cascadeselectstyle.ts
@@ -17,10 +17,14 @@ const theme = ({ dt }) => `
     box-shadow: ${dt('cascadeselect.shadow')};
 }
 
+p-cascadeSelect.ng-invalid.ng-dirty .p-cascadeselect,
+p-cascade-select.ng-invalid.ng-dirty .p-cascadeselect,
 p-cascadeselect.ng-invalid.ng-dirty .p-cascadeselect {
     border-color: ${dt('cascadeselect.invalid.border.color')};
 }
 
+p-cascadeSelect.ng-invalid.ng-dirty .p-cascadeselect.p-focus,
+p-cascade-select.ng-invalid.ng-dirty .p-cascadeselect.p-focus,
 p-cascadeselect.ng-invalid.ng-dirty .p-cascadeselect.p-focus {
     border-color: ${dt('cascadeselect.focus.border.color')};
 }

--- a/packages/primeng/src/checkbox/style/checkboxstyle.ts
+++ b/packages/primeng/src/checkbox/style/checkboxstyle.ts
@@ -85,6 +85,8 @@ const theme = ({ dt }) => `
     border-color: ${dt('checkbox.checked.focus.border.color')};
 }
 
+p-checkBox.ng-invalid.ng-dirty .p-checkbox-box,
+p-check-box.ng-invalid.ng-dirty .p-checkbox-box,
 p-checkbox.ng-invalid.ng-dirty .p-checkbox-box {
     border-color: ${dt('checkbox.invalid.border.color')};
 }

--- a/packages/primeng/src/datepicker/style/datepickerstyle.ts
+++ b/packages/primeng/src/datepicker/style/datepickerstyle.ts
@@ -418,9 +418,12 @@ p-calendar.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext{
     border-color: ${dt('inputtext.invalid.border.color')};
 }
 
-p-datepicker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext{
+p-datePicker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext,
+p-date-picker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext,
+p-datepicker.ng-invalid.ng-dirty .p-datepicker.p-inputwrapper .p-inputtext {
     border-color: ${dt('inputtext.invalid.border.color')};
 }
+
 `;
 
 const inlineStyles = {

--- a/packages/primeng/src/inputmask/style/inputmaskstyle.ts
+++ b/packages/primeng/src/inputmask/style/inputmaskstyle.ts
@@ -15,14 +15,20 @@ p-inputmask {
     color: ${dt('form.field.icon.color')};
 }
 
+p-inputMask.ng-invalid.ng-dirty > .p-inputtext,
+p-input-mask.ng-invalid.ng-dirty > .p-inputtext,
 p-inputmask.ng-invalid.ng-dirty > .p-inputtext {
     border-color: ${dt('inputtext.invalid.border.color')};
 }
 
+p-inputMask.ng-invalid.ng-dirty > .p-inputtext:enabled:focus,
+p-input-mask.ng-invalid.ng-dirty > .p-inputtext:enabled:focus,
 p-inputmask.ng-invalid.ng-dirty > .p-inputtext:enabled:focus {
     border-color: ${dt('inputtext.focus.border.color')};
 }
 
+p-inputMask.ng-invalid.ng-dirty > .p-inputtext::placeholder,
+p-input-mask.ng-invalid.ng-dirty > .p-inputtext::placeholder,
 p-inputmask.ng-invalid.ng-dirty > .p-inputtext::placeholder {
     color: ${dt('inputtext.invalid.placeholder.color')};
 }

--- a/packages/primeng/src/inputnumber/style/inputnumberstyle.ts
+++ b/packages/primeng/src/inputnumber/style/inputnumberstyle.ts
@@ -171,14 +171,20 @@ const theme = ({ dt }) => `
     height: ${dt('form.field.lg.font.size')};
 }
 
+p-inputNumber.ng-invalid.ng-dirty > .p-inputtext,
+p-input-number.ng-invalid.ng-dirty > .p-inputtext,
 p-inputnumber.ng-invalid.ng-dirty > .p-inputtext {
     border-color: ${dt('inputtext.invalid.border.color')};
 }
 
+p-inputNumber.ng-invalid.ng-dirty > .p-inputtext:enabled:focus,
+p-input-number.ng-invalid.ng-dirty > .p-inputtext:enabled:focus,
 p-inputnumber.ng-invalid.ng-dirty > .p-inputtext:enabled:focus {
     border-color: ${dt('inputtext.focus.border.color')};
 }
 
+p-inputNumber.ng-invalid.ng-dirty > .p-inputtext::placeholder,
+p-input-number.ng-invalid.ng-dirty > .p-inputtext::placeholder,
 p-inputnumber.ng-invalid.ng-dirty > .p-inputtext::placeholder {
     color: ${dt('inputtext.invalid.placeholder.color')};
 }

--- a/packages/primeng/src/listbox/style/listboxstyle.ts
+++ b/packages/primeng/src/listbox/style/listboxstyle.ts
@@ -125,6 +125,8 @@ const theme = ({ dt }) => `
 
 /* For PrimeNG */
 
+p-listBox.ng-invalid.ng-dirty > .p-listbox.p-component,
+p-list-box.ng-invalid.ng-dirty > .p-listbox.p-component,
 p-listbox.ng-invalid.ng-dirty > .p-listbox.p-component {
     border-color: ${dt('listbox.invalid.border.color')};
 }

--- a/packages/primeng/src/multiselect/style/multiselectstyle.ts
+++ b/packages/primeng/src/multiselect/style/multiselectstyle.ts
@@ -83,6 +83,8 @@ const theme = ({ dt }) => `
     color: ${dt('multiselect.placeholder.color')};
 }
 
+p-multiSelect.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder,
+p-multi-select.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder,
 p-multiselect.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder {
     color: ${dt('multiselect.invalid.placeholder.color')};
 }

--- a/packages/primeng/src/radiobutton/style/radiobuttonstyle.ts
+++ b/packages/primeng/src/radiobutton/style/radiobuttonstyle.ts
@@ -90,6 +90,8 @@ const theme = ({ dt }) => `
     border-color: ${dt('radiobutton.checked.focus.border.color')};
 }
 
+p-radioButton.ng-invalid.ng-dirty .p-radiobutton-box,
+p-radio-button.ng-invalid.ng-dirty .p-radiobutton-box,
 p-radiobutton.ng-invalid.ng-dirty .p-radiobutton-box {
     border-color: ${dt('radiobutton.invalid.border.color')};
 }

--- a/packages/primeng/src/toggleswitch/style/toggleswitchstyle.ts
+++ b/packages/primeng/src/toggleswitch/style/toggleswitchstyle.ts
@@ -112,6 +112,8 @@ const theme = ({ dt }) => `
 
 /* For PrimeNG */
 
+p-toggleSwitch.ng-invalid.ng-dirty > .p-toggleswitch > .p-toggleswitch-slider,
+p-toggle-switch.ng-invalid.ng-dirty > .p-toggleswitch > .p-toggleswitch-slider,
 p-toggleswitch.ng-invalid.ng-dirty > .p-toggleswitch > .p-toggleswitch-slider {
     border-color: ${dt('toggleswitch.invalid.border.color')};
 }`;

--- a/packages/primeng/src/treeselect/style/treeselectstyle.ts
+++ b/packages/primeng/src/treeselect/style/treeselectstyle.ts
@@ -17,10 +17,14 @@ const theme = ({ dt }) => `
     box-shadow: ${dt('treeselect.shadow')};
 }
 
+p-treeSelect.ng-invalid.ng-dirty .p-treeselect,
+p-tree-select.ng-invalid.ng-dirty .p-treeselect,
 p-treeselect.ng-invalid.ng-dirty .p-treeselect {
     border-color: ${dt('treeselect.invalid.border.color')};
 }
 
+p-treeSelect.ng-invalid.ng-dirty .p-treeselect.p-focus,
+p-tree-select.ng-invalid.ng-dirty .p-treeselect.p-focus,
 p-treeselect.ng-invalid.ng-dirty .p-treeselect.p-focus {
     border-color: ${dt('treeselect.focus.border.color')};
 }


### PR DESCRIPTION
Add missing css rules to allow the ng-invalide markings also for alternative supported selectors of components where these rules were missing

Issue will be created shortly.