### PR TITLE
fix(#19156): properly hides toggle-all checkbox when showToggleAll is combined with filter

### DIFF
--- a/packages/primeng/src/listbox/listbox.ts
+++ b/packages/primeng/src/listbox/listbox.ts
@@ -92,7 +92,7 @@ export const LISTBOX_VALUE_ACCESSOR: any = {
             <p-checkbox
                 #headerchkbox
                 (onChange)="onToggleAll($event)"
-                *ngIf="checkbox && multiple"
+                *ngIf="checkbox && multiple && showToggleAll"
                 [class]="cx('optionCheckIcon')"
                 [ngModel]="allSelected()"
                 [disabled]="$disabled()"


### PR DESCRIPTION
Fixes #19156 