### PR TITLE
FIX: Select Placeholder and null/undefined Options overlap

### DIFF
--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1381,6 +1381,17 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
         return !this._options() || (this.visibleOptions() && this.visibleOptions().length === 0);
     }
 
+    hasNullOrUndefinedOption = computed(() => {
+        const options = this.getAllVisibleAndNonVisibleOptions();;
+        if (options) {
+            return options.some((option) => {
+                const optionValue = this.getOptionValue(option);
+                return optionValue === null || optionValue === undefined;
+            });
+        }
+        return false;
+    });
+
     onEditableInput(event: Event) {
         const value = (event.target as HTMLInputElement).value;
         this.searchValue = '';

--- a/packages/primeng/src/select/style/selectstyle.ts
+++ b/packages/primeng/src/select/style/selectstyle.ts
@@ -28,7 +28,7 @@ const classes = {
             'p-variant-filled': instance.$variant() === 'filled',
             'p-focus': instance.focused,
             'p-invalid': instance.invalid(),
-            'p-inputwrapper-filled': instance.$filled(),
+            'p-inputwrapper-filled': instance.$filled() || instance.placeholder(),
             'p-inputwrapper-focus': instance.focused || instance.overlayVisible,
             'p-select-open': instance.overlayVisible,
             'p-select-fluid': instance.hasFluid,

--- a/packages/primeng/src/select/style/selectstyle.ts
+++ b/packages/primeng/src/select/style/selectstyle.ts
@@ -28,7 +28,7 @@ const classes = {
             'p-variant-filled': instance.$variant() === 'filled',
             'p-focus': instance.focused,
             'p-invalid': instance.invalid(),
-            'p-inputwrapper-filled': instance.$filled() || instance.placeholder(),
+            'p-inputwrapper-filled': instance.$filled() || instance.placeholder() || instance.hasNullOrUndefinedOption(),
             'p-inputwrapper-focus': instance.focused || instance.overlayVisible,
             'p-select-open': instance.overlayVisible,
             'p-select-fluid': instance.hasFluid,


### PR DESCRIPTION
closes #19299

## Before
<img width="222" height="385" alt="image" src="https://github.com/user-attachments/assets/980fe3f1-ef38-4d99-a432-8a3c73517662" />

## After
<img width="223" height="385" alt="image" src="https://github.com/user-attachments/assets/0b12c939-6d33-4c9c-92e0-60c471ba4e5f" />

### Summary

This pull request introduces an enhancement to the `Select` component to improve how the input wrapper's filled state is determined. The main change is the addition of logic to check for `null` or `undefined` options, ensuring that the component visually reflects its state more accurately.

Enhancement to input wrapper filled state:

* Added a new computed property `hasNullOrUndefinedOption` in `select.ts` that checks if any option value is `null` or `undefined`.
* Updated the `p-inputwrapper-filled` class logic in `selectstyle.ts` to also consider the presence of a placeholder or any `null`/`undefined` options, making the filled state more robust.