### PR TITLE
[#18385] brackets added to not override aria-label

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -4892,7 +4892,7 @@ export class TableRadioButton implements OnInit, OnDestroy {
         this.subscription = this.dt.tableService.selectionSource$.subscribe(() => {
             this.checked = this.dt.isSelected(this.value);
 
-            this.ariaLabel = this.ariaLabel || this.dt.config.translation.aria ? (this.checked ? this.dt.config.translation.aria.selectRow : this.dt.config.translation.aria.unselectRow) : undefined;
+            this.ariaLabel = this.ariaLabel || (this.dt.config.translation.aria ? (this.checked ? this.dt.config.translation.aria.selectRow : this.dt.config.translation.aria.unselectRow) : undefined);
             this.cd.markForCheck();
         });
     }
@@ -4960,7 +4960,7 @@ export class TableCheckbox implements OnInit, OnDestroy {
     ) {
         this.subscription = this.dt.tableService.selectionSource$.subscribe(() => {
             this.checked = this.dt.isSelected(this.value);
-            this.ariaLabel = this.ariaLabel || this.dt.config.translation.aria ? (this.checked ? this.dt.config.translation.aria.selectRow : this.dt.config.translation.aria.unselectRow) : undefined;
+            this.ariaLabel = this.ariaLabel || (this.dt.config.translation.aria ? (this.checked ? this.dt.config.translation.aria.selectRow : this.dt.config.translation.aria.unselectRow) : undefined);
             this.cd.markForCheck();
         });
     }
@@ -5024,7 +5024,7 @@ export class TableHeaderCheckbox implements OnInit, OnDestroy {
     ) {
         this.valueChangeSubscription = this.dt.tableService.valueSource$.subscribe(() => {
             this.checked = this.updateCheckedState();
-            this.ariaLabel = this.ariaLabel || this.dt.config.translation.aria ? (this.checked ? this.dt.config.translation.aria.selectAll : this.dt.config.translation.aria.unselectAll) : undefined;
+            this.ariaLabel = this.ariaLabel || (this.dt.config.translation.aria ? (this.checked ? this.dt.config.translation.aria.selectAll : this.dt.config.translation.aria.unselectAll) : undefined);
         });
 
         this.selectionChangeSubscription = this.dt.tableService.selectionSource$.subscribe(() => {


### PR DESCRIPTION
### Defect Fixes
The assignment fails because the intended expression isn't properly grouped with parentheses.
[#18385](https://github.com/primefaces/primeng/issues/18385)

Reproducer example: https://playcode.io/2394614

#18386