### PR TITLE
fix: tab list next button visibility

### DIFF
--- a/packages/primeng/src/tabs/tablist.ts
+++ b/packages/primeng/src/tabs/tablist.ts
@@ -176,7 +176,7 @@ export class TabList extends BaseComponent implements AfterViewInit, AfterConten
         const width = getWidth(_content);
 
         this.isPrevButtonEnabled.set(scrollLeft !== 0);
-        this.isNextButtonEnabled.set(_list.offsetWidth >= offsetWidth && scrollLeft !== scrollWidth - width);
+        this.isNextButtonEnabled.set(_list.offsetWidth >= offsetWidth && Math.abs(scrollLeft - scrollWidth + width) > 1);
     }
 
     updateInkBar() {


### PR DESCRIPTION
This pull request makes a small but important change to the `TabList` component in `tablist.ts` to improve the precision of scroll button state calculation.

* [`packages/primeng/src/tabs/tablist.ts`](diffhunk://#diff-001e0f27b24210e78810794c168e2a487ee37be1f06fd17f36981a3344fd4f09L179-R179): Updated the condition for enabling the "next" scroll button to use `Math.abs` for comparing `scrollLeft` and `scrollWidth - width`, ensuring a more accurate calculation with a tolerance of 1 pixel.