### PR TITLE
feat(tree): add CSS classes to first and last

### DIFF
--- a/packages/primeng/src/tree/style/treestyle.ts
+++ b/packages/primeng/src/tree/style/treestyle.ts
@@ -244,6 +244,8 @@ const classes = {
         [instance.styleClass]: !!instance.styleClass,
         'p-tree-node-selectable': instance.selectable,
         'p-tree-node-dragover': instance.draghoverNode,
+        'p-tree-node-first': instance.firstChild,
+        'p-tree-node-last':instance.lastChild,
         'p-tree-node-selected': instance.selectionMode === 'checkbox' && instance.tree.highlightOnSelect ? instance.checked : instance.selected
     }),
     nodeToggleButton: 'p-tree-node-toggle-button',


### PR DESCRIPTION

first node class: p-tree-node-first
last node class: p-tree-node-last


This change allows identifying the first and last child nodes in the Tree component
by adding specific CSS classes.

It is particularly useful when you want to apply custom styles only to the first or last node,
for example to handle rounded borders or spacing.

More generally, it improves the ability to style the tree in a flexible and context-aware way.



**Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
