### PR TITLE
fix(#18448): hardcoded css variable in domhandler breaks overlay styles

### DIFF
--- a/packages/primeng/src/dom/domhandler.ts
+++ b/packages/primeng/src/dom/domhandler.ts
@@ -164,7 +164,7 @@ export class DomHandler {
 
         element.style.top = top + 'px';
         element.style.left = left + 'px';
-        gutter && (element.style.marginTop = origin === 'bottom' ? 'calc(var(--p-anchor-gutter) * -1)' : 'calc(var(--p-anchor-gutter))');
+        gutter && (element.style.marginTop = origin === 'bottom' ? `calc(${dt('anchor.gutter')} * -1)` : dt('anchor.gutter'));
     }
 
     public static absolutePosition(element: any, target: any, gutter: boolean = true): void {
@@ -843,7 +843,7 @@ export class DomHandler {
     }
 }
 
-import { $dt } from '@primeuix/styled';
+import { $dt, dt } from '@primeuix/styled';
 import * as utils from '@primeuix/utils';
 
 // @todo: update this when we remove the old domhandler


### PR DESCRIPTION
In `packages/primeng/src/dom/domhandler.ts` in the static method `relativePosition` there is a styling that is using hardcoded CSS variables. 

This is creating a bug where if you use different prefix than '--p', then `--p-anchor-gutter` is undefined and the styles are not applied.

Fixes Issue: https://github.com/primefaces/primeng/issues/18448

