### PR TITLE
fix: Use p-footer content again in confirm dialogs if present

### DIFF
--- a/packages/primeng/src/confirmdialog/confirmdialog.ts
+++ b/packages/primeng/src/confirmdialog/confirmdialog.ts
@@ -98,7 +98,7 @@ const hideAnimation = animation([animate('{{transition}}', style({ transform: '{
                     <ng-content select="p-footer"></ng-content>
                     <ng-container *ngTemplateOutlet="footerTemplate || _footerTemplate"></ng-container>
                 }
-                @if (!footerTemplate && !_footerTemplate) {
+                @if (!footer && !footerTemplate && !_footerTemplate) {
                     <p-button
                         *ngIf="option('rejectVisible')"
                         [label]="rejectButtonLabel"


### PR DESCRIPTION
Closes #18915