### PR TITLE
fix #18211 :  fix SelectButton when allowEmpty=false and multiple=false

### DIFF
--- a/packages/primeng/src/selectbutton/selectbutton.ts
+++ b/packages/primeng/src/selectbutton/selectbutton.ts
@@ -193,7 +193,10 @@ export class SelectButton extends BaseComponent implements AfterContentInit, Con
     _componentStyle = inject(SelectButtonStyle);
 
     getAllowEmpty() {
-        return this.allowEmpty || this.value?.length !== 1;
+        if (this.multiple) {
+            return this.allowEmpty || this.value?.length !== 1;
+        }
+        return this.allowEmpty;
     }
 
     getOptionLabel(option: any) {


### PR DESCRIPTION
fix #18211

This PR  preserves the  fix made for Issue #17576 (PR #18148) when multiple=true and reverts back to  PrimeNG v19.1.0 logic when multiple=false

The video  shows the reproducer working after the fix.

https://github.com/user-attachments/assets/7a2c3ced-0916-4a87-99d0-9368656cce12

 