### PR TITLE
[Issue17100] Fix inputOtp on mobile

### DIFF
--- a/packages/primeng/src/inputotp/inputotp.ts
+++ b/packages/primeng/src/inputotp/inputotp.ts
@@ -5,8 +5,8 @@ import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { AutoFocus } from 'primeng/autofocus';
 import { BaseComponent } from 'primeng/basecomponent';
 import { InputText } from 'primeng/inputtext';
-import { InputOtpStyle } from './style/inputotpstyle';
 import { Nullable } from 'primeng/ts-helpers';
+import { InputOtpStyle } from './style/inputotpstyle';
 
 export const INPUT_OTP_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
@@ -85,6 +85,7 @@ export interface InputOtpInputTemplateContext {
                     (keydown)="onKeyDown($event)"
                     [pAutoFocus]="getAutofocus(i)"
                     [ngClass]="styleClass"
+                    [attr.inputmode]="integerOnly ? 'numeric' : undefined"
                 />
             </ng-container>
             <ng-container *ngIf="inputTemplate || _inputTemplate">
@@ -232,17 +233,30 @@ export class InputOtp extends BaseComponent implements AfterContentInit {
 
     onInput(event, index) {
         const value = event.target.value;
+
+        if(value.length > 1 && index === this.length-1) {
+            event.target.value = value[0];
+            event.stopPropagation();
+            return;
+        }
+
+        if (this.tokens.join('').length >= this.length && event.inputType !== 'deleteContentBackward') {
+            event.stopPropagation();
+            return;
+        }
+
         if (index === 0 && value.length > 1) {
             this.handleOnPaste(value, event);
             event.stopPropagation();
             return;
         }
+
         this.tokens[index] = value;
         this.updateModel(event);
 
         if (event.inputType === 'deleteContentBackward') {
             this.moveToPrev(event);
-        } else if (event.inputType === 'insertText' || event.inputType === 'deleteContentForward') {
+        } else if (event.inputType === 'insertText' || event.inputType === 'insertCompositionText' || event.inputType === 'deleteContentForward') {
             this.moveToNext(event);
         }
     }
@@ -350,7 +364,7 @@ export class InputOtp extends BaseComponent implements AfterContentInit {
             return;
         }
 
-        switch (event.code) {
+        switch (event.key) {
             case 'ArrowLeft':
                 this.moveToPrev(event);
                 event.preventDefault();
@@ -377,8 +391,15 @@ export class InputOtp extends BaseComponent implements AfterContentInit {
 
                 break;
 
+            case 'Tab':
+                break;
+
             default:
-                if ((this.integerOnly && !(Number(event.key) >= 0 && Number(event.key) <= 9)) || (this.tokens.join('').length >= this.length && event.code !== 'Delete')) {
+                if (this.integerOnly && !(Number(event.key) >= 0 && Number(event.key) <= 9)) {
+                    event.preventDefault();
+                }
+
+                if(this.tokens.join('').length >= this.length && event.code !== 'Delete') {
                     event.preventDefault();
                 }
 


### PR DESCRIPTION
This branch contain several fixes :
- fix input otp behavior on mobile :
Keydown do not work on mobile virtual keyboard, so I made a double check in the input event handler.
Also, mobile keyboard event dos not have a code, but have a key, so I changed it.
- fix focus trap on integerOnly
- Add an inputmode to open the numeric pad if integerOnly

## How to test
On desktop :
- Run `pnpm dev`
- Got to your localhost and in the input otp documentation part
- Play with base input otp and integerOnly input otp

On mobile (only work with wifi) :
- To the package.json of the showcase app, modify script start : `"start": "ng serve --host 0.0.0.0",`
- Run `pnpm dev`
- Connect your phone to the wifi ans go to your ip address (the link is shown by the terminal)
- Play with base input otp and integerOnly input otp

[Link to the issue](https://github.com/primefaces/primeng/issues/17100)
Thanks for your time !
