### PR TITLE
Backward compatibility : fix(primeng): resolve TS2416 error in DynamicDialogInjector get() sig…

### DIFF
--- a/packages/primeng/src/dynamicdialog/dynamicdialog-injector.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-injector.ts
@@ -6,7 +6,7 @@ export class DynamicDialogInjector implements Injector {
         private _additionalTokens: WeakMap<any, any>
     ) {}
 
-    get<T>(token: ProviderToken<T>, notFoundValue?: T, options?: InjectOptions): T {
+    get<T>(token: ProviderToken<T>, notFoundValue?: T, options?: InjectOptions | i0.InjectFlags): T {
         const value = this._additionalTokens.get(token);
 
         if (value) return value;


### PR DESCRIPTION
…nature

Updated the `get` method signature in `DynamicDialogInjector` to accept `InjectOptions | i0.InjectFlags` instead of only `InjectOptions`. This aligns it with the base `Injector` interface and resolves the TypeScript compatibility error.

with angular 19, and primeNG 20

Error: node_modules/primeng/dynamicdialog/index.d.ts:540:5 - error TS2416: Property 'get' in type 'DynamicDialogInjector' is not assignable to the same property in base type 'Injector'.
  Type '<T>(token: ProviderToken<T>, notFoundValue?: T | undefined, options?: InjectOptions | undefined) => T' is not assignable to type '{ <T>(token: ProviderToken<T>, notFoundValue: undefined, options: InjectOptions & { optional?: false | undefined; }): T; <T>(token: ProviderToken<T>, notFoundValue: null | undefined, options: InjectOptions): T | null; <T>(token: ProviderToken<...>, notFoundValue?: T | undefined, options?: InjectOptions | ... 1 more ...'.
    Types of parameters 'options' and 'flags' are incompatible.
      Type 'InjectFlags | undefined' is not assignable to type 'InjectOptions | undefined'.
        Type 'InjectFlags.Default' has no properties in common with type 'InjectOptions'.

540     get<T>(token: ProviderToken<T>, notFoundValue?: T, options?: InjectOptions): T;
        ~~~

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
