### PR TITLE
fix(multiselect): prevent value selection on tab key

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -1823,19 +1823,13 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
         }
     }
 
-    onTabKey(event, pressedInInputText = false) {
+    onTabKey(event: KeyboardEvent, pressedInInputText = false) {
         if (!pressedInInputText) {
             if (this.overlayVisible && this.hasFocusableElements()) {
                 focus(event.shiftKey ? this.lastHiddenFocusableElementOnOverlay?.nativeElement : this.firstHiddenFocusableElementOnOverlay?.nativeElement);
 
                 event.preventDefault();
             } else {
-                if (this.focusedOptionIndex() !== -1) {
-                    const option = this.visibleOptions()[this.focusedOptionIndex()];
-
-                    !this.isSelected(option) && this.onOptionSelect({ originalEvent: event, option });
-                }
-
                 this.overlayVisible && this.hide(this.filter);
             }
         }


### PR DESCRIPTION
fixes https://github.com/primefaces/primeng/issues/18584

By WAI-ARIA Authoring Practices, Tab is a focus-navigation key. It should move focus to the next focusable element (Shift+Tab to the previous) and, if the popup is open, typically close it without changing selection.

Selection should only change with Space/Enter, not Tab.