### PR TITLE
[docs]: Replace module imports with standalone

### DIFF
--- a/apps/showcase/doc/Image/importdoc.ts
+++ b/apps/showcase/doc/Image/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ImageModule } from 'primeng/image';`
+        typescript: `import { Image } from 'primeng/image';`
     };
 }

--- a/apps/showcase/doc/accordion/importdoc.ts
+++ b/apps/showcase/doc/accordion/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { AccordionModule } from 'primeng/accordion';`
+        typescript: `import { Accordion } from 'primeng/accordion';`
     };
 }

--- a/apps/showcase/doc/animateonscroll/importdoc.ts
+++ b/apps/showcase/doc/animateonscroll/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { AnimateOnScrollModule } from 'primeng/animateonscroll';`
+        typescript: `import { AnimateOnScroll } from 'primeng/animateonscroll';`
     };
 }

--- a/apps/showcase/doc/autocomplete/importdoc.ts
+++ b/apps/showcase/doc/autocomplete/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { AutoCompleteModule } from 'primeng/autocomplete';`
+        typescript: `import { AutoComplete } from 'primeng/autocomplete';`
     };
 }

--- a/apps/showcase/doc/autofocus/importdoc.ts
+++ b/apps/showcase/doc/autofocus/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { AutoFocusModule } from 'primeng/autofocus';`
+        typescript: `import { AutoFocus } from 'primeng/autofocus';`
     };
 }

--- a/apps/showcase/doc/avatar/importdoc.ts
+++ b/apps/showcase/doc/avatar/importdoc.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { AvatarModule } from 'primeng/avatar';
+        typescript: `import { Avatar } from 'primeng/avatar';
 import { AvatarGroupModule } from 'primeng/avatargroup';`
     };
 }

--- a/apps/showcase/doc/badge/importdoc.ts
+++ b/apps/showcase/doc/badge/importdoc.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { BadgeModule } from 'primeng/badge';
+        typescript: `import { Badge } from 'primeng/badge';
 import { OverlayBadgeModule } from 'primeng/overlaybadge';`
     };
 }

--- a/apps/showcase/doc/blockui/importdoc.ts
+++ b/apps/showcase/doc/blockui/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { BlockUIModule } from 'primeng/blockui';`
+        typescript: `import { BlockUI } from 'primeng/blockui';`
     };
 }

--- a/apps/showcase/doc/breadcrumb/importdoc.ts
+++ b/apps/showcase/doc/breadcrumb/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { BreadcrumbModule } from 'primeng/breadcrumb';`
+        typescript: `import { Breadcrumb } from 'primeng/breadcrumb';`
     };
 }

--- a/apps/showcase/doc/button/importdoc.ts
+++ b/apps/showcase/doc/button/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ButtonModule } from 'primeng/button';`
+        typescript: `import { Button } from 'primeng/button';`
     };
 }

--- a/apps/showcase/doc/card/importdoc.ts
+++ b/apps/showcase/doc/card/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { CardModule } from 'primeng/card';`
+        typescript: `import { Card } from 'primeng/card';`
     };
 }

--- a/apps/showcase/doc/carousel/importdoc.ts
+++ b/apps/showcase/doc/carousel/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { CarouselModule } from 'primeng/carousel';`
+        typescript: `import { Carousel } from 'primeng/carousel';`
     };
 }

--- a/apps/showcase/doc/cascadeselect/importdoc.ts
+++ b/apps/showcase/doc/cascadeselect/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { CascadeSelectModule } from 'primeng/cascadeselect';`
+        typescript: `import { CascadeSelect } from 'primeng/cascadeselect';`
     };
 }

--- a/apps/showcase/doc/chart/importdoc.ts
+++ b/apps/showcase/doc/chart/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ChartModule } from 'primeng/chart';`
+        typescript: `import { Chart } from 'primeng/chart';`
     };
 }

--- a/apps/showcase/doc/checkbox/importdoc.ts
+++ b/apps/showcase/doc/checkbox/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { CheckboxModule } from 'primeng/checkbox';`
+        typescript: `import { Checkbox } from 'primeng/checkbox';`
     };
 }

--- a/apps/showcase/doc/chip/importdoc.ts
+++ b/apps/showcase/doc/chip/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ChipModule } from 'primeng/chip';`
+        typescript: `import { Chip } from 'primeng/chip';`
     };
 }

--- a/apps/showcase/doc/colorpicker/importdoc.ts
+++ b/apps/showcase/doc/colorpicker/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ColorPickerModule } from 'primeng/colorpicker';`
+        typescript: `import { ColorPicker } from 'primeng/colorpicker';`
     };
 }

--- a/apps/showcase/doc/confirmdialog/importdoc.ts
+++ b/apps/showcase/doc/confirmdialog/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ConfirmDialogModule } from 'primeng/confirmdialog';`
+        typescript: `import { ConfirmDialog } from 'primeng/confirmdialog';`
     };
 }

--- a/apps/showcase/doc/confirmpopup/importdoc.ts
+++ b/apps/showcase/doc/confirmpopup/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ConfirmPopupModule } from 'primeng/confirmpopup';`
+        typescript: `import { ConfirmPopup } from 'primeng/confirmpopup';`
     };
 }

--- a/apps/showcase/doc/contextmenu/importdoc.ts
+++ b/apps/showcase/doc/contextmenu/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ContextMenuModule } from 'primeng/contextmenu';`
+        typescript: `import { ContextMenu } from 'primeng/contextmenu';`
     };
 }

--- a/apps/showcase/doc/dataview/importdoc.ts
+++ b/apps/showcase/doc/dataview/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DataViewModule } from 'primeng/dataview';`
+        typescript: `import { DataView } from 'primeng/dataview';`
     };
 }

--- a/apps/showcase/doc/datepicker/importdoc.ts
+++ b/apps/showcase/doc/datepicker/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DatePickerModule } from 'primeng/datepicker';`
+        typescript: `import { DatePicker } from 'primeng/datepicker';`
     };
 }

--- a/apps/showcase/doc/dialog/importdoc.ts
+++ b/apps/showcase/doc/dialog/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DialogModule } from 'primeng/dialog';`
+        typescript: `import { Dialog } from 'primeng/dialog';`
     };
 }

--- a/apps/showcase/doc/divider/importdoc.ts
+++ b/apps/showcase/doc/divider/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DividerModule } from 'primeng/divider';`
+        typescript: `import { Divider } from 'primeng/divider';`
     };
 }

--- a/apps/showcase/doc/dock/importdoc.ts
+++ b/apps/showcase/doc/dock/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DockModule } from 'primeng/dock';`
+        typescript: `import { Dock } from 'primeng/dock';`
     };
 }

--- a/apps/showcase/doc/dragdrop/importdoc.ts
+++ b/apps/showcase/doc/dragdrop/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DragDropModule } from 'primeng/dragdrop';`
+        typescript: `import { DragDrop } from 'primeng/dragdrop';`
     };
 }

--- a/apps/showcase/doc/drawer/importdoc.ts
+++ b/apps/showcase/doc/drawer/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DrawerModule } from 'primeng/drawer';`
+        typescript: `import { Drawer } from 'primeng/drawer';`
     };
 }

--- a/apps/showcase/doc/dynamicdialog/importdoc.ts
+++ b/apps/showcase/doc/dynamicdialog/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { DynamicDialogModule } from 'primeng/dynamicdialog';`
+        typescript: `import { DynamicDialog } from 'primeng/dynamicdialog';`
     };
 }

--- a/apps/showcase/doc/editor/importdoc.ts
+++ b/apps/showcase/doc/editor/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { EditorModule } from 'primeng/editor';`
+        typescript: `import { Editor } from 'primeng/editor';`
     };
 }

--- a/apps/showcase/doc/fieldset/importdoc.ts
+++ b/apps/showcase/doc/fieldset/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { FieldsetModule } from 'primeng/fieldset';`
+        typescript: `import { Fieldset } from 'primeng/fieldset';`
     };
 }

--- a/apps/showcase/doc/fileupload/importdoc.ts
+++ b/apps/showcase/doc/fileupload/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { FileUploadModule } from 'primeng/fileupload';`
+        typescript: `import { FileUpload } from 'primeng/fileupload';`
     };
 }

--- a/apps/showcase/doc/floatlabel/importdoc.ts
+++ b/apps/showcase/doc/floatlabel/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { FloatLabelModule } from 'primeng/floatlabel';`
+        typescript: `import { FloatLabel } from 'primeng/floatlabel';`
     };
 }

--- a/apps/showcase/doc/fluid/importdoc.ts
+++ b/apps/showcase/doc/fluid/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { FluidModule } from 'primeng/fluid';`
+        typescript: `import { Fluid } from 'primeng/fluid';`
     };
 }

--- a/apps/showcase/doc/focustrap/importdoc.ts
+++ b/apps/showcase/doc/focustrap/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { FocusTrapModule } from 'primeng/focustrap';`
+        typescript: `import { FocusTrap } from 'primeng/focustrap';`
     };
 }

--- a/apps/showcase/doc/galleria/importdoc.ts
+++ b/apps/showcase/doc/galleria/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { GalleriaModule } from 'primeng/galleria';`
+        typescript: `import { Galleria } from 'primeng/galleria';`
     };
 }

--- a/apps/showcase/doc/iconfield/importdoc.ts
+++ b/apps/showcase/doc/iconfield/importdoc.ts
@@ -7,7 +7,7 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { IconFieldModule } from 'primeng/iconfield';
+        typescript: `import { IconField } from 'primeng/iconfield';
 import { InputIconModule } from 'primeng/inputicon';`
     };
 }

--- a/apps/showcase/doc/iftalabel/importdoc.ts
+++ b/apps/showcase/doc/iftalabel/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { IftaLabelModule } from 'primeng/iftalabel';`
+        typescript: `import { IftaLabel } from 'primeng/iftalabel';`
     };
 }

--- a/apps/showcase/doc/imagecompare/importdoc.ts
+++ b/apps/showcase/doc/imagecompare/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ImageCompareModule } from 'primeng/imagecompare';`
+        typescript: `import { ImageCompare } from 'primeng/imagecompare';`
     };
 }

--- a/apps/showcase/doc/inplace/importdoc.ts
+++ b/apps/showcase/doc/inplace/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { InplaceModule } from 'primeng/inplace';`
+        typescript: `import { Inplace } from 'primeng/inplace';`
     };
 }

--- a/apps/showcase/doc/inputgroup/importdoc.ts
+++ b/apps/showcase/doc/inputgroup/importdoc.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { InputGroupModule } from 'primeng/inputgroup';
+        typescript: `import { InputGroup } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';`
     };
 }

--- a/apps/showcase/doc/inputmask/importdoc.ts
+++ b/apps/showcase/doc/inputmask/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { InputMaskModule } from 'primeng/inputmask';`
+        typescript: `import { InputMask } from 'primeng/inputmask';`
     };
 }

--- a/apps/showcase/doc/inputnumber/importdoc.ts
+++ b/apps/showcase/doc/inputnumber/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { InputNumberModule } from 'primeng/inputnumber';`
+        typescript: `import { InputNumber } from 'primeng/inputnumber';`
     };
 }

--- a/apps/showcase/doc/inputotp/importdoc.ts
+++ b/apps/showcase/doc/inputotp/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { InputOtpModule } from 'primeng/inputotp';`
+        typescript: `import { InputOtp } from 'primeng/inputotp';`
     };
 }

--- a/apps/showcase/doc/inputtext/importdoc.ts
+++ b/apps/showcase/doc/inputtext/importdoc.ts
@@ -10,6 +10,6 @@ export class ImportDoc {
     value1: string;
 
     code: Code = {
-        typescript: `import { InputTextModule } from 'primeng/inputtext';`
+        typescript: `import { InputText } from 'primeng/inputtext';`
     };
 }

--- a/apps/showcase/doc/keyfilter/importdoc.ts
+++ b/apps/showcase/doc/keyfilter/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { KeyFilterModule } from 'primeng/keyfilter';`
+        typescript: `import { KeyFilter } from 'primeng/keyfilter';`
     };
 }

--- a/apps/showcase/doc/knob/importdoc.ts
+++ b/apps/showcase/doc/knob/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { KnobModule } from 'primeng/knob';`
+        typescript: `import { Knob } from 'primeng/knob';`
     };
 }

--- a/apps/showcase/doc/listbox/importdoc.ts
+++ b/apps/showcase/doc/listbox/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ListboxModule } from 'primeng/listbox';`
+        typescript: `import { Listbox } from 'primeng/listbox';`
     };
 }

--- a/apps/showcase/doc/megamenu/importdoc.ts
+++ b/apps/showcase/doc/megamenu/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { MegaMenuModule } from 'primeng/megamenu';`
+        typescript: `import { MegaMenu } from 'primeng/megamenu';`
     };
 }

--- a/apps/showcase/doc/menu/importdoc.ts
+++ b/apps/showcase/doc/menu/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { MenuModule } from 'primeng/menu';`
+        typescript: `import { Menu } from 'primeng/menu';`
     };
 }

--- a/apps/showcase/doc/menubar/importdoc.ts
+++ b/apps/showcase/doc/menubar/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { MenubarModule } from 'primeng/menubar';`
+        typescript: `import { Menubar } from 'primeng/menubar';`
     };
 }

--- a/apps/showcase/doc/message/importdoc.ts
+++ b/apps/showcase/doc/message/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { MessageModule } from 'primeng/message';`
+        typescript: `import { Message } from 'primeng/message';`
     };
 }

--- a/apps/showcase/doc/metergroup/importdoc.ts
+++ b/apps/showcase/doc/metergroup/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { MeterGroupModule } from 'primeng/metergroup';`
+        typescript: `import { MeterGroup } from 'primeng/metergroup';`
     };
 }

--- a/apps/showcase/doc/multiselect/importdoc.ts
+++ b/apps/showcase/doc/multiselect/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { MultiSelectModule } from 'primeng/multiselect';`
+        typescript: `import { MultiSelect } from 'primeng/multiselect';`
     };
 }

--- a/apps/showcase/doc/orderlist/importdoc.ts
+++ b/apps/showcase/doc/orderlist/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { OrderListModule } from 'primeng/orderlist';`
+        typescript: `import { OrderList } from 'primeng/orderlist';`
     };
 }

--- a/apps/showcase/doc/organizationchart/importdoc.ts
+++ b/apps/showcase/doc/organizationchart/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { OrganizationChartModule } from 'primeng/organizationchart';`
+        typescript: `import { OrganizationChart } from 'primeng/organizationchart';`
     };
 }

--- a/apps/showcase/doc/overlay/importdoc.ts
+++ b/apps/showcase/doc/overlay/importdoc.ts
@@ -12,6 +12,6 @@ export class ImportDoc {
     @Input() title: string;
 
     code: Code = {
-        typescript: `import { OverlayModule } from 'primeng/overlay';`
+        typescript: `import { Overlay } from 'primeng/overlay';`
     };
 }

--- a/apps/showcase/doc/paginator/importdoc.ts
+++ b/apps/showcase/doc/paginator/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { PaginatorModule } from 'primeng/paginator';`
+        typescript: `import { Paginator } from 'primeng/paginator';`
     };
 }

--- a/apps/showcase/doc/panel/importdoc.ts
+++ b/apps/showcase/doc/panel/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { PanelModule } from 'primeng/panel';`
+        typescript: `import { Panel } from 'primeng/panel';`
     };
 }

--- a/apps/showcase/doc/panelmenu/importdoc.ts
+++ b/apps/showcase/doc/panelmenu/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { PanelMenuModule } from 'primeng/panelmenu';`
+        typescript: `import { PanelMenu } from 'primeng/panelmenu';`
     };
 }

--- a/apps/showcase/doc/password/importdoc.ts
+++ b/apps/showcase/doc/password/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { PasswordModule } from 'primeng/password';`
+        typescript: `import { Password } from 'primeng/password';`
     };
 }

--- a/apps/showcase/doc/picklist/importdoc.ts
+++ b/apps/showcase/doc/picklist/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { PickListModule } from 'primeng/picklist';`
+        typescript: `import { PickList } from 'primeng/picklist';`
     };
 }

--- a/apps/showcase/doc/popover/importdoc.ts
+++ b/apps/showcase/doc/popover/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { PopoverModule } from 'primeng/popover';`
+        typescript: `import { Popover } from 'primeng/popover';`
     };
 }

--- a/apps/showcase/doc/progressbar/importdoc.ts
+++ b/apps/showcase/doc/progressbar/importdoc.ts
@@ -8,7 +8,7 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ProgressBarModule } from 'primeng/progressbar';
+        typescript: `import { ProgressBar } from 'primeng/progressbar';
 // For dynamic progressbar demo
 import { ToastModule } from 'primeng/toast';`
     };

--- a/apps/showcase/doc/progressspinner/importdoc.ts
+++ b/apps/showcase/doc/progressspinner/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ProgressSpinnerModule } from 'primeng/progressspinner';`
+        typescript: `import { ProgressSpinner } from 'primeng/progressspinner';`
     };
 }

--- a/apps/showcase/doc/radiobutton/importdoc.ts
+++ b/apps/showcase/doc/radiobutton/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { RadioButtonModule } from 'primeng/radiobutton';`
+        typescript: `import { RadioButton } from 'primeng/radiobutton';`
     };
 }

--- a/apps/showcase/doc/rating/importdoc.ts
+++ b/apps/showcase/doc/rating/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { RatingModule } from 'primeng/rating';`
+        typescript: `import { Rating } from 'primeng/rating';`
     };
 }

--- a/apps/showcase/doc/ripple/importdoc.ts
+++ b/apps/showcase/doc/ripple/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { RippleModule } from 'primeng/ripple';`
+        typescript: `import { Ripple } from 'primeng/ripple';`
     };
 }

--- a/apps/showcase/doc/scroller/importdoc.ts
+++ b/apps/showcase/doc/scroller/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ScrollerModule } from 'primeng/scroller';`
+        typescript: `import { Scroller } from 'primeng/scroller';`
     };
 }

--- a/apps/showcase/doc/scrollpanel/importdoc.ts
+++ b/apps/showcase/doc/scrollpanel/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ScrollPanelModule } from 'primeng/scrollpanel';`
+        typescript: `import { ScrollPanel } from 'primeng/scrollpanel';`
     };
 }

--- a/apps/showcase/doc/scrolltop/importdoc.ts
+++ b/apps/showcase/doc/scrolltop/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ScrollTopModule } from 'primeng/scrolltop';`
+        typescript: `import { ScrollTop } from 'primeng/scrolltop';`
     };
 }

--- a/apps/showcase/doc/select/importdoc.ts
+++ b/apps/showcase/doc/select/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { SelectModule } from 'primeng/select';`
+        typescript: `import { Select } from 'primeng/select';`
     };
 }

--- a/apps/showcase/doc/selectbutton/importdoc.ts
+++ b/apps/showcase/doc/selectbutton/importdoc.ts
@@ -7,6 +7,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { SelectButtonModule } from 'primeng/selectbutton';`
+        typescript: `import { SelectButton } from 'primeng/selectbutton';`
     };
 }

--- a/apps/showcase/doc/skeleton/importdoc.ts
+++ b/apps/showcase/doc/skeleton/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { SkeletonModule } from 'primeng/skeleton';`
+        typescript: `import { Skeleton } from 'primeng/skeleton';`
     };
 }

--- a/apps/showcase/doc/slider/importdoc.ts
+++ b/apps/showcase/doc/slider/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { SliderModule } from 'primeng/slider';`
+        typescript: `import { Slider } from 'primeng/slider';`
     };
 }

--- a/apps/showcase/doc/speeddial/importdoc.ts
+++ b/apps/showcase/doc/speeddial/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { SpeedDialModule } from 'primeng/speeddial';`
+        typescript: `import { SpeedDial } from 'primeng/speeddial';`
     };
 }

--- a/apps/showcase/doc/splitbutton/importdoc.ts
+++ b/apps/showcase/doc/splitbutton/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { SplitButtonModule } from 'primeng/splitbutton';`
+        typescript: `import { SplitButton } from 'primeng/splitbutton';`
     };
 }

--- a/apps/showcase/doc/splitter/importdoc.ts
+++ b/apps/showcase/doc/splitter/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { SplitterModule } from 'primeng/splitter';`
+        typescript: `import { Splitter } from 'primeng/splitter';`
     };
 }

--- a/apps/showcase/doc/stepper/importdoc.ts
+++ b/apps/showcase/doc/stepper/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { StepperModule } from 'primeng/stepper';`
+        typescript: `import { Stepper } from 'primeng/stepper';`
     };
 }

--- a/apps/showcase/doc/steps/importdoc.ts
+++ b/apps/showcase/doc/steps/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { StepsModule } from 'primeng/steps';`
+        typescript: `import { Steps } from 'primeng/steps';`
     };
 }

--- a/apps/showcase/doc/styleclass/importdoc.ts
+++ b/apps/showcase/doc/styleclass/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { StyleClassModule } from 'primeng/styleclass';`
+        typescript: `import { StyleClass } from 'primeng/styleclass';`
     };
 }

--- a/apps/showcase/doc/table/importdoc.ts
+++ b/apps/showcase/doc/table/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TableModule } from 'primeng/table';`
+        typescript: `import { Table } from 'primeng/table';`
     };
 }

--- a/apps/showcase/doc/tabs/importdoc.ts
+++ b/apps/showcase/doc/tabs/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TabsModule } from 'primeng/tabs';`
+        typescript: `import { Tabs } from 'primeng/tabs';`
     };
 }

--- a/apps/showcase/doc/tag/importdoc.ts
+++ b/apps/showcase/doc/tag/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TagModule } from 'primeng/tag';`
+        typescript: `import { Tag } from 'primeng/tag';`
     };
 }

--- a/apps/showcase/doc/terminal/importdoc.ts
+++ b/apps/showcase/doc/terminal/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TerminalModule } from 'primeng/terminal';`
+        typescript: `import { Terminal } from 'primeng/terminal';`
     };
 }

--- a/apps/showcase/doc/textarea/importdoc.ts
+++ b/apps/showcase/doc/textarea/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TextareaModule } from 'primeng/textarea';`
+        typescript: `import { Textarea } from 'primeng/textarea';`
     };
 }

--- a/apps/showcase/doc/tieredmenu/importdoc.ts
+++ b/apps/showcase/doc/tieredmenu/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TieredMenuModule } from 'primeng/tieredmenu';`
+        typescript: `import { TieredMenu } from 'primeng/tieredmenu';`
     };
 }

--- a/apps/showcase/doc/timeline/importdoc.ts
+++ b/apps/showcase/doc/timeline/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TimelineModule } from 'primeng/timeline';`
+        typescript: `import { Timeline } from 'primeng/timeline';`
     };
 }

--- a/apps/showcase/doc/toast/importdoc.ts
+++ b/apps/showcase/doc/toast/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ToastModule } from 'primeng/toast';`
+        typescript: `import { Toast } from 'primeng/toast';`
     };
 }

--- a/apps/showcase/doc/togglebutton/importdoc.ts
+++ b/apps/showcase/doc/togglebutton/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ToggleButtonModule } from 'primeng/togglebutton';`
+        typescript: `import { ToggleButton } from 'primeng/togglebutton';`
     };
 }

--- a/apps/showcase/doc/toggleswitch/importdoc.ts
+++ b/apps/showcase/doc/toggleswitch/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ToggleSwitchModule } from 'primeng/toggleswitch';`
+        typescript: `import { ToggleSwitch } from 'primeng/toggleswitch';`
     };
 }

--- a/apps/showcase/doc/toolbar/importdoc.ts
+++ b/apps/showcase/doc/toolbar/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { ToolbarModule } from 'primeng/toolbar';`
+        typescript: `import { Toolbar } from 'primeng/toolbar';`
     };
 }

--- a/apps/showcase/doc/tooltip/importdoc.ts
+++ b/apps/showcase/doc/tooltip/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TooltipModule } from 'primeng/tooltip';`
+        typescript: `import { Tooltip } from 'primeng/tooltip';`
     };
 }

--- a/apps/showcase/doc/tree/importdoc.ts
+++ b/apps/showcase/doc/tree/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TreeModule } from 'primeng/tree';`
+        typescript: `import { Tree } from 'primeng/tree';`
     };
 }

--- a/apps/showcase/doc/treeselect/importdoc.ts
+++ b/apps/showcase/doc/treeselect/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TreeSelectModule } from 'primeng/treeselect';`
+        typescript: `import { TreeSelect } from 'primeng/treeselect';`
     };
 }

--- a/apps/showcase/doc/treetable/importdoc.ts
+++ b/apps/showcase/doc/treetable/importdoc.ts
@@ -8,6 +8,6 @@ import { Component } from '@angular/core';
 })
 export class ImportDoc {
     code: Code = {
-        typescript: `import { TreeTableModule } from 'primeng/treetable';`
+        typescript: `import { TreeTable } from 'primeng/treetable';`
     };
 }


### PR DESCRIPTION
Replace `NgModule` imports in the documentation with standalone component imports.

For example:
`import { ImageModule } from 'primeng/image';` -> `import { Image } from 'primeng/image';`

Fixes https://github.com/primefaces/primeng/issues/18763