### PR TITLE
fix: #18888 Fixes button height in input group addon

### DIFF
--- a/packages/primeng/src/inputgroup/style/inputgroupstyle.ts
+++ b/packages/primeng/src/inputgroup/style/inputgroupstyle.ts
@@ -21,6 +21,7 @@ const theme = /*css*/ `
     .p-inputgroup p-button:first-child,
     .p-inputgroup p-button:last-child {
         display: inline-flex;
+        height: 100%;
     }
 
     .p-inputgroup:has(> p-button:first-child) .p-button {


### PR DESCRIPTION
Ensures button within input group addon covers full height, addressing layout issues in `p-floatlabel` with
`variant="in"`.

Fixes #18888