### PR TITLE
Fix: Attribute binding - use [attr.aria-xxx] instead of [aria-xxx] to comply with Angular template validation and support strict mode testing.

### DIFF
--- a/packages/primeng/src/divider/divider.ts
+++ b/packages/primeng/src/divider/divider.ts
@@ -20,7 +20,7 @@ import { DividerStyle } from './style/dividerstyle';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
-        '[aria-orientation]': 'layout',
+        '[attr.aria-orientation]': 'layout',
         'data-pc-name': 'divider',
         role: 'separator',
         '[class]': "cn(cx('root'), styleClass)",

--- a/packages/primeng/src/menubar/menubar.ts
+++ b/packages/primeng/src/menubar/menubar.ts
@@ -183,7 +183,7 @@ export class MenubarService {
     encapsulation: ViewEncapsulation.None,
     host: {
         '[id]': 'root ? menuId : null',
-        '[aria-activedescendant]': 'focusedItemId',
+        '[attr.aria-activedescendant]': 'focusedItemId',
         '[class]': "level === 0 ? cx('rootList') : cx('submenu')",
         'data-pc-section': 'menu',
         role: 'menubar',

--- a/packages/primeng/src/treetable/treetable.ts
+++ b/packages/primeng/src/treetable/treetable.ts
@@ -3047,7 +3047,7 @@ export class TTReorderableColumn implements AfterViewInit, OnDestroy {
     standalone: false,
     host: {
         '[class]': 'cx("row")',
-        '[aria-checked]': 'selected'
+        '[attr.aria-checked]': 'selected'
     },
     providers: [TreeTableStyle]
 })
@@ -3669,8 +3669,8 @@ export class TreeTableCellEditor extends BaseComponent implements AfterContentIn
     host: {
         '[class]': `'p-element ' + styleClass`,
         '[tabindex]': "'0'",
-        '[aria-expanded]': 'expanded',
-        '[aria-level]': 'level',
+        '[attr.aria-expanded]': 'expanded',
+        '[attr.aria-level]': 'level',
         '[data-pc-section]': 'row',
         '[role]': 'row'
     },


### PR DESCRIPTION
A follow on to https://github.com/primefaces/primeng/pull/18570 in order to apply this fix to all other affected components.

See angular docs here:

https://angular.dev/best-practices/a11y

### Fixes
https://github.com/primefaces/primeng/issues/18579

### Remaining affected components

1. `Divider`
2. `MenubarSub` within menubar
3. `TTSelectableRow` and `TTRow` within treetable