### PR TITLE
fix #19326 - pagination rows and first not overwritten by undefined (Table)

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -2971,12 +2971,12 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             let state: TableState = JSON.parse(stateString, reviver);
 
             if (this.paginator) {
-                if (this.first) {
+                if (this.first !== undefined && state.first) {
                     this.first = state.first;
                     this.firstChange.emit(this.first);
                 }
 
-                if (this.rows) {
+                if (this.rows !== undefined && state.rows) {
                     this.rows = state.rows;
                     this.rowsChange.emit(this.rows);
                 }


### PR DESCRIPTION
This way missing data in the localStorage of the user should not overwrite the default values of rows and first from the table component.. Closes #19326
