### PR TITLE
fix(docs): correct typo in ToastMessageOptions JSDoc comment

### DIFF
--- a/packages/primeng/src/api/toastmessage.ts
+++ b/packages/primeng/src/api/toastmessage.ts
@@ -1,5 +1,5 @@
 /**
- * Deines valid options for the toast message.
+ * Defines valid options for the toast message.
  * @group Interface
  */
 export interface ToastMessageOptions {


### PR DESCRIPTION
Fixed typo: 'Deines' → 'Defines' in the JSDoc comment for ToastMessageOptions interface.

Closes #19509