### PR TITLE
fix: fixes #18185, allow submitting form via autocomplete

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1472,18 +1472,16 @@ export class AutoComplete extends BaseComponent implements AfterViewChecked, Aft
                 this.updateModel([...(this.modelValue() || []), event.target.value]);
                 this.inputEL.nativeElement.value = '';
             }
+            event.preventDefault();
         }
-        if (!this.overlayVisible) {
-            this.onArrowDownKey(event);
-        } else {
+        if (this.overlayVisible) {
             if (this.focusedOptionIndex() !== -1) {
                 this.onOptionSelect(event, this.visibleOptions()[this.focusedOptionIndex()]);
             }
 
             this.hide();
+            event.preventDefault();
         }
-
-        event.preventDefault();
     }
 
     onEscapeKey(event) {


### PR DESCRIPTION
Fixes #18185

Allows submitting form by not always doing `event.preventDefault()`.

I've also removed `this.onArrowDownKey(event);` on `!this.overlayVisible` because the guard inside `onArrowDownKey` will prevent anything from happening when `!this.overlayVisible` anyway.