### PR TITLE
fix: fix moveAllRight and moveAllLeft picklist buttons

### DIFF
--- a/packages/primeng/src/picklist/picklist.spec.ts
+++ b/packages/primeng/src/picklist/picklist.spec.ts
@@ -748,14 +748,20 @@ describe('PickList', () => {
         }));
 
         it('should allow drag&drop after moveAllRight', fakeAsync(() => {
+            // Verify initial state and keep tracking source and target form original references as a parent component
+            const source = picklistComponent.source;
+            const target = picklistComponent.target;
+            expect(source?.length).toBe(4);
+            expect(target?.length).toBe(2);
+
             // Move all items to target
             picklistComponent.moveAllRight();
             tick();
             fixture.detectChanges();
 
-            // Verify all items were moved
-            expect(picklistComponent.source?.length).toBe(0);
-            expect(picklistComponent.target?.length).toBe(6); // 2 original + 4 moved
+            // Verify all items were moved by using previous references
+            expect(source?.length).toBe(0);
+            expect(target?.length).toBe(6); // 2 original + 4 moved
 
             // Now try to drag&drop an item back from target to source
             const itemToMove = picklistComponent.target![0];
@@ -790,14 +796,20 @@ describe('PickList', () => {
         }));
 
         it('should allow drag&drop after moveAllLeft', fakeAsync(() => {
+            // Verify initial state and keep tracking source and target form original references as a parent component
+            const source = picklistComponent.source;
+            const target = picklistComponent.target;
+            expect(source?.length).toBe(4);
+            expect(target?.length).toBe(2);
+
             // Move all items to source
             picklistComponent.moveAllLeft();
             tick();
             fixture.detectChanges();
 
             // Verify all items were moved
-            expect(picklistComponent.target?.length).toBe(0);
-            expect(picklistComponent.source?.length).toBe(6); // 4 original + 2 moved
+            expect(source?.length).toBe(6); // 4 original + 2 moved
+            expect(target?.length).toBe(0);
 
             // Now try to drag&drop an item from source to target
             const itemToMove = picklistComponent.source![0];

--- a/packages/primeng/src/picklist/picklist.ts
+++ b/packages/primeng/src/picklist/picklist.ts
@@ -1346,7 +1346,7 @@ export class PickList extends BaseComponent implements AfterContentInit {
                 if (this.isItemVisible(this.source[i], this.SOURCE_LIST)) {
                     let removedItem = this.source.splice(i, 1)[0];
                     if (this.target) {
-                        this.target = [...this.target, removedItem];
+                        this.target.push(removedItem);
                     }
 
                     movedItems.push(removedItem);
@@ -1412,7 +1412,7 @@ export class PickList extends BaseComponent implements AfterContentInit {
                 if (this.isItemVisible(this.target[i], this.TARGET_LIST)) {
                     let removedItem = this.target.splice(i, 1)[0];
                     if (this.source) {
-                        this.source = [...this.source, removedItem];
+                        this.source.push(removedItem);
                     }
                     movedItems.push(removedItem);
                     i--;


### PR DESCRIPTION
Fix moveAllRight and moveAllLeft picklist buttons to continue to update parent source and target references (no copy which break the parent vision).

https://github.com/primefaces/primeng/issues/18953

