### PR TITLE
fix: #19531 - tooltip respects overlayAppendTo config

### DIFF
--- a/packages/primeng/src/tooltip/tooltip.spec.ts
+++ b/packages/primeng/src/tooltip/tooltip.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { TooltipOptions } from 'primeng/api';
+import { PrimeNG } from 'primeng/config';
 import { Tooltip } from './tooltip';
 
 @Component({
@@ -873,6 +874,109 @@ describe('Tooltip', () => {
             await fixture.whenStable();
 
             expect(container?.hasAttribute('data-test')).toBeFalsy();
+        });
+    });
+
+    describe('Append To', () => {
+        @Component({
+            standalone: false,
+            template: `<input #inputElement pTooltip="AppendTo tooltip" [appendTo]="appendTo" [tooltipOptions]="tooltipOptions" type="text" />`
+        })
+        class TestAppendToTooltipComponent {
+            @ViewChild('inputElement', { read: ElementRef }) inputElement!: ElementRef;
+            appendTo: any;
+            tooltipOptions: TooltipOptions | undefined;
+        }
+
+        let fixture: ComponentFixture<TestAppendToTooltipComponent>;
+        let component: TestAppendToTooltipComponent;
+        let tooltipDirective: Tooltip;
+        let customContainer: HTMLDivElement;
+        let primengConfig: PrimeNG;
+
+        beforeEach(async () => {
+            await TestBed.configureTestingModule({
+                imports: [Tooltip],
+                declarations: [TestAppendToTooltipComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            customContainer = document.createElement('div');
+            customContainer.id = 'custom-tooltip-container';
+            document.body.appendChild(customContainer);
+
+            primengConfig = TestBed.inject(PrimeNG);
+        });
+
+        afterEach(() => {
+            if (tooltipDirective?.container) {
+                tooltipDirective.deactivate();
+            }
+            primengConfig.overlayAppendTo.set('self');
+            customContainer.remove();
+        });
+
+        function createFixture() {
+            fixture = TestBed.createComponent(TestAppendToTooltipComponent);
+            component = fixture.componentInstance;
+            fixture.detectChanges();
+            tooltipDirective = fixture.debugElement.query(By.directive(Tooltip)).injector.get(Tooltip);
+        }
+
+        it('should append tooltip to document.body by default', () => {
+            createFixture();
+            tooltipDirective.activate();
+
+            expect(tooltipDirective.container).toBeTruthy();
+            expect(tooltipDirective.container.parentElement).toBe(document.body);
+        });
+
+        it('should keep body fallback when config.overlayAppendTo is the default "self" value', () => {
+            expect(primengConfig.overlayAppendTo()).toBe('self');
+            createFixture();
+            tooltipDirective.activate();
+
+            expect(tooltipDirective.container.parentElement).toBe(document.body);
+        });
+
+        it('should respect config.overlayAppendTo when set to a custom element', () => {
+            primengConfig.overlayAppendTo.set(customContainer);
+            createFixture();
+            tooltipDirective.activate();
+
+            expect(tooltipDirective.container.parentElement).toBe(customContainer);
+        });
+
+        it('should prefer local appendTo input over config.overlayAppendTo', async () => {
+            const otherContainer = document.createElement('div');
+            document.body.appendChild(otherContainer);
+
+            try {
+                primengConfig.overlayAppendTo.set(customContainer);
+                createFixture();
+                component.appendTo = otherContainer;
+                fixture.changeDetectorRef.markForCheck();
+                await fixture.whenStable();
+                fixture.detectChanges();
+
+                tooltipDirective.activate();
+
+                expect(tooltipDirective.container.parentElement).toBe(otherContainer);
+            } finally {
+                otherContainer.remove();
+            }
+        });
+
+        it('should remove tooltip from the same container used on create', () => {
+            primengConfig.overlayAppendTo.set(customContainer);
+            createFixture();
+
+            tooltipDirective.activate();
+            expect(customContainer.contains(tooltipDirective.container)).toBe(true);
+
+            tooltipDirective.deactivate();
+
+            expect(customContainer.children.length).toBe(0);
         });
     });
 });

--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -131,7 +131,15 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
      */
     appendTo = input<HTMLElement | ElementRef | TemplateRef<any> | 'self' | 'body' | null | undefined | any>(undefined);
 
-    $appendTo = computed(() => this.appendTo() || this.config.overlayAppendTo());
+    $appendTo = computed(() => {
+        const localAppendTo = this.appendTo();
+        if (localAppendTo) return localAppendTo;
+
+        const globalAppendTo = this.config.overlayAppendTo();
+        if (globalAppendTo && globalAppendTo !== 'self') return globalAppendTo;
+
+        return this._tooltipOptions.appendTo;
+    });
 
     _tooltipOptions = {
         tooltipLabel: null,
@@ -276,10 +284,6 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
         if (simpleChange.tooltipEvent) {
             this.setOption({ tooltipEvent: simpleChange.tooltipEvent.currentValue });
-        }
-
-        if (simpleChange.appendTo) {
-            this.setOption({ appendTo: simpleChange.appendTo.currentValue });
         }
 
         if (simpleChange.positionStyle) {
@@ -510,9 +514,10 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
         this.container.appendChild(this.tooltipText);
 
-        if (this.getOption('appendTo') === 'body') document.body.appendChild(this.container);
-        else if (this.getOption('appendTo') === 'target') appendChild(this.container, this.el.nativeElement);
-        else appendChild(this.getOption('appendTo'), this.container);
+        const appendTo = this.$appendTo();
+        if (appendTo === 'body') document.body.appendChild(this.container);
+        else if (appendTo === 'target') appendChild(this.container, this.el.nativeElement);
+        else appendChild(appendTo, this.container);
 
         this.container.style.display = 'none';
 
@@ -614,7 +619,8 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
     }
 
     getHostOffset() {
-        if (this.getOption('appendTo') === 'body' || this.getOption('appendTo') === 'target') {
+        const appendTo = this.$appendTo();
+        if (appendTo === 'body' || appendTo === 'target') {
             let offset = this.el.nativeElement.getBoundingClientRect();
             let targetLeft = offset.left + getWindowScrollLeft();
             let targetTop = offset.top + getWindowScrollTop();
@@ -795,9 +801,10 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
 
     remove() {
         if (this.container && this.container.parentElement) {
-            if (this.getOption('appendTo') === 'body') document.body.removeChild(this.container);
-            else if (this.getOption('appendTo') === 'target') this.el.nativeElement.removeChild(this.container);
-            else removeChild(this.getOption('appendTo'), this.container);
+            const appendTo = this.$appendTo();
+            if (appendTo === 'body') document.body.removeChild(this.container);
+            else if (appendTo === 'target') this.el.nativeElement.removeChild(this.container);
+            else removeChild(appendTo, this.container);
         }
 
         this.unbindDocumentResizeListener();


### PR DESCRIPTION
## Description

Fixes [#19531](https://github.com/primefaces/primeng/issues/19531).

The `pTooltip` directive exposed a `$appendTo` computed signal that resolved `config.overlayAppendTo()`, but the signal was never consumed. The three DOM paths — `create()`, `getHostOffset()`, `remove()` — read `_tooltipOptions.appendTo` directly (default `'body'`), so the global `PrimeNG.overlayAppendTo` configuration was ignored. This broke overlay portaling in Shadow DOM / Angular Elements scenarios, where Tooltip diverged from other overlays (Select, DatePicker, MultiSelect, etc.) that correctly use the global config.

## Changes

**`packages/primeng/src/tooltip/tooltip.ts`**
- Extended the `$appendTo` computed signal with a full resolution chain:
  1. local `appendTo` input
  2. `config.overlayAppendTo()` (skipped when it is the default `'self'`, so the historical `'body'` default is preserved for non-configured users)
  3. `_tooltipOptions.appendTo` (`'body'` by default, preserves `tooltipOptions.appendTo` back-compat)
- Routed `create()`, `getHostOffset()` and `remove()` through `this.$appendTo()` instead of `getOption('appendTo')`, ensuring create/remove use the same container.
- Removed a dead `onChanges` branch for `simpleChange.appendTo` — `appendTo` is an `input()` signal and does not emit `SimpleChanges`; in Angular 21 the block still fired with `currentValue === undefined` and wiped the `'body'` default.

## Tests

Added a new `describe('Append To')` block in `tooltip.spec.ts` with 5 regression tests covering:
- default append to `document.body`;
- `config.overlayAppendTo === 'self'` (default) does not hijack the tooltip;
- `config.overlayAppendTo` set to a custom element is honored;
- local `[appendTo]` input wins over the global config;
- `remove()` cleans up from the same container used by `create()`.

All tooltip unit tests pass (`49/49` via `ng test primeng --include='**/tooltip/tooltip.spec.ts'`).

## Backwards compatibility

No breaking change:
- users without any configuration keep the historical `'body'` behavior;
- `tooltipOptions: { appendTo: ... }` continues to work;
- `[appendTo]` input binding continues to work and keeps the highest priority.