### PR TITLE
fix(table): ensure filter timeout is cleared on destroy

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -348,7 +348,7 @@ export class TableService {
     changeDetection: ChangeDetectionStrategy.Default,
     encapsulation: ViewEncapsulation.None
 })
-export class Table<RowData = any> extends BaseComponent implements OnInit, AfterViewInit, AfterContentInit, BlockableUI, OnChanges {
+export class Table<RowData = any> extends BaseComponent implements OnInit, AfterViewInit, AfterContentInit, BlockableUI, OnChanges, OnDestroy {
     /**
      * An array of objects to represent dynamic columns that are frozen.
      * @group Props
@@ -3202,6 +3202,11 @@ export class Table<RowData = any> extends BaseComponent implements OnInit, After
 
         this.destroyStyleElement();
         this.destroyResponsiveStyle();
+
+        if (this.filterTimeout) {
+            clearTimeout(this.filterTimeout);
+        }
+
         super.ngOnDestroy();
     }
 }


### PR DESCRIPTION
This makes sure that the scheduled timeout is always cleared on destroying the Table component.