### PR TITLE
Fix p-multiselect to only use p-variant-filled when appropriate

### DIFF
--- a/packages/primeng/src/multiselect/style/multiselectstyle.ts
+++ b/packages/primeng/src/multiselect/style/multiselectstyle.ts
@@ -28,7 +28,7 @@ const classes = {
             'p-multiselect-display-chip': instance.display === 'chip',
             'p-disabled': instance.$disabled(),
             'p-invalid': instance.invalid(),
-            'p-variant-filled': instance.$variant(),
+            'p-variant-filled': instance.$variant() === 'filled',
             'p-focus': instance.focused,
             'p-inputwrapper-filled': instance.$filled(),
             'p-inputwrapper-focus': instance.focused || instance.overlayVisible,


### PR DESCRIPTION
It is currently always applying the p-variant-filled class if _any_ value is provided in the variant.

You can see from the references - https://github.com/search?q=repo%3Aprimefaces%2Fprimeng%20p-variant-filled&type=code) it should be comparing to `filled` to match all the other components.
