### PR TITLE
fix(datepicker): hour decrement loops incorrectly when minDate hour i…

### DIFF
--- a/packages/primeng/src/datepicker/datepicker.spec.ts
+++ b/packages/primeng/src/datepicker/datepicker.spec.ts
@@ -605,6 +605,28 @@ describe('DatePicker', () => {
             expect(datePickerComponent.stepMinute).toBe(15);
             expect(datePickerComponent.stepSecond).toBe(30);
         });
+
+        it('should not loop incorrectly when decrementing hour below minDate hour', async () => {
+            const minDate = new Date();
+            minDate.setHours(9, 0, 0, 0);
+
+            testComponent.showTime = true;
+            testComponent.inline = true;
+            testComponent.minDate = minDate;
+            testComponent.selectedDate = new Date(minDate);
+            testComponent.selectedDate.setHours(9, 0, 0, 0);
+
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const datePickerComponent = testFixture.debugElement.query(By.css('p-datepicker')).componentInstance;
+            const mockEvent = { preventDefault: jasmine.createSpy('preventDefault') };
+            datePickerComponent.decrementHour(mockEvent);
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            expect(datePickerComponent.currentHour).toBe(9);
+        });
     });
 
     describe('Inline Mode', () => {

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -2813,15 +2813,6 @@ export class DatePicker extends BaseInput<DatePickerPassThrough> {
             case isMinDate && this.minDate!.getHours() === convertedHour && this.minDate!.getMinutes() === minute && this.minDate!.getSeconds() > second:
                 returnTimeTriple[2] = this.minDate!.getSeconds();
                 break;
-            case isMinDate && !minHoursExceeds12 && this.minDate!.getHours() - 1 === convertedHour && this.minDate!.getHours() > convertedHour:
-                returnTimeTriple[0] = 11;
-                this.pm = true;
-            case isMinDate && this.minDate!.getHours() === convertedHour && this.minDate!.getMinutes() > minute:
-                returnTimeTriple[1] = this.minDate!.getMinutes();
-            case isMinDate && this.minDate!.getHours() === convertedHour && this.minDate!.getMinutes() === minute && this.minDate!.getSeconds() > second:
-                returnTimeTriple[2] = this.minDate!.getSeconds();
-                break;
-
             case isMinDate && minHoursExceeds12 && this.minDate!.getHours() > convertedHour && convertedHour !== 12:
                 this.setCurrentHourPM(this.minDate!.getHours());
                 returnTimeTriple[0] = this.currentHour || 0;


### PR DESCRIPTION
## Description
Fixes incorrect behaviour in the `constrainTime` method where clicking 
the hour decrement button causes the hour to loop incorrectly 
(e.g. 9 → 11 → 10 → 9) when a `minDate` with a specific hour is set.

## Root Cause
A `switch(true)` case in `constrainTime` was incorrectly setting 
`returnTimeTriple[0] = 11` and flipping `this.pm = true` whenever 
the decremented hour was exactly one below the `minDate` hour. 
This case was redundant as AM/PM toggling is already handled 
by `toggleAMPMIfNotMinDate` before `constrainTime` is called.

## Fix
Removed the redundant and incorrect case from the `switch(true)` 
block in `constrainTime`.

Fixes #19557