### PR TITLE
fix(dialog): use textContent instead of innerHTML for dynamic styles

### DIFF
--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -807,29 +807,29 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
         }
     }
 
-    createStyle() {
-        if (isPlatformBrowser(this.platformId)) {
-            if (!this.styleElement && !this.$unstyled()) {
-                this.styleElement = this.renderer.createElement('style');
-                this.styleElement.type = 'text/css';
-                setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
-                this.renderer.appendChild(this.document.head, this.styleElement);
-                let innerHTML = '';
-                for (let breakpoint in this.breakpoints) {
-                    innerHTML += `
-                        @media screen and (max-width: ${breakpoint}) {
-                            .p-dialog[${this.id}]:not(.p-dialog-maximized) {
-                                width: ${this.breakpoints[breakpoint]} !important;
-                            }
-                        }
-                    `;
-                }
+createStyle() {
+    if (isPlatformBrowser(this.platformId)) {
+        if (!this.styleElement && !this.$unstyled()) {
+            this.styleElement = this.renderer.createElement('style');
+            this.styleElement.type = 'text/css';
+            setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
+            this.renderer.appendChild(this.document.head, this.styleElement);
 
-                this.renderer.setProperty(this.styleElement, 'innerHTML', innerHTML);
-                setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
+            let cssText = '';
+            for (let breakpoint in this.breakpoints) {
+                cssText += `
+                    @media screen and (max-width: ${breakpoint}) {
+                        .p-dialog[${this.id}]:not(.p-dialog-maximized) {
+                            width: ${this.breakpoints[breakpoint]} !important;
+                        }
+                    }
+                `;
             }
+
+            this.renderer.setProperty(this.styleElement, 'textContent', cssText);
         }
     }
+}
 
     initDrag(event: MouseEvent) {
         const target = event.target as HTMLElement;

--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -807,29 +807,28 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
         }
     }
 
-createStyle() {
-    if (isPlatformBrowser(this.platformId)) {
-        if (!this.styleElement && !this.$unstyled()) {
-            this.styleElement = this.renderer.createElement('style');
-            this.styleElement.type = 'text/css';
-            setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
-            this.renderer.appendChild(this.document.head, this.styleElement);
-
-            let cssText = '';
-            for (let breakpoint in this.breakpoints) {
-                cssText += `
-                    @media screen and (max-width: ${breakpoint}) {
-                        .p-dialog[${this.id}]:not(.p-dialog-maximized) {
-                            width: ${this.breakpoints[breakpoint]} !important;
+    createStyle() {
+        if (isPlatformBrowser(this.platformId)) {
+            if (!this.styleElement && !this.$unstyled()) {
+                this.styleElement = this.renderer.createElement('style');
+                this.styleElement.type = 'text/css';
+                setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
+                this.renderer.appendChild(this.document.head, this.styleElement);
+                let cssText = '';
+                for (let breakpoint in this.breakpoints) {
+                    cssText += `
+                        @media screen and (max-width: ${breakpoint}) {
+                            .p-dialog[${this.id}]:not(.p-dialog-maximized) {
+                                width: ${this.breakpoints[breakpoint]} !important;
+                            }
                         }
-                    }
-                `;
-            }
+                    `;
+                }
 
-            this.renderer.setProperty(this.styleElement, 'textContent', cssText);
+                this.renderer.setProperty(this.styleElement, 'textContent', cssText);
+            }
         }
     }
-}
 
     initDrag(event: MouseEvent) {
         const target = event.target as HTMLElement;

--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -814,9 +814,9 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
                 this.styleElement.type = 'text/css';
                 setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
                 this.renderer.appendChild(this.document.head, this.styleElement);
-                let cssText = '';
+                let innerHTML = '';
                 for (let breakpoint in this.breakpoints) {
-                    cssText += `
+                    innerHTML += `
                         @media screen and (max-width: ${breakpoint}) {
                             .p-dialog[${this.id}]:not(.p-dialog-maximized) {
                                 width: ${this.breakpoints[breakpoint]} !important;
@@ -825,7 +825,8 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
                     `;
                 }
 
-                this.renderer.setProperty(this.styleElement, 'textContent', cssText);
+                this.renderer.setProperty(this.styleElement, 'textContent', innerHTML);
+                setAttribute(this.styleElement, 'nonce', this.config?.csp()?.nonce);
             }
         }
     }


### PR DESCRIPTION
### What’s changed
Replaced `innerHTML` with `textContent` when injecting dynamic CSS into the `<style>` element used for responsive dialog breakpoints.

### Why
Avoids using the `innerHTML` sink when no HTML parsing is required, improving compatibility with CSP / Trusted Types environments.

### Tests
- `pnpm --filter primeng test:unit -- --include="**/dialog/*.spec.ts"`

