### PR TITLE
Refactor datepicker to also use ng-container for previousIconTemplate

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -180,9 +180,9 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                 >
                                     <ng-template #icon>
                                         <svg data-p-icon="chevron-left" *ngIf="!previousIconTemplate && !_previousIconTemplate" />
-                                        <span *ngIf="previousIconTemplate || _previousIconTemplate">
+                                        <ng-container *ngIf="previousIconTemplate || _previousIconTemplate">
                                             <ng-template *ngTemplateOutlet="previousIconTemplate || _previousIconTemplate"></ng-template>
-                                        </span>
+                                        </ng-container>
                                     </ng-template>
                                 </p-button>
                                 <div [class]="cx('title')" [pBind]="ptm('title')">


### PR DESCRIPTION
**Refactor datepicker to also use ng-container for previousIconTemplate in stead of span**

When providing custom icons for the datepicker component, you can do so by providing a previous and a next icon template (amongst others).
I noticed styling was off between both my icons, so I checked the sourcecode.
It turns out the "previous" icon template gets wrapped in a span but the next icon is wrapped in an ng-container tag.

This extra span made it so my icon is slightly higher up than where it needs to be (compared to the button it gets put in).