### PR TITLE
fix(togglebutton): Replace `type` attribute with `role` attribute in togglebutton

### DIFF
--- a/packages/primeng/src/togglebutton/togglebutton.ts
+++ b/packages/primeng/src/togglebutton/togglebutton.ts
@@ -31,7 +31,7 @@ export const TOGGLEBUTTON_VALUE_ACCESSOR: any = {
         '[attr.data-p-checked]': 'active',
         '[attr.data-p-disabled]': 'disabled()',
         '[attr.required]': 'required()',
-        '[attr.type]': '"button"'
+        '[attr.role]': '"button"'
     },
     template: `<span [class]="cx('content')">
         <ng-container *ngTemplateOutlet="contentTemplate || _contentTemplate; context: { $implicit: checked }"></ng-container>


### PR DESCRIPTION
The `togglebutton` component is now correctly displayed as a button:
![image](https://github.com/user-attachments/assets/723066f6-a71b-4172-8cd9-db70f0b4d721)

Fixes primefaces#18250
