### PR TITLE
fix: #19442 - p-select: with virtual scroll and filter, option list gets hidden after clearing clearing letter one by one

### DIFF
--- a/packages/primeng/src/scroller/scroller.ts
+++ b/packages/primeng/src/scroller/scroller.ts
@@ -626,7 +626,6 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
 
             if (isChanged) {
                 this.init();
-                this.calculateAutoSize();
             }
         }
     }
@@ -702,6 +701,7 @@ export class Scroller extends BaseComponent<VirtualScrollerPassThrough> {
                 this.setSpacerSize();
                 this.setSize();
                 this.calculateOptions();
+                this.calculateAutoSize();
                 this.cd.detectChanges();
             }, 1);
         }


### PR DESCRIPTION
fixes #19442 