### PR TITLE
Fix long option not truncated issue in dropdown

### DIFF
--- a/packages/primeng/src/api/overlayoptions.ts
+++ b/packages/primeng/src/api/overlayoptions.ts
@@ -159,6 +159,10 @@ export interface OverlayOptions {
      */
     motionOptions?: MotionOptions;
     /**
+     * Indicates whether the overlay should have a max-width based on the target element.
+     */
+    autoMaxWidth?: boolean;
+    /**
      * Indicates whether the overlay should be hidden when the escape key is pressed.
      */
     hideOnEscape?: boolean;

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -293,7 +293,7 @@ export class MultiSelectItem extends BaseComponent {
             #overlay
             [hostAttrSelector]="$attrSelector"
             [(visible)]="overlayVisible"
-            [options]="overlayOptions"
+            [options]="{ ...overlayOptions, autoMaxWidth: !autoWidth }"
             [target]="'@parent'"
             [appendTo]="$appendTo()"
             [unstyled]="unstyled()"
@@ -740,6 +740,11 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
      * @group Props
      */
     @Input({ transform: booleanAttribute }) autofocusFilter: boolean = false;
+    /**
+     * Whether the width of the overlay mirrors the width of the component.
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) autoWidth: boolean = true;
     /**
      * Defines how the selected items are displayed.
      * @group Props

--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -89,7 +89,7 @@ export const MULTISELECT_VALUE_ACCESSOR: any = {
                 </ng-template>
             </ng-container>
         </p-checkbox>
-        <span *ngIf="!template">{{ label ?? 'empty' }}</span>
+        <span *ngIf="!template" [class]="cx('optionLabel')" [pBind]="getPTOptions('optionLabel')">{{ label ?? 'empty' }}</span>
         <ng-container *ngTemplateOutlet="template; context: { $implicit: option }"></ng-container>
     `,
     encapsulation: ViewEncapsulation.None,
@@ -293,7 +293,7 @@ export class MultiSelectItem extends BaseComponent {
             #overlay
             [hostAttrSelector]="$attrSelector"
             [(visible)]="overlayVisible"
-            [options]="{ ...overlayOptions, autoMaxWidth: !autoWidth }"
+            [options]="{ ...overlayOptions, autoMaxWidth: autoWidth }"
             [target]="'@parent'"
             [appendTo]="$appendTo()"
             [unstyled]="unstyled()"

--- a/packages/primeng/src/multiselect/style/multiselectstyle.ts
+++ b/packages/primeng/src/multiselect/style/multiselectstyle.ts
@@ -9,11 +9,13 @@ const style = /*css*/ `
    .p-multiselect.ng-invalid.ng-dirty {
         border-color: dt('multiselect.invalid.border.color');
     }
+    p-multiSelect.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder,
+    p-multi-select.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder,
     p-multiselect.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder {
         color: dt('multiselect.invalid.placeholder.color');
     }
 
-    .p-multiselect-option {
+    .p-multiselect-option-label {
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -73,6 +75,7 @@ const classes = {
         'p-disabled': instance.disabled,
         'p-focus': instance.focused
     }),
+    optionLabel: 'p-multiselect-option-label',
     emptyMessage: 'p-multiselect-empty-message',
     clearIcon: 'p-multiselect-clear-icon'
 };
@@ -166,6 +169,10 @@ export enum MultiSelectClasses {
      * Class name of the option element
      */
     option = 'p-multiselect-option',
+    /**
+     * Class name of the option label element
+     */
+    optionLabel = 'p-multiselect-option-label',
     /**
      * Class name of the empty message element
      */

--- a/packages/primeng/src/multiselect/style/multiselectstyle.ts
+++ b/packages/primeng/src/multiselect/style/multiselectstyle.ts
@@ -9,10 +9,20 @@ const style = /*css*/ `
    .p-multiselect.ng-invalid.ng-dirty {
         border-color: dt('multiselect.invalid.border.color');
     }
-    p-multiSelect.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder,
-    p-multi-select.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder,
     p-multiselect.ng-invalid.ng-dirty .p-multiselect-label.p-placeholder {
         color: dt('multiselect.invalid.placeholder.color');
+    }
+
+    .p-multiselect-option {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .p-multiselect-label {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 `;
 

--- a/packages/primeng/src/overlay/overlay.ts
+++ b/packages/primeng/src/overlay/overlay.ts
@@ -607,6 +607,8 @@ export class Overlay extends BaseComponent {
 
                 if (this.overlayOptions.autoMaxWidth) {
                     this.overlayEl.style.maxWidth = targetWidth + 'px';
+                } else {
+                    this.overlayEl.style.maxWidth = '';
                 }
 
                 if (this.$appendTo() === 'self') {

--- a/packages/primeng/src/overlay/overlay.ts
+++ b/packages/primeng/src/overlay/overlay.ts
@@ -602,7 +602,13 @@ export class Overlay extends BaseComponent {
     alignOverlay() {
         if (!this.modal) {
             if (this.overlayEl && this.targetEl) {
-                this.overlayEl.style.minWidth = getOuterWidth(this.targetEl) + 'px';
+                const targetWidth = getOuterWidth(this.targetEl);
+                this.overlayEl.style.minWidth = targetWidth + 'px';
+
+                if (this.overlayOptions.autoMaxWidth) {
+                    this.overlayEl.style.maxWidth = targetWidth + 'px';
+                }
+
                 if (this.$appendTo() === 'self') {
                     relativePosition(this.overlayEl, this.targetEl);
                 } else {

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -96,7 +96,7 @@ export const SELECT_VALUE_ACCESSOR: any = {
                 <svg data-p-icon="check" *ngIf="selected" [class]="cx('optionCheckIcon')" [pBind]="$pcSelect?.ptm('optionCheckIcon')" />
                 <svg data-p-icon="blank" *ngIf="!selected" [class]="cx('optionBlankIcon')" [pBind]="$pcSelect?.ptm('optionBlankIcon')" />
             </ng-container>
-            <span *ngIf="!template" [pBind]="$pcSelect?.ptm('optionLabel')">{{ label ?? 'empty' }}</span>
+            <span *ngIf="!template" [class]="cx('optionLabel')" [pBind]="$pcSelect?.ptm('optionLabel')">{{ label ?? 'empty' }}</span>
             <ng-container *ngTemplateOutlet="template; context: { $implicit: option }"></ng-container>
         </li>
     `,
@@ -272,7 +272,7 @@ export class SelectItem extends BaseComponent {
             #overlay
             [hostAttrSelector]="$attrSelector"
             [(visible)]="overlayVisible"
-            [options]="{ ...overlayOptions, autoMaxWidth: !autoWidth }"
+            [options]="{ ...overlayOptions, autoMaxWidth: autoWidth }"
             [target]="'@parent'"
             [appendTo]="$appendTo()"
             [unstyled]="unstyled()"

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -272,7 +272,7 @@ export class SelectItem extends BaseComponent {
             #overlay
             [hostAttrSelector]="$attrSelector"
             [(visible)]="overlayVisible"
-            [options]="overlayOptions"
+            [options]="{ ...overlayOptions, autoMaxWidth: !autoWidth }"
             [target]="'@parent'"
             [appendTo]="$appendTo()"
             [unstyled]="unstyled()"
@@ -680,6 +680,11 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
      * @group Props
      */
     @Input({ transform: booleanAttribute }) autofocusFilter: boolean = true;
+    /**
+     * Whether the width of the overlay mirrors the width of the component.
+     * @group Props
+     */
+    @Input({ transform: booleanAttribute }) autoWidth: boolean = true;
     /**
      * When specified, filter displays with this value.
      * @group Props

--- a/packages/primeng/src/select/style/selectstyle.ts
+++ b/packages/primeng/src/select/style/selectstyle.ts
@@ -18,6 +18,18 @@ const style = /*css*/ `
     .p-select.ng-invalid.ng-dirty .p-select-label.p-placeholder {
         color: dt('select.invalid.placeholder.color');
     }
+
+    .p-select-option-label {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .p-select-label {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 `;
 
 const classes = {


### PR DESCRIPTION
fixes https://github.com/primefaces/primeng/issues/19427

The Issue:
Dropdown overlays for p-select and p-multiselect only had a min-width set (to match the input box) but no max-width. When options contained long text, the overlay expanded beyond the input box width instead of staying aligned and truncating the content.

The Fix:
Overlay constraint: Added an autoMaxWidth property to OverlayOptions and updated the Overlay layout alignment logic to apply maxWidth matching the target's width when enabled.
Component config: Exposed `autoWidth` (default true) on Select and MultiSelect components, which forwards `autoMaxWidth: !autoWidth` to the underlying overlay.
Ellipsis styles: Added default CSS truncation styles (text-overflow: ellipsis, overflow: hidden, white-space: nowrap) to option/label classes in both components to handle constrained widths cleanly.

Video with fix is [here:](https://github.com/primefaces/primeng/issues/19427#issuecomment-4412705670)