### PR TITLE
docs(datepicker): clarify usage of hourFormat with backticks  Updated…

### DIFF
--- a/apps/showcase/doc/datepicker/timedoc.ts
+++ b/apps/showcase/doc/datepicker/timedoc.ts
@@ -18,11 +18,11 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
         <p-fluid class="card flex flex-wrap gap-4">
             <div class="flex-auto">
                 <label for="calendar-12h" class="font-bold block mb-2"> 12h Format </label>
-                <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]="12" />
+                <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]=`12` />
             </div>
             <div class="flex-auto">
                 <label for="calendar-24h" class="font-bold block mb-2"> 24h Format </label>
-                <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]="24" />
+                <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]=`24` />
             </div>
             <div class="flex-auto">
                 <label for="calendar-timeonly" class="font-bold block mb-2"> Time Only </label>
@@ -41,20 +41,20 @@ export class TimeDoc {
     time: Date[] | undefined;
 
     code: Code = {
-        basic: `<p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]="12" />
+        basic: `<p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]=`12` />
 
-<p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]="24" />
+<p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]=`24` />
 
 <p-datepicker inputId="calendar-timeonly" [(ngModel)]="time" [timeOnly]="true" />`,
 
         html: `<p-fluid class="card flex flex-wrap gap-4">
     <div class="flex-auto">
         <label for="calendar-12h" class="font-bold block mb-2"> 12h Format </label>
-        <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]="12" />
+        <p-datepicker inputId="calendar-12h" [(ngModel)]="datetime12h" [showTime]="true" [hourFormat]=`12` />
     </div>
     <div class="flex-auto">
         <label for="calendar-24h" class="font-bold block mb-2"> 24h Format </label>
-        <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]="24" />
+        <p-datepicker inputId="calendar-24h" [(ngModel)]="datetime24h" [showTime]="true" [hourFormat]=`24` />
     </div>
     <div class="flex-auto">
         <label for="calendar-timeonly" class="font-bold block mb-2"> Time Only </label>


### PR DESCRIPTION
… the DatePicker time demo to use backticks for hourFormat values (`12`, `24`) instead of plain numbers to avoid Angular type errors (Type 'number' is not assignable to type 'string'). This makes the documentation examples consistent with the component API.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://github.com/primefaces/primeng/issues/18869).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
