### PR TITLE
fix: toggle-button missing disabled attribute #18152

### DIFF
--- a/packages/primeng/src/togglebutton/togglebutton.ts
+++ b/packages/primeng/src/togglebutton/togglebutton.ts
@@ -42,7 +42,7 @@ export const TOGGLEBUTTON_VALUE_ACCESSOR: any = {
     hostDirectives: [{ directive: Ripple }],
     host: {
         '[tabindex]': 'tabindex',
-        '[disabled]': 'disabled',
+        '[attr.disabled]': 'disabled',
         '[attr.aria-labelledby]': 'ariaLabelledBy',
         '[attr.aria-pressed]': 'checked',
         '[attr.data-p-checked]': 'active',


### PR DESCRIPTION
Fixes #18152 by resolving the [binding collision](https://angular.dev/guide/components/host-elements#binding-collisions)