### PR TITLE
[19600] fix: Scroll behavior on hover and open, fix partialSelected with groups

### DIFF
--- a/packages/primeng/src/multiselect/multiselect.ts
+++ b/packages/primeng/src/multiselect/multiselect.ts
@@ -1916,7 +1916,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
     onOptionMouseEnter(event, index) {
         if (this.focusOnHover) {
-            this.changeFocusedOptionIndex(event, index);
+            this.focusedOptionIndex.set(index);
         }
     }
 
@@ -2007,7 +2007,7 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
     }
 
     partialSelected() {
-        return this.selectedOptions && this.selectedOptions.length > 0 && this.selectedOptions.length < (this.options?.length || 0);
+        return this.hasSelectedOption() && !this.allSelected();
     }
 
     /**
@@ -2052,12 +2052,14 @@ export class MultiSelect extends BaseEditableHolder<MultiSelectPassThrough> {
 
         if (this.options && this.options.length) {
             if (this.virtualScroll) {
-                const selectedIndex = this.modelValue() ? this.focusedOptionIndex() : -1;
+                const selectedIndex = this.modelValue() ? this.findSelectedOptionIndex() : -1;
                 if (selectedIndex !== -1) {
-                    this.scroller?.scrollToIndex(selectedIndex);
+                    setTimeout(() => {
+                        this.scroller?.scrollToIndex(selectedIndex);
+                    }, 20);
                 }
             } else {
-                let selectedListItem = findSingle(this.itemsWrapper, '[data-pc-section="option"][data-p-selected="true"]');
+                let selectedListItem = findSingle(this.itemsWrapper, '[data-p-selected="true"]');
 
                 if (selectedListItem) {
                     selectedListItem.scrollIntoView({ block: 'nearest', inline: 'nearest' });

--- a/packages/primeng/src/select/select.ts
+++ b/packages/primeng/src/select/select.ts
@@ -1241,7 +1241,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
     onOptionMouseEnter(event, index) {
         if (this.focusOnHover) {
-            this.changeFocusedOptionIndex(event, index);
+            this.focusedOptionIndex.set(index);
         }
     }
 
@@ -1419,7 +1419,7 @@ export class Select extends BaseInput<SelectPassThrough> implements AfterViewIni
 
         if (this.options && this.options.length) {
             if (this.virtualScroll) {
-                const selectedIndex = this.modelValue() ? this.focusedOptionIndex() : -1;
+                const selectedIndex = this.modelValue() ? this.findSelectedOptionIndex() : -1;
                 if (selectedIndex !== -1) {
                     setTimeout(() => {
                         this.scroller?.scrollToIndex(selectedIndex);


### PR DESCRIPTION
fixes: #19600

### Description
This PR fixes several issues in Select and MultiSelect components related to scroll behavior and partial selection state.

### Issues Fixed

#### 1. Hover causes unwanted scroll jumping
When hovering over options in Select/MultiSelect dropdowns with virtual scroll, the list would unexpectedly jump/scroll.

**Root cause:** `onOptionMouseEnter` was calling `changeFocusedOptionIndex()`, which triggers `scrollInView()`.

**Fix:** Changed `onOptionMouseEnter` to directly set `focusedOptionIndex` for visual styling without triggering scroll.

#### 2. Dropdown not scrolling to selected item on open
When reopening a Select/MultiSelect with virtual scroll, it would sometimes show the wrong position or not scroll to the selected item.

**Root cause:** Was using `focusedOptionIndex()` (which could be changed by hover) instead of the actual selected item index.

**Fix:** Use `findSelectedOptionIndex()` when determining scroll position on overlay open, with proper timing for virtual scroller initialization.

#### 3. MultiSelect `partialSelected()` broken with grouped options
When using grouped options with a custom header checkbox template, the indeterminate state would disappear after selecting items.

**Root cause:** `partialSelected()` compared `selectedOptions.length` with `options.length`, but `options` includes group objects when using groups.

**Fix:** Changed `partialSelected()` to use `hasSelectedOption() && !allSelected()` which properly handles groups.

### Steps to Reproduce

**Issue 1 & 2:**
1. Create a Select/MultiSelect with `[virtualScroll]="true"` and many options
2. Select an item lower in the list
3. Close and reopen the dropdown
4. Observe scroll position and try hovering near the top

**Issue 3:**
1. Create a MultiSelect with `[group]="true"` and custom `headerCheckboxIconTemplate`
2. Select multiple items
3. Observe the header checkbox indeterminate state

### Expected Behavior
- Hovering over options should only update visual focus styling, not cause scrolling
- Opening dropdown should scroll to show the selected item immediately
- `partialSelected()` should return `true` when some (but not all) selectable items are selected, regardless of grouping

### Files Changed
- `packages/primeng/src/select/select.ts`
- `packages/primeng/src/multiselect/multiselect.ts`