### PR TITLE
fix: prevent value change when exceeding maxLength (fixes #16715)

### DIFF
--- a/packages/primeng/src/inputnumber/inputnumber.ts
+++ b/packages/primeng/src/inputnumber/inputnumber.ts
@@ -678,7 +678,8 @@ export class InputNumber extends BaseInput implements OnInit, AfterContentInit, 
         let step = (this.step() ?? 1) * dir;
         let currentValue = this.parseValue(this.input?.nativeElement.value) || 0;
         let newValue = this.validateValue((currentValue as number) + step);
-        if (this.maxlength() && this.maxlength() < this.formatValue(newValue).length) {
+        let rawValue = newValue.toString().replace(/[^\d]/g, '');
+        if (this.maxlength() && this.maxlength() < rawValue.length) {
             return;
         }
         this.updateInput(newValue, null, 'spin', null);


### PR DESCRIPTION
## Description
Fixes #16715 - InputNumber buttons bypass maxLength constraint

## Changes
- Added early return when `maxLength` is exceeded
- Preserves existing value instead of allowing overflow