### PR TITLE
fix(table): #19314 Add missing ariaLabel property for filter type boolean

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -6414,6 +6414,7 @@ export class ColumnFilter extends BaseComponent {
                     [pt]="ptm('pcFilterCheckbox')"
                     [indeterminate]="filterConstraint?.value === null"
                     [binary]="true"
+                    [ariaLabel]="ariaLabel"
                     *ngSwitchCase="'boolean'"
                     [ngModel]="filterConstraint?.value"
                     (ngModelChange)="onModelChange($event)"


### PR DESCRIPTION
Fix #19314 
Add missing `ariaLabel` input to p-checkbox
