### PR TITLE
fix: #19083 - InputOTP integerOnly does not use numeric inputmode

### DIFF
--- a/packages/primeng/src/inputotp/inputotp.ts
+++ b/packages/primeng/src/inputotp/inputotp.ts
@@ -101,6 +101,7 @@ export interface InputOtpInputTemplateContext {
                     [pSize]="size()"
                     [variant]="$variant()"
                     [invalid]="invalid()"
+                    [attr.inputmode]="inputMode"
                     [attr.name]="name()"
                     [attr.tabindex]="tabindex"
                     [attr.required]="required() ? '' : undefined"


### PR DESCRIPTION
fixes #19083 
