### PR TITLE
fix: radiobutton icon misalignment at non-100% zoom levels

### DIFF
--- a/packages/primeng/src/radiobutton/style/radiobuttonstyle.ts
+++ b/packages/primeng/src/radiobutton/style/radiobuttonstyle.ts
@@ -11,6 +11,14 @@ const style = /*css*/ `
     p-radiobutton.ng-invalid.ng-dirty .p-radiobutton-box {
         border-color: dt('radiobutton.invalid.border.color');
     }
+    
+    .p-radiobutton-box {
+        will-change: transform;
+    }
+
+    .p-radiobutton-icon {
+        transform: translateZ(0);
+    }
 `;
 
 const classes = {


### PR DESCRIPTION
   Forces GPU rendering to fix subpixel rounding issues that caused
   the icon to be off-center when page is scaled to 110% or other
   non-standard zoom levels.

   Fixed #17642"

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://github.com/primefaces/primeng/issues/17642).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
