### PR TITLE
fix(tabs): scrollable background does not span the whole content

### DIFF
--- a/packages/primeng/src/tabs/style/tabsstyle.ts
+++ b/packages/primeng/src/tabs/style/tabsstyle.ts
@@ -30,11 +30,12 @@ const theme = ({ dt }) => `
 
 .p-tablist-tab-list {
     position: relative;
-    display: flex;
+    display: inline-flex;
     background: ${dt('tabs.tablist.background')};
     border-style: solid;
     border-color: ${dt('tabs.tablist.border.color')};
     border-width: ${dt('tabs.tablist.border.width')};
+    min-width: 100%;
 }
 
 .p-tablist-content {


### PR DESCRIPTION
With references to the linked issue:
`display: flex` only currently make the background color span the viewable width. Changing this to `display: inline-flex` will make it span the whole content strip.

`min-width: 100%` cover the cases where there is no scroll buttons, then it will span the whole width of its parent.

### Defect Fixes
Fixes https://github.com/primefaces/primeng/issues/17791