### PR TITLE
Fix/primeng render performance regression

### DIFF
--- a/packages/primeng/src/base/base.ts
+++ b/packages/primeng/src/base/base.ts
@@ -1,5 +1,47 @@
+import { ThemeService } from '@primeuix/styled';
+
 export default {
     _loadedStyleNames: new Set(),
+    _themeChangeWired: false,
+    _groupedThemeChangeListeners: new Map(),
+    _ensureThemeChangeWired() {
+        if (this._themeChangeWired) {
+            return;
+        }
+
+        this._themeChangeWired = true;
+        ThemeService.on('theme:change', () => this._loadedStyleNames.clear());
+    },
+    _registerGroupedThemeChangeListener(name, callback) {
+        const listener = this._groupedThemeChangeListeners.get(name);
+
+        if (listener) {
+            listener.callbacks.add(callback);
+            return () => {
+                listener.callbacks.delete(callback);
+
+                if (!listener.callbacks.size) {
+                    ThemeService.off('theme:change', listener.hold);
+                    this._groupedThemeChangeListeners.delete(name);
+                }
+            };
+        }
+
+        const callbacks = new Set([callback]);
+        const hold = (...args) => callbacks.forEach((callback) => callback(...args));
+
+        this._groupedThemeChangeListeners.set(name, { callbacks, hold });
+        ThemeService.on('theme:change', hold);
+
+        return () => {
+            callbacks.delete(callback);
+
+            if (!callbacks.size) {
+                ThemeService.off('theme:change', hold);
+                this._groupedThemeChangeListeners.delete(name);
+            }
+        };
+    },
     getLoadedStyleNames() {
         return this._loadedStyleNames;
     },

--- a/packages/primeng/src/basecomponent/basecomponent.ts
+++ b/packages/primeng/src/basecomponent/basecomponent.ts
@@ -9,6 +9,13 @@ import { BaseComponentStyle } from './style/basecomponentstyle';
 
 export const PARENT_INSTANCE = new InjectionToken<BaseComponent>('PARENT_INSTANCE');
 
+export interface BaseComponentPerformanceContext {
+    themeReactive?: () => boolean | undefined;
+    scopedTokens?: () => boolean | undefined;
+}
+
+export const PERFORMANCE_CONTEXT = new InjectionToken<BaseComponentPerformanceContext>('PERFORMANCE_CONTEXT');
+
 @Directive({
     standalone: true,
     providers: [BaseComponentStyle, BaseStyle]
@@ -30,6 +37,8 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
     public $parentInstance: BaseComponent | undefined = inject(PARENT_INSTANCE, { optional: true, skipSelf: true }) ?? undefined;
 
+    public $performanceContext: BaseComponentPerformanceContext | undefined = inject(PERFORMANCE_CONTEXT, { optional: true, skipSelf: true }) ?? undefined;
+
     public baseComponentStyle: BaseComponentStyle = inject(BaseComponentStyle);
 
     public baseStyle: BaseStyle = inject(BaseStyle);
@@ -43,6 +52,26 @@ export class BaseComponent<PT = any> implements Lifecycle {
     private _themeScopedListener: () => void;
 
     private themeChangeListenerMap: Map<string, any> = new Map();
+
+    private ptmCache: Map<string, Record<string, any>> = new Map();
+
+    private ptmsCache: Map<string, Record<string, any>> = new Map();
+
+    private cxStaticCache: Map<string, string | undefined> = new Map();
+
+    private sxStaticCache: Map<string, Record<string, any> | undefined> = new Map();
+
+    private styleCache: any;
+
+    private emptyPT: Record<string, any> = {};
+
+    private paramsCache: any;
+
+    private paramsCacheName: string | undefined;
+
+    private paramsCacheHostName: any;
+
+    private paramsCacheParentInstance: BaseComponent | undefined;
 
     /******************** Inputs ********************/
 
@@ -70,6 +99,18 @@ export class BaseComponent<PT = any> implements Lifecycle {
      * @defaultValue undefined
      */
     ptOptions = input<PassThroughOptions | undefined>();
+    /**
+     * Enables per-instance theme change reactivity.
+     * Set to `false` in performance-sensitive component subtrees when runtime theme changes are not needed.
+     * @defaultValue undefined
+     */
+    themeReactive = input<boolean | undefined>();
+    /**
+     * Enables scoped design token handling through the `dt` input.
+     * Set to `false` in performance-sensitive component subtrees when scoped tokens are not used.
+     * @defaultValue undefined
+     */
+    scopedTokens = input<boolean | undefined>();
 
     /******************** Computed ********************/
 
@@ -108,7 +149,19 @@ export class BaseComponent<PT = any> implements Lifecycle {
     }
 
     get $style() {
-        return { theme: undefined, css: undefined, classes: undefined, inlineStyles: undefined, ...(this._getHostInstance(this) || {}).$style, ...this['_componentStyle'] };
+        if (this.styleCache) {
+            return this.styleCache;
+        }
+
+        const hostStyle = (this._getHostInstance(this) || {}).$style;
+        const componentStyle = this['_componentStyle'];
+        const style = { theme: undefined, css: undefined, classes: undefined, inlineStyles: undefined, ...hostStyle, ...componentStyle };
+
+        if (hostStyle || componentStyle) {
+            this.styleCache = style;
+        }
+
+        return style;
     }
 
     get $styleOptions() {
@@ -116,14 +169,25 @@ export class BaseComponent<PT = any> implements Lifecycle {
     }
 
     get $params() {
+        const name = this.$name;
+        const hostName = this.$hostName;
         const parentInstance = this._getHostInstance(this) || this.$parentInstance;
 
-        return {
+        if (this.paramsCache && this.paramsCacheName === name && this.paramsCacheHostName === hostName && this.paramsCacheParentInstance === parentInstance) {
+            return this.paramsCache;
+        }
+
+        this.paramsCacheName = name;
+        this.paramsCacheHostName = hostName;
+        this.paramsCacheParentInstance = parentInstance;
+        this.paramsCache = {
             instance: this as any,
             parent: {
                 instance: parentInstance
             }
         };
+
+        return this.paramsCache;
     }
 
     /******************** Lifecycle Hooks ********************/
@@ -166,10 +230,13 @@ export class BaseComponent<PT = any> implements Lifecycle {
         // watch _dt_ changes
         effect((onCleanup) => {
             if (this.document && !isPlatformServer(this.platformId)) {
-                if (this.dt()) {
+                if (this._isScopedTokensEnabled() && this.dt()) {
                     this._loadScopedThemeStyles(this.dt());
-                    this._themeScopedListener = () => this._loadScopedThemeStyles(this.dt());
-                    this._themeChangeListener('_themeScopedListener', this._themeScopedListener);
+
+                    if (this._isThemeReactive()) {
+                        this._themeScopedListener = () => this._loadScopedThemeStyles(this.dt());
+                        this._themeChangeListener('_themeScopedListener', this._themeScopedListener);
+                    }
                 } else {
                     this._unloadScopedThemeStyles();
                 }
@@ -183,7 +250,7 @@ export class BaseComponent<PT = any> implements Lifecycle {
         // watch _unstyled_ changes
         effect((onCleanup) => {
             if (this.document && !isPlatformServer(this.platformId)) {
-                if (!this.$unstyled()) {
+                if (this._isThemeReactive() && !this.$unstyled() && this._hasCoreStyles()) {
                     this._loadCoreStyles();
                     this._themeChangeListener('_loadCoreStyles', this._loadCoreStyles); // Update styles with theme settings
                 }
@@ -203,7 +270,10 @@ export class BaseComponent<PT = any> implements Lifecycle {
      * Use 'onInit()' in subclasses instead.
      */
     ngOnInit() {
-        this._loadCoreStyles();
+        if (this._hasCoreStyles()) {
+            this._loadCoreStyles();
+        }
+
         this._loadStyles();
 
         this.onInit();
@@ -257,7 +327,9 @@ export class BaseComponent<PT = any> implements Lifecycle {
      */
     ngAfterViewInit() {
         // @todo - remove this after implementing pt for root
-        this.$el?.setAttribute(this.$attrSelector, '');
+        if (this.config?.ptMetadata()) {
+            this.$el?.setAttribute(this.$attrSelector, '');
+        }
 
         this.onAfterViewInit();
         this._hook('onAfterViewInit');
@@ -304,8 +376,46 @@ export class BaseComponent<PT = any> implements Lifecycle {
         return getKeyValue(options, key, params);
     }
 
+    private _getRawOptionValue(options: any, key = '') {
+        if (!key || !options) {
+            return options;
+        }
+
+        return key.split('.').reduce((acc, part) => acc?.[part], options);
+    }
+
+    private _isStaticClassValue(value: any) {
+        return isString(value) || (isArray(value) && value.every((item) => isString(item)));
+    }
+
+    private _isStaticStyleValue(value: any) {
+        return !isFunction(value);
+    }
+
+    private _getInheritedBooleanOption(name: string, defaultValue = true) {
+        const ownValue = this[name]?.();
+
+        if (ownValue !== undefined) {
+            return ownValue;
+        }
+
+        const parentInstance = this._getHostInstance(this) || this.$parentInstance;
+        const parentValue = parentInstance?.[name];
+        const contextValue = this.$performanceContext?.[name];
+
+        return (isFunction(parentValue) ? parentValue.call(parentInstance) : parentValue) ?? (isFunction(contextValue) ? contextValue.call(this.$performanceContext) : contextValue) ?? defaultValue;
+    }
+
+    private _isThemeReactive() {
+        return this._getInheritedBooleanOption('themeReactive');
+    }
+
+    private _isScopedTokensEnabled() {
+        return this._getInheritedBooleanOption('scopedTokens');
+    }
+
     private _hook(hookName: string, ...args: any[]) {
-        if (!this.$hostName) {
+        if (this.config?.ptBinding() && !this.$hostName && this._hasPTConfig()) {
             const selfHook = this._usePT(this._getPT(this.$pt(), this.$name), this._getOptionValue, `hooks.${hookName}`);
             const defaultHook = this._useDefaultPT(this._getOptionValue, `hooks.${hookName}`);
 
@@ -329,7 +439,10 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
     private _loadStyles() {
         this._load();
-        this._themeChangeListener('_load', () => this._load());
+
+        if (this._isThemeReactive()) {
+            this._themeChangeListener('_load', () => this._load());
+        }
     }
 
     private _loadGlobalStyles() {
@@ -345,6 +458,10 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
             Base.setLoadedStyleName(this.$style.name);
         }
+    }
+
+    private _hasCoreStyles() {
+        return !!(this.baseComponentStyle?.css || this.$style?.css);
     }
 
     private _loadThemeStyles() {
@@ -393,11 +510,17 @@ export class BaseComponent<PT = any> implements Lifecycle {
     }
 
     private _themeChangeListener(id: string, callback = () => {}) {
+        Base._ensureThemeChangeWired();
         this._offThemeChangeListener(id);
-        Base.clearLoadedStyleNames();
         const hold = callback.bind(this);
-        this.themeChangeListenerMap.set(id, hold);
-        ThemeService.on('theme:change', hold);
+        const styleName = this.$style?.name;
+
+        if ((id === '_load' || id === '_loadCoreStyles') && styleName) {
+            this.themeChangeListenerMap.set(id, Base._registerGroupedThemeChangeListener(`${id}:${styleName}`, hold));
+        } else {
+            this.themeChangeListenerMap.set(id, () => ThemeService.off('theme:change', hold));
+            ThemeService.on('theme:change', hold);
+        }
     }
 
     private _removeThemeListeners() {
@@ -408,7 +531,7 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
     private _offThemeChangeListener(id: string) {
         if (this.themeChangeListenerMap.has(id)) {
-            ThemeService.off('theme:change', this.themeChangeListenerMap.get(id));
+            this.themeChangeListenerMap.get(id)?.();
             this.themeChangeListenerMap.delete(id);
         }
     }
@@ -426,6 +549,10 @@ export class BaseComponent<PT = any> implements Lifecycle {
     }
 
     private _getPTDatasets(key = '') {
+        if (!this.config?.ptBinding() || !this.config?.ptMetadata()) {
+            return undefined;
+        }
+
         const datasetPrefix = 'data-pc-';
         const isExtended = key === 'root' && isNotEmpty(this.$pt()?.['data-pc-section']);
 
@@ -439,6 +566,26 @@ export class BaseComponent<PT = any> implements Lifecycle {
                 [`${datasetPrefix}section`]: toFlatCase(key.includes('.') ? (key.split('.').at(-1) ?? '') : key)
             }
         );
+    }
+
+    private _hasPTConfig() {
+        return !!(this.pt() || this.directivePT() || this.config?.pt());
+    }
+
+    private _hasPTParams(params: Record<string, any> | undefined) {
+        return params ? Object.keys(params).length > 0 : false;
+    }
+
+    private _getCachedPTMDatasets(key = '') {
+        let cached = this.ptmCache.get(key);
+
+        if (!cached) {
+            const datasets = this._getPTDatasets(key);
+            cached = datasets ? { ...datasets } : {};
+            this.ptmCache.set(key, cached);
+        }
+
+        return cached;
     }
 
     private _getPTClassValue(options?: any, key?: any, params?: any) {
@@ -493,29 +640,107 @@ export class BaseComponent<PT = any> implements Lifecycle {
 
     /******************** Exposed API ********************/
 
-    public ptm(key = '', params = {}) {
+    public ptm(key = '', params?: Record<string, any>) {
+        if (!this.config?.ptBinding()) {
+            return this.emptyPT;
+        }
+
+        if (!this._hasPTConfig() && !this._hasPTParams(params)) {
+            return this._getCachedPTMDatasets(key);
+        }
+
         return this._getPTValue(this.$pt() as any, key, { ...this.$params, ...params });
     }
 
-    public ptms(keys: string[], params = {}) {
-        return keys.reduce((acc, arg) => {
-            acc = mergeProps(acc, this.ptm(arg, params)) || {};
-            return acc;
-        }, {});
+    public ptms(keys: string[], params?: Record<string, any>) {
+        if (!this.config?.ptBinding()) {
+            return this.emptyPT;
+        }
+
+        if (!this._hasPTConfig() && !this._hasPTParams(params)) {
+            const cacheKey = keys.join('|');
+            let cached = this.ptmsCache.get(cacheKey);
+
+            if (!cached) {
+                cached =
+                    keys.reduce((acc, arg) => {
+                        acc = mergeProps(acc, this._getCachedPTMDatasets(arg)) || {};
+                        return acc;
+                    }, {}) || {};
+                this.ptmsCache.set(cacheKey, cached);
+            }
+
+            return cached;
+        }
+
+        return (
+            keys.reduce((acc, arg) => {
+                acc = mergeProps(acc, this.ptm(arg, params)) || {};
+                return acc;
+            }, {}) || {}
+        );
     }
 
     public ptmo(obj = {}, key = '', params = {}) {
+        if (!this.config?.ptBinding()) {
+            return this.emptyPT;
+        }
+
         return this._getPTValue(obj, key, { instance: this, ...params }, false);
     }
 
     public cx(key: string, params = {}) {
-        return !this.$unstyled() ? cn(this._getOptionValue(this.$style.classes, key, { ...this.$params, ...params })) : undefined;
+        if (this.$unstyled()) {
+            return undefined;
+        }
+
+        if (!this._hasPTParams(params)) {
+            if (this.cxStaticCache.has(key)) {
+                return this.cxStaticCache.get(key);
+            }
+
+            const rawValue = this._getRawOptionValue(this.$style.classes, key);
+
+            if (this._isStaticClassValue(rawValue)) {
+                const className = cn(rawValue);
+
+                this.cxStaticCache.set(key, className);
+
+                return className;
+            }
+        }
+
+        return cn(this._getOptionValue(this.$style.classes, key, { ...this.$params, ...params }));
     }
 
     public sx(key = '', when = true, params = {}) {
         if (when) {
+            if (!this._hasPTParams(params)) {
+                const rawSelf = this._getRawOptionValue(this.$style.inlineStyles, key);
+                const rawBase = this._getRawOptionValue(this.baseComponentStyle.inlineStyles, key);
+
+                if (this._isStaticStyleValue(rawSelf) && this._isStaticStyleValue(rawBase)) {
+                    const cacheKey = key || '$root';
+
+                    if (this.sxStaticCache.has(cacheKey)) {
+                        return this.sxStaticCache.get(cacheKey);
+                    }
+
+                    const style = { ...rawBase, ...rawSelf };
+                    const cached = isNotEmpty(style) ? style : undefined;
+
+                    this.sxStaticCache.set(cacheKey, cached);
+
+                    return cached;
+                }
+            }
+
             const self = this._getOptionValue(this.$style.inlineStyles, key, { ...this.$params, ...params }) as Record<string, any>;
             const base = this._getOptionValue(this.baseComponentStyle.inlineStyles, key, { ...this.$params, ...params }) as Record<string, any>;
+
+            if (!isNotEmpty(base) && !isNotEmpty(self)) {
+                return undefined;
+            }
 
             return { ...base, ...self };
         }

--- a/packages/primeng/src/bind/bind.ts
+++ b/packages/primeng/src/bind/bind.ts
@@ -1,5 +1,6 @@
-import { computed, Directive, effect, ElementRef, input, NgModule, Renderer2, signal } from '@angular/core';
+import { computed, Directive, effect, ElementRef, inject, input, NgModule, Renderer2, signal } from '@angular/core';
 import { cn, equals } from '@primeuix/utils';
+import { PrimeNG } from 'primeng/config';
 
 /**
  * Bind directive provides dynamic attribute, property, and event listener binding functionality.
@@ -14,6 +15,8 @@ import { cn, equals } from '@primeuix/utils';
     }
 })
 export class Bind {
+    private config = inject(PrimeNG);
+
     /**
      * Dynamic attributes, properties, and event listeners to be applied to the host element.
      * @group Props
@@ -23,8 +26,10 @@ export class Bind {
     private _attrs = signal<{ [key: string]: any } | undefined>(undefined);
     private attrs = computed(() => this._attrs() || this.pBind());
 
-    styles = computed(() => this.attrs()?.style);
-    classes = computed(() => cn(this.attrs()?.class));
+    styles = computed(() => (this.config.ptBinding() ? this.attrs()?.style : undefined));
+    classes = computed(() => (this.config.ptBinding() ? cn(this.attrs()?.class) : undefined));
+
+    private appliedAttrs: { [key: string]: any } = {};
 
     private listeners: { eventName: string; unlisten: () => void }[] = [];
 
@@ -33,7 +38,19 @@ export class Bind {
         private renderer: Renderer2
     ) {
         effect(() => {
-            const { style, class: className, ...rest } = this.attrs() || {};
+            if (!this.config.ptBinding()) {
+                this.clearAppliedAttrs();
+                this.clearListeners();
+                return;
+            }
+
+            const attrs = this.attrs();
+
+            if (!attrs) {
+                return;
+            }
+
+            const { style, class: className, ...rest } = attrs;
 
             for (const [key, value] of Object.entries(rest)) {
                 if (key.startsWith('on') && typeof value === 'function') {
@@ -47,12 +64,18 @@ export class Bind {
                 } else if (value === null || value === undefined) {
                     // remove attr
                     this.renderer.removeAttribute(this.el.nativeElement, key);
-                } else {
-                    // attr & prop fallback
-                    this.renderer.setAttribute(this.el.nativeElement, key, value.toString());
+                    delete this.appliedAttrs[key];
+                } else if (this.appliedAttrs[key] !== value) {
+                    const attrValue = value.toString();
+
+                    this.appliedAttrs[key] = value;
+                    this.renderer.setAttribute(this.el.nativeElement, key, attrValue);
+
                     if (key in this.el.nativeElement) {
                         (this.el.nativeElement as any)[key] = value;
                     }
+                } else {
+                    continue;
                 }
             }
         });
@@ -63,7 +86,7 @@ export class Bind {
     }
 
     public setAttrs(attrs: { [key: string]: any } | undefined) {
-        if (!equals(this._attrs(), attrs)) {
+        if (this._attrs() !== attrs && !equals(this._attrs(), attrs)) {
             this._attrs.set(attrs);
         }
     }
@@ -71,6 +94,14 @@ export class Bind {
     private clearListeners() {
         this.listeners.forEach(({ unlisten }) => unlisten());
         this.listeners = [];
+    }
+
+    private clearAppliedAttrs() {
+        for (const key of Object.keys(this.appliedAttrs)) {
+            this.renderer.removeAttribute(this.el.nativeElement, key);
+        }
+
+        this.appliedAttrs = {};
     }
 }
 

--- a/packages/primeng/src/button/button.ts
+++ b/packages/primeng/src/button/button.ts
@@ -25,7 +25,7 @@ import { addClass, createElement, findSingle, isEmpty } from '@primeuix/utils';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
 import { AutoFocus } from 'primeng/autofocus';
 import { BadgeModule } from 'primeng/badge';
-import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
+import { BaseComponent, PARENT_INSTANCE, PERFORMANCE_CONTEXT } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { Fluid } from 'primeng/fluid';
 import { SpinnerIcon } from 'primeng/icons';
@@ -54,7 +54,7 @@ const INTERNAL_BUTTON_CLASSES = {
 
 @Directive({
     selector: '[pButtonLabel]',
-    providers: [ButtonStyle, { provide: BUTTON_LABEL_INSTANCE, useExisting: ButtonLabel }, { provide: PARENT_INSTANCE, useExisting: ButtonLabel }],
+    providers: [ButtonStyle, { provide: BUTTON_LABEL_INSTANCE, useExisting: ButtonLabel }, { provide: PARENT_INSTANCE, useExisting: ButtonLabel }, { provide: PERFORMANCE_CONTEXT, useExisting: ButtonLabel }],
     standalone: true,
     host: {
         '[class.p-button-label]': '!$unstyled() && true'
@@ -107,7 +107,7 @@ export class ButtonLabel extends BaseComponent {
 
 @Directive({
     selector: '[pButtonIcon]',
-    providers: [ButtonStyle, { provide: BUTTON_ICON_INSTANCE, useExisting: ButtonIcon }, { provide: PARENT_INSTANCE, useExisting: ButtonIcon }],
+    providers: [ButtonStyle, { provide: BUTTON_ICON_INSTANCE, useExisting: ButtonIcon }, { provide: PARENT_INSTANCE, useExisting: ButtonIcon }, { provide: PERFORMANCE_CONTEXT, useExisting: ButtonIcon }],
     standalone: true,
     host: {
         '[class.p-button-icon]': '!$unstyled() && true'
@@ -164,7 +164,7 @@ export class ButtonIcon extends BaseComponent {
 @Directive({
     selector: '[pButton]',
     standalone: true,
-    providers: [ButtonStyle, { provide: BUTTON_DIRECTIVE_INSTANCE, useExisting: ButtonDirective }, { provide: PARENT_INSTANCE, useExisting: ButtonDirective }],
+    providers: [ButtonStyle, { provide: BUTTON_DIRECTIVE_INSTANCE, useExisting: ButtonDirective }, { provide: PARENT_INSTANCE, useExisting: ButtonDirective }, { provide: PERFORMANCE_CONTEXT, useExisting: ButtonDirective }],
     host: {
         '[class.p-button-icon-only]': '!$unstyled() && isIconOnly()',
         '[class.p-button-text]': ' !$unstyled() && isTextButton()'
@@ -304,6 +304,10 @@ export class ButtonDirective extends BaseComponent {
     }
 
     private _internalClasses: string[] = Object.values(INTERNAL_BUTTON_CLASSES);
+
+    private dynamicLabelElement: HTMLElement | undefined;
+
+    private dynamicIconElement: HTMLElement | undefined;
 
     pcFluid: Fluid | null = inject(Fluid, { optional: true, host: true, skipSelf: true });
 
@@ -506,16 +510,17 @@ export class ButtonDirective extends BaseComponent {
     }
 
     createLabel() {
-        const created = findSingle(this.htmlElement, '[data-pc-section="buttonlabel"]');
+        const created = this.getDynamicLabelElement();
         if (!created && this.label) {
             let labelElement = <HTMLElement>createElement('span', { class: this.cx('label'), 'p-bind': this.ptm('buttonlabel'), 'aria-hidden': this.icon && !this.label ? 'true' : null });
             labelElement.appendChild(this.document.createTextNode(this.label));
             this.htmlElement.appendChild(labelElement);
+            this.dynamicLabelElement = labelElement;
         }
     }
 
     createIcon() {
-        const created = findSingle(this.htmlElement, '[data-pc-section="buttonicon"]');
+        const created = this.getDynamicIconElement();
         if (!created && (this.icon || this.loading)) {
             let iconPosClass = this.label && !this.$unstyled() ? 'p-button-icon-' + this.iconPos : null;
             let iconClass = !this.$unstyled() && this.getIconClass();
@@ -526,14 +531,16 @@ export class ButtonDirective extends BaseComponent {
             }
 
             this.htmlElement.insertBefore(iconElement, this.htmlElement.firstChild);
+            this.dynamicIconElement = iconElement;
         }
     }
 
     updateLabel() {
-        let labelElement = findSingle(this.htmlElement, '[data-pc-section="buttonlabel"]');
+        let labelElement = this.getDynamicLabelElement();
 
         if (!this.label) {
             labelElement && this.htmlElement.removeChild(labelElement);
+            this.dynamicLabelElement = undefined;
             return;
         }
 
@@ -541,8 +548,8 @@ export class ButtonDirective extends BaseComponent {
     }
 
     updateIcon() {
-        let iconElement = findSingle(this.htmlElement, '[data-pc-section="buttonicon"]');
-        let labelElement = findSingle(this.htmlElement, '[data-pc-section="buttonlabel"]');
+        let iconElement = this.getDynamicIconElement();
+        let labelElement = this.getDynamicLabelElement();
 
         if (this.loading && !this.loadingIcon && iconElement) {
             iconElement.innerHTML = this.spinnerIcon;
@@ -559,6 +566,26 @@ export class ButtonDirective extends BaseComponent {
         } else {
             this.createIcon();
         }
+    }
+
+    private getDynamicLabelElement() {
+        if (this.dynamicLabelElement && this.htmlElement.contains(this.dynamicLabelElement)) {
+            return this.dynamicLabelElement;
+        }
+
+        this.dynamicLabelElement = findSingle(this.htmlElement, '[data-pc-section="buttonlabel"]') as HTMLElement | undefined;
+
+        return this.dynamicLabelElement;
+    }
+
+    private getDynamicIconElement() {
+        if (this.dynamicIconElement && this.htmlElement.contains(this.dynamicIconElement)) {
+            return this.dynamicIconElement;
+        }
+
+        this.dynamicIconElement = findSingle(this.htmlElement, '[data-pc-section="buttonicon"]') as HTMLElement | undefined;
+
+        return this.dynamicIconElement;
     }
 
     getIconClass() {
@@ -627,7 +654,7 @@ export class ButtonDirective extends BaseComponent {
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [ButtonStyle, { provide: BUTTON_INSTANCE, useExisting: Button }, { provide: PARENT_INSTANCE, useExisting: Button }],
+    providers: [ButtonStyle, { provide: BUTTON_INSTANCE, useExisting: Button }, { provide: PARENT_INSTANCE, useExisting: Button }, { provide: PERFORMANCE_CONTEXT, useExisting: Button }],
     hostDirectives: [Bind]
 })
 export class Button extends BaseComponent<ButtonPassThrough> {

--- a/packages/primeng/src/chip/chip.ts
+++ b/packages/primeng/src/chip/chip.ts
@@ -18,7 +18,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { PrimeTemplate, SharedModule, TranslationKeys } from 'primeng/api';
-import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
+import { BaseComponent, PARENT_INSTANCE, PERFORMANCE_CONTEXT } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { TimesCircleIcon } from 'primeng/icons';
 import { ChipProps, ChipPassThrough } from 'primeng/types/chip';
@@ -80,7 +80,7 @@ const CHIP_INSTANCE = new InjectionToken<Chip>('CHIP_INSTANCE');
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [ChipStyle, { provide: CHIP_INSTANCE, useExisting: Chip }, { provide: PARENT_INSTANCE, useExisting: Chip }],
+    providers: [ChipStyle, { provide: CHIP_INSTANCE, useExisting: Chip }, { provide: PARENT_INSTANCE, useExisting: Chip }, { provide: PERFORMANCE_CONTEXT, useExisting: Chip }],
     host: {
         '[class]': "cn(cx('root'), styleClass)",
         '[style]': "sx('root')",

--- a/packages/primeng/src/config/primeng.ts
+++ b/packages/primeng/src/config/primeng.ts
@@ -28,6 +28,10 @@ export class PrimeNG extends ThemeProvider {
 
     ptOptions = signal<PrimeNGConfigType['ptOptions']>(undefined);
 
+    ptMetadata = signal<boolean>(true);
+
+    ptBinding = signal<boolean>(true);
+
     filterMatchModeOptions = {
         text: [FilterMatchMode.STARTS_WITH, FilterMatchMode.CONTAINS, FilterMatchMode.NOT_CONTAINS, FilterMatchMode.ENDS_WITH, FilterMatchMode.EQUALS, FilterMatchMode.NOT_EQUALS],
         numeric: [FilterMatchMode.EQUALS, FilterMatchMode.NOT_EQUALS, FilterMatchMode.LESS_THAN, FilterMatchMode.LESS_THAN_OR_EQUAL_TO, FilterMatchMode.GREATER_THAN, FilterMatchMode.GREATER_THAN_OR_EQUAL_TO],
@@ -186,7 +190,7 @@ export class PrimeNG extends ThemeProvider {
     }
 
     setConfig(config: PrimeNGConfigType): void {
-        const { csp, ripple, inputStyle, inputVariant, theme, overlayOptions, translation, filterMatchModeOptions, overlayAppendTo, zIndex, ptOptions, pt, unstyled } = config || {};
+        const { csp, ripple, inputStyle, inputVariant, theme, overlayOptions, translation, filterMatchModeOptions, overlayAppendTo, zIndex, ptOptions, pt, ptMetadata, ptBinding, unstyled } = config || {};
 
         if (csp) this.csp.set(csp);
         if (overlayAppendTo) this.overlayAppendTo.set(overlayAppendTo);
@@ -199,6 +203,8 @@ export class PrimeNG extends ThemeProvider {
         if (zIndex) this.zIndex = zIndex;
         if (pt) this.pt.set(pt);
         if (ptOptions) this.ptOptions.set(ptOptions);
+        if (ptMetadata !== undefined) this.ptMetadata.set(ptMetadata);
+        if (ptBinding !== undefined) this.ptBinding.set(ptBinding);
         if (unstyled) this.unstyled.set(unstyled);
 
         if (theme)

--- a/packages/primeng/src/config/primeng.types.ts
+++ b/packages/primeng/src/config/primeng.types.ts
@@ -205,5 +205,17 @@ export type PrimeNGConfigType = {
     zIndex?: ZIndex | null | undefined;
     pt?: GlobalPassThrough | null | undefined;
     ptOptions?: PassThroughOptions | null | undefined;
+    /**
+     * Enables automatic metadata attributes for PassThrough sections.
+     * Disable this in performance-sensitive views when `data-pc-*` attributes are not needed for tests, styling, or tooling.
+     * @defaultValue true
+     */
+    ptMetadata?: boolean;
+    /**
+     * Enables PassThrough binding.
+     * Disable this in performance-sensitive views when `pt`, `data-pc-*`, and `pBind` driven attributes/classes/styles/events are not needed.
+     * @defaultValue true
+     */
+    ptBinding?: boolean;
     filterMatchModeOptions?: any;
 } & ThemeConfigType;

--- a/packages/primeng/src/table/table.ts
+++ b/packages/primeng/src/table/table.ts
@@ -33,7 +33,7 @@ import { MotionEvent, MotionOptions } from '@primeuix/motion';
 import { absolutePosition, addStyle, appendChild, find, findSingle, getAttribute, isClickable, setAttribute } from '@primeuix/utils';
 import { BlockableUI, FilterMatchMode, FilterMetadata, FilterOperator, FilterService, LazyLoadMeta, OverlayService, PrimeTemplate, ScrollerOptions, SelectItem, SharedModule, SortMeta, TableState, TranslationKeys } from 'primeng/api';
 import { BadgeModule } from 'primeng/badge';
-import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
+import { BaseComponent, PARENT_INSTANCE, PERFORMANCE_CONTEXT } from 'primeng/basecomponent';
 import { Bind, BindModule } from 'primeng/bind';
 import { Button, ButtonModule } from 'primeng/button';
 import { CheckboxChangeEvent, CheckboxModule } from 'primeng/checkbox';
@@ -353,7 +353,7 @@ export class TableService {
             <ng-template *ngTemplateOutlet="reorderIndicatorDownIconTemplate || _reorderIndicatorDownIconTemplate"></ng-template>
         </span>
     `,
-    providers: [TableService, TableStyle, { provide: TABLE_INSTANCE, useExisting: Table }, { provide: PARENT_INSTANCE, useExisting: Table }],
+    providers: [TableService, TableStyle, { provide: TABLE_INSTANCE, useExisting: Table }, { provide: PARENT_INSTANCE, useExisting: Table }, { provide: PERFORMANCE_CONTEXT, useExisting: Table }],
     changeDetection: ChangeDetectionStrategy.Default,
     encapsulation: ViewEncapsulation.None,
     host: {

--- a/packages/primeng/src/tag/tag.ts
+++ b/packages/primeng/src/tag/tag.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { AfterContentInit, booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ContentChildren, inject, InjectionToken, Input, NgModule, QueryList, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { PrimeTemplate, SharedModule } from 'primeng/api';
-import { BaseComponent, PARENT_INSTANCE } from 'primeng/basecomponent';
+import { BaseComponent, PARENT_INSTANCE, PERFORMANCE_CONTEXT } from 'primeng/basecomponent';
 import { Bind } from 'primeng/bind';
 import { TagPassThrough } from 'primeng/types/tag';
 import { TagStyle } from './style/tagstyle';
@@ -28,7 +28,7 @@ const TAG_INSTANCE = new InjectionToken<Tag>('TAG_INSTANCE');
     `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
-    providers: [TagStyle, { provide: TAG_INSTANCE, useExisting: Tag }, { provide: PARENT_INSTANCE, useExisting: Tag }],
+    providers: [TagStyle, { provide: TAG_INSTANCE, useExisting: Tag }, { provide: PARENT_INSTANCE, useExisting: Tag }, { provide: PERFORMANCE_CONTEXT, useExisting: Tag }],
     host: {
         '[class]': "cn(cx('root'), styleClass)",
         '[attr.data-p]': 'dataP'


### PR DESCRIPTION
This PR reduces PrimeNG table rendering overhead in component-heavy rows. Spent a lot of time on it, because it really annoyed me.

The issue is most visible in large, non-virtualized `p-table` instances where each row contains nested PrimeNG components like `p-button`, `p-chip`, and `p-tag`. In v21, these components all go through the newer `BaseComponent`, PassThrough, metadata, style, and theme-reactivity infrastructure. That infrastructure is useful, but in dense tables the per-instance cost multiplies quickly.

The changes keep default behavior backwards compatible and add explicit opt-out paths for performance-sensitive use cases.

New global config options:

```ts
providePrimeNG({
    ptMetadata: false,
    ptBinding: false
});
```

New component-level attributes:

```html
<p-table
    [themeReactive]="false"
    [scopedTokens]="false"
/>
```

All options default to the current behavior (enabled / `true`).

---

**The Root Cause**

PrimeNG v21 does more work per component instance than v17:

- `BaseComponent` prepares theme and scoped token handling
- `pBind` applies PassThrough attributes/classes/styles/events
- metadata attributes like `data-pc-section` are generated even when no custom PT is used
- static classes/styles are recomputed repeatedly
- many identical theme-change listeners can be registered across repeated components

For a table with many rows, this becomes a large amount of repeated setup and DOM work.

---

**File-by-file Changes**

`packages/primeng/src/base/base.ts`

Adds shared theme-change wiring and grouped theme listeners.

Before, many component instances could register equivalent theme-change listeners. Now shared style invalidation is wired once, and listeners can be grouped by style name.

Impact:

- fewer duplicate theme listeners
- less listener cleanup work
- less memory pressure in large component trees

---

`packages/primeng/src/basecomponent/basecomponent.ts`

Main performance work.

Changes:

- caches `$style`
- caches `$params`
- caches static `cx()` class values
- caches static `sx()` style values
- caches metadata-only `ptm()` / `ptms()` results
- short-circuits `ptm()`, `ptms()`, and `ptmo()` when PT binding is disabled
- skips metadata generation when configured
- adds local inputs for theme/scoped-token opt-out:
  - `themeReactive`
  - `scopedTokens`
- adds `PERFORMANCE_CONTEXT` so those options can flow through PrimeNG component subtrees

Impact:

- fewer object allocations
- fewer repeated class/style computations
- less PT work in large tables
- optional per-table opt-out for runtime theme/scoped-token handling

---

`packages/primeng/src/bind/bind.ts`

Makes `pBind` cheaper.

Changes include:

- `pBind` becomes a no-op when `ptBinding` is disabled
- repeated identical attribute/property writes are skipped
- repeated identical `setAttrs()` calls avoid deep equality checks when object identity is unchanged
- event listeners are cleaned up when binding is disabled

Impact:

- less DOM attribute churn
- cheaper PassThrough handling
- significant reduction when many internal elements use `[pBind]`

---

`packages/primeng/src/button/button.ts`

Adds performance-context propagation through:

- `p-button`
- `pButton`
- `pButtonLabel`
- `pButtonIcon`

Also fixes a bug exposed by disabling PT metadata.

The legacy dynamic `pButton` path searched for generated icon/label elements using `data-pc-section`. When metadata was disabled, those lookups failed and repeated icon updates could create duplicate icons. This affected expandable table row toggles.

The fix stores direct references to dynamically-created icon/label elements and only uses the metadata selector as a fallback.

Impact:

- button-related components inherit table-level performance settings
- expandable row toggle icons work correctly with PT metadata disabled

---

`packages/primeng/src/chip/chip.ts`
`packages/primeng/src/tag/tag.ts`

Adds `PERFORMANCE_CONTEXT` provider.

Impact:

- `p-chip` and `p-tag` can inherit table-level `themeReactive` / `scopedTokens` settings
- useful because chips are commonly rendered repeatedly in table cells
- useful for status-heavy table columns

---

`packages/primeng/src/config/primeng.ts`

Adds two global config signals:

- `ptMetadata`
- `ptBinding`

These are wired through `providePrimeNG`.

Impact:

- apps can disable only automatic metadata
- apps can fully disable PassThrough binding when they do not use PT

---

`packages/primeng/src/config/primeng.types.ts`

Adds the public config typings:

- `ptMetadata?: boolean`
- `ptBinding?: boolean`

Usage:

```ts
providePrimeNG({
    ptMetadata: false,
    ptBinding: false
});
```

Defaults are `true`.

---

`packages/primeng/src/table/table.ts`

Adds `PERFORMANCE_CONTEXT` provider to `p-table`.

This allows a table to act as the local performance boundary:

```html
<p-table
    [themeReactive]="false"
    [scopedTokens]="false"
/>
```

Impact:

- no need to disable these behaviors globally
- large tables can opt out locally while the rest of the app keeps normal runtime theme behavior

---

**New Options**

`ptMetadata`

Disables automatic PrimeNG metadata attributes such as:

- `data-pc-name`
- `data-pc-section`
- `data-pc-extend`
- generated `pc-*` attrs

Use when the app does not rely on these attributes for tests, styling, or tooling.

`ptBinding`

Disables PassThrough binding entirely.

This disables:

- global `pt`
- local `[pt]`
- PT classes/styles/attributes
- PT event listeners
- PT hooks

Use only when the app does not use PassThrough.

`themeReactive`

Component-level opt-out for runtime theme reactivity.

Use when a component/subtree does not need to react to theme changes after initial render.

`scopedTokens`

Component-level opt-out for scoped `dt` token handling.

Use when the component/subtree does not use scoped design tokens.

---

**Compatibility Notes**

Default behavior is unchanged.

The new performance options are opt-in.

Caveats:

- `ptMetadata: false` can break tests or selectors relying on `data-pc-*`
- `ptBinding: false` disables PassThrough completely
- `themeReactive: false` means runtime theme changes are not applied reactively in that subtree
- `scopedTokens: false` disables scoped `dt` handling in that subtree

---

**Validation**

Checked with:

```bash
node_modules/.bin/prettier --check ...
git diff --check ...
node_modules/.bin/tsc -p packages/primeng/tsconfig.json --noEmit
node_modules/.bin/tsc -p apps/showcase/tsconfig.json --noEmit
```

The local PrimeNG package build completed successfully.

---

**Performance**

Based on the Stackblitz demo: https://stackblitz.com/edit/ypa916vr-a8fnitry?file=package.json  
* Officla avg. rendering time for 10 runs: (420 + 388 + 382 + 368 + 386 + 386 + 376 + 377 + 377 + 389)/10 = ~ 384ms  
* Patched avg. rendering time for 10 runs: (209 + 218 + 207 + 212 + 197 + 180 + 200 + 206 + 221 + 207)/10 = ~ 205ms  

So the performance of the patch is about 1.87x faster / 87% speed increase.  

I'm providing also two demo cases:  
* https://github.com/devidevio/primeng-table-fix-demo  
* https://github.com/devidevio/primeng-table-current-demo  

You can also check the package out and try it in your own application:
* https://github.com/devidevio/primeng/releases/tag/21.1.8

Or via:
```
"dependencies": {
    "primeng": "https://github.com/devidevio/primeng/releases/download/21.1.8/primeng-21.1.8.tgz"
}
```

Clone the repo locally, run `npm install` & `npm start` - open the browser and play around (open dev tools / console to see the performance logs).  

**Additional note**
I've only added the `PERFORMANCE_CONTEXT` to a few components, the most common used in an table. May this needs to be extended too.  

As this includes an change on the base component level, it needs some more testing and more eyes on it without breaking anything else, as this is an fundamental change.

---

https://github.com/user-attachments/assets/c9fb4963-9b22-4c44-802e-b9f45bb06775



https://github.com/user-attachments/assets/f9989007-77df-4a5b-91d2-9d418cd53c87

