### PR TITLE
fix: #18284 - Checkbox: fix icon template, remove checkboxicon template

### DIFF
--- a/packages/primeng/src/checkbox/checkbox.ts
+++ b/packages/primeng/src/checkbox/checkbox.ts
@@ -233,7 +233,7 @@ export class Checkbox extends BaseComponent implements AfterContentInit, Control
      * The template of the checkbox icon.
      * @group Templates
      */
-    @ContentChild('checkboxicon', { descendants: false }) checkboxIconTemplate: TemplateRef<any>;
+    @ContentChild('icon', { descendants: false }) checkboxIconTemplate: TemplateRef<any>;
 
     @ContentChildren(PrimeTemplate) templates: Nullable<QueryList<PrimeTemplate>>;
 
@@ -253,9 +253,6 @@ export class Checkbox extends BaseComponent implements AfterContentInit, Control
         this.templates.forEach((item) => {
             switch (item.getType()) {
                 case 'icon':
-                    this._checkboxIconTemplate = item.template;
-                    break;
-                case 'checkboxicon':
                     this._checkboxIconTemplate = item.template;
                     break;
             }


### PR DESCRIPTION
fixes #18284 

There were two templates in the p-checkbox component: `icon` and `checkboxicon`. Only the `icon` template is documented. I changed the `@ContentChild` selector to `icon` so the template can be set with `<ng-template #icon>`.
