### PR TITLE
fix: primeng card change [data-pc-name] binding to attribute binding …

### DIFF
--- a/packages/primeng/src/card/card.ts
+++ b/packages/primeng/src/card/card.ts
@@ -42,7 +42,7 @@ import { CardStyle } from './style/cardstyle';
     providers: [CardStyle],
     host: {
         '[class]': "cn(cx('root'), styleClass)",
-        '[data-pc-name]': '"card"',
+        '[attr.data-pc-name]': '"card"',
         '[style]': '_style()'
     }
 })


### PR DESCRIPTION
…[attr.data-pc-name]

Using [data-pc-name] as an input binding caused Angular template errors in tests and apps because it’s not a declared @Input property on p-card. Switching to attribute binding [attr.data-pc-name] resolves this by binding the attribute directly, avoiding Angular binding errors.

This improves compatibility with Angular's strict template checking and test environments.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
