### PR TITLE
feat(floatlabel): Global config of default FloatLabel variant

### DIFF
--- a/apps/showcase/doc/configuration/floatvariantdoc.ts
+++ b/apps/showcase/doc/configuration/floatvariantdoc.ts
@@ -1,0 +1,23 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Code } from '@/domain/code';
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'floatvariant-doc',
+    standalone: true,
+    imports: [AppDocSectionText, AppCode],
+    template: `
+        <app-docsectiontext>
+            <p>Float labels for input fields come in three styles, (<i>over</i>, <i>on</i>, and <i>in</i>). The name of each option specifies where the label element will float relative to its input's top border. The default is <i>over</i>.</p>
+        </app-docsectiontext>
+        <app-code [code]="code" [hideToggleCode]="true"></app-code>
+    `
+})
+export class FloatVariantDoc {
+    code: Code = {
+        typescript: `providePrimeNG({
+    floatVariant: 'over' 
+})`
+    };
+}

--- a/apps/showcase/pages/configuration/index.ts
+++ b/apps/showcase/pages/configuration/index.ts
@@ -1,18 +1,19 @@
+import { AppDoc } from '@/components/doc/app.doc';
 import { CspDoc } from '@/doc/configuration/csp-doc';
 import { DynamicDoc } from '@/doc/configuration/dynamic-doc';
 import { FilterModeDoc } from '@/doc/configuration/filtermode-doc';
+import { FloatVariantDoc } from '@/doc/configuration/floatvariantdoc';
 import { InputVariantDoc } from '@/doc/configuration/inputvariant-doc';
 import { ApiDoc } from '@/doc/configuration/locale/apidoc';
 import { RepositoryDoc } from '@/doc/configuration/locale/repositorydoc';
 import { RuntimeDoc } from '@/doc/configuration/locale/runtimedoc';
 import { TranslationDoc } from '@/doc/configuration/locale/translationdoc';
+import { OverlayAppendToDoc } from '@/doc/configuration/overlayappendto-doc';
 import { ProviderDoc } from '@/doc/configuration/provider-doc';
 import { RippleDoc } from '@/doc/configuration/ripple-doc';
-import { OverlayAppendToDoc } from '@/doc/configuration/overlayappendto-doc';
 import { ThemeDoc } from '@/doc/configuration/theme-doc';
 import { ZIndexDoc } from '@/doc/configuration/zindex-doc';
 import { Component } from '@angular/core';
-import { AppDoc } from '@/components/doc/app.doc';
 
 @Component({
     selector: 'configuration',
@@ -46,6 +47,11 @@ export class ConfigurationDemo {
             id: 'inputvariant',
             label: 'InputVariant',
             component: InputVariantDoc
+        },
+        {
+            id: 'floatvariant',
+            label: 'FloatVariant',
+            component: FloatVariantDoc
         },
         {
             id: 'overlayappendto',

--- a/packages/primeng/src/config/primeng.ts
+++ b/packages/primeng/src/config/primeng.ts
@@ -18,6 +18,8 @@ export class PrimeNG extends ThemeProvider {
 
     overlayAppendTo = signal<HTMLElement | ElementRef | TemplateRef<any> | 'self' | 'body' | null | undefined | any>('self');
 
+    floatVariant = signal<'in' | 'over' | 'on' | null>(null);
+
     overlayOptions: OverlayOptions = {};
 
     csp = signal<{ nonce: string | undefined }>({ nonce: undefined });
@@ -186,13 +188,14 @@ export class PrimeNG extends ThemeProvider {
     }
 
     setConfig(config: PrimeNGConfigType): void {
-        const { csp, ripple, inputStyle, inputVariant, theme, overlayOptions, translation, filterMatchModeOptions, overlayAppendTo, zIndex, ptOptions, pt, unstyled } = config || {};
+        const { csp, ripple, inputStyle, inputVariant, floatVariant, theme, overlayOptions, translation, filterMatchModeOptions, overlayAppendTo, zIndex, ptOptions, pt, unstyled } = config || {};
 
         if (csp) this.csp.set(csp);
         if (overlayAppendTo) this.overlayAppendTo.set(overlayAppendTo);
         if (ripple) this.ripple.set(ripple);
         if (inputStyle) this.inputStyle.set(inputStyle);
         if (inputVariant) this.inputVariant.set(inputVariant);
+        if (floatVariant) this.floatVariant.set(floatVariant);
         if (overlayOptions) this.overlayOptions = overlayOptions;
         if (translation) this.setTranslation(translation);
         if (filterMatchModeOptions) this.filterMatchModeOptions = filterMatchModeOptions;

--- a/packages/primeng/src/config/primeng.types.ts
+++ b/packages/primeng/src/config/primeng.types.ts
@@ -195,6 +195,7 @@ export type PrimeNGConfigType = {
      */
     inputStyle?: 'outlined' | 'filled';
     inputVariant?: 'outlined' | 'filled';
+    floatVariant?: 'in' | 'over' | 'on';
     overlayOptions?: OverlayOptions;
     translation?: Translation;
     /**

--- a/packages/primeng/src/floatlabel/floatlabel.ts
+++ b/packages/primeng/src/floatlabel/floatlabel.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { AfterViewChecked, ChangeDetectionStrategy, Component, inject, InjectionToken, Input, NgModule, ViewEncapsulation } from '@angular/core';
+import { AfterViewChecked, ChangeDetectionStrategy, Component, computed, inject, InjectionToken, input, NgModule, ViewEncapsulation } from '@angular/core';
 import { SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind, BindModule } from 'primeng/bind';
@@ -42,7 +42,9 @@ export class FloatLabel extends BaseComponent<FloatLabelPassThrough> implements 
      * Defines the positioning of the label relative to the input.
      * @group Props
      */
-    @Input() variant: 'in' | 'over' | 'on' = 'over';
+    variant = input<'in' | 'over' | 'on' | undefined>();
+
+    $variant = computed(() => this.variant() || this.config.floatVariant() || 'over');
 }
 
 @NgModule({

--- a/packages/primeng/src/floatlabel/style/floatlabelstyle.ts
+++ b/packages/primeng/src/floatlabel/style/floatlabelstyle.ts
@@ -15,9 +15,9 @@ const classes = {
     root: ({ instance }) => [
         'p-floatlabel',
         {
-            'p-floatlabel-over': instance.variant === 'over',
-            'p-floatlabel-on': instance.variant === 'on',
-            'p-floatlabel-in': instance.variant === 'in'
+            'p-floatlabel-over': instance.$variant() === 'over',
+            'p-floatlabel-on': instance.$variant() === 'on',
+            'p-floatlabel-in': instance.$variant() === 'in'
         }
     ]
 };


### PR DESCRIPTION
Added support for defining the default FloatLabel variant.
I followed the example of the input components.

Issue: https://github.com/primefaces/primeng/issues/18523
