### PR TITLE
Fix trigger for onSelect when multiple is true and typeahead is false

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1470,6 +1470,7 @@ export class AutoComplete extends BaseComponent implements AfterViewChecked, Aft
         if (!this.typeahead) {
             if (this.multiple) {
                 this.updateModel([...(this.modelValue() || []), event.target.value]);
+                this.onSelect.emit({ originalEvent: event, value: event.target.value });
                 this.inputEL.nativeElement.value = '';
             }
         }


### PR DESCRIPTION
**Issue:**
When using the p-autocomplete component with `multiple: true` and `typeahead: false`, the `onSelect` event is not triggered when a new item is added manually.

**Steps to Reproduce:**
1. Set up p-autocomplete with `multiple: true` and `typeahead: false`.
2. Manually add a value in the input field.
3. The `onSelect` event is not triggered.

**Expected Behavior:**
The `onSelect` event should be triggered when a new item is added manually.

**Actual Behavior:**
The `onSelect` event is not triggered when manually adding a value.

**Fix:**
The issue was fixed by calling `onSelect` explicitly in the `onEnterKey` method when `multiple: true` and `typeahead: false`.
