### PR TITLE
feat: add missing closeAriaLabel option to ConfirmDialog component

### DIFF
--- a/packages/primeng/src/confirmdialog/confirmdialog.ts
+++ b/packages/primeng/src/confirmdialog/confirmdialog.ts
@@ -57,6 +57,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
             [style]="style"
             [dismissableMask]="dismissableMask"
             [draggable]="draggable"
+            [closeAriaLabel]="option('closeAriaLabel')"
         >
             @if (headlessTemplate || _headlessTemplate) {
                 <ng-template #headless>


### PR DESCRIPTION
### Defect Fixes
Fixes #18163

The `aria-labelledby` attribute in the ConfirmDialog component had a broken reference when the target ID did not exist.  
This PR fixes the issue by ensuring the ID is properly set and referenced, improving accessibility compliance.

### Notes
- Only a small fix (non-breaking).
- Tested locally on Chrome Accessibility tools.