### PR TITLE
fix/remove invalid behaviour before releasing selected option

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1383,7 +1383,7 @@ export class Select extends BaseInput implements OnInit, AfterViewInit, AfterCon
         this.focused = false;
         this.onBlur.emit(event);
 
-        if (!this.preventModelTouched) {
+        if (!this.preventModelTouched && !this.overlayVisible) {
             this.onModelTouched();
         }
         this.preventModelTouched = false;


### PR DESCRIPTION
## What is the purpose of this PR?

Fixes the issue where the **Select** component briefly displays a validation error when a required field is interacted with but the selected option is not yet released. The invalid state also flashes when the selection is released.

This addresses the existing issue [#18802]
---

## Changes made

- **Updated the `onInputBlur` method:**  
  Only marks the control as "touched" if the overlay is not visible and model touch prevention is not active.
- **Prevents premature validation error display:**  
  Ensures errors do not show while the dropdown is open or the user is still interacting.
- **Verified the change in the showcase app:**  
  Confirmed the error no longer flashes unexpectedly.

---

## Notes

- Only affects the **Select** component.
- No breaking changes; fully backward-compatible.