### PR TITLE
Prevent autocomplete inadvertent value change

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1622,7 +1622,7 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
     }
 
     onOptionMouseEnter(event, index) {
-        if (this.focusOnHover) {
+        if (this.focusOnHover && this.overlayVisible) {
             this.changeFocusedOptionIndex(event, index);
         }
     }


### PR DESCRIPTION
The user can change the autocomplete value when he presses tab, without purposefully selecting a different option.

Steps to reproduce:
Go to https://primeng.org/autocomplete#basic 
Type an a into the input field.
Move the mouse quickly around in the opened dropdown for a few seconds.
Immediately click one of the options.
Assuming you selected a-4, the input field will reflect your selection.
Without delay press the tab key.
The selected a-4 input may change to a different value, e.g. a-3.

I would expect a-4 to remain as selection was not explicitly changed by the user.
To follow the steps is not the easiest, since you have to be somewhat quick, but it should be reproducible quite consistently.

I am using the latest Chrome browser and [focusOnHover]="true" (is default value) must be set.

Debugging shows that shortly after the overlay is hidden, the mousenter event still triggers the onOptionMouseEnter function which may set a focusedOptionIndex and when the tab key is pressed, whatever focusedOptionIndex  is set to, will be applied to the input.