### PR TITLE
Fix: filterFields input is not applied in MultiSelect filtering

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -1448,7 +1448,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     searchFields() {
-        return (this.filterBy || this.optionLabel || 'label').split(',');
+        return this.filterBy?.split(',') || this.filterFields || [this.optionLabel];
     }
 
     findNearestSelectedOptionIndex(index, firstCheckUp = false) {

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -1448,8 +1448,9 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     searchFields() {
-        return this.filterBy?.split(',') || this.filterFields || [this.optionLabel];
+        return this.filterBy?.split(',') || this.filterFields || [this.optionLabel ?? 'label'];
     }
+
 
     findNearestSelectedOptionIndex(index, firstCheckUp = false) {
         let matchedOptionIndex = -1;


### PR DESCRIPTION
**Issue**

filterFields input in MultiSelect was defined in the public API but not used anywhere in the filtering logic.
As a result, providing filterFields had no effect and filtering always relied on the default field (filterBy/ optionLabel / implicit string matching), causing incorrect filtered results.

This leads to incorrect filtering behavior and makes the filterFields API ineffective.

This PR will fix the above issue.

