### PR TITLE
fix(frozen-column): correctly accumulate offsets for multiple frozen columns for #18036

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -3565,22 +3565,23 @@ export class FrozenColumn implements AfterViewInit {
         if (this._frozen) {
             if (this.alignFrozen === 'right') {
                 let right = 0;
-                let next = this.el.nativeElement.nextElementSibling;
-                if (next) {
-                    right = DomHandler.getOuterWidth(next) + (parseFloat(next.style.right) || 0);
+                let sibling = this.el.nativeElement.nextElementSibling;
+                while (sibling) {
+                    right += DomHandler.getOuterWidth(sibling);
+                    sibling = sibling.nextElementSibling;
                 }
                 this.el.nativeElement.style.right = right + 'px';
             } else {
                 let left = 0;
-                let prev = this.el.nativeElement.previousElementSibling;
-                if (prev) {
-                    left = DomHandler.getOuterWidth(prev) + (parseFloat(prev.style.left) || 0);
+                let sibling = this.el.nativeElement.previousElementSibling;
+                while (sibling) {
+                    left += DomHandler.getOuterWidth(sibling);
+                    sibling = sibling.previousElementSibling;
                 }
                 this.el.nativeElement.style.left = left + 'px';
             }
 
             const filterRow = this.el.nativeElement?.parentElement?.nextElementSibling;
-
             if (filterRow) {
                 let index = DomHandler.index(this.el.nativeElement);
                 if (filterRow.children && filterRow.children[index]) {


### PR DESCRIPTION
## Description

This PR addresses an issue with frozen columns in PrimeNG where three or more frozen columns were overlapping. The problem stemmed from the sticky position calculation in the `FrozenColumn` directive, which only considered the immediate previous (or next) sibling. As a result, the offset was not accumulated properly when multiple frozen columns were present.

## Changes

- **Updated Offset Calculation:**  
  The `updateStickyPosition()` method in the `FrozenColumn` directive now iterates over all previous siblings (for left alignment) or all next siblings (for right alignment) to accumulate their outer widths. This ensures each frozen column is positioned correctly without overlapping.

- **Responsive Recalculation:**  
  The recalculation on window resize now correctly accounts for the cumulative widths of adjacent frozen columns.

## Benefits

- **Correct Layout:**  
  Prevents overlapping of frozen columns when three or more are used.

- **Improved User Experience:**  
  Ensures frozen columns remain properly aligned during window resize and table layout changes.

Please review the changes and let me know if any further adjustments are needed. Thanks!

#18036 
