### PR TITLE
fix(19325): properly set overlay as display none if blocked equals false

### DIFF
--- a/packages/primeng/src/blockui/blockui.ts
+++ b/packages/primeng/src/blockui/blockui.ts
@@ -99,6 +99,7 @@ export class BlockUI extends BaseComponent<BlockUIPassThrough> {
 
     onAfterViewInit() {
         if (this._blocked) this.block();
+        else this.hideSelf();
 
         if (this.target && !this.target.getBlockableElement) {
             throw 'Target of BlockUI must implement BlockableUI interface';
@@ -157,10 +158,14 @@ export class BlockUI extends BaseComponent<BlockUIPassThrough> {
         }
     }
 
+    hideSelf() {
+        this.el.nativeElement.style.display = 'none';
+    }
+
     destroyModal() {
         this._blocked = false;
         if (this.el && isPlatformBrowser(this.platformId)) {
-            this.el.nativeElement.style.display = 'none';
+            this.hideSelf();
             this.renderer.removeClass(this.el.nativeElement, 'p-overlay-mask');
             this.renderer.removeClass(this.el.nativeElement, 'p-overlay-mask-leave-active');
             ZIndexUtils.clear(this.el.nativeElement);


### PR DESCRIPTION
Fixes [19325](https://github.com/primefaces/primeng/issues/19325)

Disclaimer : As of today, PrimeNG implementation of BlockUI is quite different from PrimeVue & PrimeReact  one which is unified (the component is a wrapper of content and the overlay is projected within the wrapper boundaries, whereas in PrimeNG BlockUi is much likely a sibling of the target to be blocked). I did not know if this component had any major plan coming from PrimeNG team, so I opted for a quick working fix which just makes sure that if the blocked flag is false at startup then it should consider the overlay as invisible (hence the display: none, which is already called when manually hiding the overlay and then prevents the overlay content to show in the first place - which was the description of the issue)