### PR TITLE
fix(p-checkbox): accessibility issue

### DIFF
--- a/apps/showcase/doc/checkbox/basicdoc.ts
+++ b/apps/showcase/doc/checkbox/basicdoc.ts
@@ -1,9 +1,9 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CheckboxModule } from 'primeng/checkbox';
-import { AppCode } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'checkbox-basic-demo',
@@ -14,7 +14,7 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>Binary checkbox is used as a controlled input with <i>ngModel</i> and <i>binary</i> properties.</p>
         </app-docsectiontext>
         <div class="card flex justify-center gap-4">
-            <p-checkbox [(ngModel)]="checked" [binary]="true" />
+            <p-checkbox [(ngModel)]="checked" [binary]="true" [ariaLabel]="'basic checkbox with true or false value'" />
         </div>
         <app-code [code]="code" selector="checkbox-basic-demo"></app-code>
     `
@@ -26,7 +26,7 @@ export class BasicDoc {
         basic: `<p-checkbox [(ngModel)]="checked" [binary]="true" />`,
 
         html: `<div class="card flex justify-center">
-    <p-checkbox [(ngModel)]="checked" [binary]="true" />
+    <p-checkbox [(ngModel)]="checked" [binary]="true" [ariaLabel]="'basic checkbox with true and false value'"/>
 </div>`,
 
         typescript: `import { Component } from '@angular/core';

--- a/apps/showcase/doc/checkbox/disableddoc.ts
+++ b/apps/showcase/doc/checkbox/disableddoc.ts
@@ -1,9 +1,9 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CheckboxModule } from 'primeng/checkbox';
-import { AppCode } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'checkbox-disabled-demo',
@@ -14,8 +14,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>When <i>disabled</i> is present, the element cannot be edited and focused.</p>
         </app-docsectiontext>
         <div class="card flex justify-center gap-2">
-            <p-checkbox [(ngModel)]="checked1" [binary]="true" [disabled]="true" />
-            <p-checkbox [(ngModel)]="checked2" [binary]="true" [disabled]="true" />
+            <p-checkbox [(ngModel)]="checked1" [binary]="true" [disabled]="true" [ariaLabel]="'checkbox disable with false value'" />
+            <p-checkbox [(ngModel)]="checked2" [binary]="true" [disabled]="true" [ariaLabel]="'checkbox disable with true value'" />
         </div>
         <app-code [code]="code" selector="checkbox-disabled-demo"></app-code>
     `
@@ -30,8 +30,8 @@ export class DisabledDoc {
 <p-checkbox [(ngModel)]="checked2" [binary]="true" [disabled]="true" />`,
 
         html: `<div class="card flex justify-center gap-2">
-    <p-checkbox [(ngModel)]="checked1" [binary]="true" [disabled]="true" />
-    <p-checkbox [(ngModel)]="checked2" [binary]="true" [disabled]="true" />
+    <p-checkbox [(ngModel)]="checked1" [binary]="true" [disabled]="true" [ariaLabel]="'checkbox disable with false value'" />
+    <p-checkbox [(ngModel)]="checked2" [binary]="true" [disabled]="true" [ariaLabel]="'checkbox disable with false value'" />
 </div>`,
 
         typescript: `import { Component } from '@angular/core';

--- a/apps/showcase/doc/checkbox/dynamicdoc.ts
+++ b/apps/showcase/doc/checkbox/dynamicdoc.ts
@@ -1,10 +1,10 @@
-import { Code } from '@/domain/code';
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { CheckboxModule } from 'primeng/checkbox';
 import { AppCode } from '@/components/doc/app.code';
 import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
+import { Code } from '@/domain/code';
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { CheckboxModule } from 'primeng/checkbox';
 
 @Component({
     selector: 'checkbox-dynamic-demo',
@@ -17,8 +17,8 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
         <div class="card flex justify-center">
             <div class="flex flex-col gap-4">
                 <div *ngFor="let category of categories" class="flex items-center">
-                    <p-checkbox [inputId]="category.key" name="group" [value]="category" [(ngModel)]="selectedCategories" />
-                    <label [for]="category.key" class="ml-2"> {{ category.name }} </label>
+                    <p-checkbox [inputId]="category.key" name="group" [value]="category" [(ngModel)]="selectedCategories" [ariaLabelledBy]="category.id" />
+                    <label [for]="category.key" class="ml-2" [id]="category.id"> {{ category.name }} </label>
                 </div>
             </div>
         </div>
@@ -29,10 +29,10 @@ export class DynamicDoc {
     selectedCategories: any[] = [];
 
     categories: any[] = [
-        { name: 'Accounting', key: 'A' },
-        { name: 'Marketing', key: 'M' },
-        { name: 'Production', key: 'P' },
-        { name: 'Research', key: 'R' }
+        { id: 1, name: 'Accounting', key: 'A' },
+        { id: 2, name: 'Marketing', key: 'M' },
+        { id: 3, name: 'Production', key: 'P' },
+        { id: 4, name: 'Research', key: 'R' }
     ];
 
     code: Code = {
@@ -44,8 +44,8 @@ export class DynamicDoc {
         html: `<div class="card flex justify-center">
     <div class="flex flex-col gap-4">
         <div *ngFor="let category of categories" class="flex items-center">
-            <p-checkbox [inputId]="category.key" name="group" [value]="category" [(ngModel)]="selectedCategories" />
-            <label [for]="category.key" class="ml-2"> {{ category.name }} </label>
+            <p-checkbox [inputId]="category.key" name="group" [value]="category" [(ngModel)]="selectedCategories" [ariaLabelledBy]="category.id"/>
+            <label [for]="category.key" class="ml-2" [id]="category.id"> {{ category.name }} </label>
         </div>
     </div>
 </div>`,
@@ -65,10 +65,10 @@ export class CheckboxDynamicDemo {
     selectedCategories: any[] = [];
 
     categories: any[] = [
-        { name: 'Accounting', key: 'A' },
-        { name: 'Marketing', key: 'M' },
-        { name: 'Production', key: 'P' },
-        { name: 'Research', key: 'R' },
+        { id: 1, name: 'Accounting', key: 'A' },
+        { id: 2, name: 'Marketing', key: 'M' },
+        { id: 3, name: 'Production', key: 'P' },
+        { id: 4, name: 'Research', key: 'R' },
     ];
 
     ngOnInit() {

--- a/apps/showcase/doc/checkbox/filleddoc.ts
+++ b/apps/showcase/doc/checkbox/filleddoc.ts
@@ -1,9 +1,9 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CheckboxModule } from 'primeng/checkbox';
-import { AppCode } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'checkbox-filled-demo',
@@ -14,7 +14,7 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>Specify the <i>variant</i> property as <i>filled</i> to display the component with a higher visual emphasis than the default <i>outlined</i> style.</p>
         </app-docsectiontext>
         <div class="card flex justify-center">
-            <p-checkbox [(ngModel)]="checked" [binary]="true" variant="filled" />
+            <p-checkbox [(ngModel)]="checked" [binary]="true" variant="filled" [ariaLabel]="'basic checkbox with true or false value'" />
         </div>
         <app-code [code]="code" selector="checkbox-filled-demo"></app-code>
     `
@@ -26,7 +26,7 @@ export class FilledDoc {
         basic: `<p-checkbox [(ngModel)]="checked" [binary]="true" variant="filled" />`,
 
         html: `<div class="card flex justify-center">
-    <p-checkbox [(ngModel)]="checked" [binary]="true" variant="filled" />
+    <p-checkbox [(ngModel)]="checked" [binary]="true" variant="filled" [ariaLabel]="'basic checkbox with true or false value'"/>
 </div>`,
 
         typescript: `import { Component } from '@angular/core';

--- a/apps/showcase/doc/checkbox/indeterminatedoc.ts
+++ b/apps/showcase/doc/checkbox/indeterminatedoc.ts
@@ -1,9 +1,9 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CheckboxModule } from 'primeng/checkbox';
-import { AppCode } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'checkbox-indeterminate-demo',
@@ -14,7 +14,7 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>The <i>indeterminate</i> state indicates that a checkbox is neither "on" or "off".</p>
         </app-docsectiontext>
         <div class="card flex justify-center gap-4">
-            <p-checkbox [(ngModel)]="checked" [binary]="true" [indeterminate]="true" />
+            <p-checkbox [(ngModel)]="checked" [binary]="true" [indeterminate]="true" [ariaLabel]="'indeterminate checkbox with true or false value'" />
         </div>
         <app-code [code]="code" selector="checkbox-indeterminate-demo"></app-code>
     `
@@ -26,7 +26,7 @@ export class IndeterminateDoc {
         basic: `<p-checkbox [(ngModel)]="checked" [binary]="true" [indeterminate]="true" />`,
 
         html: `<div class="card flex justify-center">
-    <p-checkbox [(ngModel)]="checked" [binary]="true" [indeterminate]="true" />
+    <p-checkbox [(ngModel)]="checked" [binary]="true" [indeterminate]="true" [ariaLabel]="'indeterminate checkbox with true and false value'"/>
 </div>`,
 
         typescript: `import { Component } from '@angular/core';

--- a/apps/showcase/doc/checkbox/invaliddoc.ts
+++ b/apps/showcase/doc/checkbox/invaliddoc.ts
@@ -1,9 +1,9 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CheckboxModule } from 'primeng/checkbox';
-import { AppCode } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'checkbox-invalid-demo',
@@ -14,7 +14,7 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
             <p>The invalid state is applied using the <i>⁠invalid</i> property to indicate failed validation, which can be integrated with Angular Forms.</p>
         </app-docsectiontext>
         <div class="card flex justify-center">
-            <p-checkbox [(ngModel)]="checked" [binary]="true" [invalid]="!checked" />
+            <p-checkbox [(ngModel)]="checked" [binary]="true" [invalid]="!checked" [ariaLabel]="'checkbox with true or false value'" />
         </div>
         <app-code [code]="code" selector="checkbox-invalid-demo"></app-code>
     `
@@ -26,7 +26,7 @@ export class InvalidDoc {
         basic: `<p-checkbox [(ngModel)]="checked" [binary]="true" [invalid]="!checked" />`,
 
         html: `<div class="card flex justify-center">
-    <p-checkbox [(ngModel)]="checked" [binary]="true" [invalid]="!checked" />
+    <p-checkbox [(ngModel)]="checked" [binary]="true" [invalid]="!checked" [ariaLabel]="'checkbox with true or false value'"/>
 </div>`,
 
         typescript: `import { Component } from '@angular/core';

--- a/apps/showcase/doc/checkbox/sizesdoc.ts
+++ b/apps/showcase/doc/checkbox/sizesdoc.ts
@@ -1,9 +1,9 @@
+import { AppCode } from '@/components/doc/app.code';
+import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 import { Code } from '@/domain/code';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CheckboxModule } from 'primeng/checkbox';
-import { AppCode } from '@/components/doc/app.code';
-import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
 
 @Component({
     selector: 'checkbox-sizes-demo',
@@ -15,16 +15,16 @@ import { AppDocSectionText } from '@/components/doc/app.docsectiontext';
         </app-docsectiontext>
         <div class="card flex flex-wrap justify-center gap-4">
             <div class="flex items-center gap-2">
-                <p-checkbox [(ngModel)]="size" inputId="size_small" name="size" value="Small" size="small" />
-                <label for="size_small" class="text-sm">Small</label>
+                <p-checkbox [(ngModel)]="size" inputId="size_small" name="size" value="Small" size="small" [ariaLabelledBy]="'size_small_label'" />
+                <label id="size_small_label" for="size_small" class="text-sm">Small</label>
             </div>
             <div class="flex items-center gap-2">
-                <p-checkbox [(ngModel)]="size" inputId="size_normal" name="size" value="Normal" />
-                <label for="size_normal">Normal</label>
+                <p-checkbox [(ngModel)]="size" inputId="size_normal" name="size" value="Normal" [ariaLabelledBy]="'size_normal_label'" />
+                <label id="size_normal_label" for="size_normal">Normal</label>
             </div>
             <div class="flex items-center gap-2">
-                <p-checkbox [(ngModel)]="size" inputId="size_large" name="size" value="Large" size="large" />
-                <label for="size_large" class="text-lg">Large</label>
+                <p-checkbox [(ngModel)]="size" inputId="size_large" name="size" value="Large" size="large" [ariaLabelledBy]="'size_large_label'" />
+                <label id="size_large_label" for="size_large" class="text-lg">Large</label>
             </div>
         </div>
         <app-code [code]="code" selector="checkbox-sizes-demo"></app-code>
@@ -49,16 +49,16 @@ export class SizesDoc {
 
         html: `<div class="card flex flex-wrap justify-center gap-4">
     <div class="flex items-center gap-2">
-        <p-checkbox [(ngModel)]="size" inputId="size_small" name="size" value="Small" size="small" />
-        <label for="size_small" class="text-sm">Small</label>
+        <p-checkbox [(ngModel)]="size" inputId="size_small" name="size" value="Small" size="small" [ariaLabelledBy]="'size_small_label'" />
+        <label id="size_small_label" for="size_small" class="text-sm">Small</label>
     </div>
     <div class="flex items-center gap-2">
-        <p-checkbox [(ngModel)]="size" inputId="size_normal" name="size" value="Normal" />
-        <label for="size_normal">Normal</label>
+        <p-checkbox [(ngModel)]="size" inputId="size_normal" name="size" value="Normal" [ariaLabelledBy]="'size_normal_label'"/>
+        <label id="size_normal_label" for="size_normal">Normal</label>
     </div>
     <div class="flex items-center gap-2">
-        <p-checkbox [(ngModel)]="size" inputId="size_large" name="size" value="Large" size="large" />
-        <label for="size_large" class="text-lg">Large</label>
+        <p-checkbox [(ngModel)]="size" inputId="size_large" name="size" value="Large" size="large" [ariaLabelledBy]="'size_large_label'"/>
+        <label id="size_large_label" for="size_large" class="text-lg">Large</label>
     </div>
 </div>`,
 


### PR DESCRIPTION
I improve the `p-checkbox` documentation by fixing accessibility issue providing `aria-label` or `aria-labelledby` in all the examples.
I open this issue where there is the complete description https://github.com/primefaces/primeng/issues/18925