### PR TITLE
The class p-datatable-column-title should have "display: none" by default.

### DIFF
--- a/packages/primeng/src/table/style/tablestyle.ts
+++ b/packages/primeng/src/table/style/tablestyle.ts
@@ -333,6 +333,10 @@ const theme = ({ dt }) => `
 }
 */
 
+.p-datatable-column-title {
+    display: none;
+}
+
 .p-datatable-tbody > tr {
     outline-color: transparent;
     background: ${dt('datatable.row.background')};


### PR DESCRIPTION
There is a @media screen and (max-width) style that sets "display: block".

Contributes to #16510 