### PR TITLE
fix: check all filter rules to determine if column has a filter

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -5993,7 +5993,7 @@ export class ColumnFilter extends BaseComponent implements AfterContentInit {
     get hasFilter(): boolean {
         let fieldFilter = this.dt.filters[<string>this.field];
         if (fieldFilter) {
-            if (Array.isArray(fieldFilter)) return !this.dt.isFilterBlank((<FilterMetadata[]>fieldFilter)[0].value);
+            if (Array.isArray(fieldFilter)) return (<FilterMetadata[]>fieldFilter).some((rule) => !this.dt.isFilterBlank(rule.value));
             else return !this.dt.isFilterBlank(fieldFilter.value);
         }
 


### PR DESCRIPTION
the hasFilter context variable on the ColumnFilter icon template only checks the first rule of the array. Other rules might still apply. This check for any non blank rule when more than one.