### PR TITLE
fix(tooltip): set tooltip role again

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.spec.ts
+++ b/packages/primeng/src/tooltip/tooltip.spec.ts
@@ -410,6 +410,14 @@ describe('Tooltip', () => {
             const target = tooltipDirective.getTarget(mockElement);
             expect(target).toBe(mockElement);
         });
+
+        it('should set role="tooltip" on the container element', fakeAsync(() => {
+            tooltipDirective.activate();
+            tick();
+            expect(tooltipDirective.container?.getAttribute('role')).toBe('tooltip');
+            tooltipDirective.deactivate();
+            flush();
+        }));
     });
 
     describe('Styling and Custom Options', () => {

--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -406,7 +406,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
             this.remove();
         }
 
-        this.container = createElement('div', { class: this.cx('root'), 'p-bind': this.ptm('root'), 'data-pc-section': 'root' });
+        this.container = createElement('div', { class: this.cx('root'), role: 'tooltip', 'p-bind': this.ptm('root'), 'data-pc-section': 'root' });
         let tooltipArrow = createElement('div', { class: 'p-tooltip-arrow', 'p-bind': this.ptm('arrow'), 'data-pc-section': 'arrow' });
         this.container.appendChild(tooltipArrow);
         this.tooltipText = createElement('div', { class: 'p-tooltip-text', 'p-bind': this.ptm('text'), 'data-pc-section': 'text' });


### PR DESCRIPTION
This fixes a regression of prime@20 where the tooltip role isn't set anymore. This breaks a11y tests.

See prime@19 tooltip create:
https://github.com/primefaces/primeng/blob/v19-prod/packages/primeng/src/tooltip/tooltip.ts#L397
