### PR TITLE
fix(stepper): resolve a11y issues

### DIFF
--- a/packages/primeng/src/stepper/stepper.ts
+++ b/packages/primeng/src/stepper/stepper.ts
@@ -28,12 +28,12 @@ import { find, findIndexInList, uuid } from '@primeuix/utils';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent } from 'primeng/basecomponent';
 import { transformToBoolean } from 'primeng/utils';
-import { StepperStyle } from './style/stepperstyle';
-import { StepStyle } from './style/stepstyle';
 import { StepItemStyle } from './style/stepitemstyle';
 import { StepListStyle } from './style/stepliststyle';
-import { StepPanelStyle } from './style/steppanelstyle';
 import { StepPanelsStyle } from './style/steppanelsstyle';
+import { StepPanelStyle } from './style/steppanelstyle';
+import { StepperStyle } from './style/stepperstyle';
+import { StepStyle } from './style/stepstyle';
 
 /**
  * Context interface for the StepPanel content template.
@@ -173,6 +173,7 @@ export class StepItem extends BaseComponent {
     host: {
         '[class]': 'cx("root")',
         '[attr.aria-current]': 'active() ? "step" : undefined',
+        '[attr.aria-labelledby]': 'ariaLabelledBy()',
         '[attr.data-p-active]': 'active()',
         '[attr.data-p-disabled]': 'isStepDisabled()',
         '[attr.data-pc-name]': '"step"'
@@ -268,7 +269,7 @@ export class Step extends BaseComponent implements AfterContentInit {
         '[class]': 'cx("root")',
         '[attr.role]': '"tabpanel"',
         '[attr.id]': 'id()',
-    '[attr.aria-labelledby]': 'ariaLabelledBy()',
+        '[attr.aria-labelledby]': 'ariaLabelledBy()',
         '[attr.data-p-active]': 'active()',
         '[attr.data-pc-name]': '"steppanel"'
     },
@@ -383,7 +384,8 @@ export class StepPanels extends BaseComponent {
     host: {
         '[class]': 'cx("root")',
         '[attr.role]': '"tablist"',
-        '[attr.id]': 'id()'
+        '[attr.id]': 'id()',
+        '[attr.aria-labelledby]': 'ariaLabelledBy()'
     }
 })
 export class Stepper extends BaseComponent {

--- a/packages/primeng/src/stepper/stepper.ts
+++ b/packages/primeng/src/stepper/stepper.ts
@@ -173,7 +173,6 @@ export class StepItem extends BaseComponent {
     host: {
         '[class]': 'cx("root")',
         '[attr.aria-current]': 'active() ? "step" : undefined',
-        '[attr.role]': '"presentation"',
         '[attr.data-p-active]': 'active()',
         '[attr.data-p-disabled]': 'isStepDisabled()',
         '[attr.data-pc-name]': '"step"'
@@ -268,8 +267,8 @@ export class Step extends BaseComponent implements AfterContentInit {
     host: {
         '[class]': 'cx("root")',
         '[attr.role]': '"tabpanel"',
-        '[attr.aria-controls]': 'ariaControls()',
         '[attr.id]': 'id()',
+    '[attr.aria-labelledby]': 'ariaLabelledBy()',
         '[attr.data-p-active]': 'active()',
         '[attr.data-pc-name]': '"steppanel"'
     },
@@ -309,7 +308,7 @@ export class StepPanel extends BaseComponent implements AfterContentInit {
 
     active = computed(() => this.pcStepper.value() === this.value());
 
-    ariaControls = computed(() => `${this.pcStepper.id()}_step_${this.value()}`);
+    ariaLabelledBy = computed(() => `${this.pcStepper.id()}_step_${this.value()}`);
 
     id = computed(() => `${this.pcStepper.id()}_steppanel_${this.value()}`);
 


### PR DESCRIPTION
### Defect Fixes
Resolve the following two a11y issues:
- ARIA attributes must conform to valid values (aria-valid-attr-value)
- Certain ARIA roles must contain particular children (aria-required-children)

### Before
![image](https://github.com/user-attachments/assets/edcb991a-8be5-4401-86ed-692d06f21567)

### After
![image](https://github.com/user-attachments/assets/3bf9d5c9-0144-4d78-8f16-9c9d9e877a73)

Fixes #17669 
