### PR TITLE
Fix(Table): Correct RTL positioning and sticky offset calculation for pFrozenColumn

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -3625,30 +3625,31 @@ export class FrozenColumn extends BaseComponent {
 
     updateStickyPosition() {
         if (this._frozen) {
-            if (this.alignFrozen === 'right') {
-                let right = 0;
-                let sibling = this.el.nativeElement.nextElementSibling;
-                while (sibling) {
-                    right += DomHandler.getOuterWidth(sibling);
-                    sibling = sibling.nextElementSibling;
-                }
-                this.el.nativeElement.style.right = right + 'px';
-            } else {
-                let left = 0;
-                let sibling = this.el.nativeElement.previousElementSibling;
-                while (sibling) {
-                    left += DomHandler.getOuterWidth(sibling);
-                    sibling = sibling.previousElementSibling;
-                }
-                this.el.nativeElement.style.left = left + 'px';
+            const isRtl = getComputedStyle(this.el.nativeElement).direction === 'rtl';
+            const isPhysicalRight = (this.alignFrozen === 'right' && !isRtl) || (this.alignFrozen === 'left' && isRtl);
+
+            let offset = 0;
+            let sibling = this.alignFrozen === 'right' ? this.el.nativeElement.nextElementSibling : this.el.nativeElement.previousElementSibling;
+
+            while (sibling) {
+                offset += DomHandler.getOuterWidth(sibling);
+                sibling = this.alignFrozen === 'right' ? sibling.nextElementSibling : sibling.previousElementSibling;
             }
 
+            if (isPhysicalRight) {
+                this.el.nativeElement.style.right = offset + 'px';
+                this.el.nativeElement.style.left = 'auto';
+            } else {
+                this.el.nativeElement.style.left = offset + 'px';
+                this.el.nativeElement.style.right = 'auto';
+            }
             const filterRow = this.el.nativeElement?.parentElement?.nextElementSibling;
             if (filterRow) {
                 let index = DomHandler.index(this.el.nativeElement);
                 if (filterRow.children && filterRow.children[index]) {
-                    filterRow.children[index].style.left = this.el.nativeElement.style.left;
-                    filterRow.children[index].style.right = this.el.nativeElement.style.right;
+                    const filterCell = filterRow.children[index] as HTMLElement;
+                    filterCell.style.left = this.el.nativeElement.style.left;
+                    filterCell.style.right = this.el.nativeElement.style.right;
                 }
             }
         }

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -3632,7 +3632,13 @@ export class FrozenColumn extends BaseComponent {
             let sibling = this.alignFrozen === 'right' ? this.el.nativeElement.nextElementSibling : this.el.nativeElement.previousElementSibling;
 
             while (sibling) {
-                offset += DomHandler.getOuterWidth(sibling);
+                const style = getComputedStyle(sibling);
+                const isSticky = style.position === 'sticky' || style.position === '-webkit-sticky';
+
+                if (isSticky) {
+                    offset += DomHandler.getOuterWidth(sibling);
+                }
+
                 sibling = this.alignFrozen === 'right' ? sibling.nextElementSibling : sibling.previousElementSibling;
             }
 


### PR DESCRIPTION
### Related Issue
Closes #19310

### Description
This PR addresses two critical issues in the `FrozenColumn` directive (`pFrozenColumn`) regarding how sticky positions are calculated.

**1. RTL Support Added**
* **Problem:** The directive was unaware of the document direction. `alignFrozen="left"` always set `style.left`, which is incorrect for RTL layouts where the start is on the right.
* **Fix:** Added a check for `getComputedStyle().direction === 'rtl'`.
    * If RTL is detected and alignment is "left", the directive now applies `style.right`.
    * If RTL is detected and alignment is "right", the directive now applies `style.left`.
* **Cleanup:** explicitly sets the opposing style to `'auto'` (e.g., `style.left = 'auto'`) to prevent CSS conflicts when switching directions or alignment dynamically.

**2. Offset Calculation Logic**
* **Problem:** The `updateStickyPosition` loop summed the width of *all* previous/next siblings to determine the `left`/`right` value. This included non-frozen (scrollable) columns.
* **Fix:** Updated the sibling loop to check `getComputedStyle(sibling).position`. The offset now only accumulates widths from siblings that are explicitly `sticky` or `-webkit-sticky`.

### Visual Proof / Reproduction
* **RTL Mode:** Columns now correctly stick to the "Start" (Right side) in RTL.
* **Middle Columns:** Frozen columns placed after scrollable columns now correctly snap to the edge of the frozen group instead of floating in the middle of the table.

### Scope
- **Modified Component:** `pFrozenColumn` directive (specifically `updateStickyPosition`).
- **Breaking Changes:** No.
- **API Changes:** No (no new inputs/outputs).
- **DOM/CSS Changes:** No external CSS or template structure modifications (logic is purely inline style calculation).
- **Behavioral Changes:**
    - **RTL:** Fixed column positioning to respect physical direction.
    - **LTR & RTL:** Fixed sticky offset calculation to exclude non-frozen siblings (removes incorrect gaps for middle columns).

