### PR TITLE
fix #18296: fixed Accordion Memory Leak

### DIFF
--- a/packages/primeng/src/accordion/accordion.ts
+++ b/packages/primeng/src/accordion/accordion.ts
@@ -313,6 +313,7 @@ export class AccordionHeader extends BaseComponent {
                 'hidden',
                 style({
                     height: '0',
+                    paddingBottom: '0',
                     visibility: 'hidden'
                 })
             ),

--- a/packages/primeng/src/accordion/accordion.ts
+++ b/packages/primeng/src/accordion/accordion.ts
@@ -294,7 +294,7 @@ export class AccordionHeader extends BaseComponent {
     selector: 'p-accordion-content, p-accordioncontent',
     imports: [CommonModule],
     standalone: true,
-    template: ` <div class="p-accordioncontent-content">
+    template: ` <div [@content]="active() ? { value: 'visible', params: { transitionParams: pcAccordion.transitionOptions } } : { value: 'hidden', params: { transitionParams: pcAccordion.transitionOptions } }" class="p-accordioncontent-content">
         <ng-content />
     </div>`,
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -305,10 +305,7 @@ export class AccordionHeader extends BaseComponent {
         '[attr.role]': '"region"',
         '[attr.data-pc-name]': '"accordioncontent"',
         '[attr.data-p-active]': 'active()',
-        '[attr.aria-labelledby]': 'ariaLabelledby()',
-        '[@content]': `active()
-            ? { value: 'visible', params: { transitionParams: pcAccordion.transitionOptions } }
-            : { value: 'hidden', params: { transitionParams: pcAccordion.transitionOptions } }`
+        '[attr.aria-labelledby]': 'ariaLabelledby()'
     },
     animations: [
         trigger('content', [


### PR DESCRIPTION
Fix #18296
Fixed memory leak in AccordionContent  component.

While investigating the memory leak I determined the problem was caused by the component's use of animation.   I initially assumed the problem was caused by the implementation of signals.  I confirmed that signals was not causing the problem.  I then compared the current v19 Accordion code with the deprecated AccordionTab, since v17 PrimeNG demo didn't have the memory leak.  The difference between the animation implementation was that v17  animation was attached to the content **DIV** and v19 animation was attached to the host.  Moving the animation back to the content **DIV** fixed the memory leak.

The video listed below shows this PR fixes the  memory leak is fixed


https://github.com/user-attachments/assets/2f90d57a-4449-406e-94d8-d4bdadc8fd4d

