### PR TITLE
fix #18135 - SelectButton: use option styleClass if provided

### DIFF
--- a/packages/primeng/src/selectbutton/selectbutton.ts
+++ b/packages/primeng/src/selectbutton/selectbutton.ts
@@ -42,7 +42,7 @@ export const SELECTBUTTON_VALUE_ACCESSOR: any = {
         @for (option of options; track option; let i = $index) {
             <p-toggleButton
                 [autofocus]="autofocus"
-                [styleClass]="styleClass"
+                [styleClass]="option?.styleClass || styleClass"
                 [ngModel]="isSelected(option)"
                 [onLabel]="this.getOptionLabel(option)"
                 [offLabel]="this.getOptionLabel(option)"


### PR DESCRIPTION
Issue: https://github.com/primefaces/primeng/issues/18135

In previous versions it was possible to pass a `styleClass` property for each option so we could have a custom style for each button.
Since we migrated to Angular/PrimeNG 19, this feature stopped working.

Also reported here: https://github.com/primefaces/primeng/issues/3485#issuecomment-2796684540
