### PR TITLE
fixed #18033 - DynamicDialog selects content when resized

### DIFF
--- a/packages/primeng/src/base/style/basestyle.ts
+++ b/packages/primeng/src/base/style/basestyle.ts
@@ -90,6 +90,10 @@ const theme = ({ dt }) => `
     height: ${dt('icon.size')};
 }
 
+.p-unselectable-text {
+    user-select: none;
+}
+
 .p-overlay-mask {
     background: ${dt('mask.background')};
     color: ${dt('mask.color')};


### PR DESCRIPTION

fixed #18033 

After analyzing v17 which did not have this problem,  I determined that some CSS was inadvertently removed.  The fix was to add back the missing CSS.


The video listed below shows the functionality working properly after the code fix


https://github.com/user-attachments/assets/d3ad67fd-995f-4377-a495-a856cdb2b965

