### PR TITLE
fix(16570): Autocompete: do not clear whole input on backspace

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1510,10 +1510,6 @@ export class AutoComplete extends BaseComponent implements AfterViewChecked, Aft
 
             event.stopPropagation(); // To prevent onBackspaceKeyOnMultiple method
         }
-
-        if (!this.multiple && this.showClear && this.findSelectedOptionIndex() != -1) {
-            this.clear();
-        }
     }
 
     onArrowLeftKeyOnMultiple(event) {


### PR DESCRIPTION
fixes #16570 again for v19 (it was previously fixed for v17 but somehow broken in v19 again)