### PR TITLE
Issue #18196 : Fix input number mobile integer only behavior

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -78,7 +78,7 @@ export const INPUTNUMBER_VALUE_ACCESSOR: any = {
             [attr.required]="required"
             [attr.min]="min"
             [attr.max]="max"
-            inputmode="decimal"
+            [attr.inputmode]="isIntegerMode ? 'numeric' : 'decimal'"
             (input)="onUserInput($event)"
             (keydown)="onInputKeyDown($event)"
             (keypress)="onInputKeyPress($event)"
@@ -341,7 +341,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
      * Defines the behavior of the component, valid values are "decimal" and "currency".
      * @group Props
      */
-    @Input() mode: string | any = 'decimal';
+    @Input() mode: string | any = 'integer';
     /**
      * The currency to use in currency formatting. Possible values are the ISO 4217 currency codes, such as "USD" for the US dollar, "EUR" for the euro, or "CNY" for the Chinese RMB. There is no default value; if the style is "currency", the currency property must be provided.
      * @group Props
@@ -606,13 +606,17 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
     getOptions() {
         return {
             localeMatcher: this.localeMatcher,
-            style: this.mode,
+            style: this.getFormatMode(),
             currency: this.currency,
             currencyDisplay: this.currencyDisplay,
             useGrouping: this.useGrouping,
-            minimumFractionDigits: this.minFractionDigits ?? undefined,
-            maximumFractionDigits: this.maxFractionDigits ?? undefined
+            minimumFractionDigits: this.isIntegerMode() ? 0 : this.minFractionDigits,
+            maximumFractionDigits: this.isIntegerMode() ? 0 : this.maxFractionDigits
         };
+    }
+
+    getFormatMode() {
+        return this.mode === 'integer' ? 'decimal' : this.mode;
     }
 
     constructParser() {
@@ -684,7 +688,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
             this.prefixChar = this.prefix;
         } else {
             const formatter = new Intl.NumberFormat(this.locale, {
-                style: this.mode,
+                style: this.getFormatMode(),
                 currency: this.currency,
                 currencyDisplay: this.currencyDisplay
             });
@@ -699,7 +703,7 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
             this.suffixChar = this.suffix;
         } else {
             const formatter = new Intl.NumberFormat(this.locale, {
-                style: this.mode,
+                style: this.getFormatMode(),
                 currency: this.currency,
                 currencyDisplay: this.currencyDisplay,
                 minimumFractionDigits: 0,
@@ -1133,6 +1137,10 @@ export class InputNumber extends BaseComponent implements OnInit, AfterContentIn
 
     isDecimalMode() {
         return this.mode === 'decimal';
+    }
+
+    isIntegerMode() {
+        return this.mode === 'integer';
     }
 
     getDecimalCharIndexes(val: string) {


### PR DESCRIPTION
This branch contains a fix to a better compatibility with mobile device :
The mode is now by default "integer" because decimal with undefined min / max fraction was causing the error.

## How to test
On desktop :
- Run `pnpm dev`
- Got to your localhost and in the input number documentation part
- Play with base input number and input number with minimal fraction

On mobile (only work with wifi) :
- To the package.json of the showcase app, modify script start : `"start": "ng serve --host 0.0.0.0",`
- Run `pnpm dev`
- Connect your phone to the wifi and go to your ip address (the link is shown by the terminal)
- Play with base input number and input number with minimal fraction

[Link to the issue](https://github.com/primefaces/primeng/pull/18377)
Thanks for your time !
