### PR TITLE
fix(table): fix resizableColumns with column grouping

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -2684,7 +2684,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
     private _totalTableWidth(): number[] {
         let widths = [];
         const tableHead = DomHandler.findSingle(this.el.nativeElement, '[data-pc-section="thead"]');
-        let headers = DomHandler.find(tableHead, 'tr > th');
+        let headers = DomHandler.find(tableHead, 'tr:last-child > th');
         headers.forEach((header) => (widths as any[]).push(DomHandler.getOuterWidth(header)));
 
         return widths;


### PR DESCRIPTION
## Summary

- Fix `_totalTableWidth()` selector from `"tr > th"` to `"tr:last-child > th"` so only the actual column headers are measured, not group headers in preceding rows

## Root cause

When using column grouping (multiple `<tr>` rows in `<thead>`), the selector `"tr > th"` matches `<th>` elements across all header rows. This causes the widths array to contain more entries than actual columns, making `updateStyleElement` apply widths to wrong `nth-child` indices.

closes #19487