### PR TITLE
chore: update TreeNode interface to clarify loading property

### DIFF
--- a/packages/primeng/src/api/treenode.ts
+++ b/packages/primeng/src/api/treenode.ts
@@ -76,7 +76,7 @@ export interface TreeNode<T = any> {
      */
     key?: string;
     /**
-     * Mandatory unique key of the node.
+     * Whether the node is loading. Used in lazy loading.
      */
     loading?: boolean;
 }


### PR DESCRIPTION
The description of the loading property on the tree node interface doesn't reflect accurately it's purpose
<img width="1028" height="580" alt="image" src="https://github.com/user-attachments/assets/6dcc810c-1b1b-4910-bf80-644b76094659" />

This pull request corrects it to an accurate description
<img width="1020" height="557" alt="image" src="https://github.com/user-attachments/assets/22956302-ea49-41b0-90be-aceb2748ba3c" />
