### PR TITLE
fix(table): correct column resize direction in RTL mode

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -2641,12 +2641,14 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
         (<ElementRef>this.resizeHelperViewChild).nativeElement.style.display = 'block';
     }
 
-    onColumnResizeEnd() {
-        const delta = this.resizeHelperViewChild?.nativeElement.offsetLeft - <number>this.lastResizerHelperX;
-        const columnWidth = this.resizeColumnElement.offsetWidth;
-        const newColumnWidth = columnWidth + delta;
-        const elementMinWidth = this.resizeColumnElement.style.minWidth.replace(/[^\d.]/g, '');
-        const minWidth = elementMinWidth ? parseFloat(elementMinWidth) : 15;
+onColumnResizeEnd() {
+    const isRTL = getComputedStyle(this.el?.nativeElement ?? document.documentElement).direction === 'rtl';
+    const rawDelta = this.resizeHelperViewChild?.nativeElement.offsetLeft - <number>this.lastResizerHelperX;
+    const delta = isRTL ? -rawDelta : rawDelta;
+    const columnWidth = this.resizeColumnElement.offsetWidth;
+    const newColumnWidth = columnWidth + delta;
+    const elementMinWidth = this.resizeColumnElement.style.minWidth.replace(/[^\d.]/g, '');
+    const minWidth = elementMinWidth ? parseFloat(elementMinWidth) : 15;
 
         if (newColumnWidth >= minWidth) {
             if (this.columnResizeMode === 'fit') {


### PR DESCRIPTION
### Fix RTL column resizing in Table

Fixes #19290

### Problem
In RTL layouts, resizing table columns behaves in the opposite direction
of the mouse movement.

### Solution
- Detect RTL direction from table host element
- Invert resize delta only for RTL
- Preserve existing LTR behavior

### Scope
- Table column resize logic only
- No breaking changes
- No visual or API changes
- No behavior change for LTR
- No CSS or DOM structure changes

### Reproduction
1. Enable RTL (`dir="rtl"`)
2. Resize a table column
3. Observe reversed resizing behavior

### Fix Verification
- Tested in LTR and RTL
- Mouse movement unchanged
- Resize direction now matches visual intent
