### PR TITLE
fix(19405): messageService.clearAll() should properly remove toasts with lifetime

### DIFF
--- a/packages/primeng/src/toast/toast.spec.ts
+++ b/packages/primeng/src/toast/toast.spec.ts
@@ -6,6 +6,7 @@ import { By } from '@angular/platform-browser';
 import { MessageService, PrimeTemplate, SharedModule, ToastMessageOptions } from 'primeng/api';
 import { providePrimeNG } from 'primeng/config';
 import { Toast, ToastItem } from './toast';
+import { resolveDuration } from '@primeuix/motion';
 
 // Test Components for different scenarios
 @Component({
@@ -394,12 +395,23 @@ describe('Toast', () => {
             expect(toastInstance.messages?.length).toBe(1);
 
             spyOn(toastInstance, 'clearAll').and.callThrough();
-            messageService.clear();
+            messageService.clear('test');
             await new Promise((resolve) => setTimeout(resolve, 100));
             await fixture.whenStable();
             fixture.detectChanges();
 
             expect(toastInstance.clearAll).toHaveBeenCalled();
+
+
+            const hideTransitionMs = resolveDuration(toastInstance.motionOptions()?.duration, 'leave') || +toastInstance.hideTransitionOptions.replaceAll(/[^0-9]/g, '')
+            const toastItemEl = fixture.debugElement.query(By.css('p-toastitem'));
+            const toastItemInstance = toastItemEl.componentInstance;
+            expect(toastItemInstance.visible()).toBeFalsy();
+
+
+            await new Promise((resolve) => setTimeout(resolve, hideTransitionMs));
+            const allItems = fixture.debugElement.queryAll(By.css('p-toastitem'));
+            expect(allItems.length).toBe(0);
         });
     });
 

--- a/packages/primeng/src/toast/toast.ts
+++ b/packages/primeng/src/toast/toast.ts
@@ -182,7 +182,7 @@ export class ToastItem extends BaseComponent<ToastPassThrough> {
 
         effect(() => {
             if (this.clearAll()) {
-                this.visible.set(false);
+                this.close();
             }
         });
     }
@@ -225,11 +225,15 @@ export class ToastItem extends BaseComponent<ToastPassThrough> {
     }
 
     onCloseIconClick = (event: Event) => {
+        this.close();
+        event.preventDefault();
+    };
+
+    close() {
         this.isClosing = true;
         this.clearTimeout();
         this.visible.set(false);
-        event.preventDefault();
-    };
+    }
 
     get closeAriaLabel() {
         return this.config.translation.aria ? this.config.translation.aria.close : undefined;


### PR DESCRIPTION
Fixes [19405](https://github.com/primefaces/primeng/issues/19405)

Previously, calling `clearAll()` would not follow the same principles as calling the manual close button (via `onCloseIconClick`), making the toast flash (most likely because the timeout is never cleared, thus the motion never emits the leave event, leading into the parent toast not removing the toastitem instance despite the toastitem `visible()` being set to false)