### PR TITLE
feat(table): allow setting value filter filtering table

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -6254,9 +6254,12 @@ export class ColumnFilterFormElement implements OnInit {
     ) {}
 
     ngOnInit() {
-        this.filterCallback = (value: any) => {
+        this.filterCallback = (value: any, skipFilter: boolean = false) => {
             (<any>this.filterConstraint).value = value;
-            this.dt._filter();
+
+            if (!skipFilter) {
+                this.dt._filter();
+            }
         };
     }
 


### PR DESCRIPTION
### Defect Fixes

#16132 

### Changes

This PR addresses an oversight with the table column filtering mechanism when combined with the `lazy` property and a custom `#filter` template.

Currently, using a custom filter template causes the parent `p-table` to trigger the `onFilter` event every time the input changes. This behavior can be undesirable in `lazy` mode, as it often initiates an API request in response to filter updates. The changes in this PR introduce the option to trigger the `onFilter` event only when the user clicks the submit button.

```html
<p-columnFilter
  field="tags"
  matchMode="contains"
  display="menu"
  showMatchModes="false"
  showOperator="false"
  showAddButton="false">
  <ng-template #filter let-value let-filter="filterCallback">
    <p-select
      [ngModel]="value"
      [options]="[]"
      <!-- passing true here will avoid an onFilter trigger when the input changes -->
      (onChange)="filter($event.value, true)"
      placeholder="Tag"
      styleClass="w-full">
    </p-select>
  </ng-template>
</p-columnFilter>
```