### PR TITLE
feat: #16567 - Add Shadow DOM support for dynamic styles and overlays

### DIFF
--- a/packages/primeng/src/basecomponent/basecomponent.spec.ts
+++ b/packages/primeng/src/basecomponent/basecomponent.spec.ts
@@ -1,0 +1,56 @@
+import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Base } from 'primeng/base';
+import { PrimeNG } from 'primeng/config';
+import { BaseComponent } from './basecomponent';
+
+@Component({
+    standalone: false,
+    selector: 'test-base-component',
+    template: `<div class="test-base-component"></div>`
+})
+class TestBaseComponent extends BaseComponent {}
+
+describe('BaseComponent', () => {
+    let fixture: ComponentFixture<TestBaseComponent>;
+    let component: TestBaseComponent;
+    let host: HTMLDivElement;
+    let shadowRoot: ShadowRoot;
+    let config: PrimeNG;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestBaseComponent],
+            providers: [provideZonelessChangeDetection()]
+        });
+
+        Base.clearLoadedStyleNames();
+
+        config = TestBed.inject(PrimeNG);
+        host = document.createElement('div');
+        document.body.appendChild(host);
+        shadowRoot = host.attachShadow({ mode: 'open' });
+        config.styleContainer.set(shadowRoot);
+
+        fixture = TestBed.createComponent(TestBaseComponent);
+        fixture.detectChanges();
+        component = fixture.componentInstance;
+    });
+
+    afterEach(() => {
+        fixture.destroy();
+        config.styleContainer.set(undefined);
+        host.remove();
+        Base.clearLoadedStyleNames();
+        document.head.querySelectorAll('style[data-primeng-style-id="base"], style[data-primeng-style-id="global"]').forEach((style) => style.remove());
+    });
+
+    it('should expose the configured style container in style options', () => {
+        expect(component.$styleOptions.styleContainer).toBe(shadowRoot);
+    });
+
+    it('should load shared styles into the configured style container', () => {
+        expect(shadowRoot.querySelector('style[data-primeng-style-id="base"]')).toBeTruthy();
+        expect(document.head.querySelector('style[data-primeng-style-id="base"]')).toBeNull();
+    });
+});

--- a/packages/primeng/src/basecomponent/basecomponent.ts
+++ b/packages/primeng/src/basecomponent/basecomponent.ts
@@ -112,7 +112,7 @@ export class BaseComponent<PT = any> implements Lifecycle {
     }
 
     get $styleOptions() {
-        return { nonce: this.config?.csp().nonce };
+        return { nonce: this.config?.csp().nonce, styleContainer: this.config?.styleContainer?.() };
     }
 
     get $params() {

--- a/packages/primeng/src/config/primeng.ts
+++ b/packages/primeng/src/config/primeng.ts
@@ -22,6 +22,8 @@ export class PrimeNG extends ThemeProvider {
 
     csp = signal<{ nonce: string | undefined }>({ nonce: undefined });
 
+    styleContainer = signal<PrimeNGConfigType['styleContainer']>(undefined);
+
     unstyled = signal<boolean | undefined>(undefined);
 
     pt = signal<PrimeNGConfigType['pt']>(undefined);
@@ -186,10 +188,11 @@ export class PrimeNG extends ThemeProvider {
     }
 
     setConfig(config: PrimeNGConfigType): void {
-        const { csp, ripple, inputStyle, inputVariant, theme, overlayOptions, translation, filterMatchModeOptions, overlayAppendTo, zIndex, ptOptions, pt, unstyled } = config || {};
+        const { csp, ripple, inputStyle, inputVariant, theme, overlayOptions, translation, filterMatchModeOptions, overlayAppendTo, styleContainer, zIndex, ptOptions, pt, unstyled } = config || {};
 
         if (csp) this.csp.set(csp);
         if (overlayAppendTo) this.overlayAppendTo.set(overlayAppendTo);
+        if (styleContainer !== undefined) this.styleContainer.set(styleContainer);
         if (ripple) this.ripple.set(ripple);
         if (inputStyle) this.inputStyle.set(inputStyle);
         if (inputVariant) this.inputVariant.set(inputVariant);

--- a/packages/primeng/src/config/primeng.ts
+++ b/packages/primeng/src/config/primeng.ts
@@ -16,7 +16,7 @@ export class PrimeNG extends ThemeProvider {
 
     inputVariant = signal<'outlined' | 'filled' | null>(null);
 
-    overlayAppendTo = signal<HTMLElement | ElementRef | TemplateRef<any> | 'self' | 'body' | null | undefined | any>('self');
+    overlayAppendTo = signal<HTMLElement | ShadowRoot | ElementRef | TemplateRef<any> | 'self' | 'body' | null | undefined | any>('self');
 
     overlayOptions: OverlayOptions = {};
 

--- a/packages/primeng/src/config/primeng.types.ts
+++ b/packages/primeng/src/config/primeng.types.ts
@@ -192,7 +192,7 @@ export interface GlobalPassThrough {
 
 export type PrimeNGConfigType = {
     ripple?: boolean;
-    overlayAppendTo?: HTMLElement | ElementRef | TemplateRef<any> | string | null | undefined | any;
+    overlayAppendTo?: HTMLElement | ShadowRoot | ElementRef | TemplateRef<any> | string | null | undefined | any;
     styleContainer?: StyleContainerType;
     /**
      * @deprecated Since v20. Use `inputVariant` instead.

--- a/packages/primeng/src/config/primeng.types.ts
+++ b/packages/primeng/src/config/primeng.types.ts
@@ -90,6 +90,9 @@ export type ZIndex = {
 /** Theme configuration */
 export type ThemeType = { preset?: any; options?: any } | 'none' | boolean | undefined;
 
+/** Dynamic style container configuration */
+export type StyleContainerType = HTMLElement | ShadowRoot | null | undefined;
+
 export type ThemeConfigType = {
     theme?: ThemeType;
     csp?: {
@@ -190,6 +193,7 @@ export interface GlobalPassThrough {
 export type PrimeNGConfigType = {
     ripple?: boolean;
     overlayAppendTo?: HTMLElement | ElementRef | TemplateRef<any> | string | null | undefined | any;
+    styleContainer?: StyleContainerType;
     /**
      * @deprecated Since v20. Use `inputVariant` instead.
      */

--- a/packages/primeng/src/config/themeprovider.ts
+++ b/packages/primeng/src/config/themeprovider.ts
@@ -11,6 +11,8 @@ export class ThemeProvider {
 
     csp = signal<{ nonce: string | undefined }>({ nonce: undefined });
 
+    styleContainer = signal<HTMLElement | ShadowRoot | null | undefined>(undefined);
+
     isThemeChanged: boolean = false;
 
     public document: Document = inject(DOCUMENT);
@@ -56,7 +58,7 @@ export class ThemeProvider {
         // common
         if (!Theme.isStyleNameLoaded('common')) {
             const { primitive, semantic, global, style } = this.baseStyle.getCommonTheme?.() || {};
-            const styleOptions = { nonce: this.csp?.()?.nonce };
+            const styleOptions = { nonce: this.csp?.()?.nonce, styleContainer: this.styleContainer?.() };
 
             this.baseStyle.load(primitive?.css, { name: 'primitive-variables', ...styleOptions });
             this.baseStyle.load(semantic?.css, { name: 'semantic-variables', ...styleOptions });

--- a/packages/primeng/src/confirmpopup/confirmpopup.ts
+++ b/packages/primeng/src/confirmpopup/confirmpopup.ts
@@ -27,12 +27,12 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { absolutePosition, addClass, appendChild, findSingle, focus, getOffset, isIOS, isTouchDevice } from '@primeuix/utils';
+import { absolutePosition, addClass, findSingle, focus, getOffset, isIOS, isTouchDevice } from '@primeuix/utils';
 import { Confirmation, ConfirmationService, OverlayService, PrimeTemplate, SharedModule, TranslationKeys } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { ButtonModule } from 'primeng/button';
-import { ConnectedOverlayScrollHandler } from 'primeng/dom';
+import { appendChild, ConnectedOverlayScrollHandler } from 'primeng/dom';
 import { FocusTrap } from 'primeng/focustrap';
 import { MotionModule } from 'primeng/motion';
 import { Nullable, VoidListener } from 'primeng/ts-helpers';

--- a/packages/primeng/src/contextmenu/contextmenu.ts
+++ b/packages/primeng/src/contextmenu/contextmenu.ts
@@ -30,7 +30,6 @@ import {
 import { RouterModule } from '@angular/router';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
 import {
-    appendChild,
     calculateScrollbarWidth,
     findLastIndex,
     findSingle,
@@ -54,6 +53,7 @@ import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { BindModule } from 'primeng/bind';
 import { AngleRightIcon } from 'primeng/icons';
 import { MotionModule } from 'primeng/motion';
+import { appendChild } from 'primeng/dom';
 import { Ripple } from 'primeng/ripple';
 import { TooltipModule } from 'primeng/tooltip';
 import { VoidListener } from 'primeng/ts-helpers';

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -24,14 +24,14 @@ import {
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { absolutePosition, addClass, addStyle, appendChild, find, findSingle, getFocusableElements, getIndex, getOuterWidth, hasClass, isDate, isNotEmpty, isTouchDevice, relativePosition, setAttribute, uuid } from '@primeuix/utils';
+import { absolutePosition, addClass, addStyle, find, findSingle, getFocusableElements, getIndex, getOuterWidth, hasClass, isDate, isNotEmpty, isTouchDevice, relativePosition, setAttribute, uuid } from '@primeuix/utils';
 import { OverlayService, PrimeTemplate, SharedModule, TranslationKeys } from 'primeng/api';
 import { AutoFocus } from 'primeng/autofocus';
 import { PARENT_INSTANCE } from 'primeng/basecomponent';
 import { BaseInput } from 'primeng/baseinput';
 import { Bind, BindModule } from 'primeng/bind';
 import { Button } from 'primeng/button';
-import { blockBodyScroll, ConnectedOverlayScrollHandler, unblockBodyScroll } from 'primeng/dom';
+import { appendChild, blockBodyScroll, ConnectedOverlayScrollHandler, unblockBodyScroll } from 'primeng/dom';
 import { CalendarIcon, ChevronDownIcon, ChevronLeftIcon, ChevronRightIcon, ChevronUpIcon, TimesIcon } from 'primeng/icons';
 import { InputText } from 'primeng/inputtext';
 import { MotionModule } from 'primeng/motion';

--- a/packages/primeng/src/dialog/dialog.ts
+++ b/packages/primeng/src/dialog/dialog.ts
@@ -27,12 +27,12 @@ import {
     ViewRef
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { addStyle, appendChild, getOuterHeight, getOuterWidth, getViewport, hasClass, removeClass, setAttribute, uuid } from '@primeuix/utils';
+import { addStyle, getOuterHeight, getOuterWidth, getViewport, hasClass, removeClass, setAttribute, uuid } from '@primeuix/utils';
 import { OverlayService, PrimeTemplate, SharedModule, TranslationKeys } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { Button, ButtonProps } from 'primeng/button';
-import { blockBodyScroll, DomHandler, unblockBodyScroll } from 'primeng/dom';
+import { appendChild, blockBodyScroll, DomHandler, unblockBodyScroll } from 'primeng/dom';
 import { FocusTrap } from 'primeng/focustrap';
 import { TimesIcon, WindowMaximizeIcon, WindowMinimizeIcon } from 'primeng/icons';
 import { MotionModule } from 'primeng/motion';
@@ -1074,7 +1074,7 @@ export class Dialog extends BaseComponent<DialogPassThrough> implements OnInit, 
 
     appendContainer() {
         if (this.$appendTo() !== 'self') {
-            appendChild(this.document.body, this.wrapper as HTMLElement);
+            appendChild(this.$appendTo() === 'body' ? this.document.body : this.$appendTo(), this.wrapper as HTMLElement);
         }
     }
 

--- a/packages/primeng/src/dom/domhandler.spec.ts
+++ b/packages/primeng/src/dom/domhandler.spec.ts
@@ -1,4 +1,4 @@
-import { appendChild, removeChild } from './domhandler';
+import { appendChild, DomHandler, removeChild } from './domhandler';
 
 describe('DomHandler append targets', () => {
     let host: HTMLDivElement;
@@ -27,5 +27,15 @@ describe('DomHandler append targets', () => {
         removeChild(shadowRoot, element);
 
         expect(shadowRoot.contains(element)).toBe(false);
+    });
+
+    it('should resolve scrollable parents across a shadow root boundary', () => {
+        host.style.overflow = 'auto';
+        appendChild(shadowRoot, element);
+
+        const scrollableParents = DomHandler.getScrollableParents(element);
+
+        expect(scrollableParents).toContain(host);
+        expect(scrollableParents).not.toContain(shadowRoot);
     });
 });

--- a/packages/primeng/src/dom/domhandler.spec.ts
+++ b/packages/primeng/src/dom/domhandler.spec.ts
@@ -1,0 +1,31 @@
+import { appendChild, removeChild } from './domhandler';
+
+describe('DomHandler append targets', () => {
+    let host: HTMLDivElement;
+    let shadowRoot: ShadowRoot;
+    let element: HTMLDivElement;
+
+    beforeEach(() => {
+        host = document.createElement('div');
+        document.body.appendChild(host);
+        shadowRoot = host.attachShadow({ mode: 'open' });
+        element = document.createElement('div');
+    });
+
+    afterEach(() => {
+        host.remove();
+    });
+
+    it('should append elements to a shadow root target', () => {
+        appendChild(shadowRoot, element);
+
+        expect(shadowRoot.contains(element)).toBe(true);
+    });
+
+    it('should remove elements from a shadow root target', () => {
+        appendChild(shadowRoot, element);
+        removeChild(shadowRoot, element);
+
+        expect(shadowRoot.contains(element)).toBe(false);
+    });
+});

--- a/packages/primeng/src/dom/domhandler.ts
+++ b/packages/primeng/src/dom/domhandler.ts
@@ -209,7 +209,15 @@ export class DomHandler {
     }
 
     static getParents(element: any, parents: any = []): any {
-        return element['parentNode'] === null ? parents : this.getParents(element.parentNode, parents.concat([element.parentNode]));
+        if (!element) {
+            return parents;
+        }
+
+        if (element['parentNode']) {
+            return this.getParents(element.parentNode, parents.concat([element.parentNode]));
+        }
+
+        return element.host ? this.getParents(element.host, parents.concat([element.host])) : parents;
     }
 
     static getScrollableParents(element: any) {
@@ -219,6 +227,10 @@ export class DomHandler {
             let parents = this.getParents(element);
             const overflowRegex = /(auto|scroll)/;
             const overflowCheck = (node: any) => {
+                if (!this.isElement(node)) {
+                    return false;
+                }
+
                 let styleDeclaration = window['getComputedStyle'](node, null);
                 return overflowRegex.test(styleDeclaration.getPropertyValue('overflow')) || overflowRegex.test(styleDeclaration.getPropertyValue('overflowX')) || overflowRegex.test(styleDeclaration.getPropertyValue('overflowY'));
             };

--- a/packages/primeng/src/dom/domhandler.ts
+++ b/packages/primeng/src/dom/domhandler.ts
@@ -500,13 +500,13 @@ export class DomHandler {
     }
 
     public static appendChild(element: any, target: any) {
-        if (this.isElement(target)) target.appendChild(element);
+        if (this.isAppendTarget(target)) target.appendChild(element);
         else if (target && target.el && target.el.nativeElement) target.el.nativeElement.appendChild(element);
         else throw 'Cannot append ' + target + ' to ' + element;
     }
 
     public static removeChild(element: any, target: any) {
-        if (this.isElement(target)) target.removeChild(element);
+        if (this.isAppendTarget(target)) target.removeChild(element);
         else if (target.el && target.el.nativeElement) target.el.nativeElement.removeChild(element);
         else throw 'Cannot remove ' + element + ' from ' + target;
     }
@@ -518,6 +518,10 @@ export class DomHandler {
 
     public static isElement(obj: any) {
         return typeof HTMLElement === 'object' ? obj instanceof HTMLElement : obj && typeof obj === 'object' && obj !== null && obj.nodeType === 1 && typeof obj.nodeName === 'string';
+    }
+
+    public static isAppendTarget(obj: any) {
+        return this.isElement(obj) || (typeof ShadowRoot === 'object' ? obj instanceof ShadowRoot : obj && typeof obj === 'object' && obj !== null && obj.nodeType === 11 && !!obj.host);
     }
 
     public static calculateScrollbarWidth(el?: HTMLElement): number {
@@ -852,6 +856,10 @@ export class DomHandler {
             : false;
     }
 }
+
+export const appendChild = (target: any, element: any) => DomHandler.appendChild(element, target);
+
+export const removeChild = (target: any, element: any) => DomHandler.removeChild(element, target);
 
 import { $dt } from '@primeuix/styled';
 import * as utils from '@primeuix/utils';

--- a/packages/primeng/src/drawer/drawer.spec.ts
+++ b/packages/primeng/src/drawer/drawer.spec.ts
@@ -810,6 +810,27 @@ describe('Drawer', () => {
                 expect(testComponent.visible).toBe(true);
             }
         });
+
+        it('should support modal overlays in a shadow root append target', async () => {
+            const shadowFixture = TestBed.createComponent(TestDrawerBasicComponent);
+            const shadowComponent = shadowFixture.componentInstance;
+            const host = document.createElement('div');
+            document.body.appendChild(host);
+            const shadowRoot = host.attachShadow({ mode: 'open' });
+
+            shadowComponent.appendTo = shadowRoot;
+            shadowComponent.visible = true;
+
+            shadowFixture.changeDetectorRef.markForCheck();
+            await shadowFixture.whenStable();
+            await new Promise((resolve) => setTimeout(resolve, 100));
+
+            expect(shadowRoot.querySelector('.p-drawer')).toBeTruthy();
+            expect(shadowRoot.querySelector('.p-drawer-mask')).toBeTruthy();
+
+            shadowFixture.destroy();
+            host.remove();
+        });
     });
 
     describe('Accessibility', () => {

--- a/packages/primeng/src/drawer/drawer.ts
+++ b/packages/primeng/src/drawer/drawer.ts
@@ -21,12 +21,12 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { addClass, appendChild, removeClass, setAttribute } from '@primeuix/utils';
+import { addClass, removeClass, setAttribute } from '@primeuix/utils';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { Button, ButtonProps } from 'primeng/button';
-import { blockBodyScroll, unblockBodyScroll } from 'primeng/dom';
+import { appendChild, blockBodyScroll, removeChild, unblockBodyScroll } from 'primeng/dom';
 import { FocusTrapModule } from 'primeng/focustrap';
 import { TimesIcon } from 'primeng/icons';
 import { MotionModule } from 'primeng/motion';
@@ -398,9 +398,9 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
     }
 
     enableModality() {
-        const activeDrawers = this.document.querySelectorAll('[data-p-open="true"]');
+        const activeDrawers = this.getModalRoot().querySelectorAll('[data-p-open="true"]');
         const activeDrawersLength = activeDrawers.length;
-        const zIndex = activeDrawersLength == 1 ? String(parseInt((this.container as HTMLDivElement).style.zIndex) - 1) : String(parseInt((activeDrawers[activeDrawersLength - 1] as HTMLElement).style.zIndex) - 1);
+        const zIndex = activeDrawersLength <= 1 ? String(parseInt((this.container as HTMLDivElement).style.zIndex) - 1) : String(parseInt((activeDrawers[activeDrawersLength - 1] as HTMLElement).style.zIndex) - 1);
 
         if (!this.mask) {
             this.mask = this.renderer.createElement('div');
@@ -420,7 +420,7 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
                 });
             }
 
-            this.renderer.appendChild(this.document.body, this.mask);
+            appendChild(this.getModalRoot(), this.mask);
             if (this.blockScroll) {
                 blockBodyScroll();
             }
@@ -447,7 +447,7 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
         this.unbindMaskClickListener();
 
         if (this.mask) {
-            this.renderer.removeChild(this.document.body, this.mask);
+            removeChild(this.getModalRoot(), this.mask);
         }
 
         if (this.blockScroll) {
@@ -551,6 +551,18 @@ export class Drawer extends BaseComponent<DrawerPassThrough> {
             open: this.visible,
             modal: this.modal
         });
+    }
+
+    private getModalRoot(): HTMLElement | ShadowRoot {
+        const appendTo = this.$appendTo();
+
+        if (appendTo && appendTo !== 'self' && appendTo !== 'body') {
+            return appendTo;
+        }
+
+        const rootNode = this.container?.getRootNode?.();
+
+        return rootNode instanceof ShadowRoot ? rootNode : this.document.body;
     }
 }
 

--- a/packages/primeng/src/dynamicdialog/dialogservice.ts
+++ b/packages/primeng/src/dynamicdialog/dialogservice.ts
@@ -1,10 +1,10 @@
 import { DOCUMENT } from '@angular/common';
 import { ApplicationRef, ComponentRef, EmbeddedViewRef, Inject, Injectable, Injector, Type, createComponent } from '@angular/core';
-import { appendChild } from '@primeuix/utils';
 import { DynamicDialog } from './dynamicdialog';
 import { DynamicDialogConfig } from './dynamicdialog-config';
 import { DynamicDialogInjector } from './dynamicdialog-injector';
 import { DynamicDialogRef } from './dynamicdialog-ref';
+import { appendChild } from 'primeng/dom';
 
 /**
  * Dynamic Dialog component methods.

--- a/packages/primeng/src/image/image.ts
+++ b/packages/primeng/src/image/image.ts
@@ -23,11 +23,11 @@ import {
 } from '@angular/core';
 import { SafeUrl } from '@angular/platform-browser';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { appendChild, focus } from '@primeuix/utils';
+import { focus } from '@primeuix/utils';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind, BindModule } from 'primeng/bind';
-import { blockBodyScroll, unblockBodyScroll } from 'primeng/dom';
+import { appendChild, blockBodyScroll, unblockBodyScroll } from 'primeng/dom';
 import { FocusTrap } from 'primeng/focustrap';
 import { EyeIcon, RefreshIcon, SearchMinusIcon, SearchPlusIcon, TimesIcon, UndoIcon } from 'primeng/icons';
 import { MotionModule } from 'primeng/motion';

--- a/packages/primeng/src/menu/menu.ts
+++ b/packages/primeng/src/menu/menu.ts
@@ -30,12 +30,12 @@ import {
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { absolutePosition, addStyle, appendChild, find, findSingle, focus, isTouchDevice, uuid } from '@primeuix/utils';
+import { absolutePosition, addStyle, find, findSingle, focus, isTouchDevice, uuid } from '@primeuix/utils';
 import { MenuItem, OverlayService, PrimeTemplate, SharedModule } from 'primeng/api';
 import { BadgeModule } from 'primeng/badge';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind, BindModule } from 'primeng/bind';
-import { ConnectedOverlayScrollHandler } from 'primeng/dom';
+import { appendChild, ConnectedOverlayScrollHandler } from 'primeng/dom';
 import { MotionModule } from 'primeng/motion';
 import { Ripple } from 'primeng/ripple';
 import { TooltipModule } from 'primeng/tooltip';

--- a/packages/primeng/src/overlay/overlay.ts
+++ b/packages/primeng/src/overlay/overlay.ts
@@ -21,11 +21,11 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { absolutePosition, addClass, appendChild, focus, getOuterWidth, getTargetElement, isTouchDevice, relativePosition, removeClass } from '@primeuix/utils';
+import { absolutePosition, addClass, focus, getOuterWidth, getTargetElement, isTouchDevice, relativePosition, removeClass } from '@primeuix/utils';
 import { OverlayModeType, OverlayOnBeforeHideEvent, OverlayOnBeforeShowEvent, OverlayOnHideEvent, OverlayOnShowEvent, OverlayOptions, OverlayService, PrimeTemplate, ResponsiveOverlayOptions, SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
-import { ConnectedOverlayScrollHandler } from 'primeng/dom';
+import { appendChild, ConnectedOverlayScrollHandler } from 'primeng/dom';
 import { MotionModule } from 'primeng/motion';
 import { Subscription } from 'rxjs';
 import { VoidListener } from 'primeng/ts-helpers';

--- a/packages/primeng/src/popover/popover.ts
+++ b/packages/primeng/src/popover/popover.ts
@@ -24,11 +24,11 @@ import {
 } from '@angular/core';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
 import { $dt } from '@primeuix/styled';
-import { absolutePosition, addClass, appendChild, findSingle, getOffset, isIOS, isTouchDevice } from '@primeuix/utils';
+import { absolutePosition, addClass, findSingle, getOffset, isIOS, isTouchDevice } from '@primeuix/utils';
 import { OverlayService, PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
-import { ConnectedOverlayScrollHandler } from 'primeng/dom';
+import { appendChild, ConnectedOverlayScrollHandler } from 'primeng/dom';
 import { MotionModule } from 'primeng/motion';
 import { Nullable, VoidListener } from 'primeng/ts-helpers';
 import { PopoverContentTemplateContext, PopoverPassThrough } from 'primeng/types/popover';

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -30,7 +30,7 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { absolutePosition, addStyle, appendChild, find, findSingle, getAttribute, isClickable, setAttribute } from '@primeuix/utils';
+import { absolutePosition, addStyle, find, findSingle, getAttribute, isClickable, setAttribute } from '@primeuix/utils';
 import { BlockableUI, FilterMatchMode, FilterMetadata, FilterOperator, FilterService, LazyLoadMeta, OverlayService, PrimeTemplate, ScrollerOptions, SelectItem, SharedModule, SortMeta, TableState, TranslationKeys } from 'primeng/api';
 import { BadgeModule } from 'primeng/badge';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
@@ -38,7 +38,7 @@ import { Bind, BindModule } from 'primeng/bind';
 import { Button, ButtonModule } from 'primeng/button';
 import { CheckboxChangeEvent, CheckboxModule } from 'primeng/checkbox';
 import { DatePickerModule } from 'primeng/datepicker';
-import { ConnectedOverlayScrollHandler, DomHandler } from 'primeng/dom';
+import { appendChild, ConnectedOverlayScrollHandler, DomHandler } from 'primeng/dom';
 import { ArrowDownIcon } from 'primeng/icons/arrowdown';
 import { ArrowUpIcon } from 'primeng/icons/arrowup';
 import { FilterIcon } from 'primeng/icons/filter';

--- a/packages/primeng/src/tieredmenu/tieredmenu.ts
+++ b/packages/primeng/src/tieredmenu/tieredmenu.ts
@@ -28,11 +28,11 @@ import {
 } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { MotionEvent, MotionOptions } from '@primeuix/motion';
-import { absolutePosition, addStyle, appendChild, findLastIndex, findSingle, focus, getOuterWidth, isEmpty, isNotEmpty, isPrintableCharacter, isTouchDevice, nestedPosition, relativePosition, resolve, uuid } from '@primeuix/utils';
+import { absolutePosition, addStyle, findLastIndex, findSingle, focus, getOuterWidth, isEmpty, isNotEmpty, isPrintableCharacter, isTouchDevice, nestedPosition, relativePosition, resolve, uuid } from '@primeuix/utils';
 import { MenuItem, OverlayService, PrimeTemplate, SharedModule } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { Bind, BindModule } from 'primeng/bind';
-import { ConnectedOverlayScrollHandler } from 'primeng/dom';
+import { appendChild, ConnectedOverlayScrollHandler } from 'primeng/dom';
 import { AngleRightIcon } from 'primeng/icons';
 import { MotionModule } from 'primeng/motion';
 import { Ripple } from 'primeng/ripple';

--- a/packages/primeng/src/tooltip/tooltip.ts
+++ b/packages/primeng/src/tooltip/tooltip.ts
@@ -1,10 +1,10 @@
 import { isPlatformBrowser } from '@angular/common';
 import { booleanAttribute, computed, Directive, effect, ElementRef, inject, InjectionToken, input, Input, NgModule, NgZone, numberAttribute, SimpleChanges, TemplateRef, ViewContainerRef } from '@angular/core';
-import { appendChild, createElement, fadeIn, findSingle, getOuterHeight, getOuterWidth, getViewport, getWindowScrollLeft, getWindowScrollTop, hasClass, removeChild, uuid } from '@primeuix/utils';
+import { createElement, fadeIn, findSingle, getOuterHeight, getOuterWidth, getViewport, getWindowScrollLeft, getWindowScrollTop, hasClass, uuid } from '@primeuix/utils';
 import { TooltipOptions } from 'primeng/api';
 import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
 import { BindModule } from 'primeng/bind';
-import { ConnectedOverlayScrollHandler } from 'primeng/dom';
+import { appendChild, ConnectedOverlayScrollHandler, removeChild } from 'primeng/dom';
 import { Nullable } from 'primeng/ts-helpers';
 import { TooltipPassThroughOptions } from 'primeng/types/tooltip';
 import { ZIndexUtils } from 'primeng/utils';
@@ -794,7 +794,7 @@ export class Tooltip extends BaseComponent<TooltipPassThroughOptions> {
     }
 
     remove() {
-        if (this.container && this.container.parentElement) {
+        if (this.container && this.container.parentNode) {
             if (this.getOption('appendTo') === 'body') document.body.removeChild(this.container);
             else if (this.getOption('appendTo') === 'target') this.el.nativeElement.removeChild(this.container);
             else removeChild(this.getOption('appendTo'), this.container);

--- a/packages/primeng/src/usestyle/usestyle.spec.ts
+++ b/packages/primeng/src/usestyle/usestyle.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from '@angular/core/testing';
+
+import { UseStyle } from './usestyle';
+
+describe('UseStyle', () => {
+    let service: UseStyle;
+    let host: HTMLDivElement;
+    let shadowRoot: ShadowRoot;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({});
+        service = TestBed.inject(UseStyle);
+
+        host = document.createElement('div');
+        document.body.appendChild(host);
+        shadowRoot = host.attachShadow({ mode: 'open' });
+    });
+
+    afterEach(() => {
+        host.remove();
+        document.head.querySelectorAll('style[data-primeng-style-id^="test-style"]').forEach((style) => style.remove());
+    });
+
+    it('should append styles to the provided style container', () => {
+        service.use('.test { color: red; }', { name: 'test-style-shadow', styleContainer: shadowRoot });
+
+        expect(shadowRoot.querySelector('style[data-primeng-style-id="test-style-shadow"]')?.textContent).toContain('color: red;');
+        expect(document.head.querySelector('style[data-primeng-style-id="test-style-shadow"]')).toBeNull();
+    });
+
+    it('should reuse a style element by id within the provided style container', () => {
+        service.use('.test { color: red; }', { id: 'test-style-by-id', name: 'test-style-initial', styleContainer: shadowRoot });
+        service.use('.test { color: blue; }', { id: 'test-style-by-id', name: 'test-style-updated', styleContainer: shadowRoot });
+
+        const styleElement = shadowRoot.querySelector('style[id="test-style-by-id"]') as HTMLStyleElement;
+
+        expect(shadowRoot.querySelectorAll('style[id="test-style-by-id"]').length).toBe(1);
+        expect(styleElement.textContent).toContain('color: blue;');
+        expect(document.head.querySelector('style[id="test-style-by-id"]')).toBeNull();
+    });
+});

--- a/packages/primeng/src/usestyle/usestyle.ts
+++ b/packages/primeng/src/usestyle/usestyle.ts
@@ -1,38 +1,52 @@
 import { DOCUMENT } from '@angular/common';
 import { Injectable, inject } from '@angular/core';
-import { setAttribute, setAttributes } from '@primeuix/utils';
+import { setAttributes } from '@primeuix/utils';
 
 let _id = 0;
+
+export type StyleContainerType = HTMLElement | ShadowRoot | null | undefined;
+
+export interface UseStyleOptions {
+    immediate?: boolean;
+    manual?: boolean;
+    name?: string;
+    id?: string;
+    media?: string;
+    nonce?: string;
+    first?: boolean;
+    props?: Record<string, unknown>;
+    styleContainer?: StyleContainerType;
+}
 
 @Injectable({ providedIn: 'root' })
 export class UseStyle {
     document: Document = inject(DOCUMENT);
 
-    use(css, options: any = {}) {
+    use(css: string | undefined, options: UseStyleOptions = {}) {
         let isLoaded = false;
-        let cssRef = css;
+        let cssRef = css ?? '';
         let styleRef: HTMLStyleElement | null = null;
 
-        const { immediate = true, manual = false, name = `style_${++_id}`, id = undefined, media = undefined, nonce = undefined, first = false, props = {} } = options;
+        const { immediate = true, manual = false, name = `style_${++_id}`, id = undefined, media = undefined, nonce = undefined, first = false, props = {}, styleContainer = undefined } = options;
+        const styleContainerRef = styleContainer || this.document.head;
 
-        if (!this.document) return;
-        styleRef = (this.document.querySelector(`style[data-primeng-style-id="${name}"]`) || (id && this.document.getElementById(id)) || this.document.createElement('style')) as HTMLStyleElement;
+        if (!this.document || !styleContainerRef) return;
+        styleRef = (styleContainerRef.querySelector(`style[data-primeng-style-id="${name}"]`) || (id && styleContainerRef.querySelector(`style[id="${id}"]`)) || this.document.createElement('style')) as HTMLStyleElement;
 
         if (styleRef) {
             if (!styleRef.isConnected) {
-                cssRef = css;
+                cssRef = css ?? '';
 
-                const HEAD = this.document.head;
-
-                setAttribute(styleRef, 'nonce', nonce);
-
-                first && HEAD.firstChild ? HEAD.insertBefore(styleRef, HEAD.firstChild) : HEAD.appendChild(styleRef);
                 setAttributes(styleRef, {
                     type: 'text/css',
+                    id,
                     media,
                     nonce,
+                    ...props,
                     'data-primeng-style-id': name
                 });
+
+                first && styleContainerRef.firstChild ? styleContainerRef.insertBefore(styleRef, styleContainerRef.firstChild) : styleContainerRef.appendChild(styleRef);
             }
 
             if (styleRef.textContent !== cssRef) {


### PR DESCRIPTION
## Summary

Resolves [#16567](https://github.com/primefaces/primeng/issues/16567)

This PR adds support for running PrimeNG inside a Shadow DOM by allowing both dynamic styles and overlay containers to target a custom root instead of always using the global document.

## Changes

 - add styleContainer support so dynamic styles, theme variables, and shared styles can be injected into a custom container such as a ShadowRoot
 - allow overlayAppendTo to work with ShadowRoot
 - update shared DOM append/remove handling to support ShadowRoot targets
 - fix Drawer modal/mask handling so mask creation, removal, and z-index lookup use the same root as the overlay container
 - extend types for styleContainer and overlayAppendTo
 - add regression coverage for Shadow DOM style injection, shared DOM append/remove behavior, and Drawer overlays in Shadow DOM

## Why

PrimeNG currently assumes global document-level style and overlay rendering in several paths. That breaks when components are rendered inside Web Components or micro frontends that mount into a Shadow DOM. These changes make PrimeNG usable in those setups while preserving the existing default behavior for non-Shadow DOM apps.

## Example

```
 providePrimeNG({
   theme: { preset: Aura },
   styleContainer: shadowRoot,
   overlayAppendTo: shadowRoot
 });
```

## Notes

 - default behavior remains unchanged when no custom container is provided
 - this focuses on the shared dynamic style/overlay paths and Drawer modal behavior that previously failed in Shadow DOM setups

## TODOs

- ~~Found an unresolved issue with Select component. It works but with an error:~~ SOLVED

```
ERROR TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.
    at overflowCheck (primeng-dom.mjs:209:65)
    at _DomHandler.getScrollableParents (primeng-dom.mjs:223:46)
    at ConnectedOverlayScrollHandler.bindScrollListener (primeng-dom.mjs:758:45)
    at _Overlay.bindScrollListener (primeng-overlay.mjs:806:24)
    at _Overlay.bindListeners (primeng-overlay.mjs:768:10)
    at _Overlay.onOverlayAfterEnter (primeng-overlay.mjs:712:10)
    at Overlay_Conditional_1_div_0_Template_p_motion_onAfterEnter_2_listener (primeng-overlay.mjs:70:36)
    at executeListenerWithErrorHandling (_debug_node-chunk.mjs:8218:12)
    at wrapListenerIn_markDirtyAndPreventDefault (_debug_node-chunk.mjs:8205:18)
    at OutputEmitterRef.emit (_resource-chunk.mjs:50:11)
```
