### PR TITLE
fix: add draggable property to Confirmation interface

### DIFF
--- a/packages/primeng/src/api/confirmation.ts
+++ b/packages/primeng/src/api/confirmation.ts
@@ -114,4 +114,8 @@ export interface Confirmation {
      * @defaultValue true
      */
     modal?: boolean;
+    /**
+     * Specifies whether the confirmation dialog can be dragged.
+     */
+    draggable?: boolean;
 }


### PR DESCRIPTION
This PR adds the missing `draggable` property to the `Confirmation` interface, allowing users to configure whether the confirmation dialog can be dragged.

Fixes #19516