### PR TITLE
DatePicker fix: Fixed incorrect automatic date change for the DatePicker Component

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -3543,7 +3543,7 @@ export class DatePicker extends BaseInput implements OnInit, AfterContentInit, A
             month = 1;
             day = doy;
             do {
-                dim = this.getDaysCountInMonth(year, month - 1);
+                dim = this.getDaysCountInMonth(month - 1, year);
                 if (day <= dim) {
                     break;
                 }


### PR DESCRIPTION
Fixed incorrect automatic date change for the "oo/y" and "o/y" dateformat cases in the input field after changing date values using the keyboard instead of using the embedded calendar menu

How to reproduce this issue:
You need to fill in the date field in the Datepicker field using the drop-down calendar (if you enter the start date in the input field manually, the error will not be reproduced). Next, you need to click on the input field, change the first 2 or 3 digits of the month and remove the focus from the input field (for example, by clicking somewhere outside the field or pressing the Tab button). After that, the changed part of the date is automatically converted to an incorrect value. However, if you enter values from 001 to 060 (or from 1 to 60 for dateFormat="o/y" case), then everything seems to be working correctly. So only if you enter values greater than 060 (or 60), these side effects will start to show up.

https://stackblitz.com/edit/github-xjxzfq9m