### PR TITLE
Tree-node: Add missing parentheses for PT signal

### DIFF
--- a/packages/primeng/src/tree/tree.ts
+++ b/packages/primeng/src/tree/tree.ts
@@ -172,7 +172,7 @@ const TREENODE_INSTANCE = new InjectionToken<UITreeNode>('TREENODE_INSTANCE');
                         [itemSize]="itemSize"
                         [level]="level + 1"
                         [loadingMode]="loadingMode"
-                        [pt]="pt"
+                        [pt]="pt()"
                         [unstyled]="unstyled()"
                     ></p-treeNode>
                 </ul>


### PR DESCRIPTION
### Defect Fix
Resolves https://github.com/primefaces/primeng/issues/19374 an issue where styling was not passed through to children tree-nodes as the PT parameters were being passed as a raw signal rather than being called.