### PR TITLE
fix: #19196 - Ensure onClose fires on close icon click and ESC key press (v20)

### DIFF
--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -54,6 +54,7 @@ const DYNAMIC_DIALOG_INSTANCE = new InjectionToken<DynamicDialog>('DYNAMIC_DIALO
             (onResizeInit)="onDialogResizeInit($event)"
             (onResizeEnd)="onDialogResizeEnd($event)"
             (onDragEnd)="onDialogDragEnd($event)"
+            (visibleChange)="onVisibleChange($event)"
             [pt]="ptm('pcDialog')"
             hostName="DynamicDialog"
         >
@@ -235,6 +236,12 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
         private dialogRef: DynamicDialogRef
     ) {
         super();
+    }
+
+    onVisibleChange(visible: boolean) {
+        if (!visible) {
+            this.dialogRef.close();
+        }
     }
 
     onAfterViewInit() {


### PR DESCRIPTION
Can we please create a hotfix for the v20 version regarding this fix [PR](https://github.com/primefaces/primeng/pull/19209)

Solves https://github.com/primefaces/primeng/issues/19196

In DynamicDialog, visibleChange event handler is added, in which we call close on the dialogRef.
The fix ensures that onClose fires and the toast message shows up.