### PR TITLE
fix(inputotp): input type set to "number" when integerOnly is true

### DIFF
--- a/packages/primeng/src/inputotp/inputotp.ts
+++ b/packages/primeng/src/inputotp/inputotp.ts
@@ -197,7 +197,7 @@ export class InputOtp extends BaseComponent implements AfterContentInit {
     }
 
     get inputType(): string {
-        return this.mask ? 'password' : 'text';
+        return this.mask ? 'password' : this.integerOnly ? 'number' : 'text';
     }
 
     _componentStyle = inject(InputOtpStyle);


### PR DESCRIPTION
This branch contains several fixes :

fix input otp behavior on mobile :
Keydown do not work properly on mobile "virtual" keyboard, so I made a double check in the input event handler. Also, mobile keyboard event dos not have a code, but have a key, so I changed it. fix focus trap on integerOnly
Add an inputmode to open the numeric pad if integerOnly How to test
On desktop :

Run pnpm dev
Got to your localhost and in the input otp documentation part Play with base input otp and integerOnly input otp On mobile (only work with wifi) :

To the package.json of the showcase app, modify script start : "start": "ng serve --host 0.0.0.0", Run pnpm dev
Connect your phone to the wifi and go to your ip address (the link is shown by the terminal) Play with base input otp and integerOnly input otp Link to the issue : #17100

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
