### PR TITLE
fix(autocomplete): improve multiple mode accessibility

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.spec.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.spec.ts
@@ -1366,6 +1366,55 @@ describe('AutoComplete', () => {
             }
         });
 
+        it('should provide an accessible name for the multiple listbox', async () => {
+            testComponent.multiple = true;
+            testComponent.ariaLabel = undefined as any;
+            testComponent.ariaLabelledBy = undefined as any;
+            testComponent.placeholder = 'Select tags';
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const listElement = testFixture.debugElement.query(By.css('ul[role="listbox"]'));
+
+            expect(listElement.nativeElement.getAttribute('aria-label')).toBe('Select tags');
+            expect(listElement.nativeElement.getAttribute('aria-labelledby')).toBeNull();
+        });
+
+        it('should support labelledby for the multiple listbox', async () => {
+            testComponent.multiple = true;
+            testComponent.ariaLabelledBy = 'autocomplete-label';
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const listElement = testFixture.debugElement.query(By.css('ul[role="listbox"]'));
+
+            expect(listElement.nativeElement.getAttribute('aria-labelledby')).toBe('autocomplete-label');
+        });
+
+        it('should provide a default accessible name for the multiple listbox', async () => {
+            testComponent.multiple = true;
+            testComponent.ariaLabel = undefined as any;
+            testComponent.ariaLabelledBy = undefined as any;
+            testComponent.placeholder = undefined as any;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const listElement = testFixture.debugElement.query(By.css('ul[role="listbox"]'));
+
+            expect(listElement.nativeElement.getAttribute('aria-label')).toBe('Option List');
+        });
+
+        it('should not render the multiple input wrapper as an option', async () => {
+            testComponent.multiple = true;
+            testFixture.changeDetectorRef.markForCheck();
+            await testFixture.whenStable();
+
+            const inputElement = testFixture.debugElement.query(By.css('input[role="combobox"]'));
+            const inputWrapper = inputElement.nativeElement.closest('li');
+
+            expect(inputWrapper.getAttribute('role')).toBe('presentation');
+        });
+
         it('should support keyboard navigation', () => {
             const inputElement = testFixture.debugElement.query(By.css('input'));
 

--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -133,6 +133,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             [attr.data-p]="inputMultipleDataP"
             [tabindex]="-1"
             role="listbox"
+            [attr.aria-label]="ariaLabelledBy ? undefined : ariaLabel || placeholder || listLabel"
+            [attr.aria-labelledby]="ariaLabelledBy"
             [attr.aria-orientation]="'horizontal'"
             [attr.aria-activedescendant]="focused ? focusedMultipleOptionId : undefined"
             (focus)="onMultipleContainerFocus($event)"
@@ -171,7 +173,7 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
                     </ng-template>
                 </p-chip>
             </li>
-            <li [pBind]="ptm('inputChip')" [class]="cx('inputChip')" role="option">
+            <li [pBind]="ptm('inputChip')" [class]="cx('inputChip')" role="presentation">
                 <input
                     #focusInput
                     #multiIn


### PR DESCRIPTION
AutoComplete multiple mode rendered its selected-value listbox without an accessible name and wrapped the input combobox in an option element.

Label the multiple listbox with existing accessibility inputs and make the input wrapper presentational so interactive controls are not nested inside options.

Fixes primefaces/primeng#17457

### Defect Fixes
When submitting a PR, please also <ins>**create an issue**</ins> documenting the error and [manually link to an issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-or-branch-to-an-issue-using-the-issue-sidebar).

### Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.
Smaller scaled feature implementations such as adding a property to a component will be considered for merging.
