### PR TITLE
fix/Component: p-inputNumber [min] property NaN #18429

### DIFF
--- a/src/app/components/animateonscroll/animateonscroll.ts
+++ b/src/app/components/animateonscroll/animateonscroll.ts
@@ -43,7 +43,7 @@ export class AnimateOnScroll implements OnInit, AfterViewInit {
      * Specifies the threshold option of the IntersectionObserver API
      * @group Props
      */
-    @Input({ transform: numberAttribute }) threshold: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) threshold: number | undefined | null;
     /**
      * Whether the scroll event listener should be removed after initial run.
      * @group Props

--- a/src/app/components/autocomplete/autocomplete.ts
+++ b/src/app/components/autocomplete/autocomplete.ts
@@ -357,7 +357,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
      * Height of an item in the list for VirtualScrolling.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) virtualScrollItemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) virtualScrollItemSize: number | undefined | null;
     /**
      * Whether to use the scroller feature. The properties of scroller component can be used like an object in it.
      * @group Props
@@ -367,7 +367,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
      * Maximum number of character allows in the input field.
      * @group Props
      */
-    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxlength: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxlength: number | undefined | null;
     /**
      * Name of the input element.
      * @group Props
@@ -382,7 +382,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
      * Size of the input field.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) size: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) size: number | undefined | null;
     /**
      * Target element to attach the overlay, valid values are "body" or a local ng-template variable of another element (note: use binding with brackets for template variables, e.g. [appendTo]="mydiv" for a div element having #mydiv as variable name).
      * @group Props
@@ -483,7 +483,7 @@ export class AutoComplete implements AfterViewChecked, AfterContentInit, OnDestr
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * A property to uniquely identify a value in options.
      * @group Props

--- a/src/app/components/button/button.ts
+++ b/src/app/components/button/button.ts
@@ -433,7 +433,7 @@ export class Button implements AfterContentInit {
      * Add a tabindex to the button.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Defines the size of the button.
      * @group Props

--- a/src/app/components/calendar/calendar.ts
+++ b/src/app/components/calendar/calendar.ts
@@ -669,7 +669,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
      * Maximum number of selectable dates in multiple mode.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) maxDateCount: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxDateCount: number | undefined | null;
     /**
      * Whether to display today and clear buttons at the footer
      * @group Props
@@ -749,7 +749,7 @@ export class Calendar implements OnInit, OnDestroy, ControlValueAccessor {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Specifies the input variant of the component.
      * @group Props

--- a/src/app/components/cascadeselect/cascadeselect.ts
+++ b/src/app/components/cascadeselect/cascadeselect.ts
@@ -468,7 +468,7 @@ export class CascadeSelect implements OnInit, AfterContentInit {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined = 0;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null = 0;
     /**
      * Establishes relationships between the component and label(s) where its value should be one or more element IDs.
      * @group Props

--- a/src/app/components/checkbox/checkbox.ts
+++ b/src/app/components/checkbox/checkbox.ts
@@ -153,7 +153,7 @@ export class Checkbox implements ControlValueAccessor {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Identifier of the focus input to match a label defined for the component.
      * @group Props

--- a/src/app/components/chips/chips.ts
+++ b/src/app/components/chips/chips.ts
@@ -163,7 +163,7 @@ export class Chips implements AfterContentInit, ControlValueAccessor {
      * Maximum number of entries allowed.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) max: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) max: number | undefined | null;
     /**
      * Maximum length of a chip.
      * @group Props
@@ -183,7 +183,7 @@ export class Chips implements AfterContentInit, ControlValueAccessor {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Identifier of the focus input to match a label defined for the component.
      * @group Props

--- a/src/app/components/contextmenu/contextmenu.ts
+++ b/src/app/components/contextmenu/contextmenu.ts
@@ -460,7 +460,7 @@ export class ContextMenu implements OnInit, AfterContentInit, OnDestroy {
      * Press delay in touch devices as miliseconds.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) pressDelay: number | undefined = 500;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) pressDelay: number | undefined | null = 500;
     /**
      * Callback to invoke when overlay menu is shown.
      * @group Emits

--- a/src/app/components/dataview/dataview.ts
+++ b/src/app/components/dataview/dataview.ts
@@ -132,12 +132,12 @@ export class DataView implements OnInit, AfterContentInit, OnDestroy, BlockableU
      * Number of rows to display per page.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) rows: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) rows: number | undefined | null;
     /**
      * Number of total records, defaults to length of value when not defined.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) totalRecords: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) totalRecords: number | undefined | null;
     /**
      * Number of page links to display in paginator.
      * @group Props
@@ -257,7 +257,7 @@ export class DataView implements OnInit, AfterContentInit, OnDestroy, BlockableU
      * Index of the first row to be displayed.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) first: number | undefined = 0;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) first: number | undefined | null = 0;
     /**
      * Property name of data to use in sorting by default.
      * @group Props
@@ -267,7 +267,7 @@ export class DataView implements OnInit, AfterContentInit, OnDestroy, BlockableU
      * Order to sort the data by default.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) sortOrder: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) sortOrder: number | undefined | null;
     /**
      * An array of objects to display.
      * @group Props

--- a/src/app/components/dropdown/dropdown.ts
+++ b/src/app/components/dropdown/dropdown.ts
@@ -100,7 +100,7 @@ export class DropdownItem {
 
     @Input({ transform: booleanAttribute }) visible: boolean | undefined;
 
-    @Input({ transform: numberAttribute }) itemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) itemSize: number | undefined | null;
 
     @Input() ariaPosInset: string | undefined;
 
@@ -431,7 +431,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined = 0;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null = 0;
     /**
      * Default text to display when no option is selected.
      * @group Props
@@ -572,7 +572,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
      * Height of an item in the list for VirtualScrolling.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) virtualScrollItemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) virtualScrollItemSize: number | undefined | null;
     /**
      * Whether to use the scroller feature. The properties of scroller component can be used like an object in it.
      * @group Props
@@ -607,7 +607,7 @@ export class Dropdown implements OnInit, AfterViewInit, AfterContentInit, AfterV
      * Maximum number of character allows in the editable input field.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) maxlength: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxlength: number | undefined | null;
     /**
      * Advisory information to display in a tooltip on hover.
      * @group Props

--- a/src/app/components/fileupload/fileupload.ts
+++ b/src/app/components/fileupload/fileupload.ts
@@ -259,7 +259,7 @@ export class FileUpload implements AfterViewInit, AfterContentInit, OnInit, OnDe
      * Maximum file size allowed in bytes.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) maxFileSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxFileSize: number | undefined | null;
     /**
      * Summary message of the invalid file size.
      * @group Props

--- a/src/app/components/galleria/galleria.ts
+++ b/src/app/components/galleria/galleria.ts
@@ -487,7 +487,7 @@ export class GalleriaContent implements DoCheck {
 
     @Input() value: any[] = [];
 
-    @Input({ transform: numberAttribute }) numVisible: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) numVisible: number | undefined | null;
 
     @Input({ transform: booleanAttribute }) fullScreen: boolean;
 
@@ -609,7 +609,7 @@ export class GalleriaContent implements DoCheck {
 export class GalleriaItemSlot {
     @Input() templates: QueryList<PrimeTemplate> | undefined;
 
-    @Input({ transform: numberAttribute }) index: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) index: number | undefined | null;
 
     @Input() get item(): any {
         return this._item;

--- a/src/app/components/inputmask/inputmask.ts
+++ b/src/app/components/inputmask/inputmask.ts
@@ -164,12 +164,12 @@ export class InputMask implements OnInit, ControlValueAccessor {
      * Size of the input field.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) size: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) size: number | undefined | null;
     /**
      * Maximum number of character allows in the input field.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) maxlength: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxlength: number | undefined | null;
     /**
      * Specifies tab order of the element.
      * @group Props

--- a/src/app/components/inputnumber/inputnumber.ts
+++ b/src/app/components/inputnumber/inputnumber.ts
@@ -251,17 +251,17 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
      * Size of the input field.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) size: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) size: number | undefined | null;
     /**
      * Maximum number of character allows in the input field.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) maxlength: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxlength: number | undefined | null;
     /**
      * Specifies tab order of the element.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Title text of the input text.
      * @group Props
@@ -381,12 +381,12 @@ export class InputNumber implements OnInit, AfterContentInit, OnChanges, Control
      * The minimum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number and percent formatting is 0; the default for currency formatting is the number of minor unit digits provided by the ISO 4217 currency code list (2 if the list doesn't provide that information).
      * @group Props
      */
-    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) minFractionDigits: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) minFractionDigits: number | undefined | null;
     /**
      * The maximum number of fraction digits to use. Possible values are from 0 to 20; the default for plain number formatting is the larger of minimumFractionDigits and 3; the default for currency formatting is the larger of minimumFractionDigits and the number of minor unit digits provided by the ISO 4217 currency code list (2 if the list doesn't provide that information).
      * @group Props
      */
-    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxFractionDigits: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxFractionDigits: number | undefined | null;
     /**
      * Text to display before the value.
      * @group Props

--- a/src/app/components/inputswitch/inputswitch.ts
+++ b/src/app/components/inputswitch/inputswitch.ts
@@ -70,7 +70,7 @@ export class InputSwitch {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Identifier of the input element.
      * @group Props

--- a/src/app/components/listbox/listbox.ts
+++ b/src/app/components/listbox/listbox.ts
@@ -304,7 +304,7 @@ export class Listbox implements AfterContentInit, OnInit, ControlValueAccessor, 
      * Height of an item in the list for VirtualScrolling.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) virtualScrollItemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) virtualScrollItemSize: number | undefined | null;
     /**
      * Whether to use the scroller feature. The properties of scroller component can be used like an object in it.
      * @group Props

--- a/src/app/components/multiselect/multiselect.ts
+++ b/src/app/components/multiselect/multiselect.ts
@@ -108,7 +108,7 @@ export class MultiSelectItem {
 
     @Input({ transform: booleanAttribute }) disabled: boolean | undefined;
 
-    @Input({ transform: numberAttribute }) itemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) itemSize: number | undefined | null;
 
     @Input({ transform: booleanAttribute }) focused: boolean | undefined;
 
@@ -671,7 +671,7 @@ export class MultiSelect implements OnInit, AfterViewInit, AfterContentInit, Aft
      * Height of an item in the list for VirtualScrolling.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) virtualScrollItemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) virtualScrollItemSize: number | undefined | null;
     /**
      * Icon to display in loading state.
      * @group Props

--- a/src/app/components/orderlist/orderlist.ts
+++ b/src/app/components/orderlist/orderlist.ts
@@ -175,7 +175,7 @@ export class OrderList implements AfterViewChecked, AfterContentInit {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
 
     /**
      * Defines a string that labels the input for accessibility.

--- a/src/app/components/panelmenu/panelmenu.ts
+++ b/src/app/components/panelmenu/panelmenu.ts
@@ -185,7 +185,7 @@ export class PanelMenuSub {
 
     @Input({ transform: booleanAttribute }) root: boolean | undefined;
 
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
 
     @Input() transitionOptions: string | undefined;
 
@@ -329,7 +329,7 @@ export class PanelMenuList implements OnChanges {
 
     @Input({ transform: booleanAttribute }) root: boolean | undefined;
 
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
 
     @Input() activeItem: any;
 
@@ -906,7 +906,7 @@ export class PanelMenu implements AfterContentInit {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined = 0;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null = 0;
 
     @ContentChildren(PrimeTemplate) templates: QueryList<PrimeTemplate> | undefined;
 

--- a/src/app/components/password/password.ts
+++ b/src/app/components/password/password.ts
@@ -479,7 +479,7 @@ export class Password implements AfterContentInit, OnInit {
      * specifies the maximum number of characters allowed in the input element.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) maxLength: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxLength: number | undefined | null;
     /**
      * Text for a strong password. Defaults to PrimeNG I18N API configuration.
      * @group Props

--- a/src/app/components/picklist/picklist.ts
+++ b/src/app/components/picklist/picklist.ts
@@ -383,7 +383,7 @@ export class PickList implements AfterViewChecked, AfterContentInit {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined = 0;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null = 0;
     /**
      * Defines a string that labels the move to right button for accessibility.
      * @group Props

--- a/src/app/components/progressbar/progressbar.ts
+++ b/src/app/components/progressbar/progressbar.ts
@@ -66,7 +66,7 @@ export class ProgressBar {
      * Current value of the progress.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) value: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) value: number | undefined | null;
     /**
      * Whether to display the progress bar value.
      * @group Props

--- a/src/app/components/radiobutton/radiobutton.ts
+++ b/src/app/components/radiobutton/radiobutton.ts
@@ -140,7 +140,7 @@ export class RadioButton implements ControlValueAccessor, OnInit, OnDestroy {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Identifier of the focus input to match a label defined for the component.
      * @group Props

--- a/src/app/components/slider/slider.ts
+++ b/src/app/components/slider/slider.ts
@@ -168,7 +168,7 @@ export class Slider implements OnDestroy, ControlValueAccessor {
      * Step factor to increment/decrement the value.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) step: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) step: number | undefined | null;
     /**
      * When specified, allows two boundary values to be picked.
      * @group Props

--- a/src/app/components/splitbutton/splitbutton.ts
+++ b/src/app/components/splitbutton/splitbutton.ts
@@ -246,7 +246,7 @@ export class SplitButton {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * When present, it specifies that the menu button element should be disabled.
      * @group Props

--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -609,7 +609,7 @@ export class Table implements OnInit, AfterViewInit, AfterContentInit, Blockable
      * Height of a row to use in calculations of virtual scrolling.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) virtualScrollItemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) virtualScrollItemSize: number | undefined | null;
     /**
      * Whether to use the scroller feature. The properties of scroller component can be used like an object in it.
      * @group Props
@@ -4681,7 +4681,7 @@ export class TableRadioButton {
 
     @Input() value: any;
 
-    @Input({ transform: numberAttribute }) index: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) index: number | undefined | null;
 
     @Input() inputId: string | undefined;
 
@@ -4781,7 +4781,7 @@ export class TableCheckbox {
 
     @Input() value: any;
 
-    @Input({ transform: numberAttribute }) index: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) index: number | undefined | null;
 
     @Input() inputId: string | undefined;
 
@@ -5334,12 +5334,12 @@ export class ColumnFilter implements AfterContentInit {
      * Defines minimum fraction of digits.
      * @group Props
      */
-    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) minFractionDigits: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) minFractionDigits: number | undefined | null;
     /**
      * Defines maximum fraction of digits.
      * @group Props
      */
-    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxFractionDigits: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxFractionDigits: number | undefined | null;
     /**
      * Defines prefix of the filter.
      * @group Props
@@ -5999,9 +5999,9 @@ export class ColumnFilterFormElement implements OnInit {
 
     @Input() placeholder: string | undefined;
 
-    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) minFractionDigits: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) minFractionDigits: number | undefined | null;
 
-    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxFractionDigits: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) maxFractionDigits: number | undefined | null;
 
     @Input() prefix: string | undefined;
 

--- a/src/app/components/toast/toast.ts
+++ b/src/app/components/toast/toast.ts
@@ -128,7 +128,7 @@ import { DomHandler } from 'primeng/dom';
 export class ToastItem implements AfterViewInit, OnDestroy {
     @Input() message: Message | null | undefined;
 
-    @Input({ transform: numberAttribute }) index: number | null | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) index: number | undefined | null;
 
     @Input({ transform: numberAttribute }) life: number;
 

--- a/src/app/components/togglebutton/togglebutton.ts
+++ b/src/app/components/togglebutton/togglebutton.ts
@@ -113,7 +113,7 @@ export class ToggleButton implements ControlValueAccessor {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined = 0;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null = 0;
     /**
      * Position of the icon.
      * @group Props

--- a/src/app/components/tooltip/tooltip.ts
+++ b/src/app/components/tooltip/tooltip.ts
@@ -55,22 +55,22 @@ export class Tooltip implements AfterViewInit, OnDestroy {
      * Delay to show the tooltip in milliseconds.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) showDelay: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) showDelay: number | undefined | null;
     /**
      * Delay to hide the tooltip in milliseconds.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) hideDelay: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) hideDelay: number | undefined | null;
     /**
      * Time to wait in milliseconds to hide the tooltip even it is active.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) life: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) life: number | undefined | null;
     /**
      * Specifies the additional vertical offset of the tooltip from its default position.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) positionTop: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) positionTop: number | undefined | null;
     /**
      * Specifies the additional horizontal offset of the tooltip from its default position.
      * @group Props

--- a/src/app/components/tree/tree.ts
+++ b/src/app/components/tree/tree.ts
@@ -241,19 +241,19 @@ export class UITreeNode implements OnInit {
 
     @Input() parentNode: TreeNode<any> | undefined;
 
-    @Input({ transform: booleanAttribute }) root: boolean | undefined;
+    @Input({ transform: booleanAttribute }) root: boolean | undefined | null;
 
-    @Input({ transform: numberAttribute }) index: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) index: number | undefined | null;
 
     @Input({ transform: booleanAttribute }) firstChild: boolean | undefined;
 
     @Input({ transform: booleanAttribute }) lastChild: boolean | undefined;
 
-    @Input({ transform: numberAttribute }) level: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) level: number | undefined | null;
 
-    @Input({ transform: numberAttribute }) indentation: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) indentation: number | undefined | null;
 
-    @Input({ transform: numberAttribute }) itemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) itemSize: number | undefined | null;
 
     @Input() loadingMode: string;
 
@@ -1051,7 +1051,7 @@ export class Tree implements OnInit, AfterContentInit, OnChanges, OnDestroy, Blo
      * Height of an item in the list for VirtualScrolling.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) virtualScrollItemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) virtualScrollItemSize: number | undefined | null;
     /**
      * Whether to use the scroller feature. The properties of scroller component can be used like an object in it.
      * @group Props

--- a/src/app/components/treetable/treetable.ts
+++ b/src/app/components/treetable/treetable.ts
@@ -307,7 +307,7 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
      * Number of rows to display per page.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) rows: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) rows: number | undefined | null;
     /**
      * Index of the first row to be displayed.
      * @group Props
@@ -457,7 +457,7 @@ export class TreeTable implements AfterContentInit, OnInit, OnDestroy, Blockable
      * Height of a row to use in calculations of virtual scrolling.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) virtualScrollItemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) virtualScrollItemSize: number | undefined | null;
     /**
      * Whether to use the scroller feature. The properties of scroller component can be used like an object in it.
      * @group Props

--- a/src/app/components/tristatecheckbox/tristatecheckbox.ts
+++ b/src/app/components/tristatecheckbox/tristatecheckbox.ts
@@ -112,7 +112,7 @@ export class TriStateCheckbox implements ControlValueAccessor {
      * Index of the element in tabbing order.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) tabindex: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) tabindex: number | undefined | null;
     /**
      * Identifier of the focus input to match a label defined for the component.
      * @group Props

--- a/src/app/components/virtualscroller/virtualscroller.ts
+++ b/src/app/components/virtualscroller/virtualscroller.ts
@@ -65,7 +65,7 @@ export class VirtualScroller implements AfterContentInit, BlockableUI {
      * Height of an item in the list.
      * @group Props
      */
-    @Input({ transform: numberAttribute }) itemSize: number | undefined;
+    @Input({ transform: (value: unknown) => numberAttribute(value, null) }) itemSize: number | undefined | null;
     /**
      * Inline style of the component.
      * @group Props


### PR DESCRIPTION

The bug was introduced in commit b3e91c77387a9169a8cec085a1cfde6df45b7f35, where the numberAttribute was added to all numeric inputs, but optional numeric inputs should be treated differently. After reading the repository, I saw that some other points had been addressed for the same issue, such as in fix #15264, and I applied the same solution to all optional numeric inputs in the source.
