### PR TITLE
fix(tooltip): correct order of arguments

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -412,7 +412,7 @@ export class Tooltip extends BaseComponent implements AfterViewInit, OnDestroy {
         this.container.appendChild(this.tooltipText);
 
         if (this.getOption('appendTo') === 'body') document.body.appendChild(this.container);
-        else if (this.getOption('appendTo') === 'target') appendChild(this.container, this.el.nativeElement);
+        else if (this.getOption('appendTo') === 'target') appendChild(this.el.nativeElement, this.container);
         else appendChild(this.getOption('appendTo'), this.container);
 
         this.container.style.display = 'none';


### PR DESCRIPTION
The appendChild method from @primeuix/utils  expects two arguments: first to be WHERE to attach newly created element, second: WHAT to attach

https://github.com/primefaces/primeuix/blob/main/packages/utils/src/dom/methods/appendChild.ts

this.el.nativeElements refers to the WHERE to attach tooltip, and container as can be seen refers to the newly created tooltip.

So if order was changed original element would not be more dissapear as it doesif using TARGET for appendTo

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
