### PR TITLE
fix: #16776 Select - Fix label association for better accessibility

### DIFF
--- a/apps/showcase/doc/select/accessibilitydoc.ts
+++ b/apps/showcase/doc/select/accessibilitydoc.ts
@@ -11,9 +11,9 @@ import { AppCode } from '@/components/doc/app.code';
         <app-docsectiontext>
             <h3>Screen Reader</h3>
             <p>
-                Value to describe the component can either be provided with <i>ariaLabelledBy</i> or <i>ariaLabel</i> props. The select element has a <i>combobox</i> role in addition to <i>aria-haspopup</i> and <i>aria-expanded</i> attributes. If the
-                editable option is enabled <i>aria-autocomplete</i> is also added. The relation between the combobox and the popup is created with <i>aria-controls</i> and <i>aria-activedescendant</i> attribute is used to instruct screen reader which
-                option to read during keyboard navigation within the popup list.
+                Value to describe the component can either be provided with <i>ariaLabelledBy</i> or <i>ariaLabel</i> props. To associate a label, the select element needs to have an <i>inputId</i> which has to match the <i>for</i> attribute of the
+                label. The select element has a <i>combobox</i> role in addition to <i>aria-haspopup</i> and <i>aria-expanded</i> attributes. If the editable option is enabled <i>aria-autocomplete</i> is also added. The relation between the combobox
+                and the popup is created with <i>aria-controls</i> and <i>aria-activedescendant</i> attribute is used to instruct screen reader which option to read during keyboard navigation within the popup list.
             </p>
             <p>
                 The popup list has an id that refers to the <i>aria-controls</i> attribute of the <i>combobox</i> element and uses <i>listbox</i> as the role. Each list item has an <i>option</i> role, an id to match the
@@ -179,6 +179,9 @@ export class AccessibilityDoc {
         basic: `<span id="dd1">Options</span>
 <p-select ariaLabelledBy="dd1"/>
 
-<p-select ariaLabel="Options"/>`
+<p-select ariaLabel="Options"/>
+
+<label for="cities">Cities</label>
+<p-select inputId="cities"/>`
     };
 }

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -176,7 +176,7 @@ export class SelectItem extends BaseComponent {
     standalone: true,
     imports: [CommonModule, SelectItem, Overlay, Tooltip, AutoFocus, TimesIcon, ChevronDownIcon, SearchIcon, InputText, IconField, InputIcon, Scroller, SharedModule, BindModule],
     template: `
-        <span
+        <button
             #focusInput
             [class]="cx('label')"
             *ngIf="!editable"
@@ -204,13 +204,14 @@ export class SelectItem extends BaseComponent {
             [attr.required]="required() ? '' : undefined"
             [attr.disabled]="$disabled() ? '' : undefined"
             [attr.data-p]="labelDataP"
+            type="button"
         >
             <ng-container *ngIf="!selectedItemTemplate && !_selectedItemTemplate; else defaultPlaceholder">{{ label() === 'p-emptylabel' ? '&nbsp;' : label() }}</ng-container>
             <ng-container *ngIf="(selectedItemTemplate || _selectedItemTemplate) && !isSelectedOptionEmpty()" [ngTemplateOutlet]="selectedItemTemplate || _selectedItemTemplate" [ngTemplateOutletContext]="{ $implicit: selectedOption }"></ng-container>
             <ng-template #defaultPlaceholder>
                 <span *ngIf="isSelectedOptionEmpty()">{{ label() === 'p-emptylabel' ? '&nbsp;' : label() }}</span>
             </ng-template>
-        </span>
+        </button>
         <input
             *ngIf="editable"
             #editableInput

--- a/packages/primeng/src/select/style/selectstyle.ts
+++ b/packages/primeng/src/select/style/selectstyle.ts
@@ -18,6 +18,10 @@ const style = /*css*/ `
     .p-select.ng-invalid.ng-dirty .p-select-label.p-placeholder {
         color: dt('select.invalid.placeholder.color');
     }
+
+    .p-select > button[role="combobox"] {
+        text-align: left;
+    }
 `;
 
 const classes = {


### PR DESCRIPTION
Fixes #16776

The span-element is not labelable. see https://developer.mozilla.org/en-US/docs/Web/HTML/Guides/Content_categories#labelable The element with the id referenced by the label must be labelable. Button is a labelable element.

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
