### PR TITLE
docs(#19066): fix link to passthrough guide

### DIFF
--- a/apps/showcase/components/doc/app.docptviewer.ts
+++ b/apps/showcase/components/doc/app.docptviewer.ts
@@ -77,7 +77,7 @@ export const getPTOptions = (name) => {
         <app-docsectiontext>
             <p>
                 Some sections may not be visible due to the availability of the particular feature. Section names that start with the <i>pc</i> prefix indicate that the element is a PrimeNG component not a DOM element. Visit the
-                <a routerLink="/guides/passthrough">pass-through</a> documentation for more information.
+                <a routerLink="/passthrough">pass-through</a> documentation for more information.
             </p>
         </app-docsectiontext>
         <div #container class="doc-ptviewerwrapper card">


### PR DESCRIPTION
Fixes https://github.com/primefaces/primeng/issues/19066