### PR TITLE
fixed: #18741, fixed Accordion Console Warnings

### DIFF
--- a/packages/primeng/src/accordion/accordion.ts
+++ b/packages/primeng/src/accordion/accordion.ts
@@ -292,8 +292,10 @@ export class AccordionHeader extends BaseComponent {
                 style({
                     height: '0',
                     // To prevent memory leak, Angular issue. https://github.com/primefaces/primeng/issues/18546
-                    paddingBlock: '0',
-                    borderBlockWidth: '0',
+                    paddingBlockStart: '0',
+                    paddingBlockEnd: '0',
+                    borderBlockStartWidth: '0',
+                    borderBlockEndWidth: '0',
                     //
                     visibility: 'hidden'
                 })


### PR DESCRIPTION
fix #18741

By replacing:

**padding-block** with with **padding-block-start** and **padding-block-end**
**border-block-width** with **border-block-start-width** and **border-block-end-width**

fixes the warnings.

**Note:  I believe that the original implementation is equivalent to the new implementation.  I have no idea why the original implementation would generate console warnings  and this fix does not.**

The video below shows that no warnings are generated after the fix (when running the PrimeNG Accordion Demo in Developer Mode):


https://github.com/user-attachments/assets/1532a82e-ac47-485e-97d0-d13a64d96fd7


The video listed below verifies this fix doesn't reintroduce the Accordion Memory Leak:

https://github.com/user-attachments/assets/bb59f604-37d3-4803-a6b4-793b7c1b44ba

