### PR TITLE
fix(19438): forceSelection should work even when input field gets emptied

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.spec.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.spec.ts
@@ -1529,6 +1529,7 @@ describe('AutoComplete', () => {
             await testFixture.whenStable();
 
             const autocompleteInstance = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+            const clearSpy = spyOn(autocompleteInstance, 'clear').and.callThrough();
 
             // First, show the suggestions
             const inputElement = testFixture.debugElement.query(By.css('input'));
@@ -1543,6 +1544,65 @@ describe('AutoComplete', () => {
             await testFixture.whenStable();
 
             expect(inputElement.nativeElement.value).toBe('' as any);
+            expect(autocompleteInstance.modelValue()).toBeNull();
+            expect(clearSpy).toHaveBeenCalled();
+        });
+
+        it('should handle forceSelection mode when input field is emptied', async () => {
+            testComponent.forceSelection = true;
+            testComponent.optionLabel = undefined as any; // Use string comparison for forceSelection
+            testComponent.suggestions = mockItems;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const autocompleteInstance = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+            const clearSpy = spyOn(autocompleteInstance, 'clear').and.callThrough();
+
+            // First, show the suggestions
+            const inputElement = testFixture.debugElement.query(By.css('input'));
+            inputElement.nativeElement.value = 'Item';
+            inputElement.nativeElement.dispatchEvent(new Event('input'));
+            await testFixture.whenStable();
+
+            // Now test invalid input
+            inputElement.nativeElement.value = '';
+            inputElement.nativeElement.defaultValue = 'Item';
+            const changeEvent = new Event('change');
+            inputElement.nativeElement.dispatchEvent(changeEvent);
+            await testFixture.whenStable();
+
+            expect(inputElement.nativeElement.value).toBe('' as any);
+            expect(autocompleteInstance.modelValue()).toBeNull();
+            expect(clearSpy).toHaveBeenCalled();
+        });
+
+        it('should empty input field but not clear inner form value when forceSelection and multiple are true and when input value does not match any suggestion', async () => {
+            testComponent.multiple = true;
+            testComponent.forceSelection = true;
+            testComponent.optionLabel = undefined as any; // Use string comparison for forceSelection
+            testComponent.suggestions = mockItems;
+            testComponent.selectedValue = [mockItems[0]];
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const autocompleteInstance = testFixture.debugElement.query(By.directive(AutoComplete)).componentInstance;
+            const clearSpy = spyOn(autocompleteInstance, 'clear').and.callThrough();
+
+            // First, show the suggestions
+            const inputElement = testFixture.debugElement.query(By.css('input'));
+            inputElement.nativeElement.value = 'nonexistent';
+            inputElement.nativeElement.dispatchEvent(new Event('input'));
+            await testFixture.whenStable();
+
+            // Now dispatch change
+            const changeEvent = new Event('change');
+            inputElement.nativeElement.dispatchEvent(changeEvent);
+            await testFixture.whenStable();
+
+            expect(inputElement.nativeElement.value).toBe('' as any);
+            expect(autocompleteInstance.modelValue()).not.toBeNull();
+            expect(autocompleteInstance.modelValue()).toEqual([mockItems[0]]);
+            expect(clearSpy).not.toHaveBeenCalled();
         });
 
         it('should handle autoHighlight feature', async () => {

--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -1679,14 +1679,15 @@ export class AutoComplete extends BaseInput<AutoCompletePassThrough> {
 
     updateInputWithForceSelection(event: any) {
         const input = this.inputEL?.nativeElement;
+        const inputCleared = !input?.value && input.defaultValue;
 
-        if (!this.forceSelection || this.overlayVisible || !input?.value) {
+        if (!(this.forceSelection && !this.overlayVisible && (inputCleared || input?.value))) {
             return;
         }
 
         const _minLength = this.minQueryLength ?? this.minLength;
 
-        if (input.value.length < _minLength) {
+        if (!inputCleared && input.value.length < _minLength) {
             return;
         }
 


### PR DESCRIPTION
Fixes [#19438 ](https://github.com/primefaces/primeng/issues/19438)

Currently, when the input field was dispatching a `change` event, the bound method `updateInputWithForceSelection` would return prematuraly if the field is empty.this is a problem as it will prevent a freshly emptied field to clear the inner autocomplete modelValue. Also, clearing the input field should not be bound to the minQueryLength condition.

The fix is focused on 2 cases : an input being cleared (value != defaultValue) or having a given value. 

I also added a case within the tests that verifies that a multiple & forceSelection autocomplete will empty the inputField value but not the autocomplete modelValue if such situation happens.
