### PR TITLE
fix: Add missing data in example tabmenudoc.ts

### DIFF
--- a/apps/showcase/doc/tabs/tabmenudoc.ts
+++ b/apps/showcase/doc/tabs/tabmenudoc.ts
@@ -73,6 +73,13 @@ import { TabsModule } from 'primeng/tabs';
     standalone: true,
     imports: [TabsModule, RouterModule, CommonModule]
 })
-export class TabsTabmenuDemo {}`
+export class TabsTabmenuDemo {
+    tabs = [
+        { route: 'dashboard', label: 'Dashboard', icon: 'pi pi-home' },
+        { route: 'transactions', label: 'Transactions', icon: 'pi pi-chart-line' },
+        { route: 'products', label: 'Products', icon: 'pi pi-list' },
+        { route: 'messages', label: 'Messages', icon: 'pi pi-inbox' }
+    ];
+}`
     };
 }


### PR DESCRIPTION
In the example provided in the docs, data is accessed in the template but this data and its format is not reflected in the typescript file. This would fix this inconsistency. 
