### PR TITLE
fix(table): table should be able to handle an empty multiSortMeta

### DIFF
--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -1654,7 +1654,7 @@ export class Table<RowData = any> extends BaseComponent<TablePassThrough> implem
             else if ((<SortMeta[]>this.multiSortMeta)[0].field !== this.groupRowsBy) this._multiSortMeta = [this.getGroupRowsMeta(), ...this._multiSortMeta];
         }
 
-        if (this.multiSortMeta) {
+        if (this.multiSortMeta && this.multiSortMeta.length > 0) {
             if (this.lazy) {
                 this.onLazyLoad.emit(this.createLazyLoadMetadata());
             } else if (this.value) {


### PR DESCRIPTION
Fixes: [#19572](https://github.com/primefaces/primeng/issues/19572)

### Problem

The table currently logs an error, when the multiSortMeta is, for some reason, an empty array. Since [] is a truthy value, the check does not guard against it and therefore, trying to access an index on the empty array leads to the error.

### What changed

Improved the check to include a .length > 0 check, to avoid accessing an invalid index