### PR TITLE
fix: accordion expand/collapse icons were swapped (#18444)

### DIFF
--- a/packages/primeng/src/accordion/accordion.ts
+++ b/packages/primeng/src/accordion/accordion.ts
@@ -130,11 +130,11 @@ export class AccordionPanel extends BaseComponent {
         } @else {
             <ng-container *ngIf="active()">
                 <span *ngIf="pcAccordion.collapseIcon" [class]="pcAccordion.collapseIcon" [ngClass]="pcAccordion.iconClass" [attr.aria-hidden]="true"></span>
-                <ChevronDownIcon *ngIf="!pcAccordion.collapseIcon" [ngClass]="pcAccordion.iconClass" [attr.aria-hidden]="true" />
+                <ChevronUpIcon *ngIf="!pcAccordion.collapseIcon" [ngClass]="pcAccordion.iconClass" [attr.aria-hidden]="true" />
             </ng-container>
             <ng-container *ngIf="!active()">
                 <span *ngIf="pcAccordion.expandIcon" [class]="pcAccordion.expandIcon" [ngClass]="pcAccordion.iconClass" [attr.aria-hidden]="true"></span>
-                <ChevronUpIcon *ngIf="!pcAccordion.expandIcon" [ngClass]="pcAccordion.iconClass" [attr.aria-hidden]="true" />
+                <ChevronDownIcon *ngIf="!pcAccordion.expandIcon" [ngClass]="pcAccordion.iconClass" [attr.aria-hidden]="true" />
             </ng-container>
         }
     `,


### PR DESCRIPTION
### Defect Fixes
Fixes [#18444](https://github.com/primefaces/primeng/issues/18444)
This PR resolves the issue where the expand/collapse icons in the Accordion component were reversed.
#### Changes:
- Corrected the logic for showing expand vs collapse icons in the Accordion header.
Tested locally and verified that icon behavior now matches expected expand/collapse actions.