### PR TITLE
fix: #18002, Knob: Hand Icon missing while hovering over knob range

### DIFF
--- a/packages/primeng/src/knob/style/knobstyle.ts
+++ b/packages/primeng/src/knob/style/knobstyle.ts
@@ -5,6 +5,7 @@ const theme = ({ dt }) => `
 .p-knob-range {
     fill: none;
     transition: stroke 0.1s ease-in;
+    cursor: pointer;
 }
 
 .p-knob-value {


### PR DESCRIPTION
fix: #18002, Knob: Hand Icon missing while hovering over knob range