### PR TITLE
fix: on esc keydown stopped event propagation only when overlay is vi…

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -1782,10 +1782,12 @@ export class MultiSelect extends BaseEditableHolder implements OnInit, AfterView
         event.preventDefault();
     }
 
-    onEscapeKey(event) {
-        this.overlayVisible && this.hide(true);
-        event.stopPropagation();
-        event.preventDefault();
+    onEscapeKey(event: KeyboardEvent) {
+        if (this.overlayVisible) {
+            this.hide(true);
+            event.stopPropagation();
+            event.preventDefault();
+        }
     }
 
     onTabKey(event, pressedInInputText = false) {

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1840,9 +1840,11 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
     }
 
     onEscapeKey(event: KeyboardEvent) {
-        this.overlayVisible && this.hide(true);
-        event.preventDefault();
-        event.stopPropagation();
+        if (this.overlayVisible) {
+            this.hide(true);
+            event.preventDefault();
+            event.stopPropagation();
+        }
     }
 
     onTabKey(event, pressedInInputText = false) {


### PR DESCRIPTION
Fixes #18439

Problem: When on the case of select and multiselect is open on a dialog component, We were stopping propagation when focus is on either of these components and user gets unexpected behaviour of dialog component not closing even when overlay of select (or multiselect) is closed.

Fix: on esc keydown stopped event propagation only when overlay visible for select and multiselect components