### PR TITLE
fix: fixes #18533

### DIFF
--- a/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
@@ -46,6 +46,11 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      */
     closeOnEscape?: boolean = false;
     /**
+     * Specifies if autofocus should happen on close.
+     * @group Props
+     */
+    focusOnClose?: boolean = true;
+    /**
      * Specifies if autofocus should happen on show.
      * @group Props
      */

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.spec.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.spec.ts
@@ -965,6 +965,37 @@ describe('DynamicDialogComponent', () => {
             flush();
         }));
 
+        it('should not focus on parent content when nested dialog closes and focusOnClose is false', fakeAsync(() => {
+            mockConfig.focusOnClose = false;
+            const parentDialog = document.createElement('div');
+            parentDialog.className = 'p-dialog';
+            const parentContent = document.createElement('div');
+            parentContent.className = 'p-dialog-content';
+            parentDialog.appendChild(parentContent);
+            document.body.appendChild(parentDialog);
+
+            spyOn(component, 'focus');
+            spyOn(component, 'onContainerDestroy');
+
+            const animationEvent: AnimationEvent = {
+                element: document.createElement('div'),
+                toState: 'void',
+                fromState: 'visible',
+                totalTime: 150,
+                phaseName: 'done',
+                triggerName: 'animation',
+                disabled: false
+            };
+
+            component.onAnimationEnd(animationEvent);
+
+            expect(component.focus).toHaveBeenCalledTimes(0);
+            expect(component.onContainerDestroy).toHaveBeenCalled();
+
+            document.body.removeChild(parentDialog);
+            flush();
+        }));
+
         it('should handle z-index layering for nested dialogs', () => {
             const wrapperElement = document.createElement('div');
             const containerElement = document.createElement('div');

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -406,7 +406,7 @@ export class DynamicDialogComponent extends BaseComponent implements AfterViewIn
 
     onAnimationEnd(event: AnimationEvent) {
         if (event.toState === 'void') {
-            if (this.parentContent) {
+            if (this.parentContent && this.ddconfig.focusOnClose) {
                 this.focus(this.parentContent);
             }
             this.onContainerDestroy();


### PR DESCRIPTION
This offer the devs to disable the autofocus of the first element when a nested modal is closed. The side-effect of the autofocus is that we scroll to top.