### PR TITLE
fix: resolve calculateScrollbarHeight returning 0 in DomHandler #19043

### DIFF
--- a/packages/primeng/src/dom/domhandler.ts
+++ b/packages/primeng/src/dom/domhandler.ts
@@ -544,13 +544,13 @@ export class DomHandler {
         if (this.calculatedScrollbarHeight !== null) return this.calculatedScrollbarHeight;
 
         let scrollDiv = document.createElement('div');
-        scrollDiv.className = 'p-scrollbar-measure';
+        scrollDiv.style.overflow = 'scroll';
         document.body.appendChild(scrollDiv);
 
         let scrollbarHeight = scrollDiv.offsetHeight - scrollDiv.clientHeight;
         document.body.removeChild(scrollDiv);
 
-        this.calculatedScrollbarWidth = scrollbarHeight;
+        this.calculatedScrollbarHeight = scrollbarHeight;
 
         return scrollbarHeight;
     }


### PR DESCRIPTION
Problem:
- calculateScrollbarHeight() relied on 'p-scrollbar-measure' CSS class
- If class doesn't exist or isn't loaded, no scrollbar is rendered
- Method returns 0 instead of actual scrollbar height
- Variable assignment bug: stored height in calculatedScrollbarWidth instead of calculatedScrollbarHeight

Solution:
- Use inline CSS styles to guarantee scrollbar rendering
- Add style: overflow:scroll;
- Fix variable assignment: store in calculatedScrollbarHeight (not calculatedScrollbarWidth)

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
