### PR TITLE
feat: add bindings support to DynamicDialog

### DIFF
--- a/packages/primeng/src/dynamicdialog/dialogservice.ts
+++ b/packages/primeng/src/dynamicdialog/dialogservice.ts
@@ -37,6 +37,7 @@ export class DialogService {
         if (componentRefInstance) {
             componentRefInstance.instance.childComponentType = componentType;
             componentRefInstance.instance.inputValues = config.inputValues || {};
+            componentRefInstance.instance.bindings = config.bindings || [];
         }
 
         return dialogRef;

--- a/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog-config.ts
@@ -1,4 +1,4 @@
-import { Type } from '@angular/core';
+import { Binding, Type } from '@angular/core';
 import type { DialogPassThrough } from 'primeng/types/dialog';
 
 /**
@@ -196,6 +196,11 @@ export class DynamicDialogConfig<DataType = any, InputValuesType extends Record<
      * @group Props
      */
     unstyled?: boolean;
+    /**
+     * An array of Angular Bindings (providers) to pass to the dynamically created component.
+     * @group Props
+     */
+    bindings?: Binding[];
 }
 
 /**

--- a/packages/primeng/src/dynamicdialog/dynamicdialog.ts
+++ b/packages/primeng/src/dynamicdialog/dynamicdialog.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, Type, ViewChild, ViewEncapsulation } from '@angular/core';
+import { Binding, ChangeDetectionStrategy, Component, ComponentRef, inject, InjectionToken, NgModule, Type, ViewChild, ViewEncapsulation } from '@angular/core';
 import { uuid } from '@primeuix/utils';
 import { SharedModule, TranslationKeys } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
@@ -112,6 +112,8 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
     childComponentType: Nullable<Type<any>>;
 
     inputValues: Record<string, any>;
+
+    bindings: Binding[] = [];
 
     get minX(): number {
         return this.ddconfig.minX ? this.ddconfig.minX : 0;
@@ -269,7 +271,7 @@ export class DynamicDialog extends BaseComponent<DialogPassThrough> {
         let viewContainerRef = this.insertionPoint?.viewContainerRef;
         viewContainerRef?.clear();
 
-        this.componentRef = viewContainerRef?.createComponent(componentType);
+        this.componentRef = viewContainerRef?.createComponent(componentType, {bindings: this.bindings});
 
         if (this.inputValues && this.componentRef) {
             Object.entries(this.inputValues).forEach(([key, value]) => {


### PR DESCRIPTION
Closes #19502

## Summary
- Adds `bindings` property to `DynamicDialogConfig`, allowing users to pass Angular `Binding[]` to dynamically created components
- Passes `bindings` through `DialogService` to `DynamicDialog`, which forwards them to `ViewContainerRef.createComponent()`
- Enables using `inputBinding()` and `outputBinding()` with dynamic dialog components — Angular's official API for binding inputs and outputs to dynamic components

## Motivation
Currently, `DynamicDialog` only supports `inputValues` for passing data, which is limited to inputs only and bypasses Angular's reactivity system. There's no way to bind outputs to a dynamic component, making patterns like picker dialogs unnecessarily complex.

With this change, a common picker pattern becomes straightforward:

```typescript
this.dialogService.open(MyListComponent, {
    header: 'Select an item',
    width: '70vw',
    maximizable: true,
    bindings: [
        inputBinding('isPicker', () => true),
        outputBinding('onItemSelected', (item) => {
            dialogRef.close();
            resolve(item);
        }),
        outputBinding('onDialogClose', () => {
            resolve(null);
        })
    ]
});
```

## Test plan
- [ ] Verify existing DynamicDialog functionality is unaffected (bindings defaults to `[]`)
- [ ] Test passing `inputBinding()` and `outputBinding()` via bindings and confirm they work in the child component

🤖 Generated with [Claude Code](https://claude.com/claude-code)