### PR TITLE
Subscribable Validation Messaging for FileUpload

### DIFF
--- a/packages/primeng/src/fileupload/fileupload.interface.ts
+++ b/packages/primeng/src/fileupload/fileupload.interface.ts
@@ -132,6 +132,25 @@ export interface FileUploadErrorEvent {
      */
     files: File[];
 }
+/**
+ * Callback to invoke when a validation message is produced.
+ * @see {@link FileUpload.onValidationMessage}
+ * @group Events
+ */
+export interface FileUploadValidationMessageEvent {
+    /**
+     * Templated summary message.
+     */
+    summary: string;
+    /**
+     * Templated detail message.
+     */
+    detail: string;
+    /**
+     * File that failed validation.
+     */
+    file: File;
+}
 
 /**
  * Defines valid templates in FileUpload.


### PR DESCRIPTION
FileUpload: Initial Implementation of the new onValidationMessage-Emitter that is invoked if ValidationMessages for the files to ne uploaded are raised. Additionally the displayValidationMessages Input was introduces to manage if validation messages shall be displayed inline.

For transparency: The changes were made leveraging coding agents.

See the Issue https://github.com/primefaces/primeng/issues/18995