### PR TITLE
Add 'normal' as a size option

### DIFF
--- a/packages/primeng/src/inputtext/inputtext.ts
+++ b/packages/primeng/src/inputtext/inputtext.ts
@@ -39,7 +39,7 @@ export class InputText extends BaseComponent implements DoCheck, AfterViewInit {
      * Defines the size of the component.
      * @group Props
      */
-    @Input('pSize') pSize: 'large' | 'small';
+    @Input('pSize') pSize: 'large' | 'normal' | 'small';
 
     filled: Nullable<boolean>;
 

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -594,7 +594,7 @@ export class Select extends BaseComponent implements OnInit, AfterViewInit, Afte
      * Defines the size of the component.
      * @group Props
      */
-    @Input() size: 'large' | 'small';
+    @Input() size: 'large' | 'normal' | 'small';
     /**
      * Whether to use overlay API feature. The properties of overlay API can be used like an object in it.
      * @group Props


### PR DESCRIPTION
Context
When wrapping primeNG components, an undefined value cannot be passed through. Allowing for a no-op 'normal' value to be passed through does not impact functionality, but does allow for the normal state to be hit.

### Defect Fixes
Creating an issue after PR to link the two, will edit PR description once created.
https://github.com/primefaces/primeng/issues/18117

### Feature Requests
