### PR TITLE
[19580] fix: Remove hardcoded aria-labels in date picker

### DIFF
--- a/packages/primeng/src/autocomplete/autocomplete.ts
+++ b/packages/primeng/src/autocomplete/autocomplete.ts
@@ -119,8 +119,8 @@ export const AUTOCOMPLETE_VALUE_ACCESSOR: any = {
             [pInputTextUnstyled]="unstyled()"
         />
         <ng-container *ngIf="$filled() && !$disabled() && showClear && !loading">
-            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true" />
-            <span *ngIf="clearIconTemplate || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" [attr.aria-hidden]="true">
+            <svg data-p-icon="times" *ngIf="!clearIconTemplate && !_clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()" />
+            <span *ngIf="clearIconTemplate || _clearIconTemplate" [pBind]="ptm('clearIcon')" [class]="cx('clearIcon')" (click)="clear()">
                 <ng-template *ngTemplateOutlet="clearIconTemplate || _clearIconTemplate"></ng-template>
             </span>
         </ng-container>

--- a/packages/primeng/src/datepicker/datepicker.ts
+++ b/packages/primeng/src/datepicker/datepicker.ts
@@ -193,7 +193,6 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                         (keydown)="onContainerButtonKeydown($event)"
                                         [class]="cx('selectMonth')"
                                         [attr.disabled]="switchViewButtonDisabled() ? '' : undefined"
-                                        [attr.aria-label]="this.getTranslation('chooseMonth')"
                                         pRipple
                                         [pBind]="ptm('selectMonth')"
                                         [attr.data-pc-group-section]="'navigator'"
@@ -207,7 +206,6 @@ const DATEPICKER_INSTANCE = new InjectionToken<DatePicker>('DATEPICKER_INSTANCE'
                                         (keydown)="onContainerButtonKeydown($event)"
                                         [class]="cx('selectYear')"
                                         [attr.disabled]="switchViewButtonDisabled() ? '' : undefined"
-                                        [attr.aria-label]="getTranslation('chooseYear')"
                                         pRipple
                                         [pBind]="ptm('selectYear')"
                                         [attr.data-pc-group-section]="'navigator'"


### PR DESCRIPTION
Fixes an accessibility label-content-name-mismatch issue in Datepicker header navigation.

The month and year switch buttons were using static aria-label values (chooseMonth / chooseYear) that could differ from their visible labels (e.g. January, 2026). This caused a mismatch between visible text and accessible name, impacting speech-input users and triggering axe violations.

This PR removes those explicit aria-label bindings so the buttons use their visible text as the accessible name, aligning behavior with WCAG/axe expectations while keeping existing Datepicker functionality unchanged.

https://github.com/primefaces/primeng/issues/19580