### PR TITLE
fix: remove `string` from severity type union for Message and Tag components

### DIFF
--- a/packages/primeng/src/message/message.ts
+++ b/packages/primeng/src/message/message.ts
@@ -98,7 +98,7 @@ export class Message extends BaseComponent implements AfterContentInit {
      * @defaultValue 'info'
      * @group Props
      */
-    @Input() severity: string | 'success' | 'info' | 'warn' | 'error' | 'secondary' | 'contrast' | undefined | null = 'info';
+    @Input() severity: 'success' | 'info' | 'warn' | 'error' | 'secondary' | 'contrast' | undefined | null = 'info';
     /**
      * Text content.
      * @deprecated since v20.0.0. Use content projection instead '<p-message>Content</p-message>'.

--- a/packages/primeng/src/tag/tag.ts
+++ b/packages/primeng/src/tag/tag.ts
@@ -40,7 +40,7 @@ export class Tag extends BaseComponent implements AfterContentInit {
      * Severity type of the tag.
      * @group Props
      */
-    @Input() severity: string | 'success' | 'secondary' | 'info' | 'warn' | 'danger' | 'contrast' | undefined | null;
+    @Input() severity: 'success' | 'secondary' | 'info' | 'warn' | 'danger' | 'contrast' | undefined | null;
     /**
      * Value to display inside the tag.
      * @group Props


### PR DESCRIPTION
This pull request makes a minor type safety improvement to the `severity` input property in both the `Message` and `Tag` components. The change restricts the allowed values for `severity` to a specific set of string literals, removing the generic `string` type.

Type safety improvements:

* [`packages/primeng/src/message/message.ts`](diffhunk://#diff-606ba510ccdb2c43fee4042e6a1990990047113e9ba923c15cb4be787cdb86c6L101-R101): Updated the `severity` property in the `Message` component to only accept specific severity string literals, eliminating the possibility of arbitrary strings.
* [`packages/primeng/src/tag/tag.ts`](diffhunk://#diff-d79ed9ef4947715c740988d6d73171e3fab0dba81f245f226acffff570f7c3aaL43-R43): Updated the `severity` property in the `Tag` component to only accept specific severity string literals, eliminating the possibility of arbitrary strings.