### PR TITLE
Add role "progressbar" to progressbar

### DIFF
--- a/packages/primeng/src/progressbar/progressbar.ts
+++ b/packages/primeng/src/progressbar/progressbar.ts
@@ -29,6 +29,7 @@ const PROGRESSBAR_INSTANCE = new InjectionToken<ProgressBar>('PROGRESSBAR_INSTAN
     encapsulation: ViewEncapsulation.None,
     providers: [ProgressBarStyle, { provide: PROGRESSBAR_INSTANCE, useExisting: ProgressBar }, { provide: PARENT_INSTANCE, useExisting: ProgressBar }],
     host: {
+        '[role]': 'progressbar',
         '[attr.aria-valuemin]': '0',
         '[attr.aria-valuenow]': 'value',
         '[attr.aria-valuemax]': '100',


### PR DESCRIPTION
Re-adding the a11y role "progressbar" to the progressbar component, that was (accidentally?) removed in the migration to primeuix in commit d204244b8e0f46865240a40dacad4de8a415ccdf
