### PR TITLE
Update runtimedoc.ts

### DIFF
--- a/apps/showcase/doc/configuration/locale/runtimedoc.ts
+++ b/apps/showcase/doc/configuration/locale/runtimedoc.ts
@@ -32,7 +32,7 @@ export class AppComponent implements OnInit {
 
     translate(lang: string) {
         this.translateService.use(lang);
-        this.translateService.get('primeng').subscribe(res => this.primeng.setTranslation(res));
+        this.translateService.get('primeng').subscribe(res => this.config.setTranslation(res));
     }
 }`
     };


### PR DESCRIPTION
Updated translation example

### Defect Fixes
There is a minor typo in the example documentation. The injected service is config: PrimeNG, but the referenced service in the example is this.primeng