### PR TITLE
fix: primefaces#18821, Select: EmptyFilterMessage does not work on Select with virtualscroll

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -329,7 +329,7 @@ export class SelectItem extends BaseComponent {
                                 </li>
                                 <li *ngIf="!filterValue && isEmpty()" [class]="cx('emptyMessage')" [ngStyle]="{ height: scrollerOptions.itemSize + 'px' }" role="option">
                                     @if (!emptyTemplate && !_emptyTemplate) {
-                                        {{ emptyMessageLabel }}
+                                        {{ emptyFilterMessageLabel || emptyMessageLabel }}
                                     } @else {
                                         <ng-container #empty *ngTemplateOutlet="emptyTemplate || _emptyTemplate"></ng-container>
                                     }


### PR DESCRIPTION
fix: primefaces#18821, Select: EmptyFilterMessage does not work on Select with virtualscroll

https://stackblitz.com/edit/mayx8jwd?file=src%2Fapp%2Fselect-virtualscroll-demo.html