### PR TITLE
fix: allow defaultDate to be null in DatePicker component

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -883,10 +883,10 @@ export class DatePicker extends BaseInput implements OnInit, AfterContentInit, A
      * Set the date to highlight on first opening if the field is blank.
      * @group Props
      */
-    @Input() get defaultDate(): Date {
+    @Input() get defaultDate(): Date | null {
         return this._defaultDate;
     }
-    set defaultDate(defaultDate: Date) {
+    set defaultDate(defaultDate: Date | null) {
         this._defaultDate = defaultDate;
 
         if (this.initialized) {


### PR DESCRIPTION
- The @Input() defaultDate property was declared as Date but the PrimeNG docs state its default value is null.

- Passing null currently causes a type error, which contradicts the documented behavior.

- This PR corrects the mismatch by changing the getter/setter signature to accept Date | null.

(I'm creating an issue right away)

