### PR TITLE
fix #19068 - Datepicker data-date attribute month off by 1

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.spec.ts
+++ b/packages/primeng/src/datepicker/datepicker.spec.ts
@@ -1159,6 +1159,19 @@ describe('DatePicker', () => {
             const today = new Date();
             expect(testComponent.selectedDate.toDateString()).toBe(today.toDateString());
         });
+
+        it('should format data-date attribute with 1-indexed month', async () => {
+            const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
+
+            const january = new Date(2023, 0, 15);
+            expect(datePickerComponent.formatDateKey(january)).toBe('2023-1-15');
+
+            const june = new Date(2023, 5, 20);
+            expect(datePickerComponent.formatDateKey(june)).toBe('2023-6-20');
+
+            const december = new Date(2023, 11, 25);
+            expect(datePickerComponent.formatDateKey(december)).toBe('2023-12-25');
+        });
     });
 
     describe('pTemplate Content Projection', () => {

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -1791,7 +1791,7 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
     }
 
     formatDateKey(date: Date): string {
-        return `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
+        return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`;
     }
 
     setCurrentHourPM(hours: number) {


### PR DESCRIPTION
Fixes #19068.

Root problem is just an off-by-1 error due to `Date.getMonth()` being zero indexed.
