### PR TITLE
DatePicker: Range that spans to previous / next month isn't completely shown

### DIFF
--- a/packages/primeng/src/datepicker/style/datepickerstyle.ts
+++ b/packages/primeng/src/datepicker/style/datepickerstyle.ts
@@ -65,7 +65,7 @@ const classes = {
     day: ({ instance, date }) => {
         let selectedDayClass = '';
 
-        if (instance.isRangeSelection() && instance.isSelected(date) && date.selectable) {
+        if (instance.isRangeSelection() && instance.isSelected(date)) {
             const startDate = instance.value[0];
             const endDate = instance.value[1];
 


### PR DESCRIPTION
See [GitHub issue 18666](https://github.com/primefaces/primeng/issues/18666).

The other days shown in a month sheet, that aren't part of the currently shown month, but are part of the range, should have the same selected style as the other days.

I'm not super familiar with the code base, but I think just removing the one part of the `if` condition might work.