### PR TITLE
fix(18369): fix autocomplete form submit when pressing enter

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1474,7 +1474,7 @@ export class AutoComplete extends BaseComponent implements AfterViewChecked, Aft
             }
         }
         if (!this.overlayVisible) {
-            this.onArrowDownKey(event);
+            return;
         } else {
             if (this.focusedOptionIndex() !== -1) {
                 this.onOptionSelect(event, this.visibleOptions()[this.focusedOptionIndex()]);


### PR DESCRIPTION
Fixes #18369 

We skip `event.preventDefault()` when the overlay is not visible. This ensures that the form submit works as intended. Note that before, `this.onArrowDownKey(event)` would have returned immediately anyway since it has an early return for `if (!this.overlayVisible)`, thus we can get rid of it. 
