### PR TITLE
enable docsearch functionality for v19 prod primeng website

### DIFF
--- a/apps/showcase/components/layout/topbar/app.topbar.component.ts
+++ b/apps/showcase/components/layout/topbar/app.topbar.component.ts
@@ -5,7 +5,7 @@ import { CommonModule, DOCUMENT } from '@angular/common';
 import { afterNextRender, booleanAttribute, Component, computed, ElementRef, Inject, Input, OnDestroy, Renderer2 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-//import docsearch from '@docsearch/js';
+import docsearch from '@docsearch/js';
 import { DomHandler } from 'primeng/dom';
 import { StyleClass } from 'primeng/styleclass';
 
@@ -167,7 +167,7 @@ export class AppTopBarComponent implements OnDestroy {
 
         afterNextRender(() => {
             this.bindScrollListener();
-            //this.initDocSearch();
+            this.initDocSearch();
         });
     }
 
@@ -199,14 +199,14 @@ export class AppTopBarComponent implements OnDestroy {
         this.configService.appState.update((state) => ({ ...state, darkTheme: !state.darkTheme }));
     }
 
-    /*initDocSearch() {
+    initDocSearch() {
         docsearch({
             appId: 'XG1L2MUWT9',
             apiKey: '0c7d92ce7c38649263123110162ac181',
             indexName: 'primeng',
             container: '#docsearch'
         });
-    }*/
+    }
 
     bindScrollListener() {
         if (!this.scrollListener) {


### PR DESCRIPTION
## Issue
- PrimeNG v19 docsearch is toggled off and logged as "chore" in a previous commit
- Handicaps developers referencing the documentation via component search
  - Forced to ctrl + f or manually search for a component
  - Unable to fuzzy find `API` and `Theming` pages for components throughout the docs

## Resolution
- Enable it again with a new `appId`/`apiKey` pairing specific to the v19 version of the primeng website

## Notes
- The maintainers of primeng will need to generate a new `appId`/`apiKey`pairing in order for this to work fully. Currently I believe it will just direct you to the latest version of the docs when searching