### PR TITLE
fix: #18010 - Different item is focussed when item is pressed

### DIFF
--- a/packages/primeng/src/panelmenu/panelmenu.ts
+++ b/packages/primeng/src/panelmenu/panelmenu.ts
@@ -948,6 +948,7 @@ export class PanelMenuList extends BaseComponent {
     hostDirectives: [Bind]
 })
 export class PanelMenu extends BaseComponent<PanelMenuPassThrough> {
+    componentName = 'PanelMenu';
     /**
      * An array of menuitems.
      * @group Props


### PR DESCRIPTION
Fixed Issue #18010

## Root Cause
The issue was caused by an incorrect `data-pc-name` property value. In production mode, due to code minification, the component name gets mangled, causing isElementInPanel method to fail in finding the panel and return null. This leads to incorrect focusedItem assignment in the onFocus event handler (defaulting to this.findLastItem).

### Dev mode
<img width="622" height="439" alt="Screenshot 2026-01-18 at 6 39 28 PM" src="https://github.com/user-attachments/assets/36e0add2-402b-4207-892d-9e53f48585dd" />

### Prod mode
<img width="627" height="428" alt="Screenshot 2026-01-18 at 6 40 43 PM" src="https://github.com/user-attachments/assets/6be3c053-24c2-4d0c-b254-a23da363c09a" />


## Solution
Used `this['componentName']` value from basecomponent's `$name` to ensure consistent component identification across build modes.

## Alternative Approach
Another potential solution would be to disable script optimization in `apps/showcase/angular.json`, though this should be evaluated based on the performance trade-offs.

```json
...
"configurations": {
    "production": {
        "optimization": {
            "scripts": false,
            "styles": true,
            "fonts": true
        }
    }
}
...
```