### PR TITLE
Handle maximum height for spacer for table

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -275,7 +275,7 @@ export class TableService {
                     <tbody
                         role="rowgroup"
                         *ngIf="scrollerOptions.spacerStyle"
-                        [style]="'height: calc(' + scrollerOptions.spacerStyle.height + ' - ' + scrollerOptions.rows.length * scrollerOptions.itemSize + 'px);'"
+                        [style]="'height: min(17000000px, calc(' + scrollerOptions.spacerStyle.height + ' - ' + scrollerOptions.rows.length * scrollerOptions.itemSize + 'px));'"
                         [class]="cx('virtualScrollerSpacer')"
                         [pBind]="ptm('virtualScrollerSpacer')"
                     ></tbody>


### PR DESCRIPTION
As described in the issue: if the spacer gets a pixel height greater than 33 or 17 million pixels the browser ignores the height style. This results in the scrollbar height just matching the loaded data, not the virtual data. 

This PR aims to mitigate this issue by making sure the height never becomes too big. However, it will result in a moving scrollbar height when the table would originally have been too big. #19226
