### PR TITLE
fix: critical flaw in InputNumber.concatValues()

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -1453,7 +1453,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
             this._decimal.lastIndex = 0;
 
             if (this.suffixChar) {
-                return decimalCharIndex !== -1 ? val1 : val1.replace(this.suffixChar, '').split(this._decimal)[0] + val2.replace(this.suffixChar, '').slice(decimalCharIndex) + this.suffixChar;
+                return decimalCharIndex !== -1 ? val1.replace(this.suffixChar, '').split(this._decimal)[0] + val2.replace(this.suffixChar, '').slice(decimalCharIndex) + this.suffixChar : val1;
             } else {
                 return decimalCharIndex !== -1 ? val1.split(this._decimal)[0] + val2.slice(decimalCharIndex) : val1;
             }


### PR DESCRIPTION
There have been some long-standing issues with InputNumber for nearly four years. I finally tracked it down to some flawed logic in concatValues.

**To Reproduce**
[Navigate to the _Prefix and Suffix_ section of the InputNumber docs](https://primeng.org/inputnumber#prefixsuffix) and enter a 4-digit number in the "Mile" field. The insertion point jumps past the suffix.

This should resolve quite a few issues that don't necessarily seem related. At a minimum, it has been causing caret positioning issues when decimal places or suffixes are enabled. I will try to search for and tag as many related issues as I can. There are also some issues that were marked fixed that were not, so I'll tag those too.

This fix should also be pushed to v17 and v18 branches.

**Open Issues**
Fixes #16189
Fixes #16297 
Fixes #16496 
Fixes #17869
Fixes #17073

**Erroneously closed issues**
Fixes #9272 
Fixes #10582 
Fixes #14227
