### PR TITLE
fix/restore autofocus on focusOnShow property

### DIFF
--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -633,7 +633,7 @@ export class Dialog extends BaseComponent implements OnInit, AfterContentInit, O
         return false;
     }
 
-    focus(focusParentElement?: HTMLElement) {
+    focus(focusParentElement: HTMLElement = this.contentViewChild?.nativeElement) {
         let focused = this._focus(focusParentElement);
 
         if (!focused) {


### PR DESCRIPTION
## What is the purpose of this PR?

Fixes the issue where the Dialog component did not reliably autofocus the first focusable element when the `focusOnShow` property was enabled.  
This ensures that keyboard users and screen readers are immediately placed inside the dialog content when it appears.

This addresses the existing issue [#18816].

---

## Changes made

- **Restored autofocus behavior:**  
  Updated the dialog logic to ensure the first focusable element receives focus when `focusOnShow` is `true` and the dialog is shown.
- **Improved accessibility:**  
  Guarantees that keyboard navigation starts inside the dialog, not on the previously focused element.
- **Verified the change in the showcase app:**  
  Confirmed that focus is correctly set to the dialog content on show.

---

## Notes

- Only affects the **Dialog** component.
- No breaking changes; fully backward-compatible.