### PR TITLE
fix(docs): fix unclosed ‎mask tag in svg #18650

### DIFF
--- a/apps/showcase/doc/toolbar/customdoc.ts
+++ b/apps/showcase/doc/toolbar/customdoc.ts
@@ -65,7 +65,7 @@ export class CustomDoc {
         <div class="flex items-center gap-2">
             <svg width="31" height="33" viewBox="0 0 31 33" fill="none" xmlns="http://www.w3.org/2000/svg" style="width: 2rem; margin-right: 1rem">
                 <path d="..." fill="var(--p-primary-color)" />
-                <mask id="mask0_1_52" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="31" height="33">
+                <mask id="mask0_1_52" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="0" y="0" width="31" height="33"></mask>
             </svg>
             <p-button label="Files" text plain />
             <p-button label="Edit" text plain />


### PR DESCRIPTION
Defect Fixes
This pull request addresses issue #18650.

Problem:
The SVG in the documentation contained an unclosed `<mask>` tag, which could lead to rendering issues or errors in browsers with strict SVG parsing.

Solution:
The `<mask>` tag in the documentation SVG has been properly closed to ensure valid SVG syntax and correct rendering.

Additional Notes:
No changes were made to the SVG's visual appearance or functionality.
All documentation SVGs were reviewed to ensure compliance.

Closes #18650.
