### PR TITLE
fix(#19116): Textarea throws error when used with Angular 21 Signal Forms

### DIFF
--- a/packages/primeng/src/textarea/textarea.ts
+++ b/packages/primeng/src/textarea/textarea.ts
@@ -103,7 +103,7 @@ export class Textarea extends BaseModelHolder<TextareaPassThrough> {
     }
 
     onInit() {
-        if (this.ngControl) {
+        if (this.ngControl?.valueChanges) {
             this.ngControlSubscription = (this.ngControl as any).valueChanges.subscribe(() => {
                 this.updateState();
             });


### PR DESCRIPTION
# Fix: Textarea throws error when used with Angular 21 Signal Forms

This PR fixes an incompatibility between PrimeNG’s Textarea component and Angular 21’s new Signal Forms.
When using Signal Forms, NgControl.valueChanges is undefined, causing the following runtime error inside Textarea.onInit():

 ``` 
ERROR TypeError: can't access property "subscribe", this.ngControl.valueChanges is undefined
    at onInit (primeng-textarea.mjs:175)
    at ngOnInit (primeng-basecomponent.mjs:205)
 ``` 
## Root cause
valueChanges does not exist on Signal-based controls.
PrimeNG’s Textarea attempts to always subscribe to:
this.ngControl.valueChanges.subscribe(...)
This works for classic Reactive Forms but fails for Signal Forms because Angular 21 removed this observable for signal-based controls.

## What this PR changes
The PR updates the condition to safely check whether valueChanges exists before subscribing:
 ``` 
if (this.ngControl?.valueChanges) {
    this.ngControlSubscription = (this.ngControl as any).valueChanges.subscribe(() => {
        this.updateState();
    });
}
 ``` 

This ensures compatibility with both:
Angular classic forms (which still expose valueChanges)
Angular Signal Forms (where valueChanges is undefined)

## Why this fix is needed
Without this fix, any Angular 21 application using:
PrimeNG Textarea
Angular Signal Forms (formControl or formGroup with signals)
…will immediately throw a runtime error and break component rendering.

Issue reference
Fixes #19116