### PR TITLE
Revert license type back to MIT in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/primefaces/primeng.git"
     },
-    "license": "SEE LICENSE IN LICENSE.md",
+    "license": "MIT",
     "bugs": {
         "url": "https://github.com/primefaces/primeng/issues"
     },


### PR DESCRIPTION
The reference to the License.md file is not recognized by dependency review tools as it is not a valid SPDX ID. Fixes #18456 
